### PR TITLE
[reconfigurator] only clear the "will remove mupdate override" field if inventory is up-to-date

### DIFF
--- a/dev-tools/reconfigurator-cli/tests/input/cmds-add-zones-with-mupdate-override.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-add-zones-with-mupdate-override.txt
@@ -26,6 +26,14 @@ blueprint-plan latest latest
 # and the target release minimum generation being set.
 blueprint-diff latest
 
+# Apply the blueprint to serial0 so that inventory's reported sled-agent
+# generation matches the blueprint. (The mupdate override remains visible in
+# inventory because we don't call `sled-set ... mupdate-override unset`.) This
+# keeps the next plan's noop check from firing the inventory-stale path,
+# letting it exercise the mupdate-override-set-in-blueprint path instead.
+sled-set serial0 omicron-config latest
+inventory-generate
+
 # Set Nexus redundancy to 4.
 set num-nexus 4
 

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-missing-measurement-manifest.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-missing-measurement-manifest.txt
@@ -33,6 +33,12 @@ blueprint-edit latest set-measurements serial1 install-dataset
 sled-update-install-dataset serial0 --to-target-release
 sled-update-install-dataset serial1 --to-target-release --with-measurement-manifest-error
 
+# Apply the latest blueprint to inventory so the noop check on the next plan
+# sees up-to-date sled-agent generations and can exercise the measurement
+# conversion path. (Earlier plans and edits bumped these generations.)
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+
 # This time we expect that sled1 should have blocked at a missing
 # measurement manifest because we are expecting one
 inventory-generate

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-missing-sled-blocks-zone-updates.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-missing-sled-blocks-zone-updates.txt
@@ -77,6 +77,12 @@ sled-update-host-phase2 serial0 --boot-disk B
 # report that we are missing sled agent inventory for measurements on sled 1.
 # This will block any MGS updates that could be pending because we must
 # observe the expected measurements on all sleds before we proceed.
+#
+# Apply the latest blueprint to serial0's inventory so that its reported
+# sled-agent generation isn't stale relative to the parent blueprint. (Earlier
+# plans bumped the blueprint's generation for this sled.) That keeps the noop
+# check on serial0 from firing the inventory-stale path.
+sled-set serial0 omicron-config latest
 sled-set serial1 inventory-hidden
 inventory-generate
 blueprint-plan latest latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-stale-inventory.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-stale-inventory.txt
@@ -1,19 +1,19 @@
-# This test exercises the bug where, in the mupdate override flow, the planner
-# would clear `remove_mupdate_override` from a sled's blueprint based on stale
-# inventory -- specifically, an inventory collection that was captured before
-# the sled was mupdated, so the override marker isn't visible in it.
+# This test verifies that when resolving a MUPdate, the planner does not clear
+# the "will remove mupdate override" field from a sled's blueprint based on stale
+# inventory -- specifically, an inventory collection that occurred before
+# the sled was MUPdated, so the mupdate override UUID isn't visible in it.
 #
 # Acting on stale inventory in this way could cause the planner to acknowledge
 # a sled recovery that hasn't happened, breaking the edge-triggered
-# mupdate override semantics. The fix is to mark a sled as ineligible for
-# both noop conversion and mupdate override clearing whenever the inventory's
-# reported sled-agent generation is older than the generation in the parent
-# blueprint.
+# mupdate override semantics. The solution is to mark a sled as ineligible for
+# both noop conversion and will-remove-mupdate-override clearing whenever the
+# inventory's reported sled-agent generation is older than the generation in
+# the parent blueprint.
 #
 # The test simulates two plans against the same parent blueprint: one against
-# the latest (post-mupdate) inventory, and one against a stale (pre-mupdate)
+# the latest (post-mupdate) inventory, and then one against a stale (pre-mupdate)
 # inventory. With the fix, planning against the stale inventory leaves
-# remove_mupdate_override alone instead of clearing it.
+# the "will remove mupdate override" field alone instead of clearing it.
 
 # Load a small example system. We only need one sled to demonstrate the bug.
 load-example --nsleds 1 --ndisks-per-sled 3
@@ -26,7 +26,7 @@ set target-release repo-1.0.0.zip
 # Update the install dataset on serial0 to the target release.
 sled-update-install-dataset serial0 --to-target-release
 
-# Generate the FIRST inventory collection. At this point the sled has no
+# Generate the first inventory collection. At this point the sled has no
 # mupdate override visible. We'll come back to this collection later to plan
 # against it as a "stale" inventory.
 inventory-generate
@@ -37,7 +37,7 @@ inventory-list
 # tracked separately.
 sled-set serial0 mupdate-override 11111111-1111-1111-1111-111111111111
 
-# Generate a SECOND inventory collection, post-mupdate. This one has the
+# Generate a second inventory collection, post-MUPdate. This one has the
 # override visible.
 inventory-generate
 inventory-list
@@ -55,13 +55,12 @@ blueprint-diff latest
 # stale inventory reports.
 #
 # The collection ID below is the deterministic UUID for the first
-# `inventory-generate` above (driven by the test harness's --seed argument).
+# `inventory-generate` above.
 #
-# Without the fix, the planner would treat the absence of the override in
-# this stale inventory as evidence that the sled has recovered, and clear
-# `remove_mupdate_override` from the blueprint. With the fix, the planner
-# correctly identifies the inventory as stale (inv gen < parent bp gen) and
-# leaves `remove_mupdate_override` alone, logging
-# "blueprint override could not be cleared, ... reason: inventory stale".
+# Without the check for stale inventory, the planner would treat the absence of
+# the override in this stale inventory as evidence that the sled has recovered,
+# and clear the "will remove mupdate override" field from the blueprint. With
+# the check, the planner leaves the "will remove mupdate override" field alone,
+# logging "blueprint override could not be cleared, ... reason: inventory stale".
 blueprint-plan latest eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51
 blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-stale-inventory.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-stale-inventory.txt
@@ -1,0 +1,67 @@
+# This test exercises the bug where, in the mupdate override flow, the planner
+# would clear `remove_mupdate_override` from a sled's blueprint based on stale
+# inventory -- specifically, an inventory collection that was captured before
+# the sled was mupdated, so the override marker isn't visible in it.
+#
+# Acting on stale inventory in this way could cause the planner to acknowledge
+# a sled recovery that hasn't happened, breaking the edge-triggere
+# mupdate override semantics. The fix is to mark a sled as ineligible for
+# both noop conversion and mupdate override clearing whenever the inventory's
+# reported sled-agent generation is older than the generation in the parent
+# blueprint.
+#
+# The test simulates two plans against the same parent blueprint: one against
+# the latest (post-mupdate) inventory, and one against a stale (pre-mupdate)
+# inventory. With the fix, planning against the stale inventory leaves
+# remove_mupdate_override alone instead of clearing it.
+
+# Load a small example system. We only need one sled to demonstrate the bug.
+load-example --nsleds 1 --ndisks-per-sled 3
+sled-list
+
+# Create a TUF repository so noop image source conversions are possible.
+tuf-assemble ../../update-common/manifests/fake.toml
+set target-release repo-1.0.0.zip
+
+# Update the install dataset on serial0 to the target release.
+sled-update-install-dataset serial0 --to-target-release
+
+# Generate the FIRST inventory collection. At this point the sled has no
+# mupdate override visible. We'll come back to this collection later to plan
+# against it as a "stale" inventory.
+inventory-generate
+inventory-list
+
+# Simulate a mupdate on serial0 by setting the mupdate override field. The
+# sled's reconciled config generation is unchanged -- the mupdate override is
+# tracked separately.
+sled-set serial0 mupdate-override 11111111-1111-1111-1111-111111111111
+
+# Generate a SECOND inventory collection, post-mupdate. This one has the
+# override visible.
+inventory-generate
+inventory-list
+
+# Plan against the latest (post-mupdate) inventory. This should set
+# `remove_mupdate_override` on serial0 in the new blueprint and bump its
+# sled-agent generation.
+blueprint-plan latest latest
+blueprint-diff latest
+
+# Now plan against the first (pre-mupdate) inventory collection. That
+# inventory shows no mupdate override on serial0, but only because the
+# inventory was captured before the mupdate ever happened. The parent
+# blueprint's sled-agent generation for serial0 is now ahead of what this
+# stale inventory reports.
+#
+# The collection ID below is the deterministic UUID for the first
+# `inventory-generate` above (driven by the test harness's --seed argument).
+#
+# Without the fix, the planner would treat the absence of the override in
+# this stale inventory as evidence that the sled has recovered, and clear
+# `remove_mupdate_override` from the blueprint. With the fix, the planner
+# correctly identifies the inventory as stale (inv gen < parent bp gen) and
+# leaves `remove_mupdate_override` alone, logging
+# "blueprint override could not be cleared, ... reason: inventory stale".
+blueprint-plan latest eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51
+blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-stale-inventory.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-stale-inventory.txt
@@ -4,7 +4,7 @@
 # the sled was mupdated, so the override marker isn't visible in it.
 #
 # Acting on stale inventory in this way could cause the planner to acknowledge
-# a sled recovery that hasn't happened, breaking the edge-triggere
+# a sled recovery that hasn't happened, breaking the edge-triggered
 # mupdate override semantics. The fix is to mark a sled as ineligible for
 # both noop conversion and mupdate override clearing whenever the inventory's
 # reported sled-agent generation is older than the generation in the parent

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
@@ -37,14 +37,6 @@ blueprint-edit latest set-host-phase2 serial1 B artifact 1.0.0 044d45ad681b44e89
 # Simulate a mupdate on sled 2 as well.
 sled-set serial2 mupdate-override 203fa72c-85c1-466a-8ed3-338ee029530d
 
-# The blueprint-edits above bumped serial0 and serial1's sled-agent generations.
-# Apply the latest blueprint to all sleds' inventories so the noop check on
-# the upcoming plan starts from fresh sled-agent generations rather than
-# firing the inventory-stale path.
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
-
 # Generate a new inventory and plan against that.
 inventory-generate
 inventory-show latest
@@ -70,12 +62,6 @@ blueprint-diff latest
 #    below.
 sled-set serial0 inventory-hidden
 
-# The previous plan set remove_mupdate_override on serial2, bumping its
-# sled-agent generation. Apply the latest blueprint to serial2's inventory so
-# the noop check on the upcoming plan exercises the mupdate-override-set path
-# rather than firing the inventory-stale path.
-sled-set serial2 omicron-config latest
-
 # Set the target release to a new repo, causing a generation number bump
 # to 3.
 set target-release repo-1.0.0.zip
@@ -87,10 +73,10 @@ blueprint-plan latest latest
 blueprint-diff latest
 
 # Now simulate the new config being applied to sled 0, which would cause the
-# mupdate override to be removed. Apply the latest blueprint to inventory too,
-# so that inventory's reported sled-agent generation advances to match the
-# blueprint's; otherwise the noop check on the next plan would correctly
-# refuse to clear remove_mupdate_override on the basis of stale inventory.
+# mupdate override to be removed. Apply the latest blueprint to inventory
+# too, so that the sled's reported sled-agent generation advances to match
+# the blueprint's; the sled clearing the override and bumping its generation
+# happen together when the sled processes the new blueprint config.
 sled-set serial0 mupdate-override unset
 sled-set serial0 inventory-visible
 sled-set serial0 omicron-config latest
@@ -116,9 +102,11 @@ blueprint-plan latest latest
 blueprint-diff latest
 
 # Clear the mupdate override on sled 2, signifying that the config has been
-# applied. Also advance serial0 and serial2's inventories to the latest
-# blueprint -- the previous plan did noop conversions on serial0 (bumping its
-# sled-agent generation) and set remove_mupdate_override on serial2.
+# applied. Also advance the sled's reported sled-agent generation to match,
+# since the sled clearing the override and bumping its generation happen
+# together when it processes the new blueprint config. Likewise advance
+# serial0's reported sled-agent generation: the previous plan did noop
+# conversions on serial0 that the sled would have applied by now in production.
 sled-set serial2 mupdate-override unset
 sled-set serial0 omicron-config latest
 sled-set serial2 omicron-config latest
@@ -131,8 +119,9 @@ blueprint-plan latest latest
 blueprint-show latest
 blueprint-diff latest
 
-# Apply the latest blueprint again so subsequent plans aren't shadowed by an
-# inventory-stale check on the just-bumped sled-agent generations.
+# Model sled-agents applying the latest blueprint between plans (this happens
+# automatically in production), advancing reported sled-agent generations to
+# match.
 sled-set serial0 omicron-config latest
 sled-set serial2 omicron-config latest
 inventory-generate
@@ -146,13 +135,8 @@ blueprint-diff latest
 
 # Now clear the mupdate override error. At this point, we're *still* blocked
 # on serial1's install dataset not being known (so cannot be noop converted).
-# Advance serial1's reported sled-agent generation alongside, simulating the
-# sled having applied the latest blueprint. Also advance serial0/2 since the
-# previous plan bumped their generations too.
 sled-set serial1 mupdate-override unset
-sled-set serial0 omicron-config latest
 sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
@@ -162,8 +146,6 @@ blueprint-diff latest
 # steps within the same blueprint. In other words, the code that considers
 # whether add/update are blocked takes into account noop conversions.)
 sled-update-install-dataset serial1 --to-target-release
-sled-set serial0 omicron-config latest
-sled-set serial2 omicron-config latest
 inventory-generate
 
 # Measurements will block further planning progress, run a planning step
@@ -211,13 +193,7 @@ sled-update-sp serial2 --active 2.0.0
 sled-update-host-phase2 serial2 --boot-disk B --slot-b 9ff631b5b7229604ab7c5aae2ee4a34a64772736b332540d38077b3aea6952df
 sled-update-host-phase1 serial2 --active B --slot-b 1eba0d79ea9d34558fb3f923a06614bd740649eeb0ca6e5086529dc60cd6f729
 
-# All MGS-based updates complete. Apply the latest blueprint to all sleds'
-# inventories so the noop check on the next plan starts from fresh sled-agent
-# generations rather than firing the inventory-stale path on the bumped
-# generations from earlier plans in this file.
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
+# All MGS-based updates complete.
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
@@ -232,11 +208,6 @@ blueprint-diff latest
 # new zones will be added.
 sled-set serial0 mupdate-override c8fba912-63ae-473a-9115-0495d10fb3bc
 sled-add c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
-# The plan above bumped sled-agent generations as it scheduled work; apply the
-# latest blueprint to inventory so subsequent noop checks aren't inventory-stale.
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
 inventory-generate
 
 # This will *not* generate the datasets and internal NTP zone on the new
@@ -246,10 +217,6 @@ blueprint-diff latest
 
 # This *will* generate the datasets and internal NTP zone on the new sled.
 set planner-config --add-zones-with-mupdate-override true
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
-inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
@@ -37,6 +37,14 @@ blueprint-edit latest set-host-phase2 serial1 B artifact 1.0.0 044d45ad681b44e89
 # Simulate a mupdate on sled 2 as well.
 sled-set serial2 mupdate-override 203fa72c-85c1-466a-8ed3-338ee029530d
 
+# The blueprint-edits above bumped serial0 and serial1's sled-agent generations.
+# Apply the latest blueprint to all sleds' inventories so the noop check on
+# the upcoming plan starts from fresh sled-agent generations rather than
+# firing the inventory-stale path.
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
+
 # Generate a new inventory and plan against that.
 inventory-generate
 inventory-show latest
@@ -62,6 +70,12 @@ blueprint-diff latest
 #    below.
 sled-set serial0 inventory-hidden
 
+# The previous plan set remove_mupdate_override on serial2, bumping its
+# sled-agent generation. Apply the latest blueprint to serial2's inventory so
+# the noop check on the upcoming plan exercises the mupdate-override-set path
+# rather than firing the inventory-stale path.
+sled-set serial2 omicron-config latest
+
 # Set the target release to a new repo, causing a generation number bump
 # to 3.
 set target-release repo-1.0.0.zip
@@ -72,10 +86,14 @@ inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 
-# Now simulate the new config being applied to sled 0, which would
-# cause the mupdate override to be removed.
+# Now simulate the new config being applied to sled 0, which would cause the
+# mupdate override to be removed. Apply the latest blueprint to inventory too,
+# so that inventory's reported sled-agent generation advances to match the
+# blueprint's; otherwise the noop check on the next plan would correctly
+# refuse to clear remove_mupdate_override on the basis of stale inventory.
 sled-set serial0 mupdate-override unset
 sled-set serial0 inventory-visible
+sled-set serial0 omicron-config latest
 
 # But simulate a second mupdate on sled 2. This should invalidate the existing
 # mupdate override on sled 2 and cause another target release minimum
@@ -98,8 +116,12 @@ blueprint-plan latest latest
 blueprint-diff latest
 
 # Clear the mupdate override on sled 2, signifying that the config has been
-# applied.
+# applied. Also advance serial0 and serial2's inventories to the latest
+# blueprint -- the previous plan did noop conversions on serial0 (bumping its
+# sled-agent generation) and set remove_mupdate_override on serial2.
 sled-set serial2 mupdate-override unset
+sled-set serial0 omicron-config latest
+sled-set serial2 omicron-config latest
 
 # Run the planner again. This will cause sled 2's blueprint
 # remove_mupdate_override to be unset. But no further planning steps will
@@ -108,6 +130,12 @@ inventory-generate
 blueprint-plan latest latest
 blueprint-show latest
 blueprint-diff latest
+
+# Apply the latest blueprint again so subsequent plans aren't shadowed by an
+# inventory-stale check on the just-bumped sled-agent generations.
+sled-set serial0 omicron-config latest
+sled-set serial2 omicron-config latest
+inventory-generate
 
 # Now set the target release -- at this point, we're still waiting on the
 # sled with the mupdate override error to be cleared.
@@ -118,7 +146,13 @@ blueprint-diff latest
 
 # Now clear the mupdate override error. At this point, we're *still* blocked
 # on serial1's install dataset not being known (so cannot be noop converted).
+# Advance serial1's reported sled-agent generation alongside, simulating the
+# sled having applied the latest blueprint. Also advance serial0/2 since the
+# previous plan bumped their generations too.
 sled-set serial1 mupdate-override unset
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
@@ -128,6 +162,8 @@ blueprint-diff latest
 # steps within the same blueprint. In other words, the code that considers
 # whether add/update are blocked takes into account noop conversions.)
 sled-update-install-dataset serial1 --to-target-release
+sled-set serial0 omicron-config latest
+sled-set serial2 omicron-config latest
 inventory-generate
 
 # Measurements will block further planning progress, run a planning step
@@ -175,7 +211,13 @@ sled-update-sp serial2 --active 2.0.0
 sled-update-host-phase2 serial2 --boot-disk B --slot-b 9ff631b5b7229604ab7c5aae2ee4a34a64772736b332540d38077b3aea6952df
 sled-update-host-phase1 serial2 --active B --slot-b 1eba0d79ea9d34558fb3f923a06614bd740649eeb0ca6e5086529dc60cd6f729
 
-# All MGS-based updates complete.
+# All MGS-based updates complete. Apply the latest blueprint to all sleds'
+# inventories so the noop check on the next plan starts from fresh sled-agent
+# generations rather than firing the inventory-stale path on the bumped
+# generations from earlier plans in this file.
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
@@ -190,6 +232,11 @@ blueprint-diff latest
 # new zones will be added.
 sled-set serial0 mupdate-override c8fba912-63ae-473a-9115-0495d10fb3bc
 sled-add c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
+# The plan above bumped sled-agent generations as it scheduled work; apply the
+# latest blueprint to inventory so subsequent noop checks aren't inventory-stale.
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
 inventory-generate
 
 # This will *not* generate the datasets and internal NTP zone on the new
@@ -199,6 +246,10 @@ blueprint-diff latest
 
 # This *will* generate the datasets and internal NTP zone on the new sled.
 set planner-config --add-zones-with-mupdate-override true
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
+inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-nexus-generation-autobump.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-nexus-generation-autobump.txt
@@ -148,28 +148,14 @@ blueprint-diff latest
 set active-nexus-gen 2
 
 # Now expungement can complete
-# (Three Nexuses, expunged one at a time). Apply each blueprint to inventory
-# between plans so the noop check doesn't fire the inventory-stale path on
-# subsequent iterations.
+# (Three Nexuses, expunged one at a time)
 blueprint-plan latest latest
 blueprint-diff latest
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
-inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
-inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 
 # Should be a no-op
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
-inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-nexus-generation-autobump.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-nexus-generation-autobump.txt
@@ -148,14 +148,28 @@ blueprint-diff latest
 set active-nexus-gen 2
 
 # Now expungement can complete
-# (Three Nexuses, expunged one at a time)
+# (Three Nexuses, expunged one at a time). Apply each blueprint to inventory
+# between plans so the noop check doesn't fire the inventory-stale path on
+# subsequent iterations.
 blueprint-plan latest latest
 blueprint-diff latest
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
+inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
+inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 
 # Should be a no-op
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
+inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-noop-image-source.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-noop-image-source.txt
@@ -28,6 +28,10 @@ sled-update-install-dataset serial1 --with-manifest-error
 sled-update-install-dataset serial2 --to-target-release
 sled-set serial2 mupdate-override ffffffff-ffff-ffff-ffff-ffffffffffff
 blueprint-edit latest set-remove-mupdate-override serial2 ffffffff-ffff-ffff-ffff-ffffffffffff
+# Apply the latest blueprint to serial2's inventory so that the noop check
+# exercises the mupdate-override-set-in-blueprint path rather than firing
+# inventory-stale on the bumped sled-agent generation.
+sled-set serial2 omicron-config latest
 
 # On a fourth sled, simulate an error validating the install dataset image on one zone.
 # We pick ntp because internal-ntp is non-discretionary.
@@ -57,6 +61,14 @@ blueprint-diff latest
 
 # Bring the hidden sled back.
 sled-set serial6 inventory-visible
+
+# The first plan bumped the sled-agent generation on the sleds where it did
+# noop conversions (serial0, serial3) and where it set remove_mupdate_override
+# (serial2). Apply that blueprint to those sleds' inventories so the next
+# plan's noop check doesn't fire the inventory-stale path for them.
+sled-set serial0 omicron-config latest
+sled-set serial2 omicron-config latest
+sled-set serial3 omicron-config latest
 
 # Run another inventory and blueprint planning step.
 inventory-generate

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-noop-stale-inventory.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-noop-stale-inventory.txt
@@ -1,0 +1,51 @@
+# This test exercises a guarantee of the inventory-staleness check
+# in `NoopConvertInfo::new`: the planner must not perform noop conversions of
+# zone image sources from InstallDataset to Artifact when planning against an
+# inventory that's older than the parent blueprint, even when no mupdate
+# override is involved.
+#
+# The test simulates: zones that would be eligible for a noop conversion to
+# Artifact, an unrelated edit that bumps the parent blueprint's sled-agent
+# generation past what inventory reports, and then a plan against that now-
+# stale inventory. With the fix, the planner skips the noop check on the
+# bumped sled and the resulting blueprint contains no zone image source
+# changes. Once inventory is up-to-date, the next plan proceeds with the
+# noop conversions as expected.
+
+# Load a small example system. We only need one sled to demonstrate the case.
+load-example --nsleds 1 --ndisks-per-sled 3
+sled-list
+
+# Create a TUF repository whose artifacts match the install dataset, so noop
+# conversions of all zones would otherwise be eligible.
+tuf-assemble ../../update-common/manifests/fake.toml
+set target-release repo-1.0.0.zip
+
+# Update the install dataset on serial0 to the target release. This populates
+# the simulated sled-agent's zone/measurement manifests but does not bump its
+# reported sled-agent generation.
+sled-update-install-dataset serial0 --to-target-release
+
+# Generate inventory. At this point the sled's reported sled-agent generation
+# matches the parent blueprint's: noop conversions would be eligible.
+inventory-generate
+
+# Bump the parent blueprint's sled-agent generation for serial0 via the debug
+# command. This simulates a blueprint edit that bumps the generation.
+blueprint-edit latest debug force-sled-generation-bump serial0
+blueprint-diff latest
+
+# Plan against the same inventory. The noop check should fire the
+# inventory-stale path on serial0, the noop conversion of zones to Artifact
+# should be skipped, and the resulting blueprint should contain no zone
+# image source changes for serial0.
+blueprint-plan latest latest
+blueprint-diff latest
+
+# Apply the latest blueprint to inventory and re-plan. inventory_gen now
+# matches parent_bp_gen, the noop check runs, and zones convert to Artifact
+# as expected.
+sled-set serial0 omicron-config latest
+inventory-generate
+blueprint-plan latest latest
+blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-noop-stale-inventory.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-noop-stale-inventory.txt
@@ -43,8 +43,7 @@ blueprint-plan latest latest
 blueprint-diff latest
 
 # Apply the latest blueprint to inventory and re-plan. inventory_gen now
-# matches parent_bp_gen, the noop check runs, and zones convert to Artifact
-# as expected.
+# matches parent_bp_gen, and zones are noop-converted to Artifact as expected.
 sled-set serial0 omicron-config latest
 inventory-generate
 blueprint-plan latest latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-target-release.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-target-release.txt
@@ -102,6 +102,13 @@ inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 
+# The plan above scheduled a host phase 2 update, which bumped serial0's
+# sled-agent generation in the blueprint. Apply the latest blueprint to
+# inventory so subsequent plans aren't blocked by the inventory-stale check
+# in the noop image source path.
+sled-set serial0 omicron-config latest
+inventory-generate
+
 # If we generate another plan, there should be no change.
 blueprint-plan latest latest
 blueprint-diff latest
@@ -133,6 +140,12 @@ inventory-generate
 # update.
 blueprint-plan latest latest
 blueprint-diff latest
+
+# Apply the latest blueprint to serial0's inventory so the next plans (which
+# work on serial1's MGS chain) aren't shadowed by an inventory-stale check on
+# serial0.
+sled-set serial0 omicron-config latest
+inventory-generate
 
 # This time, make it more interesting.  Change the inactive slot contents of
 # the simulated RoT bootloader.  This should make the configured update
@@ -182,6 +195,12 @@ inventory-generate
 # Planning should remove this update and add an OS update for this sled.
 blueprint-plan latest latest
 blueprint-diff latest
+
+# The plan above scheduled a host phase 2 update on serial1, bumping its
+# sled-agent generation. Apply the latest blueprint to inventory so subsequent
+# plans aren't blocked by the inventory-stale check on serial1.
+sled-set serial1 omicron-config latest
+inventory-generate
 
 # Try a host OS impossible update replacement: write an unknown artifact to the
 # sled's phase 1. The planner should realize the update is impossible and
@@ -252,6 +271,12 @@ sled-update-sp d81c6a84-79b8-4958-ae41-ea46c9b19763 --active 1.0.0
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
+
+# The plan above scheduled a host phase 2 update on serial2, bumping its
+# sled-agent generation. Apply the latest blueprint to inventory so subsequent
+# plans aren't blocked by the inventory-stale check on serial2.
+sled-set serial2 omicron-config latest
+inventory-generate
 
 # Finish updating the last sled's host OS.
 sled-update-host-phase2 d81c6a84-79b8-4958-ae41-ea46c9b19763 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
@@ -471,8 +496,12 @@ blueprint-plan latest latest
 blueprint-diff latest
 
 # If we expunge one of the OLD nexuses, we should observe
-# that it is re-created.
+# that it is re-created. Apply the latest blueprint to the affected sled's
+# inventory so the noop check on the next plan isn't blocked by the
+# inventory-stale path on the bumped generation.
 blueprint-edit latest expunge-zones 0c71b3b2-6ceb-4e8f-b020-b08675e83038
+sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
+inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
@@ -481,14 +510,24 @@ inventory-generate
 # Bump the set of active Nexus zones; this simulates Nexus handoff.
 set active-nexus-gen 2
 
-# Planning should now expunge one of the old Nexus zones.
+# Planning should now expunge one of the old Nexus zones. After each plan,
+# apply the latest blueprint to all sleds' inventories so subsequent plans see
+# fresh sled-agent generations rather than firing the inventory-stale path.
 blueprint-plan latest latest
 blueprint-diff latest
+sled-set 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron-config latest
+sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
+sled-set d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron-config latest
+inventory-generate
 
 # Two more planning iterations should expunge the remaining two old 0.0.1
 # version Nexus zones.
 blueprint-plan latest latest
 blueprint-diff latest
+sled-set 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron-config latest
+sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
+sled-set d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron-config latest
+inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-target-release.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-target-release.txt
@@ -102,13 +102,6 @@ inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 
-# The plan above scheduled a host phase 2 update, which bumped serial0's
-# sled-agent generation in the blueprint. Apply the latest blueprint to
-# inventory so subsequent plans aren't blocked by the inventory-stale check
-# in the noop image source path.
-sled-set serial0 omicron-config latest
-inventory-generate
-
 # If we generate another plan, there should be no change.
 blueprint-plan latest latest
 blueprint-diff latest
@@ -140,12 +133,6 @@ inventory-generate
 # update.
 blueprint-plan latest latest
 blueprint-diff latest
-
-# Apply the latest blueprint to serial0's inventory so the next plans (which
-# work on serial1's MGS chain) aren't shadowed by an inventory-stale check on
-# serial0.
-sled-set serial0 omicron-config latest
-inventory-generate
 
 # This time, make it more interesting.  Change the inactive slot contents of
 # the simulated RoT bootloader.  This should make the configured update
@@ -195,12 +182,6 @@ inventory-generate
 # Planning should remove this update and add an OS update for this sled.
 blueprint-plan latest latest
 blueprint-diff latest
-
-# The plan above scheduled a host phase 2 update on serial1, bumping its
-# sled-agent generation. Apply the latest blueprint to inventory so subsequent
-# plans aren't blocked by the inventory-stale check on serial1.
-sled-set serial1 omicron-config latest
-inventory-generate
 
 # Try a host OS impossible update replacement: write an unknown artifact to the
 # sled's phase 1. The planner should realize the update is impossible and
@@ -271,12 +252,6 @@ sled-update-sp d81c6a84-79b8-4958-ae41-ea46c9b19763 --active 1.0.0
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
-
-# The plan above scheduled a host phase 2 update on serial2, bumping its
-# sled-agent generation. Apply the latest blueprint to inventory so subsequent
-# plans aren't blocked by the inventory-stale check on serial2.
-sled-set serial2 omicron-config latest
-inventory-generate
 
 # Finish updating the last sled's host OS.
 sled-update-host-phase2 d81c6a84-79b8-4958-ae41-ea46c9b19763 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
@@ -496,12 +471,8 @@ blueprint-plan latest latest
 blueprint-diff latest
 
 # If we expunge one of the OLD nexuses, we should observe
-# that it is re-created. Apply the latest blueprint to the affected sled's
-# inventory so the noop check on the next plan isn't blocked by the
-# inventory-stale path on the bumped generation.
+# that it is re-created.
 blueprint-edit latest expunge-zones 0c71b3b2-6ceb-4e8f-b020-b08675e83038
-sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
-inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
@@ -510,24 +481,14 @@ inventory-generate
 # Bump the set of active Nexus zones; this simulates Nexus handoff.
 set active-nexus-gen 2
 
-# Planning should now expunge one of the old Nexus zones. After each plan,
-# apply the latest blueprint to all sleds' inventories so subsequent plans see
-# fresh sled-agent generations rather than firing the inventory-stale path.
+# Planning should now expunge one of the old Nexus zones.
 blueprint-plan latest latest
 blueprint-diff latest
-sled-set 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron-config latest
-sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
-sled-set d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron-config latest
-inventory-generate
 
 # Two more planning iterations should expunge the remaining two old 0.0.1
 # version Nexus zones.
 blueprint-plan latest latest
 blueprint-diff latest
-sled-set 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron-config latest
-sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
-sled-set d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron-config latest
-inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-unknown-measurements.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-unknown-measurements.txt
@@ -31,7 +31,11 @@ blueprint-plan latest latest
 # update from R18 -> R19
 blueprint-diff latest
 
-# Next plan should show waiting on inventory to have the measurements
+# The previous plan bumped each sled's sled-agent generation, but inventory
+# hasn't been advanced via `sled-set ... omicron-config latest` yet. The next
+# plan should therefore mark each sled's noop check as ineligible due to
+# stale inventory, and the planning report should still show that we're
+# waiting on measurements to converge.
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-unsafe-zone-mgs.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-unsafe-zone-mgs.txt
@@ -65,8 +65,15 @@ blueprint-show latest
 #
 # Note that since we are not running the command to emulate the sled-agent
 # performing an inventory collection and seeing the DNS zone has gone away, the
-# planner will not attemt to restore the internal DNS zone. This is intentional
-# as we want the zone to stay in this state for the purposes of this test
+# planner will not attempt to restore the internal DNS zone. This is intentional
+# as we want the zone to stay in this state for the purposes of this test.
+#
+# A secondary effect of pinning inventory this way is that the noop image source
+# check on serial1 will be skipped with reason "inventory stale" for the rest
+# of this test: the expunge bumps serial1's blueprint sled-agent generation,
+# but inventory still reports the prior generation. That's the correct
+# behavior; see `cmds-noop-stale-inventory.txt` for a focused test of the
+# inventory-staleness guarantee.
 blueprint-edit latest expunge-zones 99e2f30b-3174-40bf-a78a-90da8abba8ca
 blueprint-diff latest
 
@@ -108,8 +115,8 @@ blueprint-diff latest
 sled-update-sp serial0 --active 1.0.0
 sled-update-sp serial1 --active 1.0.0
 sled-update-sp serial2 --active 1.0.0
-sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47 
-sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b 
+sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
+sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-unsafe-zone-mgs.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-unsafe-zone-mgs.txt
@@ -70,10 +70,26 @@ blueprint-show latest
 blueprint-edit latest expunge-zones 99e2f30b-3174-40bf-a78a-90da8abba8ca
 blueprint-diff latest
 
+# The expungement above bumped the host sled's sled-agent generation. Apply
+# the latest blueprint to all sleds so the noop check on subsequent plans
+# doesn't fire the inventory-stale path for the affected sled.
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
+inventory-generate
+
 # Attempt to upgrade one RoT bootloader. This should successfully plan the
 # pending RoT bootloader update
 blueprint-plan latest latest
 blueprint-diff latest
+
+# Apply the latest blueprint to all sleds' inventories so the noop check on
+# the next plan doesn't fire the inventory-stale path for whichever sled the
+# above plan bumped.
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
+inventory-generate
 
 # We generate another plan, there should be no changes
 blueprint-plan latest latest
@@ -91,6 +107,13 @@ inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 
+# Apply the latest blueprint again before the next sled-update steps so each
+# subsequent plan starts from a fresh sled-agent generation.
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
+inventory-generate
+
 # We repeat the same process with the RoT, but now expecting to see a single
 # blocked SP update due to serial0 containing an unsafe zone. We also see a
 # pending SP update on serial1 which has no unsafe zones.
@@ -101,6 +124,12 @@ inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 
+# Apply the latest blueprint again before the next sled-update steps.
+sled-set serial0 omicron-config latest
+sled-set serial1 omicron-config latest
+sled-set serial2 omicron-config latest
+inventory-generate
+
 # Since there was a blocked update on serial0, the planner has moved on to
 # serial1. This sled has no unsafe zones, so we forcibly update it along with
 # the SPs to see the errors with the Host OS on serial2 and serial0, and plan no
@@ -108,8 +137,8 @@ blueprint-diff latest
 sled-update-sp serial0 --active 1.0.0
 sled-update-sp serial1 --active 1.0.0
 sled-update-sp serial2 --active 1.0.0
-sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47 
-sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b 
+sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
+sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-unsafe-zone-mgs.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-unsafe-zone-mgs.txt
@@ -70,26 +70,10 @@ blueprint-show latest
 blueprint-edit latest expunge-zones 99e2f30b-3174-40bf-a78a-90da8abba8ca
 blueprint-diff latest
 
-# The expungement above bumped the host sled's sled-agent generation. Apply
-# the latest blueprint to all sleds so the noop check on subsequent plans
-# doesn't fire the inventory-stale path for the affected sled.
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
-inventory-generate
-
 # Attempt to upgrade one RoT bootloader. This should successfully plan the
 # pending RoT bootloader update
 blueprint-plan latest latest
 blueprint-diff latest
-
-# Apply the latest blueprint to all sleds' inventories so the noop check on
-# the next plan doesn't fire the inventory-stale path for whichever sled the
-# above plan bumped.
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
-inventory-generate
 
 # We generate another plan, there should be no changes
 blueprint-plan latest latest
@@ -107,13 +91,6 @@ inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 
-# Apply the latest blueprint again before the next sled-update steps so each
-# subsequent plan starts from a fresh sled-agent generation.
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
-inventory-generate
-
 # We repeat the same process with the RoT, but now expecting to see a single
 # blocked SP update due to serial0 containing an unsafe zone. We also see a
 # pending SP update on serial1 which has no unsafe zones.
@@ -124,12 +101,6 @@ inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest
 
-# Apply the latest blueprint again before the next sled-update steps.
-sled-set serial0 omicron-config latest
-sled-set serial1 omicron-config latest
-sled-set serial2 omicron-config latest
-inventory-generate
-
 # Since there was a blocked update on serial0, the planner has moved on to
 # serial1. This sled has no unsafe zones, so we forcibly update it along with
 # the SPs to see the errors with the Host OS on serial2 and serial0, and plan no
@@ -137,8 +108,8 @@ inventory-generate
 sled-update-sp serial0 --active 1.0.0
 sled-update-sp serial1 --active 1.0.0
 sled-update-sp serial2 --active 1.0.0
-sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
-sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
+sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47 
+sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b 
 inventory-generate
 blueprint-plan latest latest
 blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-add-zones-with-mupdate-override-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-add-zones-with-mupdate-override-stdout
@@ -225,6 +225,18 @@ external DNS:
 
 
 
+> # Apply the blueprint to serial0 so that inventory's reported sled-agent
+> # generation matches the blueprint. (The mupdate override remains visible in
+> # inventory because we don't call `sled-set ... mupdate-override unset`.) This
+> # keeps the next plan's noop check from firing the inventory-stale path,
+> # letting it exercise the mupdate-override-set-in-blueprint path instead.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (8da82a8e-bf97-4fbd-8ddd-9f6462732cf1)
+
+> inventory-generate
+generated inventory collection 61f451b3-2121-4ed6-91c7-a550054f6c21 from configured sleds
+
+
 > # Set Nexus redundancy to 4.
 > set num-nexus 4
 target number of Nexus zones: None -> 4

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-missing-measurement-manifest-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-missing-measurement-manifest-stdout
@@ -322,6 +322,16 @@ sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: install dataset updated: to target re
 sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: install dataset updated: to target release (system version 1.0.0)
 
 
+> # Apply the latest blueprint to inventory so the noop check on the next plan
+> # sees up-to-date sled-agent generations and can exercise the measurement
+> # conversion path. (Earlier plans and edits bumped these generations.)
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (af934083-59b5-4bf6-8966-6fb5292c29e1)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (af934083-59b5-4bf6-8966-6fb5292c29e1)
+
+
 > # This time we expect that sled1 should have blocked at a missing
 > # measurement manifest because we are expecting one
 > inventory-generate

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-missing-sled-blocks-zone-updates-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-missing-sled-blocks-zone-updates-stdout
@@ -774,6 +774,14 @@ set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 details: boot_disk ->
 > # report that we are missing sled agent inventory for measurements on sled 1.
 > # This will block any MGS updates that could be pending because we must
 > # observe the expected measurements on all sleds before we proceed.
+> #
+> # Apply the latest blueprint to serial0's inventory so that its reported
+> # sled-agent generation isn't stale relative to the parent blueprint. (Earlier
+> # plans bumped the blueprint's generation for this sled.) That keeps the noop
+> # check on serial0 from firing the inventory-stale path.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
+
 > sled-set serial1 inventory-hidden
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c inventory visibility: visible -> hidden
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-stale-inventory-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-stale-inventory-stdout
@@ -1,13 +1,15 @@
 using provided RNG seed: reconfigurator-cli-test
-> # This test exercises the bug where, in the mupdate-override flow, the planner
+> # This test exercises the bug where, in the mupdate override flow, the planner
 > # would clear `remove_mupdate_override` from a sled's blueprint based on stale
-> # inventory -- specifically, an inventory collection that was captured BEFORE
-> # the sled was mupdated, so the override marker isn't visible in it. Acting on
-> # stale inventory in this way could cause the planner to acknowledge a sled
-> # recovery that hasn't happened, breaking the edge-triggered mupdate-override
-> # semantics. The fix is to mark a sled as ineligible for noop-conversion (and
-> # downstream mupdate-override clearing) whenever the inventory's reported
-> # sled-agent generation is older than the generation in the parent blueprint.
+> # inventory -- specifically, an inventory collection that was captured before
+> # the sled was mupdated, so the override marker isn't visible in it.
+> #
+> # Acting on stale inventory in this way could cause the planner to acknowledge
+> # a sled recovery that hasn't happened, breaking the edge-triggere
+> # mupdate override semantics. The fix is to mark a sled as ineligible for
+> # both noop conversion and mupdate override clearing whenever the inventory's
+> # reported sled-agent generation is older than the generation in the parent
+> # blueprint.
 > #
 > # The test simulates two plans against the same parent blueprint: one against
 > # the latest (post-mupdate) inventory, and one against a stale (pre-mupdate)
@@ -281,8 +283,8 @@ external DNS:
 
 
 
-> # Now plan against the FIRST (pre-mupdate) inventory collection. That
-> # inventory shows no mupdate override on serial0 -- but only because the
+> # Now plan against the first (pre-mupdate) inventory collection. That
+> # inventory shows no mupdate override on serial0, but only because the
 > # inventory was captured before the mupdate ever happened. The parent
 > # blueprint's sled-agent generation for serial0 is now ahead of what this
 > # stale inventory reports.

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-stale-inventory-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-stale-inventory-stdout
@@ -1,0 +1,350 @@
+using provided RNG seed: reconfigurator-cli-test
+> # This test exercises the bug where, in the mupdate-override flow, the planner
+> # would clear `remove_mupdate_override` from a sled's blueprint based on stale
+> # inventory -- specifically, an inventory collection that was captured BEFORE
+> # the sled was mupdated, so the override marker isn't visible in it. Acting on
+> # stale inventory in this way could cause the planner to acknowledge a sled
+> # recovery that hasn't happened, breaking the edge-triggered mupdate-override
+> # semantics. The fix is to mark a sled as ineligible for noop-conversion (and
+> # downstream mupdate-override clearing) whenever the inventory's reported
+> # sled-agent generation is older than the generation in the parent blueprint.
+> #
+> # The test simulates two plans against the same parent blueprint: one against
+> # the latest (post-mupdate) inventory, and one against a stale (pre-mupdate)
+> # inventory. With the fix, planning against the stale inventory leaves
+> # remove_mupdate_override alone instead of clearing it.
+
+> # Load a small example system. We only need one sled to demonstrate the bug.
+> load-example --nsleds 1 --ndisks-per-sled 3
+loaded example system with:
+- collection: f45ba181-4b56-42cc-a762-874d90184a43
+- blueprint: dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+
+> sled-list
+ID                                   SERIAL  NZPOOLS SUBNET                  
+98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 serial0 3       fd00:1122:3344:101::/64 
+
+
+> # Create a TUF repository so noop image source conversions are possible.
+> tuf-assemble ../../update-common/manifests/fake.toml
+INFO assembling repository in <ASSEMBLING_REPOSITORY_IN_REDACTED>
+INFO artifacts assembled and archived to `repo-1.0.0.zip`, component: OmicronRepoAssembler
+created repo-1.0.0.zip for system version 1.0.0
+
+> set target-release repo-1.0.0.zip
+INFO extracting uploaded archive to <EXTRACTING_UPLOADED_ARCHIVE_TO_REDACTED>
+INFO created directory to store extracted artifacts, path: <CREATED_DIRECTORY_TO_STORE_EXTRACTED_ARTIFACTS_PATH_REDACTED>
+INFO added artifact, name: fake-gimlet-sp, kind: gimlet_sp, version: 1.0.0, hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, length: 732
+INFO added artifact, name: fake-rot, kind: gimlet_rot_image_a, version: 1.0.0, hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, length: 783
+INFO added artifact, name: fake-rot, kind: gimlet_rot_image_b, version: 1.0.0, hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, length: 783
+INFO added artifact, name: fake-rot-bootloader, kind: gimlet_rot_bootloader, version: 1.0.0, hash: 5b0f601b1fbb8674db9c751a02f8b14f8e6d4e8470f4f7b686fecb2c49ec11f9, length: 797
+INFO added artifact, name: fake-host, kind: gimlet_host_phase_1, version: 1.0.0, hash: b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b, length: 524288
+INFO added artifact, name: fake-host, kind: cosmo_host_phase_1, version: 1.0.0, hash: 9525f567106549a3fc32df870a74803d77e51dcc44190b218e227a2c5d444f58, length: 524288
+INFO added artifact, name: fake-host, kind: host_phase_2, version: 1.0.0, hash: d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47, length: 1048576
+INFO added artifact, name: fake-trampoline, kind: gimlet_trampoline_phase_1, version: 1.0.0, hash: bcb27520ee5a56e19f6df9662c66d69ac681fbd873a97547be5f6a5ae3d250c4, length: 524288
+INFO added artifact, name: fake-trampoline, kind: cosmo_trampoline_phase_1, version: 1.0.0, hash: e235b8afb58ee69d966853bd5efe7c7e904da84b9035a332b3e691dc1d5cdbd0, length: 524288
+INFO added artifact, name: fake-trampoline, kind: trampoline_phase_2, version: 1.0.0, hash: a5dfcc4bc69b791f1c509df499e9e72cce844cb2b53a56d8bb357b264bdf13b6, length: 1048576
+INFO added artifact, name: clickhouse, kind: zone, version: 1.0.0, hash: 52b1eb4daff6f9140491d547b11248392920230db3db0eef5f5fa5333fe9e659, length: 1686
+INFO added artifact, name: clickhouse_keeper, kind: zone, version: 1.0.0, hash: cda702919449d86663be97295043aeca0ead69ae5db3bbdb20053972254a27a3, length: 1690
+INFO added artifact, name: clickhouse_server, kind: zone, version: 1.0.0, hash: 5f9ae6a9821bbe8ff0bf60feddf8b167902fe5f3e2c98bd21edd1ec9d969a001, length: 1690
+INFO added artifact, name: cockroachdb, kind: zone, version: 1.0.0, hash: f3a1a3c0b3469367b005ee78665d982059d5e14e93a479412426bf941c4ed291, length: 1689
+INFO added artifact, name: crucible-zone, kind: zone, version: 1.0.0, hash: 6f17cf65fb5a5bec5542dd07c03cd0acc01e59130f02c532c8d848ecae810047, length: 1690
+INFO added artifact, name: crucible-pantry-zone, kind: zone, version: 1.0.0, hash: 21f0ada306859c23917361f2e0b9235806c32607ec689c7e8cf16bb898bc5a02, length: 1695
+INFO added artifact, name: external-dns, kind: zone, version: 1.0.0, hash: ccca13ed19b8731f9adaf0d6203b02ea3b9ede4fa426b9fac0a07ce95440046d, length: 1689
+INFO added artifact, name: internal-dns, kind: zone, version: 1.0.0, hash: ffbf1373f7ee08dddd74c53ed2a94e7c4c572a982d3a9bc94000c6956b700c6a, length: 1689
+INFO added artifact, name: ntp, kind: zone, version: 1.0.0, hash: 67593d686ed04a1709f93972b71f4ebc148a9362120f65d239943e814a9a7439, length: 1681
+INFO added artifact, name: nexus, kind: zone, version: 1.0.0, hash: 0e32b4a3e5d3668bb1d6a16fb06b74dc60b973fa479dcee0aae3adbb52bf1388, length: 1682
+INFO added artifact, name: oximeter, kind: zone, version: 1.0.0, hash: 048d8fe8cdef5b175aad714d0f148aa80ce36c9114ac15ce9d02ed3d37877a77, length: 1682
+INFO added artifact, name: fake-corpus, kind: measurement_corpus, version: 1.0.0, hash: 8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f, length: 1048576
+INFO added artifact, name: fake-psc-sp, kind: psc_sp, version: 1.0.0, hash: 89245fe2ac7e6a2ac8dfa4e7d6891a6e6df95e4141395c07c64026778f6d76d7, length: 721
+INFO added artifact, name: fake-psc-rot, kind: psc_rot_image_a, version: 1.0.0, hash: 5d8ea834dd6d42d386f1eb8a2c5f6e99b697c9958bb4ab8edf63e56003e25d8d, length: 775
+INFO added artifact, name: fake-psc-rot, kind: psc_rot_image_b, version: 1.0.0, hash: 5d8ea834dd6d42d386f1eb8a2c5f6e99b697c9958bb4ab8edf63e56003e25d8d, length: 775
+INFO added artifact, name: fake-psc-rot-bootloader, kind: psc_rot_bootloader, version: 1.0.0, hash: 18c9c774bfe4bb086e869509dcccacee8476fd87670692b765aee216f2c7f003, length: 805
+INFO added artifact, name: fake-switch-sp, kind: switch_sp, version: 1.0.0, hash: bf1bc1da5059f76182c3007c3049941f8898abede2f3765b106c6e7f7c42d44c, length: 740
+INFO added artifact, name: fake-switch-rot, kind: switch_rot_image_a, version: 1.0.0, hash: 32307d6d75c9707e8499ba4a4d379f99c0358237b6e190ff6a8024b470f62342, length: 774
+INFO added artifact, name: fake-switch-rot, kind: switch_rot_image_b, version: 1.0.0, hash: 32307d6d75c9707e8499ba4a4d379f99c0358237b6e190ff6a8024b470f62342, length: 774
+INFO added artifact, name: fake-switch-rot-bootloader, kind: switch_rot_bootloader, version: 1.0.0, hash: 70836d170abd5621f95bb4225987b27b3d3dd6168e73cd60e44309bdfeb94e98, length: 804
+INFO added artifact, name: installinator_document, kind: installinator_document, version: 1.0.0, hash: 16717c0caa420c7811666e720936c7ca913cd59a4d376331cc79a90544e5e2e8, length: 526
+set target release based on repo-1.0.0.zip
+
+
+> # Update the install dataset on serial0 to the target release.
+> sled-update-install-dataset serial0 --to-target-release
+sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: install dataset updated: to target release (system version 1.0.0)
+
+
+> # Generate the FIRST inventory collection. At this point the sled has no
+> # mupdate override visible. We'll come back to this collection later to plan
+> # against it as a "stale" inventory.
+> inventory-generate
+generated inventory collection eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 from configured sleds
+
+> inventory-list
+ID                                   NERRORS TIME_DONE                
+f45ba181-4b56-42cc-a762-874d90184a43 0       <REDACTED_TIMESTAMP> 
+eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 0       <REDACTED_TIMESTAMP> 
+
+
+> # Simulate a mupdate on serial0 by setting the mupdate override field. The
+> # sled's reconciled config generation is unchanged -- the mupdate override is
+> # tracked separately.
+> sled-set serial0 mupdate-override 11111111-1111-1111-1111-111111111111
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 mupdate override: unset -> 11111111-1111-1111-1111-111111111111
+
+
+> # Generate a SECOND inventory collection, post-mupdate. This one has the
+> # override visible.
+> inventory-generate
+generated inventory collection 61f451b3-2121-4ed6-91c7-a550054f6c21 from configured sleds
+
+> inventory-list
+ID                                   NERRORS TIME_DONE                
+f45ba181-4b56-42cc-a762-874d90184a43 0       <REDACTED_TIMESTAMP> 
+eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 0       <REDACTED_TIMESTAMP> 
+61f451b3-2121-4ed6-91c7-a550054f6c21 0       <REDACTED_TIMESTAMP> 
+
+
+> # Plan against the latest (post-mupdate) inventory. This should set
+> # `remove_mupdate_override` on serial0 in the new blueprint and bump its
+> # sled-agent generation.
+> blueprint-plan latest latest
+INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, new_bp_override: 11111111-1111-1111-1111-111111111111, prev_bp_override: None, zones: 
+  - zone 005548be-c5e4-49ff-a27b-88f314f1bc51 (ExternalDns) left unchanged, image source: install dataset
+  - zone 10676bfe-b61f-40e1-bc07-a4cb76ea1f30 (Clickhouse) left unchanged, image source: install dataset
+  - zone 2205353a-e1d2-48ff-863b-9d6b1487d474 (ExternalDns) left unchanged, image source: install dataset
+  - zone 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4 (Nexus) left unchanged, image source: install dataset
+  - zone 2de1c525-4e04-4ba6-ac6b-377aaa542f96 (CruciblePantry) left unchanged, image source: install dataset
+  - zone 31b26053-8b94-4d8c-9e4a-d7d720afe265 (CruciblePantry) left unchanged, image source: install dataset
+  - zone 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe (Nexus) left unchanged, image source: install dataset
+  - zone 3d9b7487-d7b9-4e25-960f-f2086f3e2919 (Crucible) left unchanged, image source: install dataset
+  - zone 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035 (InternalDns) left unchanged, image source: install dataset
+  - zone 45ce130e-c5ac-4e26-ab73-7589ba634418 (InternalDns) left unchanged, image source: install dataset
+  - zone 4b19d194-8b25-4396-88da-3df1b3788601 (Crucible) left unchanged, image source: install dataset
+  - zone 70aab480-3d6c-47d5-aaf9-8d2ddab2931c (ExternalDns) left unchanged, image source: install dataset
+  - zone 9b135c74-c09a-4dcc-ba19-f6f8deae135a (InternalNtp) left unchanged, image source: install dataset
+  - zone a7b7bfbe-0588-4781-9a5e-fba63584e5d2 (InternalDns) left unchanged, image source: install dataset
+  - zone c204730a-0946-4793-a470-64c88e89da96 (Crucible) left unchanged, image source: install dataset
+  - zone c2cbbf34-b852-4164-a572-01d4d79445a1 (Nexus) left unchanged, image source: install dataset
+  - zone f87ada51-4419-4144-86a8-e5e4ff0f64d3 (CruciblePantry) left unchanged, image source: install dataset
+, host_phase_2: 
+  - host phase 2 slot A: current contents (unchanged)
+  - host phase 2 slot B: current contents (unchanged)
+, measurements: (unknown)
+INFO no previous MGS update found as part of updating blueprint mupdate override to match inventory, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+INFO updating target release minimum generation based on new set-override actions, phase: do_plan_mupdate_override, current_generation: 1, new_generation: 3
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (11111111-1111-1111-1111-111111111111)
+generated blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 based on parent blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+blueprint source: planner with report:
+planning report:
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - current target release generation (2) is lower than minimum required by blueprint (3)
+  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+  - sleds have deployment units with image sources not set to Artifact:
+    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 17 zones
+
+  - sleds have measurements with image sources not set to Artifact:
+    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 set to install dataset
+
+* zone updates waiting on zone add blockers
+* waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
+Measurement updates:
+Waiting on zone add/update blockers
+
+
+
+> blueprint-diff latest
+from: blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+to:   blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+
+ MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2 -> 3):
++   will remove mupdate override:   (none) -> 11111111-1111-1111-1111-111111111111
+
+    measurements:
+    -----------------------------------
+    hash              version          
+    -----------------------------------
+-   unknown           (unknown version)
++   install dataset   (no version)     
+
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              42bd3fb3-2aae-4754-9c41-0f9b50a77322   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              b7813bc0-d5ee-487d-95ad-6c5cce6fdcd6   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6dd64de1-7dd3-492c-830f-d4a4e4c3dda7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/clickhouse                                                      b1007e3d-7aaf-4ccb-9773-241dcbf79b21   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    d3cd3ec4-703f-4e73-8cc2-b4bc19c7d596   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/external_dns                                                    c7e90d9c-22db-43ca-a602-2a295bac7eec   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/external_dns                                                    bef875a9-3cf1-4b02-9682-c0286fb23d4d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    66788e15-bb3a-4369-a5cb-3357f7b85f64   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/internal_dns                                                    d88eb02f-b66d-4ae7-91a1-23154417c1f1   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/internal_dns                                                    ebfd425c-4e5d-4385-a105-8f2ce32fa9ec   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            e4b83186-c6e2-4d33-ae1b-803c32d1a86e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            20cb5d98-bcd7-4a11-9190-7570a0aa6fe0   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            aa860565-2bbb-4a70-ae8e-7d8f29f1a536   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_clickhouse_10676bfe-b61f-40e1-bc07-a4cb76ea1f30        3523db58-10ab-4e2c-95d9-fec43036c0f5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_3d9b7487-d7b9-4e25-960f-f2086f3e2919          32bb65ae-855f-461b-9203-32b2ddfe5a64   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_4b19d194-8b25-4396-88da-3df1b3788601          dd1954a2-7848-4950-a694-38870c339d3e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_c204730a-0946-4793-a470-64c88e89da96          f3ddb3ca-388d-4462-9fc8-e552cf7de668   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_pantry_2de1c525-4e04-4ba6-ac6b-377aaa542f96   c6d7ecb4-135c-4f09-8948-b73fec13db76   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_31b26053-8b94-4d8c-9e4a-d7d720afe265   d4f66eab-2870-4a74-b4d5-ae5da3276682   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_pantry_f87ada51-4419-4144-86a8-e5e4ff0f64d3   f822a7e2-28aa-4ae2-ba86-d4e552a15bcb   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_external_dns_005548be-c5e4-49ff-a27b-88f314f1bc51      0c7e4b2a-502a-4f4c-8ac4-4068db25252e   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_external_dns_2205353a-e1d2-48ff-863b-9d6b1487d474      8355e747-b375-4d9e-b5da-03d9540ab5cd   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_70aab480-3d6c-47d5-aaf9-8d2ddab2931c      49dc7c86-c865-457f-8d58-37b92b002691   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_internal_dns_3fd06852-06cb-4d8a-b4b2-eb88ff5a6035      506ddf0e-8cbf-44a9-93d7-130a550fd42d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_45ce130e-c5ac-4e26-ab73-7589ba634418      d1611973-b22d-4097-b6fd-0a480f2199a5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_internal_dns_a7b7bfbe-0588-4781-9a5e-fba63584e5d2      382cbbf2-8b08-4388-839a-b43b8bc82999   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_nexus_2bc0b0c4-63a9-44cc-afff-76ce645ef1d4             6b672182-6d17-41d5-81d7-19debe7d3f9b   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe             8b89525f-0764-4937-9fa8-022242647c0f   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_c2cbbf34-b852-4164-a572-01d4d79445a1             ac802759-2ac3-4c5c-b8e7-6d51689e1537   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_9b135c74-c09a-4dcc-ba19-f6f8deae135a               8144f1ee-dbef-45c1-9397-2031a9ca8b38   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           38fafd69-0275-4f4d-885d-3bbf2ea77551   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           ba445402-2775-4f97-87e9-640be3a00c6f   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           4d322f8a-d461-4ead-995b-9ba7d76becad   in service    100 GiB   none          gzip-9     
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cb8d5371-640d-4364-8a5e-0fde125d28af   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   f4ea4a15-b3b3-4a67-b61a-8fba7c7ab61f   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   647f344c-b4c5-4788-a732-40658e852f63   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             f306ebde-464c-49ef-94eb-1d72cf9afc7e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             2aeeb036-0e23-419f-82f7-9ab04c06d7ec   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             53e5b466-aac5-4cf0-a93b-9f68f58ac755   in service    none      none          off        
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        10676bfe-b61f-40e1-bc07-a4cb76ea1f30   install dataset   in service    fd00:1122:3344:101::7 
+    crucible          3d9b7487-d7b9-4e25-960f-f2086f3e2919   install dataset   in service    fd00:1122:3344:101::10
+    crucible          4b19d194-8b25-4396-88da-3df1b3788601   install dataset   in service    fd00:1122:3344:101::f 
+    crucible          c204730a-0946-4793-a470-64c88e89da96   install dataset   in service    fd00:1122:3344:101::e 
+    crucible_pantry   2de1c525-4e04-4ba6-ac6b-377aaa542f96   install dataset   in service    fd00:1122:3344:101::d 
+    crucible_pantry   31b26053-8b94-4d8c-9e4a-d7d720afe265   install dataset   in service    fd00:1122:3344:101::b 
+    crucible_pantry   f87ada51-4419-4144-86a8-e5e4ff0f64d3   install dataset   in service    fd00:1122:3344:101::c 
+    external_dns      005548be-c5e4-49ff-a27b-88f314f1bc51   install dataset   in service    fd00:1122:3344:101::9 
+    external_dns      2205353a-e1d2-48ff-863b-9d6b1487d474   install dataset   in service    fd00:1122:3344:101::a 
+    external_dns      70aab480-3d6c-47d5-aaf9-8d2ddab2931c   install dataset   in service    fd00:1122:3344:101::8 
+    internal_dns      3fd06852-06cb-4d8a-b4b2-eb88ff5a6035   install dataset   in service    fd00:1122:3344:2::1   
+    internal_dns      45ce130e-c5ac-4e26-ab73-7589ba634418   install dataset   in service    fd00:1122:3344:1::1   
+    internal_dns      a7b7bfbe-0588-4781-9a5e-fba63584e5d2   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      9b135c74-c09a-4dcc-ba19-f6f8deae135a   install dataset   in service    fd00:1122:3344:101::3 
+    nexus             2bc0b0c4-63a9-44cc-afff-76ce645ef1d4   install dataset   in service    fd00:1122:3344:101::6 
+    nexus             3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe   install dataset   in service    fd00:1122:3344:101::5 
+    nexus             c2cbbf34-b852-4164-a572-01d4d79445a1   install dataset   in service    fd00:1122:3344:101::4 
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+*   target release min gen:   1 -> 3
+    nexus gen::::::::::::::   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    unchanged names: 36 (records: 48)
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    unchanged names: 5 (records: 9)
+
+
+
+
+> # Now plan against the FIRST (pre-mupdate) inventory collection. That
+> # inventory shows no mupdate override on serial0 -- but only because the
+> # inventory was captured before the mupdate ever happened. The parent
+> # blueprint's sled-agent generation for serial0 is now ahead of what this
+> # stale inventory reports.
+> #
+> # The collection ID below is the deterministic UUID for the first
+> # `inventory-generate` above (driven by the test harness's --seed argument).
+> #
+> # Without the fix, the planner would treat the absence of the override in
+> # this stale inventory as evidence that the sled has recovered, and clear
+> # `remove_mupdate_override` from the blueprint. With the fix, the planner
+> # correctly identifies the inventory as stale (inv gen < parent bp gen) and
+> # leaves `remove_mupdate_override` alone, logging
+> # "blueprint override could not be cleared, ... reason: inventory stale".
+> blueprint-plan latest eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51
+INFO inventory override no longer exists, but blueprint override could not be cleared, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, bp_override: 11111111-1111-1111-1111-111111111111, reason: this sled cannot be noop-converted to Artifact: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+generated blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4 based on parent blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+blueprint source: planner with report:
+planning report:
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - current target release generation (2) is lower than minimum required by blueprint (3)
+  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+  - sleds have deployment units with image sources not set to Artifact:
+    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 17 zones
+
+  - sleds have measurements with image sources not set to Artifact:
+    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 set to install dataset
+
+* zone updates waiting on zone add blockers
+* waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
+Measurement updates:
+Waiting on zone add/update blockers
+
+
+
+> blueprint-diff latest
+from: blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   3 (unchanged)
+    nexus gen::::::::::::::   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    unchanged names: 36 (records: 48)
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    unchanged names: 5 (records: 9)
+
+
+

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-stale-inventory-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-stale-inventory-stdout
@@ -1,20 +1,20 @@
 using provided RNG seed: reconfigurator-cli-test
-> # This test exercises the bug where, in the mupdate override flow, the planner
-> # would clear `remove_mupdate_override` from a sled's blueprint based on stale
-> # inventory -- specifically, an inventory collection that was captured before
-> # the sled was mupdated, so the override marker isn't visible in it.
+> # This test verifies that when resolving a MUPdate, the planner does not clear
+> # the "will remove mupdate override" field from a sled's blueprint based on stale
+> # inventory -- specifically, an inventory collection that occurred before
+> # the sled was MUPdated, so the mupdate override UUID isn't visible in it.
 > #
 > # Acting on stale inventory in this way could cause the planner to acknowledge
 > # a sled recovery that hasn't happened, breaking the edge-triggered
-> # mupdate override semantics. The fix is to mark a sled as ineligible for
-> # both noop conversion and mupdate override clearing whenever the inventory's
-> # reported sled-agent generation is older than the generation in the parent
-> # blueprint.
+> # mupdate override semantics. The solution is to mark a sled as ineligible for
+> # both noop conversion and will-remove-mupdate-override clearing whenever the
+> # inventory's reported sled-agent generation is older than the generation in
+> # the parent blueprint.
 > #
 > # The test simulates two plans against the same parent blueprint: one against
-> # the latest (post-mupdate) inventory, and one against a stale (pre-mupdate)
+> # the latest (post-mupdate) inventory, and then one against a stale (pre-mupdate)
 > # inventory. With the fix, planning against the stale inventory leaves
-> # remove_mupdate_override alone instead of clearing it.
+> # the "will remove mupdate override" field alone instead of clearing it.
 
 > # Load a small example system. We only need one sled to demonstrate the bug.
 > load-example --nsleds 1 --ndisks-per-sled 3
@@ -75,7 +75,7 @@ set target release based on repo-1.0.0.zip
 sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: install dataset updated: to target release (system version 1.0.0)
 
 
-> # Generate the FIRST inventory collection. At this point the sled has no
+> # Generate the first inventory collection. At this point the sled has no
 > # mupdate override visible. We'll come back to this collection later to plan
 > # against it as a "stale" inventory.
 > inventory-generate
@@ -94,7 +94,7 @@ eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 0       <REDACTED_TIMESTAMP>
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 mupdate override: unset -> 11111111-1111-1111-1111-111111111111
 
 
-> # Generate a SECOND inventory collection, post-mupdate. This one has the
+> # Generate a second inventory collection, post-MUPdate. This one has the
 > # override visible.
 > inventory-generate
 generated inventory collection 61f451b3-2121-4ed6-91c7-a550054f6c21 from configured sleds
@@ -290,14 +290,13 @@ external DNS:
 > # stale inventory reports.
 > #
 > # The collection ID below is the deterministic UUID for the first
-> # `inventory-generate` above (driven by the test harness's --seed argument).
+> # `inventory-generate` above.
 > #
-> # Without the fix, the planner would treat the absence of the override in
-> # this stale inventory as evidence that the sled has recovered, and clear
-> # `remove_mupdate_override` from the blueprint. With the fix, the planner
-> # correctly identifies the inventory as stale (inv gen < parent bp gen) and
-> # leaves `remove_mupdate_override` alone, logging
-> # "blueprint override could not be cleared, ... reason: inventory stale".
+> # Without the check for stale inventory, the planner would treat the absence of
+> # the override in this stale inventory as evidence that the sled has recovered,
+> # and clear the "will remove mupdate override" field from the blueprint. With
+> # the check, the planner leaves the "will remove mupdate override" field alone,
+> # logging "blueprint override could not be cleared, ... reason: inventory stale".
 > blueprint-plan latest eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51
 INFO inventory override no longer exists, but blueprint override could not be cleared, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, bp_override: 11111111-1111-1111-1111-111111111111, reason: this sled cannot be noop-converted to Artifact: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)
 INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -639,7 +639,7 @@ INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupda
 INFO no previous MGS update found as part of updating blueprint mupdate override to match inventory, phase: do_plan_mupdate_override, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763
 INFO updating target release minimum generation based on new set-override actions, phase: do_plan_mupdate_override, current_generation: 1, new_generation: 3
 WARN skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: error retrieving mupdate override information: reconfigurator-cli simulated mupdate-override error
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (5)
 INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: remove_mupdate_override is set in the blueprint (203fa72c-85c1-466a-8ed3-338ee029530d)
 generated blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736 based on parent blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976
 blueprint source: planner with report:
@@ -958,7 +958,7 @@ INFO no previous MGS update found, so no action taken as part of updating bluepr
 WARN no inventory found for in-service sled, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 WARN skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: error retrieving mupdate override information: reconfigurator-cli simulated mupdate-override error
 INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: sled not found in inventory
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)
 generated blueprint 626487fa-7139-45ec-8416-902271fc730b based on parent blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736
 blueprint source: planner with report:
 planning report:
@@ -1105,7 +1105,7 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO measurement is eligible for noop image source conversion, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, new_measurement_source: 8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f version 1.0.0
 
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)
 generated blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b based on parent blueprint 626487fa-7139-45ec-8416-902271fc730b
 blueprint source: planner with report:
 planning report:
@@ -2089,7 +2089,7 @@ INFO current sled measurements are in an unknown state, sled_id: 2b8f0cb3-0295-4
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 generated blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1 based on parent blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700
 blueprint source: planner with report:
 planning report:
@@ -2155,7 +2155,7 @@ INFO current sled measurements are in an unknown state, sled_id: 2b8f0cb3-0295-4
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 generated blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300 based on parent blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1
 blueprint source: planner with report:
 planning report:
@@ -3263,13 +3263,13 @@ INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupda
 
 INFO no previous MGS update found as part of updating blueprint mupdate override to match inventory, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 INFO updating target release minimum generation based on new set-override actions, phase: do_plan_mupdate_override, current_generation: 4, new_generation: 5
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (6) that is older than the generation in the parent blueprint (7)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (8) that is older than the generation in the parent blueprint (9)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (6) that is older than the generation in the parent blueprint (7)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (8) that is older than the generation in the parent blueprint (9)
 INFO performed noop zone image source checks on sled, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, num_total: 0, num_already_artifact: 0, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO current sled measurements are in an unknown state, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (7) that is older than the generation in the parent blueprint (8)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (7) that is older than the generation in the parent blueprint (8)
 generated blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f based on parent blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c
 blueprint source: planner with report:
 planning report:
@@ -3412,13 +3412,13 @@ planner config updated:
 
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (6) that is older than the generation in the parent blueprint (7)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (8) that is older than the generation in the parent blueprint (10)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (6) that is older than the generation in the parent blueprint (7)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (8) that is older than the generation in the parent blueprint (10)
 INFO performed noop zone image source checks on sled, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, num_total: 0, num_already_artifact: 0, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO current sled measurements are in an unknown state, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (7) that is older than the generation in the parent blueprint (8)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (7) that is older than the generation in the parent blueprint (8)
 INFO altered physical disks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, sled_edits: SledEditCounts { disks: EditCounts { added: 10, updated: 0, expunged: 0, removed: 0 }, datasets: EditCounts { added: 40, updated: 0, expunged: 0, removed: 0 }, zones: EditCounts { added: 0, updated: 0, expunged: 0, removed: 0 }, measurements: EditCounts { added: 0, updated: 0, expunged: 0, removed: 0 } }
 generated blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35 based on parent blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f
 blueprint source: planner with report:

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -110,6 +110,20 @@ warn: no validation is done on the requested source
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 mupdate override: unset -> 203fa72c-85c1-466a-8ed3-338ee029530d
 
 
+> # The blueprint-edits above bumped serial0 and serial1's sled-agent generations.
+> # Apply the latest blueprint to all sleds' inventories so the noop check on
+> # the upcoming plan starts from fresh sled-agent generations rather than
+> # firing the inventory-stale path.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
+
+
 > # Generate a new inventory and plan against that.
 > inventory-generate
 generated inventory collection eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 from configured sleds
@@ -257,10 +271,10 @@ sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (role = Gimlet, serial serial1)
         reservation: None, quota: None
 
 LEDGERED SLED CONFIG
-    generation: 2
+    generation: 4
     remove_mupdate_override: None
-    desired host phase 2 slot a: keep current contents
-    desired host phase 2 slot b: keep current contents
+    desired host phase 2 slot a: artifact 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
+    desired host phase 2 slot b: artifact 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
     DISKS: 1
         ID                                       ZPOOL_ID                                 VENDOR          MODEL          SERIAL                                      
         f26df0e3-46bb-4c85-8146-efcab46179da     72c59873-31ff-4e36-8d76-ff834009349a     fake-vendor     fake-model     serial-72c59873-31ff-4e36-8d76-ff834009349a 
@@ -383,10 +397,10 @@ sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
         reservation: None, quota: None
 
 LEDGERED SLED CONFIG
-    generation: 2
+    generation: 5
     remove_mupdate_override: None
-    desired host phase 2 slot a: keep current contents
-    desired host phase 2 slot b: keep current contents
+    desired host phase 2 slot a: artifact 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
+    desired host phase 2 slot b: artifact 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
     DISKS: 1
         ID                                       ZPOOL_ID                                 VENDOR          MODEL          SERIAL                                      
         3f399219-7701-414c-9f07-8e97f688765c     c6d33b64-fb96-4129-bab1-7878a06a5f9b     fake-vendor     fake-model     serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b 
@@ -406,13 +420,13 @@ LEDGERED SLED CONFIG
         ad41be71-6c15-4428-b510-20ceacde4fa6     oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/external_dns                                                      off             none        none        
         cdf3684f-a6cf-4449-b9ec-e696b2c663e2     oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                     off             none        none        
     ZONES: 6
-        ID                                       KIND                IMAGE_SOURCE    
-        0c71b3b2-6ceb-4e8f-b020-b08675e83038     nexus               install-dataset 
-        427ec88f-f467-42fa-9bbb-66a91a36103c     internal_dns        install-dataset 
-        5199c033-4cf9-4ab6-8ae7-566bd7606363     crucible            install-dataset 
-        6444f8a5-6465-4f0b-a549-1993c113569c     internal_ntp        install-dataset 
-        803bfb63-c246-41db-b0da-d3b87ddfc63d     external_dns        install-dataset 
-        ba4994a8-23f9-4b1a-a84f-a08d74591389     crucible_pantry     install-dataset 
+        ID                                       KIND                IMAGE_SOURCE                                                               
+        0c71b3b2-6ceb-4e8f-b020-b08675e83038     nexus               artifact: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 
+        427ec88f-f467-42fa-9bbb-66a91a36103c     internal_dns        install-dataset                                                            
+        5199c033-4cf9-4ab6-8ae7-566bd7606363     crucible            install-dataset                                                            
+        6444f8a5-6465-4f0b-a549-1993c113569c     internal_ntp        install-dataset                                                            
+        803bfb63-c246-41db-b0da-d3b87ddfc63d     external_dns        install-dataset                                                            
+        ba4994a8-23f9-4b1a-a84f-a08d74591389     crucible_pantry     install-dataset                                                            
     measurement empty
     zone image resolver status:
         zone manifest:
@@ -904,6 +918,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 inventory visibility: visible -> hidden
 
 
+> # The previous plan set remove_mupdate_override on serial2, bumping its
+> # sled-agent generation. Apply the latest blueprint to serial2's inventory so
+> # the noop check on the upcoming plan exercises the mupdate-override-set path
+> # rather than firing the inventory-stale path.
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (a5a8f242-ffa5-473c-8efd-2acf2dc0b736)
+
+
 > # Set the target release to a new repo, causing a generation number bump
 > # to 3.
 > set target-release repo-1.0.0.zip
@@ -1012,13 +1034,19 @@ external DNS:
 
 
 
-> # Now simulate the new config being applied to sled 0, which would
-> # cause the mupdate override to be removed.
+> # Now simulate the new config being applied to sled 0, which would cause the
+> # mupdate override to be removed. Apply the latest blueprint to inventory too,
+> # so that inventory's reported sled-agent generation advances to match the
+> # blueprint's; otherwise the noop check on the next plan would correctly
+> # refuse to clear remove_mupdate_override on the basis of stale inventory.
 > sled-set serial0 mupdate-override unset
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 mupdate override: 6123eac1-ec5b-42ba-b73f-9845105a9971 -> unset
 
 > sled-set serial0 inventory-visible
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 inventory visibility: hidden -> visible
+
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (626487fa-7139-45ec-8416-902271fc730b)
 
 
 > # But simulate a second mupdate on sled 2. This should invalidate the existing
@@ -1284,9 +1312,17 @@ external DNS:
 
 
 > # Clear the mupdate override on sled 2, signifying that the config has been
-> # applied.
+> # applied. Also advance serial0 and serial2's inventories to the latest
+> # blueprint -- the previous plan did noop conversions on serial0 (bumping its
+> # sled-agent generation) and set remove_mupdate_override on serial2.
 > sled-set serial2 mupdate-override unset
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 mupdate override: 1c0ce176-6dc8-4a90-adea-d4a8000751da -> unset
+
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (c1a0d242-9160-40f4-96ae-61f8f40a0b1b)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (c1a0d242-9160-40f4-96ae-61f8f40a0b1b)
 
 
 > # Run the planner again. This will cause sled 2's blueprint
@@ -1650,6 +1686,18 @@ external DNS:
     unchanged names: 5 (records: 9)
 
 
+
+
+> # Apply the latest blueprint again so subsequent plans aren't shadowed by an
+> # inventory-stale check on the just-bumped sled-agent generations.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (afb09faf-a586-4483-9289-04d4f1d8ba23)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (afb09faf-a586-4483-9289-04d4f1d8ba23)
+
+> inventory-generate
+generated inventory collection 0b5efbb3-0b1b-4bbf-b7d8-a2d6fca074c6 from configured sleds
 
 
 > # Now set the target release -- at this point, we're still waiting on the
@@ -2043,11 +2091,23 @@ external DNS:
 
 > # Now clear the mupdate override error. At this point, we're *still* blocked
 > # on serial1's install dataset not being known (so cannot be noop converted).
+> # Advance serial1's reported sled-agent generation alongside, simulating the
+> # sled having applied the latest blueprint. Also advance serial0/2 since the
+> # previous plan bumped their generations too.
 > sled-set serial1 mupdate-override unset
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c mupdate override: error -> unset
 
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (ce365dff-2cdb-4f35-a186-b15e20e1e700)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (ce365dff-2cdb-4f35-a186-b15e20e1e700)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (ce365dff-2cdb-4f35-a186-b15e20e1e700)
+
 > inventory-generate
-generated inventory collection 0b5efbb3-0b1b-4bbf-b7d8-a2d6fca074c6 from configured sleds
+generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 7, num_already_artifact: 0, num_eligible: 0, num_ineligible: 7
@@ -2112,8 +2172,14 @@ external DNS:
 > sled-update-install-dataset serial1 --to-target-release
 sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: install dataset updated: to target release (system version 2.0.0)
 
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
+
 > inventory-generate
-generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
+generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
 
 
 > # Measurements will block further planning progress, run a planning step
@@ -2583,7 +2649,7 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest bluepri
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (12d602a6-5ab4-487a-b94e-eb30cdf30300)
 
 > inventory-generate
-generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
+generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configured sleds
 
 
 > # This will attempt to update the RoT bootloader on the first sled.
@@ -2933,9 +2999,21 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 2 details: boot_disk ->
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 1 details: active -> B, B -> 1eba0d79ea9d34558fb3f923a06614bd740649eeb0ca6e5086529dc60cd6f729
 
 
-> # All MGS-based updates complete.
+> # All MGS-based updates complete. Apply the latest blueprint to all sleds'
+> # inventories so the noop check on the next plan starts from fresh sled-agent
+> # generations rather than firing the inventory-stale path on the bumped
+> # generations from earlier plans in this file.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
+
 > inventory-generate
-generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configured sleds
+generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
@@ -3213,8 +3291,19 @@ set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 mupdate override: unset -> c8fba91
 > sled-add c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 added sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b (serial: serial3)
 
+> # The plan above bumped sled-agent generations as it scheduled work; apply the
+> # latest blueprint to inventory so subsequent noop checks aren't inventory-stale.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (27e755bc-dc10-4647-853c-f89bb3a15a2c)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (27e755bc-dc10-4647-853c-f89bb3a15a2c)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (27e755bc-dc10-4647-853c-f89bb3a15a2c)
+
 > inventory-generate
-generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configured sleds
+generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configured sleds
 
 
 > # This will *not* generate the datasets and internal NTP zone on the new
@@ -3318,20 +3407,21 @@ to:   blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f
 
 
     omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source                disposition    underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0     expunged ⏳     fd00:1122:3344:2::1  
-*   crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   - artifact: version 1.0.0   in service     fd00:1122:3344:101::7
-     └─                                                      + install dataset                                               
-*   crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   - artifact: version 1.0.0   in service     fd00:1122:3344:101::6
-     └─                                                      + install dataset                                               
-*   external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   - artifact: version 1.0.0   in service     fd00:1122:3344:101::5
-     └─                                                      + install dataset                                               
-*   internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   - artifact: version 1.0.0   in service     fd00:1122:3344:101::3
-     └─                                                      + install dataset                                               
-*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   - artifact: version 1.0.0   in service     fd00:1122:3344:101::4
-     └─                                                      + install dataset                                               
+    ---------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source                disposition      underlay IP          
+    ---------------------------------------------------------------------------------------------------------------------------
+*   crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   - artifact: version 1.0.0   in service       fd00:1122:3344:101::7
+     └─                                                      + install dataset                                                 
+*   crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   - artifact: version 1.0.0   in service       fd00:1122:3344:101::6
+     └─                                                      + install dataset                                                 
+*   external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   - artifact: version 1.0.0   in service       fd00:1122:3344:101::5
+     └─                                                      + install dataset                                                 
+*   internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0     - expunged ⏳     fd00:1122:3344:2::1  
+     └─                                                                                  + expunged ✓                          
+*   internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   - artifact: version 1.0.0   in service       fd00:1122:3344:101::3
+     └─                                                      + install dataset                                                 
+*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   - artifact: version 1.0.0   in service       fd00:1122:3344:101::4
+     └─                                                      + install dataset                                                 
 
 
  ADDED SLEDS:
@@ -3385,6 +3475,18 @@ planner config updated:
 *   add zones with mupdate override:   false -> true
 
 
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (9f89efdf-a23e-4137-b7cc-79f4a91cbe1f)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (9f89efdf-a23e-4137-b7cc-79f4a91cbe1f)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (9f89efdf-a23e-4137-b7cc-79f4a91cbe1f)
+
+> inventory-generate
+generated inventory collection b5263998-e486-4cea-8842-b32bd326fa3a from configured sleds
+
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
@@ -3415,7 +3517,9 @@ planner config:
 * discretionary zone placement waiting for NTP zones on sleds: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * missing NTP zone on sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * only placed 0/1 desired nexus zones
-* zone updates waiting on zone add blockers
+* discretionary zones placed:
+  * internal_dns zone on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 from source artifact: version 2.0.0
+* zone updates waiting on discretionary zones
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
 Measurement updates:
 Waiting on zone add/update blockers
@@ -3427,6 +3531,65 @@ from: blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f
 to:   blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35
 
  MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 10 -> 11):
+    will remove mupdate override:   c8fba912-63ae-473a-9115-0495d10fb3bc (unchanged)
+
+    measurements:
+    ------------------------------
+    hash              version     
+    ------------------------------
+    install dataset   (no version)
+
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              42430c80-7836-4191-a4f6-bcee749010fe   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/external_dns                                                    ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/internal_dns                                                    a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   expunged      none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      3ac089c9-9dec-465b-863a-188e80d71fb4   expunged      none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               686c19cf-a0d7-45f6-866f-c564612b2664   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
++   oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/internal_dns                                                    b8ba4bea-893b-42e9-a034-c7283d15c2b7   in service    none      none          off        
++   oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_internal_dns_cfc72ddd-fd83-4396-b1ad-d53f69182a09      64c1c086-6866-4a94-b9bf-1d022312d587   in service    none      none          off        
+
+
+    omicron zones:
+    -----------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition    underlay IP          
+    -----------------------------------------------------------------------------------------------------------------------
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   install dataset           in service     fd00:1122:3344:101::7
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   install dataset           in service     fd00:1122:3344:101::6
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   install dataset           in service     fd00:1122:3344:101::5
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0   expunged ✓     fd00:1122:3344:2::1  
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   install dataset           in service     fd00:1122:3344:101::3
+    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   install dataset           in service     fd00:1122:3344:101::4
++   internal_dns      cfc72ddd-fd83-4396-b1ad-d53f69182a09   artifact: version 2.0.0   in service     fd00:1122:3344:2::1  
+
 
   sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b (active, config generation 1 -> 2):
 
@@ -3532,6 +3695,12 @@ to:   blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35
 
 internal DNS:
 * DNS zone: "control-plane.oxide.internal": 
+*   name: @                                                  (records: 2 -> 3)
+-       NS   ns1.control-plane.oxide.internal
+-       NS   ns2.control-plane.oxide.internal
++       NS   ns1.control-plane.oxide.internal
++       NS   ns2.control-plane.oxide.internal
++       NS   ns3.control-plane.oxide.internal
 *   name: _internal-ntp._tcp                                 (records: 3 -> 4)
 -       SRV  port   123 62620961-fc4a-481e-968b-f5acbac0dc63.host.control-plane.oxide.internal
 -       SRV  port   123 6444f8a5-6465-4f0b-a549-1993c113569c.host.control-plane.oxide.internal
@@ -3540,9 +3709,22 @@ internal DNS:
 +       SRV  port   123 6444f8a5-6465-4f0b-a549-1993c113569c.host.control-plane.oxide.internal
 +       SRV  port   123 cee5d0c6-412c-49e9-a9a8-dab9addaa182.host.control-plane.oxide.internal
 +       SRV  port   123 f10a4fb9-759f-4a65-b25e-5794ad2d07d8.host.control-plane.oxide.internal
+*   name: _nameservice._tcp                                  (records: 2 -> 3)
+-       SRV  port  5353 99e2f30b-3174-40bf-a78a-90da8abba8ca.host.control-plane.oxide.internal
+-       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
++       SRV  port  5353 99e2f30b-3174-40bf-a78a-90da8abba8ca.host.control-plane.oxide.internal
++       SRV  port  5353 cfc72ddd-fd83-4396-b1ad-d53f69182a09.host.control-plane.oxide.internal
++       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
 +   name: cee5d0c6-412c-49e9-a9a8-dab9addaa182.host          (records: 1)
 +       AAAA fd00:1122:3344:104::3
-    unchanged names: 38 (records: 51)
++   name: cfc72ddd-fd83-4396-b1ad-d53f69182a09.host          (records: 1)
++       AAAA fd00:1122:3344:2::1
+*   name: ns2                                                (records: 1 -> 1)
+-       AAAA fd00:1122:3344:3::1
++       AAAA fd00:1122:3344:2::1
++   name: ns3                                                (records: 1)
++       AAAA fd00:1122:3344:3::1
+    unchanged names: 35 (records: 46)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
@@ -3561,7 +3743,7 @@ blueprint 13cfdd24-52ba-4e94-8c83-02e3a48fc746 created from latest blueprint (9a
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c mupdate override: unset -> cc724abe-80c1-47e6-9771-19e6540531a9
 
 > inventory-generate
-generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configured sleds
+generated inventory collection 68767302-7fed-4eb1-9611-3dfd807ff0cd from configured sleds
 
 > blueprint-plan latest latest
 INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupdate_override, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, new_bp_override: cc724abe-80c1-47e6-9771-19e6540531a9, prev_bp_override: None, zones: 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -110,20 +110,6 @@ warn: no validation is done on the requested source
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 mupdate override: unset -> 203fa72c-85c1-466a-8ed3-338ee029530d
 
 
-> # The blueprint-edits above bumped serial0 and serial1's sled-agent generations.
-> # Apply the latest blueprint to all sleds' inventories so the noop check on
-> # the upcoming plan starts from fresh sled-agent generations rather than
-> # firing the inventory-stale path.
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
-
-
 > # Generate a new inventory and plan against that.
 > inventory-generate
 generated inventory collection eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 from configured sleds
@@ -271,10 +257,10 @@ sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (role = Gimlet, serial serial1)
         reservation: None, quota: None
 
 LEDGERED SLED CONFIG
-    generation: 4
+    generation: 2
     remove_mupdate_override: None
-    desired host phase 2 slot a: artifact 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
-    desired host phase 2 slot b: artifact 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
+    desired host phase 2 slot a: keep current contents
+    desired host phase 2 slot b: keep current contents
     DISKS: 1
         ID                                       ZPOOL_ID                                 VENDOR          MODEL          SERIAL                                      
         f26df0e3-46bb-4c85-8146-efcab46179da     72c59873-31ff-4e36-8d76-ff834009349a     fake-vendor     fake-model     serial-72c59873-31ff-4e36-8d76-ff834009349a 
@@ -397,10 +383,10 @@ sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
         reservation: None, quota: None
 
 LEDGERED SLED CONFIG
-    generation: 5
+    generation: 2
     remove_mupdate_override: None
-    desired host phase 2 slot a: artifact 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
-    desired host phase 2 slot b: artifact 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
+    desired host phase 2 slot a: keep current contents
+    desired host phase 2 slot b: keep current contents
     DISKS: 1
         ID                                       ZPOOL_ID                                 VENDOR          MODEL          SERIAL                                      
         3f399219-7701-414c-9f07-8e97f688765c     c6d33b64-fb96-4129-bab1-7878a06a5f9b     fake-vendor     fake-model     serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b 
@@ -420,13 +406,13 @@ LEDGERED SLED CONFIG
         ad41be71-6c15-4428-b510-20ceacde4fa6     oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/external_dns                                                      off             none        none        
         cdf3684f-a6cf-4449-b9ec-e696b2c663e2     oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                     off             none        none        
     ZONES: 6
-        ID                                       KIND                IMAGE_SOURCE                                                               
-        0c71b3b2-6ceb-4e8f-b020-b08675e83038     nexus               artifact: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 
-        427ec88f-f467-42fa-9bbb-66a91a36103c     internal_dns        install-dataset                                                            
-        5199c033-4cf9-4ab6-8ae7-566bd7606363     crucible            install-dataset                                                            
-        6444f8a5-6465-4f0b-a549-1993c113569c     internal_ntp        install-dataset                                                            
-        803bfb63-c246-41db-b0da-d3b87ddfc63d     external_dns        install-dataset                                                            
-        ba4994a8-23f9-4b1a-a84f-a08d74591389     crucible_pantry     install-dataset                                                            
+        ID                                       KIND                IMAGE_SOURCE    
+        0c71b3b2-6ceb-4e8f-b020-b08675e83038     nexus               install-dataset 
+        427ec88f-f467-42fa-9bbb-66a91a36103c     internal_dns        install-dataset 
+        5199c033-4cf9-4ab6-8ae7-566bd7606363     crucible            install-dataset 
+        6444f8a5-6465-4f0b-a549-1993c113569c     internal_ntp        install-dataset 
+        803bfb63-c246-41db-b0da-d3b87ddfc63d     external_dns        install-dataset 
+        ba4994a8-23f9-4b1a-a84f-a08d74591389     crucible_pantry     install-dataset 
     measurement empty
     zone image resolver status:
         zone manifest:
@@ -653,7 +639,7 @@ INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupda
 INFO no previous MGS update found as part of updating blueprint mupdate override to match inventory, phase: do_plan_mupdate_override, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763
 INFO updating target release minimum generation based on new set-override actions, phase: do_plan_mupdate_override, current_generation: 1, new_generation: 3
 WARN skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: error retrieving mupdate override information: reconfigurator-cli simulated mupdate-override error
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (6123eac1-ec5b-42ba-b73f-9845105a9971)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (5)
 INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: remove_mupdate_override is set in the blueprint (203fa72c-85c1-466a-8ed3-338ee029530d)
 generated blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736 based on parent blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976
 blueprint source: planner with report:
@@ -918,14 +904,6 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 inventory visibility: visible -> hidden
 
 
-> # The previous plan set remove_mupdate_override on serial2, bumping its
-> # sled-agent generation. Apply the latest blueprint to serial2's inventory so
-> # the noop check on the upcoming plan exercises the mupdate-override-set path
-> # rather than firing the inventory-stale path.
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (a5a8f242-ffa5-473c-8efd-2acf2dc0b736)
-
-
 > # Set the target release to a new repo, causing a generation number bump
 > # to 3.
 > set target-release repo-1.0.0.zip
@@ -980,7 +958,7 @@ INFO no previous MGS update found, so no action taken as part of updating bluepr
 WARN no inventory found for in-service sled, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 WARN skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: error retrieving mupdate override information: reconfigurator-cli simulated mupdate-override error
 INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: sled not found in inventory
-WARN skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: error retrieving zone manifest: measurement manifest contained no entries
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
 generated blueprint 626487fa-7139-45ec-8416-902271fc730b based on parent blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736
 blueprint source: planner with report:
 planning report:
@@ -1035,10 +1013,10 @@ external DNS:
 
 
 > # Now simulate the new config being applied to sled 0, which would cause the
-> # mupdate override to be removed. Apply the latest blueprint to inventory too,
-> # so that inventory's reported sled-agent generation advances to match the
-> # blueprint's; otherwise the noop check on the next plan would correctly
-> # refuse to clear remove_mupdate_override on the basis of stale inventory.
+> # mupdate override to be removed. Apply the latest blueprint to inventory
+> # too, so that the sled's reported sled-agent generation advances to match
+> # the blueprint's; the sled clearing the override and bumping its generation
+> # happen together when the sled processes the new blueprint config.
 > sled-set serial0 mupdate-override unset
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 mupdate override: 6123eac1-ec5b-42ba-b73f-9845105a9971 -> unset
 
@@ -1127,7 +1105,7 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO measurement is eligible for noop image source conversion, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, new_measurement_source: 8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f version 1.0.0
 
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: remove_mupdate_override is set in the blueprint (1c0ce176-6dc8-4a90-adea-d4a8000751da)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
 generated blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b based on parent blueprint 626487fa-7139-45ec-8416-902271fc730b
 blueprint source: planner with report:
 planning report:
@@ -1312,9 +1290,11 @@ external DNS:
 
 
 > # Clear the mupdate override on sled 2, signifying that the config has been
-> # applied. Also advance serial0 and serial2's inventories to the latest
-> # blueprint -- the previous plan did noop conversions on serial0 (bumping its
-> # sled-agent generation) and set remove_mupdate_override on serial2.
+> # applied. Also advance the sled's reported sled-agent generation to match,
+> # since the sled clearing the override and bumping its generation happen
+> # together when it processes the new blueprint config. Likewise advance
+> # serial0's reported sled-agent generation: the previous plan did noop
+> # conversions on serial0 that the sled would have applied by now in production.
 > sled-set serial2 mupdate-override unset
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 mupdate override: 1c0ce176-6dc8-4a90-adea-d4a8000751da -> unset
 
@@ -1688,8 +1668,9 @@ external DNS:
 
 
 
-> # Apply the latest blueprint again so subsequent plans aren't shadowed by an
-> # inventory-stale check on the just-bumped sled-agent generations.
+> # Model sled-agents applying the latest blueprint between plans (this happens
+> # automatically in production), advancing reported sled-agent generations to
+> # match.
 > sled-set serial0 omicron-config latest
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (afb09faf-a586-4483-9289-04d4f1d8ba23)
 
@@ -2091,20 +2072,11 @@ external DNS:
 
 > # Now clear the mupdate override error. At this point, we're *still* blocked
 > # on serial1's install dataset not being known (so cannot be noop converted).
-> # Advance serial1's reported sled-agent generation alongside, simulating the
-> # sled having applied the latest blueprint. Also advance serial0/2 since the
-> # previous plan bumped their generations too.
 > sled-set serial1 mupdate-override unset
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c mupdate override: error -> unset
 
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (ce365dff-2cdb-4f35-a186-b15e20e1e700)
-
 > sled-set serial1 omicron-config latest
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (ce365dff-2cdb-4f35-a186-b15e20e1e700)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (ce365dff-2cdb-4f35-a186-b15e20e1e700)
 
 > inventory-generate
 generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
@@ -2117,9 +2089,7 @@ INFO current sled measurements are in an unknown state, sled_id: 2b8f0cb3-0295-4
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 generated blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1 based on parent blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700
 blueprint source: planner with report:
 planning report:
@@ -2172,12 +2142,6 @@ external DNS:
 > sled-update-install-dataset serial1 --to-target-release
 sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: install dataset updated: to target release (system version 2.0.0)
 
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
-
 > inventory-generate
 generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
 
@@ -2191,9 +2155,7 @@ INFO current sled measurements are in an unknown state, sled_id: 2b8f0cb3-0295-4
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 generated blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300 based on parent blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1
 blueprint source: planner with report:
 planning report:
@@ -2999,19 +2961,7 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 2 details: boot_disk ->
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 1 details: active -> B, B -> 1eba0d79ea9d34558fb3f923a06614bd740649eeb0ca6e5086529dc60cd6f729
 
 
-> # All MGS-based updates complete. Apply the latest blueprint to all sleds'
-> # inventories so the noop check on the next plan starts from fresh sled-agent
-> # generations rather than firing the inventory-stale path on the bumped
-> # generations from earlier plans in this file.
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
-
+> # All MGS-based updates complete.
 > inventory-generate
 generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configured sleds
 
@@ -3291,17 +3241,6 @@ set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 mupdate override: unset -> c8fba91
 > sled-add c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 added sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b (serial: serial3)
 
-> # The plan above bumped sled-agent generations as it scheduled work; apply the
-> # latest blueprint to inventory so subsequent noop checks aren't inventory-stale.
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (27e755bc-dc10-4647-853c-f89bb3a15a2c)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (27e755bc-dc10-4647-853c-f89bb3a15a2c)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (27e755bc-dc10-4647-853c-f89bb3a15a2c)
-
 > inventory-generate
 generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configured sleds
 
@@ -3324,15 +3263,13 @@ INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupda
 
 INFO no previous MGS update found as part of updating blueprint mupdate override to match inventory, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 INFO updating target release minimum generation based on new set-override actions, phase: do_plan_mupdate_override, current_generation: 4, new_generation: 5
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (c8fba912-63ae-473a-9115-0495d10fb3bc)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (6) that is older than the generation in the parent blueprint (7)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (8) that is older than the generation in the parent blueprint (9)
 INFO performed noop zone image source checks on sled, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, num_total: 0, num_already_artifact: 0, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO current sled measurements are in an unknown state, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (7) that is older than the generation in the parent blueprint (8)
 generated blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f based on parent blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c
 blueprint source: planner with report:
 planning report:
@@ -3407,21 +3344,20 @@ to:   blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f
 
 
     omicron zones:
-    ---------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source                disposition      underlay IP          
-    ---------------------------------------------------------------------------------------------------------------------------
-*   crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   - artifact: version 1.0.0   in service       fd00:1122:3344:101::7
-     └─                                                      + install dataset                                                 
-*   crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   - artifact: version 1.0.0   in service       fd00:1122:3344:101::6
-     └─                                                      + install dataset                                                 
-*   external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   - artifact: version 1.0.0   in service       fd00:1122:3344:101::5
-     └─                                                      + install dataset                                                 
-*   internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0     - expunged ⏳     fd00:1122:3344:2::1  
-     └─                                                                                  + expunged ✓                          
-*   internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   - artifact: version 1.0.0   in service       fd00:1122:3344:101::3
-     └─                                                      + install dataset                                                 
-*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   - artifact: version 1.0.0   in service       fd00:1122:3344:101::4
-     └─                                                      + install dataset                                                 
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source                disposition    underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0     expunged ⏳     fd00:1122:3344:2::1  
+*   crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   - artifact: version 1.0.0   in service     fd00:1122:3344:101::7
+     └─                                                      + install dataset                                               
+*   crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   - artifact: version 1.0.0   in service     fd00:1122:3344:101::6
+     └─                                                      + install dataset                                               
+*   external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   - artifact: version 1.0.0   in service     fd00:1122:3344:101::5
+     └─                                                      + install dataset                                               
+*   internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   - artifact: version 1.0.0   in service     fd00:1122:3344:101::3
+     └─                                                      + install dataset                                               
+*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   - artifact: version 1.0.0   in service     fd00:1122:3344:101::4
+     └─                                                      + install dataset                                               
 
 
  ADDED SLEDS:
@@ -3475,28 +3411,14 @@ planner config updated:
 *   add zones with mupdate override:   false -> true
 
 
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (9f89efdf-a23e-4137-b7cc-79f4a91cbe1f)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (9f89efdf-a23e-4137-b7cc-79f4a91cbe1f)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (9f89efdf-a23e-4137-b7cc-79f4a91cbe1f)
-
-> inventory-generate
-generated inventory collection b5263998-e486-4cea-8842-b32bd326fa3a from configured sleds
-
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (c8fba912-63ae-473a-9115-0495d10fb3bc)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (6) that is older than the generation in the parent blueprint (7)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (8) that is older than the generation in the parent blueprint (10)
 INFO performed noop zone image source checks on sled, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, num_total: 0, num_already_artifact: 0, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO current sled measurements are in an unknown state, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (7) that is older than the generation in the parent blueprint (8)
 INFO altered physical disks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, sled_edits: SledEditCounts { disks: EditCounts { added: 10, updated: 0, expunged: 0, removed: 0 }, datasets: EditCounts { added: 40, updated: 0, expunged: 0, removed: 0 }, zones: EditCounts { added: 0, updated: 0, expunged: 0, removed: 0 }, measurements: EditCounts { added: 0, updated: 0, expunged: 0, removed: 0 } }
 generated blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35 based on parent blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f
 blueprint source: planner with report:
@@ -3517,9 +3439,7 @@ planner config:
 * discretionary zone placement waiting for NTP zones on sleds: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * missing NTP zone on sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * only placed 0/1 desired nexus zones
-* discretionary zones placed:
-  * internal_dns zone on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 from source artifact: version 2.0.0
-* zone updates waiting on discretionary zones
+* zone updates waiting on zone add blockers
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
 Measurement updates:
 Waiting on zone add/update blockers
@@ -3531,65 +3451,6 @@ from: blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f
 to:   blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35
 
  MODIFIED SLEDS:
-
-  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 10 -> 11):
-    will remove mupdate override:   c8fba912-63ae-473a-9115-0495d10fb3bc (unchanged)
-
-    measurements:
-    ------------------------------
-    hash              version     
-    ------------------------------
-    install dataset   (no version)
-
-
-    host phase 2 contents:
-    ------------------------
-    slot   boot image source
-    ------------------------
-    A      current contents 
-    B      current contents 
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              42430c80-7836-4191-a4f6-bcee749010fe   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/external_dns                                                    ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/internal_dns                                                    a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   expunged      none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      3ac089c9-9dec-465b-863a-188e80d71fb4   expunged      none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               686c19cf-a0d7-45f6-866f-c564612b2664   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
-+   oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/internal_dns                                                    b8ba4bea-893b-42e9-a034-c7283d15c2b7   in service    none      none          off        
-+   oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_internal_dns_cfc72ddd-fd83-4396-b1ad-d53f69182a09      64c1c086-6866-4a94-b9bf-1d022312d587   in service    none      none          off        
-
-
-    omicron zones:
-    -----------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition    underlay IP          
-    -----------------------------------------------------------------------------------------------------------------------
-    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   install dataset           in service     fd00:1122:3344:101::7
-    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   install dataset           in service     fd00:1122:3344:101::6
-    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   install dataset           in service     fd00:1122:3344:101::5
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0   expunged ✓     fd00:1122:3344:2::1  
-    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   install dataset           in service     fd00:1122:3344:101::3
-    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   install dataset           in service     fd00:1122:3344:101::4
-+   internal_dns      cfc72ddd-fd83-4396-b1ad-d53f69182a09   artifact: version 2.0.0   in service     fd00:1122:3344:2::1  
-
 
   sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b (active, config generation 1 -> 2):
 
@@ -3695,12 +3556,6 @@ to:   blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35
 
 internal DNS:
 * DNS zone: "control-plane.oxide.internal": 
-*   name: @                                                  (records: 2 -> 3)
--       NS   ns1.control-plane.oxide.internal
--       NS   ns2.control-plane.oxide.internal
-+       NS   ns1.control-plane.oxide.internal
-+       NS   ns2.control-plane.oxide.internal
-+       NS   ns3.control-plane.oxide.internal
 *   name: _internal-ntp._tcp                                 (records: 3 -> 4)
 -       SRV  port   123 62620961-fc4a-481e-968b-f5acbac0dc63.host.control-plane.oxide.internal
 -       SRV  port   123 6444f8a5-6465-4f0b-a549-1993c113569c.host.control-plane.oxide.internal
@@ -3709,22 +3564,9 @@ internal DNS:
 +       SRV  port   123 6444f8a5-6465-4f0b-a549-1993c113569c.host.control-plane.oxide.internal
 +       SRV  port   123 cee5d0c6-412c-49e9-a9a8-dab9addaa182.host.control-plane.oxide.internal
 +       SRV  port   123 f10a4fb9-759f-4a65-b25e-5794ad2d07d8.host.control-plane.oxide.internal
-*   name: _nameservice._tcp                                  (records: 2 -> 3)
--       SRV  port  5353 99e2f30b-3174-40bf-a78a-90da8abba8ca.host.control-plane.oxide.internal
--       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
-+       SRV  port  5353 99e2f30b-3174-40bf-a78a-90da8abba8ca.host.control-plane.oxide.internal
-+       SRV  port  5353 cfc72ddd-fd83-4396-b1ad-d53f69182a09.host.control-plane.oxide.internal
-+       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
 +   name: cee5d0c6-412c-49e9-a9a8-dab9addaa182.host          (records: 1)
 +       AAAA fd00:1122:3344:104::3
-+   name: cfc72ddd-fd83-4396-b1ad-d53f69182a09.host          (records: 1)
-+       AAAA fd00:1122:3344:2::1
-*   name: ns2                                                (records: 1 -> 1)
--       AAAA fd00:1122:3344:3::1
-+       AAAA fd00:1122:3344:2::1
-+   name: ns3                                                (records: 1)
-+       AAAA fd00:1122:3344:3::1
-    unchanged names: 35 (records: 46)
+    unchanged names: 38 (records: 51)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
@@ -3743,7 +3585,7 @@ blueprint 13cfdd24-52ba-4e94-8c83-02e3a48fc746 created from latest blueprint (9a
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c mupdate override: unset -> cc724abe-80c1-47e6-9771-19e6540531a9
 
 > inventory-generate
-generated inventory collection 68767302-7fed-4eb1-9611-3dfd807ff0cd from configured sleds
+generated inventory collection b5263998-e486-4cea-8842-b32bd326fa3a from configured sleds
 
 > blueprint-plan latest latest
 INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupdate_override, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, new_bp_override: cc724abe-80c1-47e6-9771-19e6540531a9, prev_bp_override: None, zones: 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
@@ -1769,9 +1769,9 @@ external DNS:
 > # If we try to plan again, nothing happens.
 > # The report should say why: These zones haven't propagated to inventory yet.
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (4) that is older than the generation in the parent blueprint (5)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -1817,9 +1817,9 @@ generated inventory collection a71f7a73-35a6-45e8-acbe-f1c5925eed69 from configu
 > # This will refuse to bump the Nexus generation ("new Nexus zones
 > # are not in inventory yet")
 > blueprint-plan latest b1bda47d-2c19-4fba-96e3-d9df28db7436
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (4) that is older than the generation in the parent blueprint (5)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -2190,7 +2190,7 @@ external DNS:
 
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2315,8 +2315,8 @@ external DNS:
 
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
@@ -2441,9 +2441,9 @@ external DNS:
 
 > # Should be a no-op
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
@@ -1769,12 +1769,9 @@ external DNS:
 > # If we try to plan again, nothing happens.
 > # The report should say why: These zones haven't propagated to inventory yet.
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 10, num_already_artifact: 10, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -1820,12 +1817,9 @@ generated inventory collection a71f7a73-35a6-45e8-acbe-f1c5925eed69 from configu
 > # This will refuse to bump the Nexus generation ("new Nexus zones
 > # are not in inventory yet")
 > blueprint-plan latest b1bda47d-2c19-4fba-96e3-d9df28db7436
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 10, num_already_artifact: 10, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (4) that is older than the generation in the parent blueprint (5)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -2065,7 +2059,9 @@ will use active Nexus zones from generation 2
 
 
 > # Now expungement can complete
-> # (Three Nexuses, expunged one at a time)
+> # (Three Nexuses, expunged one at a time). Apply each blueprint to inventory
+> # between plans so the noop check doesn't fire the inventory-stale path on
+> # subsequent iterations.
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 10, num_already_artifact: 10, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2195,6 +2191,18 @@ external DNS:
 
 
 
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
+
+> inventory-generate
+generated inventory collection 0b5efbb3-0b1b-4bbf-b7d8-a2d6fca074c6 from configured sleds
+
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2220,6 +2228,83 @@ from: blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1
 to:   blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300
 
  MODIFIED SLEDS:
+
+  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 6):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    ------------------------------
+    slot   boot image source      
+    ------------------------------
+    A      artifact: version 1.0.0
+    B      current contents       
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
+    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
+    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              feecfda1-9966-43d4-aaef-440b77f0b26d   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              956966b9-8201-437b-81ba-3c8ad2032080   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          6e218d0a-13fd-4f70-884e-47e960fa8bb8   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          9073fb6b-f973-4bbd-b7cc-ba1abf6cb238   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          0582030b-aab6-4d0e-b1d2-64562ee712cd   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   expunged      none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_nexus_4c6a45f3-6754-4082-a7dd-11d59b0127b1             94447abe-3fac-44d3-8551-c32d7bad6fab   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    100 GiB   none          gzip-9     
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/local_storage                                                   2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/local_storage                                                   09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/local_storage                                                   c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/local_storage_unencrypted                                             775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/local_storage_unencrypted                                             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/local_storage_unencrypted                                             2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   artifact: version 1.0.0   in service       fd00:1122:3344:102::5
+    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   artifact: version 1.0.0   in service       fd00:1122:3344:102::a
+    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   artifact: version 1.0.0   in service       fd00:1122:3344:102::8
+    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 1.0.0   in service       fd00:1122:3344:102::9
+    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 1.0.0   in service       fd00:1122:3344:102::7
+    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 1.0.0   in service       fd00:1122:3344:102::6
+    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 1.0.0   in service       fd00:1122:3344:1::1  
+    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 1.0.0   in service       fd00:1122:3344:102::3
+    nexus             4c6a45f3-6754-4082-a7dd-11d59b0127b1   artifact: version 1.0.0   in service       fd00:1122:3344:102::b
+*   nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:102::4
+     └─                                                                                + expunged ✓                          
+
 
   sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 5 -> 6):
 
@@ -2321,6 +2406,18 @@ external DNS:
 
 
 
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (12d602a6-5ab4-487a-b94e-eb30cdf30300)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (12d602a6-5ab4-487a-b94e-eb30cdf30300)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (12d602a6-5ab4-487a-b94e-eb30cdf30300)
+
+> inventory-generate
+generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
+
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2346,6 +2443,80 @@ from: blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300
 to:   blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839
 
  MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 6):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    ------------------------------
+    slot   boot image source      
+    ------------------------------
+    A      artifact: version 1.0.0
+    B      current contents       
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   expunged      none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_9882b9e4-9a10-48ef-bf78-0cc1317dadfe             3bda9c48-485c-4a66-aa3e-b5f53e622c00   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
+    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 1.0.0   in service       fd00:1122:3344:101::6
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 1.0.0   in service       fd00:1122:3344:101::5
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 1.0.0   in service       fd00:1122:3344:101::3
+    nexus             9882b9e4-9a10-48ef-bf78-0cc1317dadfe   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
+*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::4
+     └─                                                                                + expunged ✓                          
+
 
   sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 5 -> 6):
 
@@ -2449,6 +2620,18 @@ external DNS:
 
 
 > # Should be a no-op
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
+
+> inventory-generate
+generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
+
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2469,6 +2652,82 @@ empty planning report
 > blueprint-diff latest
 from: blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839
 to:   blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c
+
+ MODIFIED SLEDS:
+
+  sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 6):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    ------------------------------
+    slot   boot image source      
+    ------------------------------
+    A      artifact: version 1.0.0
+    B      current contents       
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-18b20749-0748-4105-bb10-7b13cfc776e2   in service 
+    fake-vendor   fake-model   serial-30c16fe4-4229-49d0-ab01-3138f2c7dff2   in service 
+    fake-vendor   fake-model   serial-4930954e-9ac7-4453-b63f-5ab97c389a99   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crucible                                                              ba9311dd-89ac-47db-a5e8-d64e8a5fcf70   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crucible                                                              3c2cb304-a466-4ab5-8597-5db8172e2388   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crucible                                                              41107868-c6cc-4ec4-9159-aed688c3ceaf   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/external_dns                                                    429da94b-19f7-48bd-98e9-47842863ba7b   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/internal_dns                                                    3443a368-199e-4d26-b59f-3f2bbd507761   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone                                                            45cd9687-20be-4247-b62a-dfdacf324929   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone                                                            252ac39f-b9e2-4697-8c07-3a833115d704   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone                                                            1cb0a47a-59ac-4892-8e92-cf87b4290f96   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone/oxz_crucible_694bd14f-cb24-4be4-bb19-876e79cda2c8          543fc3b8-08eb-4e5e-9e05-cf7a91732d5d   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone/oxz_crucible_7c252b64-c5af-4ec1-989e-9a03f3b0f111          3d9537b8-05be-4b1b-a051-f47becf8ec75   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_f55647d4-5500-4ad3-893a-df45bd50d622          c895e8d5-1434-4ecf-8d46-9bf1ecc8cbc9   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_pantry_75b220ba-a0f4-4872-8202-dc7c87f062d0   a50cd13a-5749-4e79-bb8b-19229500a8b3   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_external_dns_f6ec9c67-946a-4da3-98d5-581f72ce8bf0      6f04dd20-5e2c-4fa8-8430-a886470ed140   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_internal_dns_ea5b4030-b52f-44b2-8d70-45f15f987d01      7ea73f80-c4e0-450a-92dc-8397ce2af14f   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_nexus_3eeb8d49-eb1a-43f8-bb64-c2338421c2c6             50ea8c15-c4c0-4403-a490-d14b3405dfc2   expunged      none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone/oxz_nexus_a40e7821-3ec7-4aa9-995d-7d26ecec7d0f             b01627e2-a1db-4ac9-9eb3-8f2ce7a9e64d   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_ntp_f10a4fb9-759f-4a65-b25e-5794ad2d07d8               54bbadaf-ec04-41a2-a62f-f5ac5bf321be   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/debug                                                           7a6a2058-ea78-49de-9730-cce5e28b4cfb   in service    100 GiB   none          gzip-9     
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/debug                                                           21fd4f3a-ec31-469b-87b1-087c343a2422   in service    100 GiB   none          gzip-9     
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/debug                                                           b1deff4b-51df-4a37-9043-afbd7c70a1cb   in service    100 GiB   none          gzip-9     
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/local_storage                                                   41071985-1dfd-4ce5-8bc2-897161a8bce4   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/local_storage                                                   c65a9c1c-36dc-4ddb-8aac-ec3be8dbb209   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/local_storage                                                   090bd88d-0a43-4040-a832-b13ae721f74f   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/local_storage_unencrypted                                             e009d8b8-4695-4322-b53f-f03f2744aef7   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/local_storage_unencrypted                                             4da74a5b-6911-4cca-b624-b90c65530117   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/local_storage_unencrypted                                             96ae8389-3027-4260-9374-e0f6ce851de2   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    crucible          694bd14f-cb24-4be4-bb19-876e79cda2c8   artifact: version 1.0.0   in service       fd00:1122:3344:103::8
+    crucible          7c252b64-c5af-4ec1-989e-9a03f3b0f111   artifact: version 1.0.0   in service       fd00:1122:3344:103::9
+    crucible          f55647d4-5500-4ad3-893a-df45bd50d622   artifact: version 1.0.0   in service       fd00:1122:3344:103::7
+    crucible_pantry   75b220ba-a0f4-4872-8202-dc7c87f062d0   artifact: version 1.0.0   in service       fd00:1122:3344:103::6
+    external_dns      f6ec9c67-946a-4da3-98d5-581f72ce8bf0   artifact: version 1.0.0   in service       fd00:1122:3344:103::5
+    internal_dns      ea5b4030-b52f-44b2-8d70-45f15f987d01   artifact: version 1.0.0   in service       fd00:1122:3344:3::1  
+    internal_ntp      f10a4fb9-759f-4a65-b25e-5794ad2d07d8   artifact: version 1.0.0   in service       fd00:1122:3344:103::3
+    nexus             a40e7821-3ec7-4aa9-995d-7d26ecec7d0f   artifact: version 1.0.0   in service       fd00:1122:3344:103::a
+*   nexus             3eeb8d49-eb1a-43f8-bb64-c2338421c2c6   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:103::4
+     └─                                                                                + expunged ✓                          
+
 
  COCKROACHDB SETTINGS:
     state fingerprint:::::::::::::::::   (none) (unchanged)

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
@@ -2059,9 +2059,7 @@ will use active Nexus zones from generation 2
 
 
 > # Now expungement can complete
-> # (Three Nexuses, expunged one at a time). Apply each blueprint to inventory
-> # between plans so the noop check doesn't fire the inventory-stale path on
-> # subsequent iterations.
+> # (Three Nexuses, expunged one at a time)
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 10, num_already_artifact: 10, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2191,21 +2189,8 @@ external DNS:
 
 
 
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (8f2d1f39-7c88-4701-aa43-56bf281b28c1)
-
-> inventory-generate
-generated inventory collection 0b5efbb3-0b1b-4bbf-b7d8-a2d6fca074c6 from configured sleds
-
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2228,83 +2213,6 @@ from: blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1
 to:   blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300
 
  MODIFIED SLEDS:
-
-  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 6):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    ------------------------------
-    slot   boot image source      
-    ------------------------------
-    A      artifact: version 1.0.0
-    B      current contents       
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
-    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
-    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              feecfda1-9966-43d4-aaef-440b77f0b26d   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              956966b9-8201-437b-81ba-3c8ad2032080   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          6e218d0a-13fd-4f70-884e-47e960fa8bb8   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          9073fb6b-f973-4bbd-b7cc-ba1abf6cb238   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          0582030b-aab6-4d0e-b1d2-64562ee712cd   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   expunged      none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_nexus_4c6a45f3-6754-4082-a7dd-11d59b0127b1             94447abe-3fac-44d3-8551-c32d7bad6fab   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    100 GiB   none          gzip-9     
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/local_storage                                                   2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/local_storage                                                   09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/local_storage                                                   c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/local_storage_unencrypted                                             775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/local_storage_unencrypted                                             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/local_storage_unencrypted                                             2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
-
-
-    omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   artifact: version 1.0.0   in service       fd00:1122:3344:102::5
-    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   artifact: version 1.0.0   in service       fd00:1122:3344:102::a
-    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   artifact: version 1.0.0   in service       fd00:1122:3344:102::8
-    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 1.0.0   in service       fd00:1122:3344:102::9
-    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 1.0.0   in service       fd00:1122:3344:102::7
-    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 1.0.0   in service       fd00:1122:3344:102::6
-    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 1.0.0   in service       fd00:1122:3344:1::1  
-    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 1.0.0   in service       fd00:1122:3344:102::3
-    nexus             4c6a45f3-6754-4082-a7dd-11d59b0127b1   artifact: version 1.0.0   in service       fd00:1122:3344:102::b
-*   nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:102::4
-     └─                                                                                + expunged ✓                          
-
 
   sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 5 -> 6):
 
@@ -2406,23 +2314,9 @@ external DNS:
 
 
 
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (12d602a6-5ab4-487a-b94e-eb30cdf30300)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (12d602a6-5ab4-487a-b94e-eb30cdf30300)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (12d602a6-5ab4-487a-b94e-eb30cdf30300)
-
-> inventory-generate
-generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
-
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
@@ -2443,80 +2337,6 @@ from: blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300
 to:   blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839
 
  MODIFIED SLEDS:
-
-  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 6):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    ------------------------------
-    slot   boot image source      
-    ------------------------------
-    A      artifact: version 1.0.0
-    B      current contents       
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
-    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
-    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   expunged      none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_9882b9e4-9a10-48ef-bf78-0cc1317dadfe             3bda9c48-485c-4a66-aa3e-b5f53e622c00   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
-
-
-    omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
-    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
-    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
-    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 1.0.0   in service       fd00:1122:3344:101::6
-    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 1.0.0   in service       fd00:1122:3344:101::5
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
-    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 1.0.0   in service       fd00:1122:3344:101::3
-    nexus             9882b9e4-9a10-48ef-bf78-0cc1317dadfe   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
-*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::4
-     └─                                                                                + expunged ✓                          
-
 
   sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 5 -> 6):
 
@@ -2620,25 +2440,10 @@ external DNS:
 
 
 > # Should be a no-op
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (61a93ea3-c872-48e0-aace-e86b0c52b839)
-
-> inventory-generate
-generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
-
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (5) that is older than the generation in the parent blueprint (6)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -2652,82 +2457,6 @@ empty planning report
 > blueprint-diff latest
 from: blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839
 to:   blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c
-
- MODIFIED SLEDS:
-
-  sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 6):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    ------------------------------
-    slot   boot image source      
-    ------------------------------
-    A      artifact: version 1.0.0
-    B      current contents       
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-18b20749-0748-4105-bb10-7b13cfc776e2   in service 
-    fake-vendor   fake-model   serial-30c16fe4-4229-49d0-ab01-3138f2c7dff2   in service 
-    fake-vendor   fake-model   serial-4930954e-9ac7-4453-b63f-5ab97c389a99   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crucible                                                              ba9311dd-89ac-47db-a5e8-d64e8a5fcf70   in service    none      none          off        
-    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crucible                                                              3c2cb304-a466-4ab5-8597-5db8172e2388   in service    none      none          off        
-    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crucible                                                              41107868-c6cc-4ec4-9159-aed688c3ceaf   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/external_dns                                                    429da94b-19f7-48bd-98e9-47842863ba7b   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/internal_dns                                                    3443a368-199e-4d26-b59f-3f2bbd507761   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone                                                            45cd9687-20be-4247-b62a-dfdacf324929   in service    none      none          off        
-    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone                                                            252ac39f-b9e2-4697-8c07-3a833115d704   in service    none      none          off        
-    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone                                                            1cb0a47a-59ac-4892-8e92-cf87b4290f96   in service    none      none          off        
-    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone/oxz_crucible_694bd14f-cb24-4be4-bb19-876e79cda2c8          543fc3b8-08eb-4e5e-9e05-cf7a91732d5d   in service    none      none          off        
-    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone/oxz_crucible_7c252b64-c5af-4ec1-989e-9a03f3b0f111          3d9537b8-05be-4b1b-a051-f47becf8ec75   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_f55647d4-5500-4ad3-893a-df45bd50d622          c895e8d5-1434-4ecf-8d46-9bf1ecc8cbc9   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_pantry_75b220ba-a0f4-4872-8202-dc7c87f062d0   a50cd13a-5749-4e79-bb8b-19229500a8b3   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_external_dns_f6ec9c67-946a-4da3-98d5-581f72ce8bf0      6f04dd20-5e2c-4fa8-8430-a886470ed140   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_internal_dns_ea5b4030-b52f-44b2-8d70-45f15f987d01      7ea73f80-c4e0-450a-92dc-8397ce2af14f   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_nexus_3eeb8d49-eb1a-43f8-bb64-c2338421c2c6             50ea8c15-c4c0-4403-a490-d14b3405dfc2   expunged      none      none          off        
-    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone/oxz_nexus_a40e7821-3ec7-4aa9-995d-7d26ecec7d0f             b01627e2-a1db-4ac9-9eb3-8f2ce7a9e64d   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_ntp_f10a4fb9-759f-4a65-b25e-5794ad2d07d8               54bbadaf-ec04-41a2-a62f-f5ac5bf321be   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/debug                                                           7a6a2058-ea78-49de-9730-cce5e28b4cfb   in service    100 GiB   none          gzip-9     
-    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/debug                                                           21fd4f3a-ec31-469b-87b1-087c343a2422   in service    100 GiB   none          gzip-9     
-    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/debug                                                           b1deff4b-51df-4a37-9043-afbd7c70a1cb   in service    100 GiB   none          gzip-9     
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/local_storage                                                   41071985-1dfd-4ce5-8bc2-897161a8bce4   in service    none      none          off        
-    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/local_storage                                                   c65a9c1c-36dc-4ddb-8aac-ec3be8dbb209   in service    none      none          off        
-    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/local_storage                                                   090bd88d-0a43-4040-a832-b13ae721f74f   in service    none      none          off        
-    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/local_storage_unencrypted                                             e009d8b8-4695-4322-b53f-f03f2744aef7   in service    none      none          off        
-    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/local_storage_unencrypted                                             4da74a5b-6911-4cca-b624-b90c65530117   in service    none      none          off        
-    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/local_storage_unencrypted                                             96ae8389-3027-4260-9374-e0f6ce851de2   in service    none      none          off        
-
-
-    omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    crucible          694bd14f-cb24-4be4-bb19-876e79cda2c8   artifact: version 1.0.0   in service       fd00:1122:3344:103::8
-    crucible          7c252b64-c5af-4ec1-989e-9a03f3b0f111   artifact: version 1.0.0   in service       fd00:1122:3344:103::9
-    crucible          f55647d4-5500-4ad3-893a-df45bd50d622   artifact: version 1.0.0   in service       fd00:1122:3344:103::7
-    crucible_pantry   75b220ba-a0f4-4872-8202-dc7c87f062d0   artifact: version 1.0.0   in service       fd00:1122:3344:103::6
-    external_dns      f6ec9c67-946a-4da3-98d5-581f72ce8bf0   artifact: version 1.0.0   in service       fd00:1122:3344:103::5
-    internal_dns      ea5b4030-b52f-44b2-8d70-45f15f987d01   artifact: version 1.0.0   in service       fd00:1122:3344:3::1  
-    internal_ntp      f10a4fb9-759f-4a65-b25e-5794ad2d07d8   artifact: version 1.0.0   in service       fd00:1122:3344:103::3
-    nexus             a40e7821-3ec7-4aa9-995d-7d26ecec7d0f   artifact: version 1.0.0   in service       fd00:1122:3344:103::a
-*   nexus             3eeb8d49-eb1a-43f8-bb64-c2338421c2c6   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:103::4
-     └─                                                                                + expunged ✓                          
-
 
  COCKROACHDB SETTINGS:
     state fingerprint:::::::::::::::::   (none) (unchanged)

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-noop-image-source-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-noop-image-source-stdout
@@ -95,6 +95,12 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 mupdate override: unset -> fffffff
 > blueprint-edit latest set-remove-mupdate-override serial2 ffffffff-ffff-ffff-ffff-ffffffffffff
 blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 created from latest blueprint (dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21): set remove_mupdate_override to ffffffff-ffff-ffff-ffff-ffffffffffff
 
+> # Apply the latest blueprint to serial2's inventory so that the noop check
+> # exercises the mupdate-override-set-in-blueprint path rather than firing
+> # inventory-stale on the bumped sled-agent generation.
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (8da82a8e-bf97-4fbd-8ddd-9f6462732cf1)
+
 
 > # On a fourth sled, simulate an error validating the install dataset image on one zone.
 > # We pick ntp because internal-ntp is non-discretionary.
@@ -440,6 +446,20 @@ external DNS:
 > # Bring the hidden sled back.
 > sled-set serial6 inventory-visible
 set sled e96e226f-4ed9-4c01-91b9-69a9cd076c9e inventory visibility: hidden -> visible
+
+
+> # The first plan bumped the sled-agent generation on the sleds where it did
+> # noop conversions (serial0, serial3) and where it set remove_mupdate_override
+> # (serial2). Apply that blueprint to those sleds' inventories so the next
+> # plan's noop check doesn't fire the inventory-stale path for them.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (58d5e830-0884-47d8-a7cd-b2b3751adeb4)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (58d5e830-0884-47d8-a7cd-b2b3751adeb4)
+
+> sled-set serial3 omicron-config latest
+set sled aff6c093-197d-42c5-ad80-9f10ba051a34 omicron config from latest blueprint (58d5e830-0884-47d8-a7cd-b2b3751adeb4)
 
 
 > # Run another inventory and blueprint planning step.

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-noop-stale-inventory-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-noop-stale-inventory-stdout
@@ -264,8 +264,7 @@ external DNS:
 
 
 > # Apply the latest blueprint to inventory and re-plan. inventory_gen now
-> # matches parent_bp_gen, the noop check runs, and zones convert to Artifact
-> # as expected.
+> # matches parent_bp_gen, and zones are noop-converted to Artifact as expected.
 > sled-set serial0 omicron-config latest
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (58d5e830-0884-47d8-a7cd-b2b3751adeb4)
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-noop-stale-inventory-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-noop-stale-inventory-stdout
@@ -1,22 +1,19 @@
 using provided RNG seed: reconfigurator-cli-test
-> # This test exercises the bug where, in the mupdate override flow, the planner
-> # would clear `remove_mupdate_override` from a sled's blueprint based on stale
-> # inventory -- specifically, an inventory collection that was captured before
-> # the sled was mupdated, so the override marker isn't visible in it.
+> # This test exercises a guarantee of the inventory-staleness check
+> # in `NoopConvertInfo::new`: the planner must not perform noop conversions of
+> # zone image sources from InstallDataset to Artifact when planning against an
+> # inventory that's older than the parent blueprint, even when no mupdate
+> # override is involved.
 > #
-> # Acting on stale inventory in this way could cause the planner to acknowledge
-> # a sled recovery that hasn't happened, breaking the edge-triggered
-> # mupdate override semantics. The fix is to mark a sled as ineligible for
-> # both noop conversion and mupdate override clearing whenever the inventory's
-> # reported sled-agent generation is older than the generation in the parent
-> # blueprint.
-> #
-> # The test simulates two plans against the same parent blueprint: one against
-> # the latest (post-mupdate) inventory, and one against a stale (pre-mupdate)
-> # inventory. With the fix, planning against the stale inventory leaves
-> # remove_mupdate_override alone instead of clearing it.
+> # The test simulates: zones that would be eligible for a noop conversion to
+> # Artifact, an unrelated edit that bumps the parent blueprint's sled-agent
+> # generation past what inventory reports, and then a plan against that now-
+> # stale inventory. With the fix, the planner skips the noop check on the
+> # bumped sled and the resulting blueprint contains no zone image source
+> # changes. Once inventory is up-to-date, the next plan proceeds with the
+> # noop conversions as expected.
 
-> # Load a small example system. We only need one sled to demonstrate the bug.
+> # Load a small example system. We only need one sled to demonstrate the case.
 > load-example --nsleds 1 --ndisks-per-sled 3
 loaded example system with:
 - collection: f45ba181-4b56-42cc-a762-874d90184a43
@@ -27,7 +24,8 @@ ID                                   SERIAL  NZPOOLS SUBNET
 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 serial0 3       fd00:1122:3344:101::/64 
 
 
-> # Create a TUF repository so noop image source conversions are possible.
+> # Create a TUF repository whose artifacts match the install dataset, so noop
+> # conversions of all zones would otherwise be eligible.
 > tuf-assemble ../../update-common/manifests/fake.toml
 INFO assembling repository in <ASSEMBLING_REPOSITORY_IN_REDACTED>
 INFO artifacts assembled and archived to `repo-1.0.0.zip`, component: OmicronRepoAssembler
@@ -70,90 +68,23 @@ INFO added artifact, name: installinator_document, kind: installinator_document,
 set target release based on repo-1.0.0.zip
 
 
-> # Update the install dataset on serial0 to the target release.
+> # Update the install dataset on serial0 to the target release. This populates
+> # the simulated sled-agent's zone/measurement manifests but does not bump its
+> # reported sled-agent generation.
 > sled-update-install-dataset serial0 --to-target-release
 sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: install dataset updated: to target release (system version 1.0.0)
 
 
-> # Generate the FIRST inventory collection. At this point the sled has no
-> # mupdate override visible. We'll come back to this collection later to plan
-> # against it as a "stale" inventory.
+> # Generate inventory. At this point the sled's reported sled-agent generation
+> # matches the parent blueprint's: noop conversions would be eligible.
 > inventory-generate
 generated inventory collection eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 from configured sleds
 
-> inventory-list
-ID                                   NERRORS TIME_DONE                
-f45ba181-4b56-42cc-a762-874d90184a43 0       <REDACTED_TIMESTAMP> 
-eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 0       <REDACTED_TIMESTAMP> 
 
-
-> # Simulate a mupdate on serial0 by setting the mupdate override field. The
-> # sled's reconciled config generation is unchanged -- the mupdate override is
-> # tracked separately.
-> sled-set serial0 mupdate-override 11111111-1111-1111-1111-111111111111
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 mupdate override: unset -> 11111111-1111-1111-1111-111111111111
-
-
-> # Generate a SECOND inventory collection, post-mupdate. This one has the
-> # override visible.
-> inventory-generate
-generated inventory collection 61f451b3-2121-4ed6-91c7-a550054f6c21 from configured sleds
-
-> inventory-list
-ID                                   NERRORS TIME_DONE                
-f45ba181-4b56-42cc-a762-874d90184a43 0       <REDACTED_TIMESTAMP> 
-eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 0       <REDACTED_TIMESTAMP> 
-61f451b3-2121-4ed6-91c7-a550054f6c21 0       <REDACTED_TIMESTAMP> 
-
-
-> # Plan against the latest (post-mupdate) inventory. This should set
-> # `remove_mupdate_override` on serial0 in the new blueprint and bump its
-> # sled-agent generation.
-> blueprint-plan latest latest
-INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, new_bp_override: 11111111-1111-1111-1111-111111111111, prev_bp_override: None, zones: 
-  - zone 005548be-c5e4-49ff-a27b-88f314f1bc51 (ExternalDns) left unchanged, image source: install dataset
-  - zone 10676bfe-b61f-40e1-bc07-a4cb76ea1f30 (Clickhouse) left unchanged, image source: install dataset
-  - zone 2205353a-e1d2-48ff-863b-9d6b1487d474 (ExternalDns) left unchanged, image source: install dataset
-  - zone 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4 (Nexus) left unchanged, image source: install dataset
-  - zone 2de1c525-4e04-4ba6-ac6b-377aaa542f96 (CruciblePantry) left unchanged, image source: install dataset
-  - zone 31b26053-8b94-4d8c-9e4a-d7d720afe265 (CruciblePantry) left unchanged, image source: install dataset
-  - zone 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe (Nexus) left unchanged, image source: install dataset
-  - zone 3d9b7487-d7b9-4e25-960f-f2086f3e2919 (Crucible) left unchanged, image source: install dataset
-  - zone 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035 (InternalDns) left unchanged, image source: install dataset
-  - zone 45ce130e-c5ac-4e26-ab73-7589ba634418 (InternalDns) left unchanged, image source: install dataset
-  - zone 4b19d194-8b25-4396-88da-3df1b3788601 (Crucible) left unchanged, image source: install dataset
-  - zone 70aab480-3d6c-47d5-aaf9-8d2ddab2931c (ExternalDns) left unchanged, image source: install dataset
-  - zone 9b135c74-c09a-4dcc-ba19-f6f8deae135a (InternalNtp) left unchanged, image source: install dataset
-  - zone a7b7bfbe-0588-4781-9a5e-fba63584e5d2 (InternalDns) left unchanged, image source: install dataset
-  - zone c204730a-0946-4793-a470-64c88e89da96 (Crucible) left unchanged, image source: install dataset
-  - zone c2cbbf34-b852-4164-a572-01d4d79445a1 (Nexus) left unchanged, image source: install dataset
-  - zone f87ada51-4419-4144-86a8-e5e4ff0f64d3 (CruciblePantry) left unchanged, image source: install dataset
-, host_phase_2: 
-  - host phase 2 slot A: current contents (unchanged)
-  - host phase 2 slot B: current contents (unchanged)
-, measurements: (unknown)
-INFO no previous MGS update found as part of updating blueprint mupdate override to match inventory, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
-INFO updating target release minimum generation based on new set-override actions, phase: do_plan_mupdate_override, current_generation: 1, new_generation: 3
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (11111111-1111-1111-1111-111111111111)
-generated blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 based on parent blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
-blueprint source: planner with report:
-planning report:
-* zone adds waiting on blockers
-* zone adds and updates are blocked:
-  - current target release generation (2) is lower than minimum required by blueprint (3)
-  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
-  - sleds have deployment units with image sources not set to Artifact:
-    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 17 zones
-
-  - sleds have measurements with image sources not set to Artifact:
-    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 set to install dataset
-
-* zone updates waiting on zone add blockers
-* waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
-Measurement updates:
-Waiting on zone add/update blockers
-
-
+> # Bump the parent blueprint's sled-agent generation for serial0 via the debug
+> # command. This simulates a blueprint edit that bumps the generation.
+> blueprint-edit latest debug force-sled-generation-bump serial0
+blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 created from latest blueprint (dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21): debug: forced sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 generation bump
 
 > blueprint-diff latest
 from: blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
@@ -162,14 +93,12 @@ to:   blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
  MODIFIED SLEDS:
 
   sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2 -> 3):
-+   will remove mupdate override:   (none) -> 11111111-1111-1111-1111-111111111111
 
     measurements:
-    -----------------------------------
-    hash              version          
-    -----------------------------------
--   unknown           (unknown version)
-+   install dataset   (no version)     
+    ---------------------------
+    hash      version          
+    ---------------------------
+    unknown   (unknown version)
 
 
     host phase 2 contents:
@@ -264,7 +193,7 @@ to:   blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
  METADATA:
     internal DNS version:::   1 (unchanged)
     external DNS version:::   1 (unchanged)
-*   target release min gen:   1 -> 3
+    target release min gen:   1 (unchanged)
     nexus gen::::::::::::::   1 (unchanged)
 
  OXIMETER SETTINGS:
@@ -283,36 +212,19 @@ external DNS:
 
 
 
-> # Now plan against the first (pre-mupdate) inventory collection. That
-> # inventory shows no mupdate override on serial0, but only because the
-> # inventory was captured before the mupdate ever happened. The parent
-> # blueprint's sled-agent generation for serial0 is now ahead of what this
-> # stale inventory reports.
-> #
-> # The collection ID below is the deterministic UUID for the first
-> # `inventory-generate` above (driven by the test harness's --seed argument).
-> #
-> # Without the fix, the planner would treat the absence of the override in
-> # this stale inventory as evidence that the sled has recovered, and clear
-> # `remove_mupdate_override` from the blueprint. With the fix, the planner
-> # correctly identifies the inventory as stale (inv gen < parent bp gen) and
-> # leaves `remove_mupdate_override` alone, logging
-> # "blueprint override could not be cleared, ... reason: inventory stale".
-> blueprint-plan latest eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51
-INFO inventory override no longer exists, but blueprint override could not be cleared, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, bp_override: 11111111-1111-1111-1111-111111111111, reason: this sled cannot be noop-converted to Artifact: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+> # Plan against the same inventory. The noop check should fire the
+> # inventory-stale path on serial0, the noop conversion of zones to Artifact
+> # should be skipped, and the resulting blueprint should contain no zone
+> # image source changes for serial0.
+> blueprint-plan latest latest
 INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)
 generated blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4 based on parent blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
 blueprint source: planner with report:
 planning report:
 * zone adds waiting on blockers
 * zone adds and updates are blocked:
-  - current target release generation (2) is lower than minimum required by blueprint (3)
-  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
   - sleds have deployment units with image sources not set to Artifact:
     - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 17 zones
-
-  - sleds have measurements with image sources not set to Artifact:
-    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 set to install dataset
 
 * zone updates waiting on zone add blockers
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
@@ -332,7 +244,175 @@ to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
  METADATA:
     internal DNS version:::   1 (unchanged)
     external DNS version:::   1 (unchanged)
-    target release min gen:   3 (unchanged)
+    target release min gen:   1 (unchanged)
+    nexus gen::::::::::::::   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    unchanged names: 36 (records: 48)
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    unchanged names: 5 (records: 9)
+
+
+
+
+> # Apply the latest blueprint to inventory and re-plan. inventory_gen now
+> # matches parent_bp_gen, the noop check runs, and zones convert to Artifact
+> # as expected.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (58d5e830-0884-47d8-a7cd-b2b3751adeb4)
+
+> inventory-generate
+generated inventory collection 61f451b3-2121-4ed6-91c7-a550054f6c21 from configured sleds
+
+> blueprint-plan latest latest
+INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 17, num_already_artifact: 0, num_eligible: 17, num_ineligible: 0
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO current sled measurements are in an unknown state, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+generated blueprint af934083-59b5-4bf6-8966-6fb5292c29e1 based on parent blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+blueprint source: planner with report:
+planning report:
+* noop converting 17/17 install-dataset zones to artifact store on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+* zone updates waiting on reference measurement changes
+Measurement updates:
+1 modifications
+
+
+
+> blueprint-diff latest
+from: blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+to:   blueprint af934083-59b5-4bf6-8966-6fb5292c29e1
+
+ MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 3 -> 4):
+
+    measurements:
+    ------------------------------------------------------------------------------------
+    hash                                                               version          
+    ------------------------------------------------------------------------------------
+-   unknown                                                            (unknown version)
++   8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0    
+
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              42bd3fb3-2aae-4754-9c41-0f9b50a77322   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              b7813bc0-d5ee-487d-95ad-6c5cce6fdcd6   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6dd64de1-7dd3-492c-830f-d4a4e4c3dda7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/clickhouse                                                      b1007e3d-7aaf-4ccb-9773-241dcbf79b21   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    d3cd3ec4-703f-4e73-8cc2-b4bc19c7d596   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/external_dns                                                    c7e90d9c-22db-43ca-a602-2a295bac7eec   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/external_dns                                                    bef875a9-3cf1-4b02-9682-c0286fb23d4d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    66788e15-bb3a-4369-a5cb-3357f7b85f64   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/internal_dns                                                    d88eb02f-b66d-4ae7-91a1-23154417c1f1   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/internal_dns                                                    ebfd425c-4e5d-4385-a105-8f2ce32fa9ec   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            e4b83186-c6e2-4d33-ae1b-803c32d1a86e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            20cb5d98-bcd7-4a11-9190-7570a0aa6fe0   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            aa860565-2bbb-4a70-ae8e-7d8f29f1a536   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_clickhouse_10676bfe-b61f-40e1-bc07-a4cb76ea1f30        3523db58-10ab-4e2c-95d9-fec43036c0f5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_3d9b7487-d7b9-4e25-960f-f2086f3e2919          32bb65ae-855f-461b-9203-32b2ddfe5a64   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_4b19d194-8b25-4396-88da-3df1b3788601          dd1954a2-7848-4950-a694-38870c339d3e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_c204730a-0946-4793-a470-64c88e89da96          f3ddb3ca-388d-4462-9fc8-e552cf7de668   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_pantry_2de1c525-4e04-4ba6-ac6b-377aaa542f96   c6d7ecb4-135c-4f09-8948-b73fec13db76   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_31b26053-8b94-4d8c-9e4a-d7d720afe265   d4f66eab-2870-4a74-b4d5-ae5da3276682   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_pantry_f87ada51-4419-4144-86a8-e5e4ff0f64d3   f822a7e2-28aa-4ae2-ba86-d4e552a15bcb   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_external_dns_005548be-c5e4-49ff-a27b-88f314f1bc51      0c7e4b2a-502a-4f4c-8ac4-4068db25252e   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_external_dns_2205353a-e1d2-48ff-863b-9d6b1487d474      8355e747-b375-4d9e-b5da-03d9540ab5cd   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_70aab480-3d6c-47d5-aaf9-8d2ddab2931c      49dc7c86-c865-457f-8d58-37b92b002691   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_internal_dns_3fd06852-06cb-4d8a-b4b2-eb88ff5a6035      506ddf0e-8cbf-44a9-93d7-130a550fd42d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_45ce130e-c5ac-4e26-ab73-7589ba634418      d1611973-b22d-4097-b6fd-0a480f2199a5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_internal_dns_a7b7bfbe-0588-4781-9a5e-fba63584e5d2      382cbbf2-8b08-4388-839a-b43b8bc82999   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_nexus_2bc0b0c4-63a9-44cc-afff-76ce645ef1d4             6b672182-6d17-41d5-81d7-19debe7d3f9b   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe             8b89525f-0764-4937-9fa8-022242647c0f   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_c2cbbf34-b852-4164-a572-01d4d79445a1             ac802759-2ac3-4c5c-b8e7-6d51689e1537   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_9b135c74-c09a-4dcc-ba19-f6f8deae135a               8144f1ee-dbef-45c1-9397-2031a9ca8b38   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           38fafd69-0275-4f4d-885d-3bbf2ea77551   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           ba445402-2775-4f97-87e9-640be3a00c6f   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           4d322f8a-d461-4ead-995b-9ba7d76becad   in service    100 GiB   none          gzip-9     
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cb8d5371-640d-4364-8a5e-0fde125d28af   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   f4ea4a15-b3b3-4a67-b61a-8fba7c7ab61f   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   647f344c-b4c5-4788-a732-40658e852f63   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             f306ebde-464c-49ef-94eb-1d72cf9afc7e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             2aeeb036-0e23-419f-82f7-9ab04c06d7ec   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             53e5b466-aac5-4cf0-a93b-9f68f58ac755   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source                disposition   underlay IP           
+    -------------------------------------------------------------------------------------------------------------------------
+*   clickhouse        10676bfe-b61f-40e1-bc07-a4cb76ea1f30   - install dataset           in service    fd00:1122:3344:101::7 
+     └─                                                      + artifact: version 1.0.0                                       
+*   crucible          3d9b7487-d7b9-4e25-960f-f2086f3e2919   - install dataset           in service    fd00:1122:3344:101::10
+     └─                                                      + artifact: version 1.0.0                                       
+*   crucible          4b19d194-8b25-4396-88da-3df1b3788601   - install dataset           in service    fd00:1122:3344:101::f 
+     └─                                                      + artifact: version 1.0.0                                       
+*   crucible          c204730a-0946-4793-a470-64c88e89da96   - install dataset           in service    fd00:1122:3344:101::e 
+     └─                                                      + artifact: version 1.0.0                                       
+*   crucible_pantry   2de1c525-4e04-4ba6-ac6b-377aaa542f96   - install dataset           in service    fd00:1122:3344:101::d 
+     └─                                                      + artifact: version 1.0.0                                       
+*   crucible_pantry   31b26053-8b94-4d8c-9e4a-d7d720afe265   - install dataset           in service    fd00:1122:3344:101::b 
+     └─                                                      + artifact: version 1.0.0                                       
+*   crucible_pantry   f87ada51-4419-4144-86a8-e5e4ff0f64d3   - install dataset           in service    fd00:1122:3344:101::c 
+     └─                                                      + artifact: version 1.0.0                                       
+*   external_dns      005548be-c5e4-49ff-a27b-88f314f1bc51   - install dataset           in service    fd00:1122:3344:101::9 
+     └─                                                      + artifact: version 1.0.0                                       
+*   external_dns      2205353a-e1d2-48ff-863b-9d6b1487d474   - install dataset           in service    fd00:1122:3344:101::a 
+     └─                                                      + artifact: version 1.0.0                                       
+*   external_dns      70aab480-3d6c-47d5-aaf9-8d2ddab2931c   - install dataset           in service    fd00:1122:3344:101::8 
+     └─                                                      + artifact: version 1.0.0                                       
+*   internal_dns      3fd06852-06cb-4d8a-b4b2-eb88ff5a6035   - install dataset           in service    fd00:1122:3344:2::1   
+     └─                                                      + artifact: version 1.0.0                                       
+*   internal_dns      45ce130e-c5ac-4e26-ab73-7589ba634418   - install dataset           in service    fd00:1122:3344:1::1   
+     └─                                                      + artifact: version 1.0.0                                       
+*   internal_dns      a7b7bfbe-0588-4781-9a5e-fba63584e5d2   - install dataset           in service    fd00:1122:3344:3::1   
+     └─                                                      + artifact: version 1.0.0                                       
+*   internal_ntp      9b135c74-c09a-4dcc-ba19-f6f8deae135a   - install dataset           in service    fd00:1122:3344:101::3 
+     └─                                                      + artifact: version 1.0.0                                       
+*   nexus             2bc0b0c4-63a9-44cc-afff-76ce645ef1d4   - install dataset           in service    fd00:1122:3344:101::6 
+     └─                                                      + artifact: version 1.0.0                                       
+*   nexus             3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe   - install dataset           in service    fd00:1122:3344:101::5 
+     └─                                                      + artifact: version 1.0.0                                       
+*   nexus             c2cbbf34-b852-4164-a572-01d4d79445a1   - install dataset           in service    fd00:1122:3344:101::4 
+     └─                                                      + artifact: version 1.0.0                                       
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   1 (unchanged)
     nexus gen::::::::::::::   1 (unchanged)
 
  OXIMETER SETTINGS:

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
@@ -1780,7 +1780,7 @@ external DNS:
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1841,7 +1841,7 @@ generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1901,7 +1901,7 @@ generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1961,7 +1961,7 @@ generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2035,7 +2035,7 @@ generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2103,7 +2103,7 @@ generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2175,7 +2175,7 @@ generated inventory collection b5263998-e486-4cea-8842-b32bd326fa3a from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2243,7 +2243,7 @@ generated inventory collection 68767302-7fed-4eb1-9611-3dfd807ff0cd from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2314,7 +2314,7 @@ generated inventory collection 62898097-2ff1-48d0-8bc1-91b475daa33d from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2383,7 +2383,7 @@ generated inventory collection 3086f142-62d3-4f77-bda3-674afbb42d0d from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2530,8 +2530,8 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 1 details: B -> fffffff
 generated inventory collection ae5b3bb4-ce21-465f-b18e-857614732d66 from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2601,8 +2601,8 @@ generated inventory collection 34c3258c-b2ab-4da9-9720-41a3a703c3d7 from configu
 > # Another planning step should try to update the last sled, starting with the
 > # RoT bootloader.
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2669,8 +2669,8 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT bootloader versions: stage0 ->
 generated inventory collection 5e106b73-6a14-4955-b8a8-a4f8afed6405 from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2739,8 +2739,8 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.0.0, act
 generated inventory collection 36ef425f-a672-4bf4-8d29-14815a84ccad from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2811,8 +2811,8 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.1.0, act
 generated inventory collection 70bea701-e212-4877-8e6c-925f1f73ddd2 from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2880,8 +2880,8 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.1.0, act
 generated inventory collection 8187f847-81c7-4750-88ac-d691937461af from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2947,8 +2947,8 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.0.0, act
 generated inventory collection 45c1c7bb-984a-43f7-bb3f-4a5437ed7b82 from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -3013,8 +3013,8 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 SP versions: active -> 1.0.0
 generated inventory collection ca7f27e8-5949-4ac1-8f32-18ad76d9c217 from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -3157,9 +3157,9 @@ generated inventory collection 8a02a1c6-9e86-4dc0-9293-cd17da34f319 from configu
 
 > # Do another planning run. This should start updating zones (one at a time).
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO MGS-driven update completed (will remove it and re-evaluate board), artifact_version: 1.0.0, artifact_hash: b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b, sled_agent_address: [fd00:1122:3344:103::1]:12345, expected_inactive_phase_2_hash: d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 2, sp_type: Sled, serial_number: serial2, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
@@ -3301,8 +3301,8 @@ generated inventory collection c1adcd42-121f-4580-bfb9-d8a9937ca9e1 from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -3448,8 +3448,8 @@ generated inventory collection 94b231f9-80a3-48a9-8d25-70f9b42b64ca from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -3592,8 +3592,8 @@ generated inventory collection 756aecb6-8353-46ad-a6c4-10ad0f2bbb7f from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -3750,8 +3750,8 @@ generated inventory collection 84152e52-8c2e-46ab-880e-4cc2a1fb9dcb from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -3909,8 +3909,8 @@ generated inventory collection bcfc7436-77de-47e4-8158-daad15a54da2 from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4046,8 +4046,8 @@ generated inventory collection 6dbdc88a-4828-480e-b41d-8946f41a3134 from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4207,8 +4207,8 @@ generated inventory collection eb500068-cd91-484b-a532-51081571ecbe from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4369,8 +4369,8 @@ generated inventory collection 4492baf6-5638-4c1f-bba2-608163519022 from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4518,8 +4518,8 @@ generated inventory collection 73f58d4d-6be7-4007-811c-0e578279410e from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4668,8 +4668,8 @@ generated inventory collection 74448e29-ef07-4d7f-9d31-39079eba8296 from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4810,8 +4810,8 @@ generated inventory collection a815c282-5564-4cea-b667-a7a5295fc2c1 from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4955,8 +4955,8 @@ generated inventory collection 18ca4fd2-190d-4ac5-b0f3-14a384bcd254 from configu
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5087,7 +5087,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5238,7 +5238,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5390,7 +5390,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5523,7 +5523,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5665,7 +5665,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5810,7 +5810,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5966,7 +5966,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6123,7 +6123,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6270,7 +6270,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6418,7 +6418,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6561,7 +6561,7 @@ INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -8626,7 +8626,7 @@ blueprint 6d830d26-547e-492b-adfe-c5c4ad9c3751 created from latest blueprint (47
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 10, num_already_artifact: 10, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (16) that is older than the generation in the parent blueprint (17)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (16) that is older than the generation in the parent blueprint (17)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
@@ -9000,7 +9000,7 @@ external DNS:
 > # Two more planning iterations should expunge the remaining two old 0.0.1
 > # version Nexus zones.
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (17) that is older than the generation in the parent blueprint (18)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (17) that is older than the generation in the parent blueprint (18)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -9137,8 +9137,8 @@ external DNS:
 
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (17) that is older than the generation in the parent blueprint (18)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (18) that is older than the generation in the parent blueprint (19)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (17) that is older than the generation in the parent blueprint (18)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (18) that is older than the generation in the parent blueprint (19)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
@@ -1775,6 +1775,17 @@ external DNS:
 
 
 
+> # The plan above scheduled a host phase 2 update, which bumped serial0's
+> # sled-agent generation in the blueprint. Apply the latest blueprint to
+> # inventory so subsequent plans aren't blocked by the inventory-stale check
+> # in the noop image source path.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
+
+> inventory-generate
+generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
+
+
 > # If we generate another plan, there should be no change.
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -1833,7 +1844,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 details: B -> d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
 
 > inventory-generate
-generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
+generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
 
 
 > # Planning after only phase 2 has changed should make no changes. We're still
@@ -1894,7 +1905,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 1 details: active -> B, B -> b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 
 > inventory-generate
-generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
+generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configured sleds
 
 
 > # Planning _still_ shouldn't make any new changes; the OS update as a whole
@@ -1955,7 +1966,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 details: boot_disk -> B
 
 > inventory-generate
-generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configured sleds
+generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configured sleds
 
 
 > # Planning should now remove the host OS update and plan the next RoT bootloader
@@ -2022,6 +2033,16 @@ external DNS:
 
 
 
+> # Apply the latest blueprint to serial0's inventory so the next plans (which
+> # work on serial1's MGS chain) aren't shadowed by an inventory-stale check on
+> # serial0.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (afb09faf-a586-4483-9289-04d4f1d8ba23)
+
+> inventory-generate
+generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configured sleds
+
+
 > # This time, make it more interesting.  Change the inactive slot contents of
 > # the simulated RoT bootloader.  This should make the configured update
 > # impossible and cause the planner to fix it. To test this, we also need to tell
@@ -2033,7 +2054,7 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT bootloader versions: stage0_next -> 0.5.0
 
 > inventory-generate
-generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configured sleds
+generated inventory collection b5263998-e486-4cea-8842-b32bd326fa3a from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2102,7 +2123,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT bootloader versions: stage0 -> 1.0.0
 
 > inventory-generate
-generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configured sleds
+generated inventory collection 68767302-7fed-4eb1-9611-3dfd807ff0cd from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2175,7 +2196,7 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT settings: slot b -> 0.5.0
 
 > inventory-generate
-generated inventory collection b5263998-e486-4cea-8842-b32bd326fa3a from configured sleds
+generated inventory collection 62898097-2ff1-48d0-8bc1-91b475daa33d from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2244,7 +2265,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT settings: slot b -> 1.0.0, active slot -> B, persistent boot preference -> B
 
 > inventory-generate
-generated inventory collection 68767302-7fed-4eb1-9611-3dfd807ff0cd from configured sleds
+generated inventory collection 3086f142-62d3-4f77-bda3-674afbb42d0d from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2316,7 +2337,7 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c SP versions: inactive -> 0.5.0
 
 > inventory-generate
-generated inventory collection 62898097-2ff1-48d0-8bc1-91b475daa33d from configured sleds
+generated inventory collection ae5b3bb4-ce21-465f-b18e-857614732d66 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2384,7 +2405,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c SP versions: active -> 1.0.0
 
 > inventory-generate
-generated inventory collection 3086f142-62d3-4f77-bda3-674afbb42d0d from configured sleds
+generated inventory collection 34c3258c-b2ab-4da9-9720-41a3a703c3d7 from configured sleds
 
 
 > # Planning should remove this update and add an OS update for this sled.
@@ -2526,6 +2547,16 @@ external DNS:
 
 
 
+> # The plan above scheduled a host phase 2 update on serial1, bumping its
+> # sled-agent generation. Apply the latest blueprint to inventory so subsequent
+> # plans aren't blocked by the inventory-stale check on serial1.
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (9f89efdf-a23e-4137-b7cc-79f4a91cbe1f)
+
+> inventory-generate
+generated inventory collection 5e106b73-6a14-4955-b8a8-a4f8afed6405 from configured sleds
+
+
 > # Try a host OS impossible update replacement: write an unknown artifact to the
 > # sled's phase 1. The planner should realize the update is impossible and
 > # replace it. As with the impossible SP update test above, we have to bump the
@@ -2537,7 +2568,7 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 1 details: B -> ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 > inventory-generate
-generated inventory collection ae5b3bb4-ce21-465f-b18e-857614732d66 from configured sleds
+generated inventory collection 36ef425f-a672-4bf4-8d29-14815a84ccad from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2607,7 +2638,7 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 2 details: boot_disk ->
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 1 details: active -> B, B -> b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 
 > inventory-generate
-generated inventory collection 34c3258c-b2ab-4da9-9720-41a3a703c3d7 from configured sleds
+generated inventory collection 70bea701-e212-4877-8e6c-925f1f73ddd2 from configured sleds
 
 
 > # Another planning step should try to update the last sled, starting with the
@@ -2680,7 +2711,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT bootloader versions: stage0 -> 1.0.0
 
 > inventory-generate
-generated inventory collection 5e106b73-6a14-4955-b8a8-a4f8afed6405 from configured sleds
+generated inventory collection 8187f847-81c7-4750-88ac-d691937461af from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2752,7 +2783,7 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.0.0, active slot -> A, persistent boot preference -> B
 
 > inventory-generate
-generated inventory collection 36ef425f-a672-4bf4-8d29-14815a84ccad from configured sleds
+generated inventory collection 45c1c7bb-984a-43f7-bb3f-4a5437ed7b82 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2826,7 +2857,7 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.1.0, active slot -> B, persistent boot preference -> B, pending persistent boot preference -> Some(B)
 
 > inventory-generate
-generated inventory collection 70bea701-e212-4877-8e6c-925f1f73ddd2 from configured sleds
+generated inventory collection ca7f27e8-5949-4ac1-8f32-18ad76d9c217 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2897,7 +2928,7 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.1.0, active slot -> B, persistent boot preference -> B, pending persistent boot preference -> None, transient boot preference -> Some(B)
 
 > inventory-generate
-generated inventory collection 8187f847-81c7-4750-88ac-d691937461af from configured sleds
+generated inventory collection 8a02a1c6-9e86-4dc0-9293-cd17da34f319 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -2966,7 +2997,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.0.0, active slot -> B, persistent boot preference -> B, transient boot preference -> None
 
 > inventory-generate
-generated inventory collection 45c1c7bb-984a-43f7-bb3f-4a5437ed7b82 from configured sleds
+generated inventory collection c1adcd42-121f-4580-bfb9-d8a9937ca9e1 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -3034,7 +3065,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 SP versions: active -> 1.0.0
 
 > inventory-generate
-generated inventory collection ca7f27e8-5949-4ac1-8f32-18ad76d9c217 from configured sleds
+generated inventory collection 94b231f9-80a3-48a9-8d25-70f9b42b64ca from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -3170,6 +3201,16 @@ external DNS:
 
 
 
+> # The plan above scheduled a host phase 2 update on serial2, bumping its
+> # sled-agent generation. Apply the latest blueprint to inventory so subsequent
+> # plans aren't blocked by the inventory-stale check on serial2.
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (459a45a5-616e-421f-873b-2fb08c36205c)
+
+> inventory-generate
+generated inventory collection 756aecb6-8353-46ad-a6c4-10ad0f2bbb7f from configured sleds
+
+
 > # Finish updating the last sled's host OS.
 > sled-update-host-phase2 d81c6a84-79b8-4958-ae41-ea46c9b19763 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 2 details: boot_disk -> B, B -> d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
@@ -3178,7 +3219,7 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 2 details: boot_disk ->
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 1 details: active -> B, B -> b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 
 > inventory-generate
-generated inventory collection 8a02a1c6-9e86-4dc0-9293-cd17da34f319 from configured sleds
+generated inventory collection 84152e52-8c2e-46ab-880e-4cc2a1fb9dcb from configured sleds
 
 
 > # Do another planning run. This should start updating zones (one at a time).
@@ -3325,7 +3366,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (b2295597-5788-482e-acf9-1731ec63fbd2)
 
 > inventory-generate
-generated inventory collection c1adcd42-121f-4580-bfb9-d8a9937ca9e1 from configured sleds
+generated inventory collection bcfc7436-77de-47e4-8158-daad15a54da2 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -3474,7 +3515,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (6fad8fd4-e825-433f-b76d-495484e068ce)
 
 > inventory-generate
-generated inventory collection 94b231f9-80a3-48a9-8d25-70f9b42b64ca from configured sleds
+generated inventory collection 6dbdc88a-4828-480e-b41d-8946f41a3134 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
@@ -3620,7 +3661,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (24b6e243-100c-428d-8ea6-35b504226f55)
 
 > inventory-generate
-generated inventory collection 756aecb6-8353-46ad-a6c4-10ad0f2bbb7f from configured sleds
+generated inventory collection eb500068-cd91-484b-a532-51081571ecbe from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -3780,7 +3821,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (79fff7a2-2495-4c75-8465-4dc01bab48ce)
 
 > inventory-generate
-generated inventory collection 84152e52-8c2e-46ab-880e-4cc2a1fb9dcb from configured sleds
+generated inventory collection 4492baf6-5638-4c1f-bba2-608163519022 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
@@ -3941,7 +3982,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (3bcc37b2-0c0b-44d0-b4ed-3bcb605e4312)
 
 > inventory-generate
-generated inventory collection bcfc7436-77de-47e4-8158-daad15a54da2 from configured sleds
+generated inventory collection 73f58d4d-6be7-4007-811c-0e578279410e from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -4080,7 +4121,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (4d2eb6f3-7eb1-443a-8e76-7ecf05da2f6d)
 
 > inventory-generate
-generated inventory collection 6dbdc88a-4828-480e-b41d-8946f41a3134 from configured sleds
+generated inventory collection 74448e29-ef07-4d7f-9d31-39079eba8296 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -4243,7 +4284,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (e2125c83-b255-45c9-bc9b-802cff09a812)
 
 > inventory-generate
-generated inventory collection eb500068-cd91-484b-a532-51081571ecbe from configured sleds
+generated inventory collection a815c282-5564-4cea-b667-a7a5295fc2c1 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
@@ -4407,7 +4448,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (f4a6848e-d13c-46e1-8c6a-944f886d7ba3)
 
 > inventory-generate
-generated inventory collection 4492baf6-5638-4c1f-bba2-608163519022 from configured sleds
+generated inventory collection 18ca4fd2-190d-4ac5-b0f3-14a384bcd254 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -4558,7 +4599,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (834e4dbe-3b71-443d-bd4c-20e8253abc0c)
 
 > inventory-generate
-generated inventory collection 73f58d4d-6be7-4007-811c-0e578279410e from configured sleds
+generated inventory collection b460bcc7-664d-4dff-92fb-f250def5537c from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
@@ -4710,7 +4751,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (d9c5c5e3-c532-4c45-9ef5-22cb00f6a2e1)
 
 > inventory-generate
-generated inventory collection 74448e29-ef07-4d7f-9d31-39079eba8296 from configured sleds
+generated inventory collection f8212fb6-115e-4568-a05c-b241e2e8ffb9 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -4854,7 +4895,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (e2deb7c0-2262-49fe-855f-4250c22afb36)
 
 > inventory-generate
-generated inventory collection a815c282-5564-4cea-b667-a7a5295fc2c1 from configured sleds
+generated inventory collection f7602eed-bc12-42db-8eec-6f98a05d9796 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -5001,7 +5042,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (23ce505c-8991-44a5-8863-f2b906fba9cf)
 
 > inventory-generate
-generated inventory collection 18ca4fd2-190d-4ac5-b0f3-14a384bcd254 from configured sleds
+generated inventory collection af824d9a-296d-4a2f-b704-c985c7470a1a from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -5133,7 +5174,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (c0d81ea6-909c-4efb-964e-beff67f6da0d)
 
 > inventory-generate
-generated inventory collection b460bcc7-664d-4dff-92fb-f250def5537c from configured sleds
+generated inventory collection 2d5a41c5-bf7b-464c-a4b7-b14ab35982c4 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -5285,7 +5326,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (60b55d33-5fec-4277-9864-935197eaead7)
 
 > inventory-generate
-generated inventory collection f8212fb6-115e-4568-a05c-b241e2e8ffb9 from configured sleds
+generated inventory collection 94c793da-83b2-4fdf-b085-d7ef476bf204 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -5438,7 +5479,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (aa13f40f-41ff-4b68-bee1-df2e1f805544)
 
 > inventory-generate
-generated inventory collection f7602eed-bc12-42db-8eec-6f98a05d9796 from configured sleds
+generated inventory collection 388a8c73-4ec0-4a23-9f82-225e652d8f37 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -5572,7 +5613,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (316ccd9e-5c53-46c3-a2e9-20c3867b7111)
 
 > inventory-generate
-generated inventory collection af824d9a-296d-4a2f-b704-c985c7470a1a from configured sleds
+generated inventory collection 2d608b8f-bf88-4707-ac27-6be62f3d5146 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -5715,7 +5756,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (02078c95-3d58-4b7b-a03f-9b160361c50a)
 
 > inventory-generate
-generated inventory collection 2d5a41c5-bf7b-464c-a4b7-b14ab35982c4 from configured sleds
+generated inventory collection 21e24074-fdd0-438e-a4e7-11665b7071bb from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -5861,7 +5902,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (e7a01ffc-6b0e-408b-917b-b1efe18b3110)
 
 > inventory-generate
-generated inventory collection 94c793da-83b2-4fdf-b085-d7ef476bf204 from configured sleds
+generated inventory collection ed8ea2c4-4271-407e-9c84-54129418d171 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -6018,7 +6059,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (880e2ffc-8187-4275-a2f3-1b36aa2f4482)
 
 > inventory-generate
-generated inventory collection 388a8c73-4ec0-4a23-9f82-225e652d8f37 from configured sleds
+generated inventory collection 336dbc73-f973-4962-a210-3c9d424bd6a3 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -6176,7 +6217,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (c4a20bcb-1a71-4e88-97b4-36d16f55daec)
 
 > inventory-generate
-generated inventory collection 2d608b8f-bf88-4707-ac27-6be62f3d5146 from configured sleds
+generated inventory collection 897721fc-b087-41be-a566-809d59c8aeea from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -6324,7 +6365,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (a2c6496d-98fc-444d-aa36-99508aa72367)
 
 > inventory-generate
-generated inventory collection 21e24074-fdd0-438e-a4e7-11665b7071bb from configured sleds
+generated inventory collection 5d0b9686-48df-4642-a39c-e2dea04d5330 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -6473,7 +6514,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (6ed56354-5941-40d1-a06c-b0e940701d52)
 
 > inventory-generate
-generated inventory collection ed8ea2c4-4271-407e-9c84-54129418d171 from configured sleds
+generated inventory collection 90f0f757-fd33-4744-abee-36616a645b87 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -6617,7 +6658,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (9078c4ba-3a73-4b3f-ac2c-acb501f89cb2)
 
 > inventory-generate
-generated inventory collection 336dbc73-f973-4962-a210-3c9d424bd6a3 from configured sleds
+generated inventory collection ee9bc64a-70f7-4d81-b39d-a709754ce118 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -6749,7 +6790,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (8763abc1-8a42-4932-b5a7-33109e0e0152)
 
 > inventory-generate
-generated inventory collection 897721fc-b087-41be-a566-809d59c8aeea from configured sleds
+generated inventory collection 3dc9d8c8-8f50-4d6e-9396-97058d1d2722 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -6889,7 +6930,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (2b89e0d7-f15b-4474-8ac4-85959ed1bc88)
 
 > inventory-generate
-generated inventory collection 5d0b9686-48df-4642-a39c-e2dea04d5330 from configured sleds
+generated inventory collection a4dab274-0fff-47fa-bc22-b98d11ec54d2 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7030,7 +7071,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (7f6b7297-c2bc-4f67-b3c0-c8e555ebbdc4)
 
 > inventory-generate
-generated inventory collection 90f0f757-fd33-4744-abee-36616a645b87 from configured sleds
+generated inventory collection d483be68-4bf3-4133-aed1-661cba8e1194 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7163,7 +7204,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (59630e63-c953-4807-9e84-9e750a79f68e)
 
 > inventory-generate
-generated inventory collection ee9bc64a-70f7-4d81-b39d-a709754ce118 from configured sleds
+generated inventory collection 74b742c1-01da-4461-a011-785e2e11a5b2 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7314,7 +7355,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (e93650dc-b5ba-4ec7-8550-9171c1ada194)
 
 > inventory-generate
-generated inventory collection 3dc9d8c8-8f50-4d6e-9396-97058d1d2722 from configured sleds
+generated inventory collection 78486156-ea1a-42a2-adc3-658ccd94ccd1 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7466,7 +7507,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (90650737-8142-47a6-9a48-a10efc487e57)
 
 > inventory-generate
-generated inventory collection a4dab274-0fff-47fa-bc22-b98d11ec54d2 from configured sleds
+generated inventory collection 0f80a0f2-360f-4c64-9c35-3dc067dd2620 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7611,7 +7652,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (2182613d-dc9f-41eb-9c6a-d33801849caa)
 
 > inventory-generate
-generated inventory collection d483be68-4bf3-4133-aed1-661cba8e1194 from configured sleds
+generated inventory collection c0548a65-0ee4-4876-a5e0-3384187c88cc from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7759,7 +7800,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (e8b088a8-7da0-480b-a2dc-75ffef068ece)
 
 > inventory-generate
-generated inventory collection 74b742c1-01da-4461-a011-785e2e11a5b2 from configured sleds
+generated inventory collection 7349431d-718a-4353-a1ee-357ce2aeeb28 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7897,7 +7938,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (810ea95a-4730-43dd-867e-1984aeb9d873)
 
 > inventory-generate
-generated inventory collection 78486156-ea1a-42a2-adc3-658ccd94ccd1 from configured sleds
+generated inventory collection 5ffc4b23-0e6e-40e9-bacd-f83ca33f9792 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -8053,7 +8094,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (67c074ef-c52e-4ff1-851a-598c04dc2c8d)
 
 > inventory-generate
-generated inventory collection 0f80a0f2-360f-4c64-9c35-3dc067dd2620 from configured sleds
+generated inventory collection 2c0e8abf-b92d-4682-be5f-f0fa1e9e5b2a from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -8210,7 +8251,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (0a8d2f87-1d3e-4296-ba07-108940a7a57e)
 
 > inventory-generate
-generated inventory collection c0548a65-0ee4-4876-a5e0-3384187c88cc from configured sleds
+generated inventory collection a838e97f-3fe3-475a-9dcf-760577308807 from configured sleds
 
 
 > # Start the Nexus handoff process: A planning step here should place three new
@@ -8533,7 +8574,7 @@ set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest bluepri
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (d69e1109-06be-4469-8876-4292dc7885d7)
 
 > inventory-generate
-generated inventory collection 7349431d-718a-4353-a1ee-357ce2aeeb28 from configured sleds
+generated inventory collection 70b80a63-ba91-427d-ac02-b4b245c70e76 from configured sleds
 
 
 > # Planning now should bump the top-level `nexus_generation` to 2, indicating
@@ -8682,10 +8723,18 @@ external DNS:
 
 
 > # If we expunge one of the OLD nexuses, we should observe
-> # that it is re-created.
+> # that it is re-created. Apply the latest blueprint to the affected sled's
+> # inventory so the noop check on the next plan isn't blocked by the
+> # inventory-stale path on the bumped generation.
 > blueprint-edit latest expunge-zones 0c71b3b2-6ceb-4e8f-b020-b08675e83038
 blueprint 6d830d26-547e-492b-adfe-c5c4ad9c3751 created from latest blueprint (4713f6c4-e8ba-4a28-87a0-df75ebf7b8b6): expunged zone 0c71b3b2-6ceb-4e8f-b020-b08675e83038 from sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 
+
+> sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (6d830d26-547e-492b-adfe-c5c4ad9c3751)
+
+> inventory-generate
+generated inventory collection 1330e9de-5cee-4ddc-ae6b-1981b87ac78b from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 10, num_already_artifact: 10, num_eligible: 0, num_ineligible: 0
@@ -8779,23 +8828,24 @@ to:   blueprint 8e0cc787-e068-4a45-97ed-21029cbe4ddf
 
 
     omicron zones:
-    -----------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition    underlay IP          
-    -----------------------------------------------------------------------------------------------------------------------
-    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service     fd00:1122:3344:101::9
-    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service     fd00:1122:3344:101::7
-    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service     fd00:1122:3344:101::8
-    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service     fd00:1122:3344:101::c
-    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:101::6
-    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service     fd00:1122:3344:101::b
-    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:101::5
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:2::1  
-    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service     fd00:1122:3344:2::1  
-    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:101::3
-    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service     fd00:1122:3344:101::a
-    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   expunged ⏳     fd00:1122:3344:101::4
-    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service     fd00:1122:3344:101::d
-+   nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   in service     fd00:1122:3344:101::e
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
+    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
+    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service       fd00:1122:3344:101::c
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::6
+    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service       fd00:1122:3344:101::b
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::5
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:2::1  
+    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::3
+    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
+    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service       fd00:1122:3344:101::d
+*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::4
+     └─                                                                                + expunged ✓                          
++   nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   in service       fd00:1122:3344:101::e
 
 
  COCKROACHDB SETTINGS:
@@ -8827,7 +8877,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (8e0cc787-e068-4a45-97ed-21029cbe4ddf)
 
 > inventory-generate
-generated inventory collection 5ffc4b23-0e6e-40e9-bacd-f83ca33f9792 from configured sleds
+generated inventory collection 18ad5141-06e0-4aeb-9033-c7cc49474f82 from configured sleds
 
 
 > # Bump the set of active Nexus zones; this simulates Nexus handoff.
@@ -8835,7 +8885,9 @@ generated inventory collection 5ffc4b23-0e6e-40e9-bacd-f83ca33f9792 from configu
 will use active Nexus zones from generation 2
 
 
-> # Planning should now expunge one of the old Nexus zones.
+> # Planning should now expunge one of the old Nexus zones. After each plan,
+> # apply the latest blueprint to all sleds' inventories so subsequent plans see
+> # fresh sled-agent generations rather than firing the inventory-stale path.
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 10, num_already_artifact: 10, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
@@ -8950,92 +9002,6 @@ to:   blueprint e31c9054-8549-4c68-acf9-a01f68d1fc9b
      └─                                                                                + expunged ⏳                          
 
 
-  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 18):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    ------------------------------
-    slot   boot image source      
-    ------------------------------
-    A      current contents       
-    B      artifact: version 1.0.0
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
-    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
-    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    d7f95803-df03-49e0-9ad2-37de73f01417   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    68e4149e-114c-460e-8f33-54dd5f9a274e   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_7e83b92d-6b02-47f3-a5ab-125a6bb44e29   7562b5c7-041c-44e8-9ae7-e453b63f5b03   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_26bdd109-c842-43a9-95cb-15aba9b0832b      16a8c618-d062-4bde-8ca4-301b5f14ccf2   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_abd27551-4027-4084-8b52-13a575b035b4      6119babc-cdc9-4b6b-afa4-9037eee05728   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_b9fc779e-e127-4a3b-8c6c-3294d6749a34             cf8e3f19-fd6d-4f81-9bb7-f4e2bb8d2c9d   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_d516d61b-fd96-46ad-a743-78eec814ee90             d2707e9c-d793-4a6c-8f77-2d3aa5a98390   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_e14f91b0-0c41-48a0-919d-e5078d2b89b0               312286f1-e378-464d-97cb-6fa06ba2dab7   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
-
-
-    omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
-    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
-    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
-    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service       fd00:1122:3344:101::c
-    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::6
-    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service       fd00:1122:3344:101::b
-    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::5
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:2::1  
-    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
-    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::3
-    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
-    nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   in service       fd00:1122:3344:101::e
-    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service       fd00:1122:3344:101::d
-*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::4
-     └─                                                                                + expunged ✓                          
-
-
  COCKROACHDB SETTINGS:
     state fingerprint:::::::::::::::::   (none) (unchanged)
     cluster.preserve_downgrade_option:   (do not modify) (unchanged)
@@ -9060,6 +9026,18 @@ external DNS:
     unchanged names: 5 (records: 9)
 
 
+
+> sled-set 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (e31c9054-8549-4c68-acf9-a01f68d1fc9b)
+
+> sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (e31c9054-8549-4c68-acf9-a01f68d1fc9b)
+
+> sled-set d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (e31c9054-8549-4c68-acf9-a01f68d1fc9b)
+
+> inventory-generate
+generated inventory collection b8392284-b0b2-4c3b-b6f0-42e03911e111 from configured sleds
 
 
 > # Two more planning iterations should expunge the remaining two old 0.0.1
@@ -9089,6 +9067,93 @@ from: blueprint e31c9054-8549-4c68-acf9-a01f68d1fc9b
 to:   blueprint 3e332949-6785-4aff-ad86-6134f5ce6152
 
  MODIFIED SLEDS:
+
+  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 18):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    ------------------------------
+    slot   boot image source      
+    ------------------------------
+    A      current contents       
+    B      artifact: version 1.0.0
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
+    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
+    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              feecfda1-9966-43d4-aaef-440b77f0b26d   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              956966b9-8201-437b-81ba-3c8ad2032080   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    22a4acd6-9d38-43e2-a3bf-c85f5c2f3246   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    bccbe44f-bcf8-4868-b086-c8901f896cdc   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          6e218d0a-13fd-4f70-884e-47e960fa8bb8   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          9073fb6b-f973-4bbd-b7cc-ba1abf6cb238   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          0582030b-aab6-4d0e-b1d2-64562ee712cd   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_156bfcde-e3fa-4abe-a93e-eb4a408b4e5e   7f2ba73c-1f57-4f92-8059-738059808061   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_4ab0ec67-b27e-42b5-af22-9117ad11113b      75ffc8e6-b071-4f51-966d-4a6e6b01b432   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_698d1d82-0620-4978-93ac-0ba5d40f3da9      dfe5586b-e4a8-4b98-ad72-eabc34988177   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   expunged      none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_nexus_9ae90740-7fdb-4073-ae43-048f2fca3d69             91f7f766-931f-43ef-99b4-2399f58c946b   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_ba87399e-e9b7-4ee4-8cb7-0032822630e9               484f151e-c290-48bd-99b2-c97ef85c9844   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    100 GiB   none          gzip-9     
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/local_storage                                                   2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/local_storage                                                   09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/local_storage                                                   c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/local_storage_unencrypted                                             775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/local_storage_unencrypted                                             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/local_storage_unencrypted                                             2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   artifact: version 1.0.0   in service       fd00:1122:3344:102::5
+    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   artifact: version 1.0.0   in service       fd00:1122:3344:102::a
+    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   artifact: version 1.0.0   in service       fd00:1122:3344:102::8
+    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 1.0.0   in service       fd00:1122:3344:102::9
+    crucible_pantry   156bfcde-e3fa-4abe-a93e-eb4a408b4e5e   artifact: version 1.0.0   in service       fd00:1122:3344:102::d
+    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::7
+    external_dns      4ab0ec67-b27e-42b5-af22-9117ad11113b   artifact: version 1.0.0   in service       fd00:1122:3344:102::c
+    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::6
+    internal_dns      698d1d82-0620-4978-93ac-0ba5d40f3da9   artifact: version 1.0.0   in service       fd00:1122:3344:1::1  
+    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:1::1  
+    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::3
+    internal_ntp      ba87399e-e9b7-4ee4-8cb7-0032822630e9   artifact: version 1.0.0   in service       fd00:1122:3344:102::b
+    nexus             9ae90740-7fdb-4073-ae43-048f2fca3d69   artifact: version 1.0.0   in service       fd00:1122:3344:102::e
+*   nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:102::4
+     └─                                                                                + expunged ✓                          
+
 
   sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 18 -> 19):
 
@@ -9202,6 +9267,18 @@ external DNS:
 
 
 
+> sled-set 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (3e332949-6785-4aff-ad86-6134f5ce6152)
+
+> sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (3e332949-6785-4aff-ad86-6134f5ce6152)
+
+> sled-set d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (3e332949-6785-4aff-ad86-6134f5ce6152)
+
+> inventory-generate
+generated inventory collection 2b99b4d7-debb-4b8c-b00e-a623f9f5714c from configured sleds
+
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
@@ -9227,6 +9304,92 @@ from: blueprint 3e332949-6785-4aff-ad86-6134f5ce6152
 to:   blueprint 05685571-d61f-4754-a2b2-604ea8c45dff
 
  MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 19):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    ------------------------------
+    slot   boot image source      
+    ------------------------------
+    A      current contents       
+    B      artifact: version 1.0.0
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    d7f95803-df03-49e0-9ad2-37de73f01417   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    68e4149e-114c-460e-8f33-54dd5f9a274e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_7e83b92d-6b02-47f3-a5ab-125a6bb44e29   7562b5c7-041c-44e8-9ae7-e453b63f5b03   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_26bdd109-c842-43a9-95cb-15aba9b0832b      16a8c618-d062-4bde-8ca4-301b5f14ccf2   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_abd27551-4027-4084-8b52-13a575b035b4      6119babc-cdc9-4b6b-afa4-9037eee05728   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_b9fc779e-e127-4a3b-8c6c-3294d6749a34             cf8e3f19-fd6d-4f81-9bb7-f4e2bb8d2c9d   expunged      none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_d516d61b-fd96-46ad-a743-78eec814ee90             d2707e9c-d793-4a6c-8f77-2d3aa5a98390   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_e14f91b0-0c41-48a0-919d-e5078d2b89b0               312286f1-e378-464d-97cb-6fa06ba2dab7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
+    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
+    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service       fd00:1122:3344:101::c
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::6
+    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service       fd00:1122:3344:101::b
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::5
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:2::1  
+    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::3
+    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
+    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::4
+    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service       fd00:1122:3344:101::d
+*   nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::e
+     └─                                                                                + expunged ✓                          
+
 
   sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 16 -> 17):
 
@@ -9350,7 +9513,7 @@ set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest bluepri
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (05685571-d61f-4754-a2b2-604ea8c45dff)
 
 > inventory-generate
-generated inventory collection 2c0e8abf-b92d-4682-be5f-f0fa1e9e5b2a from configured sleds
+generated inventory collection 85b886b3-77f1-448f-b80b-b519a7209328 from configured sleds
 
 
 > # Planning now should note that the old zones are gone, but do nothing else:
@@ -9378,179 +9541,6 @@ from: blueprint 05685571-d61f-4754-a2b2-604ea8c45dff
 to:   blueprint 008e1541-3d9d-4a50-a877-eed4a3cf86ab
 
  MODIFIED SLEDS:
-
-  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 18):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    ------------------------------
-    slot   boot image source      
-    ------------------------------
-    A      current contents       
-    B      artifact: version 1.0.0
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
-    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
-    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              feecfda1-9966-43d4-aaef-440b77f0b26d   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              956966b9-8201-437b-81ba-3c8ad2032080   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    22a4acd6-9d38-43e2-a3bf-c85f5c2f3246   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    bccbe44f-bcf8-4868-b086-c8901f896cdc   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          6e218d0a-13fd-4f70-884e-47e960fa8bb8   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          9073fb6b-f973-4bbd-b7cc-ba1abf6cb238   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          0582030b-aab6-4d0e-b1d2-64562ee712cd   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_156bfcde-e3fa-4abe-a93e-eb4a408b4e5e   7f2ba73c-1f57-4f92-8059-738059808061   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_4ab0ec67-b27e-42b5-af22-9117ad11113b      75ffc8e6-b071-4f51-966d-4a6e6b01b432   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_698d1d82-0620-4978-93ac-0ba5d40f3da9      dfe5586b-e4a8-4b98-ad72-eabc34988177   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   expunged      none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_nexus_9ae90740-7fdb-4073-ae43-048f2fca3d69             91f7f766-931f-43ef-99b4-2399f58c946b   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_ba87399e-e9b7-4ee4-8cb7-0032822630e9               484f151e-c290-48bd-99b2-c97ef85c9844   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    100 GiB   none          gzip-9     
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/local_storage                                                   2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/local_storage                                                   09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/local_storage                                                   c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/local_storage_unencrypted                                             775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/local_storage_unencrypted                                             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/local_storage_unencrypted                                             2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
-
-
-    omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   artifact: version 1.0.0   in service       fd00:1122:3344:102::5
-    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   artifact: version 1.0.0   in service       fd00:1122:3344:102::a
-    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   artifact: version 1.0.0   in service       fd00:1122:3344:102::8
-    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 1.0.0   in service       fd00:1122:3344:102::9
-    crucible_pantry   156bfcde-e3fa-4abe-a93e-eb4a408b4e5e   artifact: version 1.0.0   in service       fd00:1122:3344:102::d
-    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::7
-    external_dns      4ab0ec67-b27e-42b5-af22-9117ad11113b   artifact: version 1.0.0   in service       fd00:1122:3344:102::c
-    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::6
-    internal_dns      698d1d82-0620-4978-93ac-0ba5d40f3da9   artifact: version 1.0.0   in service       fd00:1122:3344:1::1  
-    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:1::1  
-    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::3
-    internal_ntp      ba87399e-e9b7-4ee4-8cb7-0032822630e9   artifact: version 1.0.0   in service       fd00:1122:3344:102::b
-    nexus             9ae90740-7fdb-4073-ae43-048f2fca3d69   artifact: version 1.0.0   in service       fd00:1122:3344:102::e
-*   nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:102::4
-     └─                                                                                + expunged ✓                          
-
-
-  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 19):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    ------------------------------
-    slot   boot image source      
-    ------------------------------
-    A      current contents       
-    B      artifact: version 1.0.0
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
-    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
-    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    d7f95803-df03-49e0-9ad2-37de73f01417   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    68e4149e-114c-460e-8f33-54dd5f9a274e   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_7e83b92d-6b02-47f3-a5ab-125a6bb44e29   7562b5c7-041c-44e8-9ae7-e453b63f5b03   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_26bdd109-c842-43a9-95cb-15aba9b0832b      16a8c618-d062-4bde-8ca4-301b5f14ccf2   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_abd27551-4027-4084-8b52-13a575b035b4      6119babc-cdc9-4b6b-afa4-9037eee05728   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_b9fc779e-e127-4a3b-8c6c-3294d6749a34             cf8e3f19-fd6d-4f81-9bb7-f4e2bb8d2c9d   expunged      none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_d516d61b-fd96-46ad-a743-78eec814ee90             d2707e9c-d793-4a6c-8f77-2d3aa5a98390   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_e14f91b0-0c41-48a0-919d-e5078d2b89b0               312286f1-e378-464d-97cb-6fa06ba2dab7   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
-
-
-    omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
-    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
-    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
-    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service       fd00:1122:3344:101::c
-    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::6
-    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service       fd00:1122:3344:101::b
-    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::5
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:2::1  
-    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
-    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::3
-    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
-    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::4
-    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service       fd00:1122:3344:101::d
-*   nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::e
-     └─                                                                                + expunged ✓                          
-
 
   sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 17):
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
@@ -1775,24 +1775,12 @@ external DNS:
 
 
 
-> # The plan above scheduled a host phase 2 update, which bumped serial0's
-> # sled-agent generation in the blueprint. Apply the latest blueprint to
-> # inventory so subsequent plans aren't blocked by the inventory-stale check
-> # in the noop image source path.
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
-
-> inventory-generate
-generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
-
-
 > # If we generate another plan, there should be no change.
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1844,7 +1832,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 details: B -> d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
 
 > inventory-generate
-generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
+generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
 
 
 > # Planning after only phase 2 has changed should make no changes. We're still
@@ -1853,8 +1841,7 @@ generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1905,7 +1892,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 1 details: active -> B, B -> b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 
 > inventory-generate
-generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configured sleds
+generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
 
 
 > # Planning _still_ shouldn't make any new changes; the OS update as a whole
@@ -1914,8 +1901,7 @@ generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1966,7 +1952,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 details: boot_disk -> B
 
 > inventory-generate
-generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configured sleds
+generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configured sleds
 
 
 > # Planning should now remove the host OS update and plan the next RoT bootloader
@@ -1975,8 +1961,7 @@ generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2033,16 +2018,6 @@ external DNS:
 
 
 
-> # Apply the latest blueprint to serial0's inventory so the next plans (which
-> # work on serial1's MGS chain) aren't shadowed by an inventory-stale check on
-> # serial0.
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (afb09faf-a586-4483-9289-04d4f1d8ba23)
-
-> inventory-generate
-generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configured sleds
-
-
 > # This time, make it more interesting.  Change the inactive slot contents of
 > # the simulated RoT bootloader.  This should make the configured update
 > # impossible and cause the planner to fix it. To test this, we also need to tell
@@ -2054,14 +2029,13 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT bootloader versions: stage0_next -> 0.5.0
 
 > inventory-generate
-generated inventory collection b5263998-e486-4cea-8842-b32bd326fa3a from configured sleds
+generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2123,14 +2097,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT bootloader versions: stage0 -> 1.0.0
 
 > inventory-generate
-generated inventory collection 68767302-7fed-4eb1-9611-3dfd807ff0cd from configured sleds
+generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2196,14 +2169,13 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT settings: slot b -> 0.5.0
 
 > inventory-generate
-generated inventory collection 62898097-2ff1-48d0-8bc1-91b475daa33d from configured sleds
+generated inventory collection b5263998-e486-4cea-8842-b32bd326fa3a from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2265,14 +2237,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT settings: slot b -> 1.0.0, active slot -> B, persistent boot preference -> B
 
 > inventory-generate
-generated inventory collection 3086f142-62d3-4f77-bda3-674afbb42d0d from configured sleds
+generated inventory collection 68767302-7fed-4eb1-9611-3dfd807ff0cd from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2337,14 +2308,13 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c SP versions: inactive -> 0.5.0
 
 > inventory-generate
-generated inventory collection ae5b3bb4-ce21-465f-b18e-857614732d66 from configured sleds
+generated inventory collection 62898097-2ff1-48d0-8bc1-91b475daa33d from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2405,7 +2375,7 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c SP versions: active -> 1.0.0
 
 > inventory-generate
-generated inventory collection 34c3258c-b2ab-4da9-9720-41a3a703c3d7 from configured sleds
+generated inventory collection 3086f142-62d3-4f77-bda3-674afbb42d0d from configured sleds
 
 
 > # Planning should remove this update and add an OS update for this sled.
@@ -2413,8 +2383,7 @@ generated inventory collection 34c3258c-b2ab-4da9-9720-41a3a703c3d7 from configu
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2547,16 +2516,6 @@ external DNS:
 
 
 
-> # The plan above scheduled a host phase 2 update on serial1, bumping its
-> # sled-agent generation. Apply the latest blueprint to inventory so subsequent
-> # plans aren't blocked by the inventory-stale check on serial1.
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (9f89efdf-a23e-4137-b7cc-79f4a91cbe1f)
-
-> inventory-generate
-generated inventory collection 5e106b73-6a14-4955-b8a8-a4f8afed6405 from configured sleds
-
-
 > # Try a host OS impossible update replacement: write an unknown artifact to the
 > # sled's phase 1. The planner should realize the update is impossible and
 > # replace it. As with the impossible SP update test above, we have to bump the
@@ -2568,13 +2527,11 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 1 details: B -> ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 > inventory-generate
-generated inventory collection 36ef425f-a672-4bf4-8d29-14815a84ccad from configured sleds
+generated inventory collection ae5b3bb4-ce21-465f-b18e-857614732d66 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2638,16 +2595,14 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 2 details: boot_disk ->
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 1 details: active -> B, B -> b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 
 > inventory-generate
-generated inventory collection 70bea701-e212-4877-8e6c-925f1f73ddd2 from configured sleds
+generated inventory collection 34c3258c-b2ab-4da9-9720-41a3a703c3d7 from configured sleds
 
 
 > # Another planning step should try to update the last sled, starting with the
 > # RoT bootloader.
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2711,13 +2666,11 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT bootloader versions: stage0 -> 1.0.0
 
 > inventory-generate
-generated inventory collection 8187f847-81c7-4750-88ac-d691937461af from configured sleds
+generated inventory collection 5e106b73-6a14-4955-b8a8-a4f8afed6405 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2783,13 +2736,11 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.0.0, active slot -> A, persistent boot preference -> B
 
 > inventory-generate
-generated inventory collection 45c1c7bb-984a-43f7-bb3f-4a5437ed7b82 from configured sleds
+generated inventory collection 36ef425f-a672-4bf4-8d29-14815a84ccad from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2857,13 +2808,11 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.1.0, active slot -> B, persistent boot preference -> B, pending persistent boot preference -> Some(B)
 
 > inventory-generate
-generated inventory collection ca7f27e8-5949-4ac1-8f32-18ad76d9c217 from configured sleds
+generated inventory collection 70bea701-e212-4877-8e6c-925f1f73ddd2 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2928,13 +2877,11 @@ ignoring impossible MGS updates since <REDACTED_TIMESTAMP>
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.1.0, active slot -> B, persistent boot preference -> B, pending persistent boot preference -> None, transient boot preference -> Some(B)
 
 > inventory-generate
-generated inventory collection 8a02a1c6-9e86-4dc0-9293-cd17da34f319 from configured sleds
+generated inventory collection 8187f847-81c7-4750-88ac-d691937461af from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2997,13 +2944,11 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.0.0, active slot -> B, persistent boot preference -> B, transient boot preference -> None
 
 > inventory-generate
-generated inventory collection c1adcd42-121f-4580-bfb9-d8a9937ca9e1 from configured sleds
+generated inventory collection 45c1c7bb-984a-43f7-bb3f-4a5437ed7b82 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -3065,13 +3010,11 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 SP versions: active -> 1.0.0
 
 > inventory-generate
-generated inventory collection 94b231f9-80a3-48a9-8d25-70f9b42b64ca from configured sleds
+generated inventory collection ca7f27e8-5949-4ac1-8f32-18ad76d9c217 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -3201,16 +3144,6 @@ external DNS:
 
 
 
-> # The plan above scheduled a host phase 2 update on serial2, bumping its
-> # sled-agent generation. Apply the latest blueprint to inventory so subsequent
-> # plans aren't blocked by the inventory-stale check on serial2.
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (459a45a5-616e-421f-873b-2fb08c36205c)
-
-> inventory-generate
-generated inventory collection 756aecb6-8353-46ad-a6c4-10ad0f2bbb7f from configured sleds
-
-
 > # Finish updating the last sled's host OS.
 > sled-update-host-phase2 d81c6a84-79b8-4958-ae41-ea46c9b19763 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 2 details: boot_disk -> B, B -> d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
@@ -3219,17 +3152,14 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 2 details: boot_disk ->
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 host phase 1 details: active -> B, B -> b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 
 > inventory-generate
-generated inventory collection 84152e52-8c2e-46ab-880e-4cc2a1fb9dcb from configured sleds
+generated inventory collection 8a02a1c6-9e86-4dc0-9293-cd17da34f319 from configured sleds
 
 
 > # Do another planning run. This should start updating zones (one at a time).
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO MGS-driven update completed (will remove it and re-evaluate board), artifact_version: 1.0.0, artifact_hash: b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b, sled_agent_address: [fd00:1122:3344:103::1]:12345, expected_inactive_phase_2_hash: d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 2, sp_type: Sled, serial_number: serial2, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
@@ -3366,15 +3296,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (b2295597-5788-482e-acf9-1731ec63fbd2)
 
 > inventory-generate
-generated inventory collection bcfc7436-77de-47e4-8158-daad15a54da2 from configured sleds
+generated inventory collection c1adcd42-121f-4580-bfb9-d8a9937ca9e1 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -3515,15 +3443,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (6fad8fd4-e825-433f-b76d-495484e068ce)
 
 > inventory-generate
-generated inventory collection 6dbdc88a-4828-480e-b41d-8946f41a3134 from configured sleds
+generated inventory collection 94b231f9-80a3-48a9-8d25-70f9b42b64ca from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -3661,15 +3587,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (24b6e243-100c-428d-8ea6-35b504226f55)
 
 > inventory-generate
-generated inventory collection eb500068-cd91-484b-a532-51081571ecbe from configured sleds
+generated inventory collection 756aecb6-8353-46ad-a6c4-10ad0f2bbb7f from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -3821,15 +3745,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (79fff7a2-2495-4c75-8465-4dc01bab48ce)
 
 > inventory-generate
-generated inventory collection 4492baf6-5638-4c1f-bba2-608163519022 from configured sleds
+generated inventory collection 84152e52-8c2e-46ab-880e-4cc2a1fb9dcb from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -3982,15 +3904,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (3bcc37b2-0c0b-44d0-b4ed-3bcb605e4312)
 
 > inventory-generate
-generated inventory collection 73f58d4d-6be7-4007-811c-0e578279410e from configured sleds
+generated inventory collection bcfc7436-77de-47e4-8158-daad15a54da2 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4121,15 +4041,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (4d2eb6f3-7eb1-443a-8e76-7ecf05da2f6d)
 
 > inventory-generate
-generated inventory collection 74448e29-ef07-4d7f-9d31-39079eba8296 from configured sleds
+generated inventory collection 6dbdc88a-4828-480e-b41d-8946f41a3134 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4284,15 +4202,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (e2125c83-b255-45c9-bc9b-802cff09a812)
 
 > inventory-generate
-generated inventory collection a815c282-5564-4cea-b667-a7a5295fc2c1 from configured sleds
+generated inventory collection eb500068-cd91-484b-a532-51081571ecbe from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4448,15 +4364,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (f4a6848e-d13c-46e1-8c6a-944f886d7ba3)
 
 > inventory-generate
-generated inventory collection 18ca4fd2-190d-4ac5-b0f3-14a384bcd254 from configured sleds
+generated inventory collection 4492baf6-5638-4c1f-bba2-608163519022 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4599,15 +4513,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (834e4dbe-3b71-443d-bd4c-20e8253abc0c)
 
 > inventory-generate
-generated inventory collection b460bcc7-664d-4dff-92fb-f250def5537c from configured sleds
+generated inventory collection 73f58d4d-6be7-4007-811c-0e578279410e from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4751,15 +4663,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (d9c5c5e3-c532-4c45-9ef5-22cb00f6a2e1)
 
 > inventory-generate
-generated inventory collection f8212fb6-115e-4568-a05c-b241e2e8ffb9 from configured sleds
+generated inventory collection 74448e29-ef07-4d7f-9d31-39079eba8296 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -4895,15 +4805,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (e2deb7c0-2262-49fe-855f-4250c22afb36)
 
 > inventory-generate
-generated inventory collection f7602eed-bc12-42db-8eec-6f98a05d9796 from configured sleds
+generated inventory collection a815c282-5564-4cea-b667-a7a5295fc2c1 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5042,15 +4950,13 @@ external DNS:
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (23ce505c-8991-44a5-8863-f2b906fba9cf)
 
 > inventory-generate
-generated inventory collection af824d9a-296d-4a2f-b704-c985c7470a1a from configured sleds
+generated inventory collection 18ca4fd2-190d-4ac5-b0f3-14a384bcd254 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5174,15 +5080,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (c0d81ea6-909c-4efb-964e-beff67f6da0d)
 
 > inventory-generate
-generated inventory collection 2d5a41c5-bf7b-464c-a4b7-b14ab35982c4 from configured sleds
+generated inventory collection b460bcc7-664d-4dff-92fb-f250def5537c from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5326,15 +5231,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (60b55d33-5fec-4277-9864-935197eaead7)
 
 > inventory-generate
-generated inventory collection 94c793da-83b2-4fdf-b085-d7ef476bf204 from configured sleds
+generated inventory collection f8212fb6-115e-4568-a05c-b241e2e8ffb9 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5479,15 +5383,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (aa13f40f-41ff-4b68-bee1-df2e1f805544)
 
 > inventory-generate
-generated inventory collection 388a8c73-4ec0-4a23-9f82-225e652d8f37 from configured sleds
+generated inventory collection f7602eed-bc12-42db-8eec-6f98a05d9796 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5613,15 +5516,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (316ccd9e-5c53-46c3-a2e9-20c3867b7111)
 
 > inventory-generate
-generated inventory collection 2d608b8f-bf88-4707-ac27-6be62f3d5146 from configured sleds
+generated inventory collection af824d9a-296d-4a2f-b704-c985c7470a1a from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5756,15 +5658,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (02078c95-3d58-4b7b-a03f-9b160361c50a)
 
 > inventory-generate
-generated inventory collection 21e24074-fdd0-438e-a4e7-11665b7071bb from configured sleds
+generated inventory collection 2d5a41c5-bf7b-464c-a4b7-b14ab35982c4 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -5902,15 +5803,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (e7a01ffc-6b0e-408b-917b-b1efe18b3110)
 
 > inventory-generate
-generated inventory collection ed8ea2c4-4271-407e-9c84-54129418d171 from configured sleds
+generated inventory collection 94c793da-83b2-4fdf-b085-d7ef476bf204 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6059,15 +5959,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (880e2ffc-8187-4275-a2f3-1b36aa2f4482)
 
 > inventory-generate
-generated inventory collection 336dbc73-f973-4962-a210-3c9d424bd6a3 from configured sleds
+generated inventory collection 388a8c73-4ec0-4a23-9f82-225e652d8f37 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6217,15 +6116,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (c4a20bcb-1a71-4e88-97b4-36d16f55daec)
 
 > inventory-generate
-generated inventory collection 897721fc-b087-41be-a566-809d59c8aeea from configured sleds
+generated inventory collection 2d608b8f-bf88-4707-ac27-6be62f3d5146 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6365,15 +6263,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (a2c6496d-98fc-444d-aa36-99508aa72367)
 
 > inventory-generate
-generated inventory collection 5d0b9686-48df-4642-a39c-e2dea04d5330 from configured sleds
+generated inventory collection 21e24074-fdd0-438e-a4e7-11665b7071bb from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6514,15 +6411,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (6ed56354-5941-40d1-a06c-b0e940701d52)
 
 > inventory-generate
-generated inventory collection 90f0f757-fd33-4744-abee-36616a645b87 from configured sleds
+generated inventory collection ed8ea2c4-4271-407e-9c84-54129418d171 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6658,15 +6554,14 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (9078c4ba-3a73-4b3f-ac2c-acb501f89cb2)
 
 > inventory-generate
-generated inventory collection ee9bc64a-70f7-4d81-b39d-a709754ce118 from configured sleds
+generated inventory collection 336dbc73-f973-4962-a210-3c9d424bd6a3 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial2, part_number: 913-0000019
@@ -6790,7 +6685,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (8763abc1-8a42-4932-b5a7-33109e0e0152)
 
 > inventory-generate
-generated inventory collection 3dc9d8c8-8f50-4d6e-9396-97058d1d2722 from configured sleds
+generated inventory collection 897721fc-b087-41be-a566-809d59c8aeea from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -6930,7 +6825,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (2b89e0d7-f15b-4474-8ac4-85959ed1bc88)
 
 > inventory-generate
-generated inventory collection a4dab274-0fff-47fa-bc22-b98d11ec54d2 from configured sleds
+generated inventory collection 5d0b9686-48df-4642-a39c-e2dea04d5330 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7071,7 +6966,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (7f6b7297-c2bc-4f67-b3c0-c8e555ebbdc4)
 
 > inventory-generate
-generated inventory collection d483be68-4bf3-4133-aed1-661cba8e1194 from configured sleds
+generated inventory collection 90f0f757-fd33-4744-abee-36616a645b87 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7204,7 +7099,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (59630e63-c953-4807-9e84-9e750a79f68e)
 
 > inventory-generate
-generated inventory collection 74b742c1-01da-4461-a011-785e2e11a5b2 from configured sleds
+generated inventory collection ee9bc64a-70f7-4d81-b39d-a709754ce118 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7355,7 +7250,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (e93650dc-b5ba-4ec7-8550-9171c1ada194)
 
 > inventory-generate
-generated inventory collection 78486156-ea1a-42a2-adc3-658ccd94ccd1 from configured sleds
+generated inventory collection 3dc9d8c8-8f50-4d6e-9396-97058d1d2722 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7507,7 +7402,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (90650737-8142-47a6-9a48-a10efc487e57)
 
 > inventory-generate
-generated inventory collection 0f80a0f2-360f-4c64-9c35-3dc067dd2620 from configured sleds
+generated inventory collection a4dab274-0fff-47fa-bc22-b98d11ec54d2 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7652,7 +7547,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (2182613d-dc9f-41eb-9c6a-d33801849caa)
 
 > inventory-generate
-generated inventory collection c0548a65-0ee4-4876-a5e0-3384187c88cc from configured sleds
+generated inventory collection d483be68-4bf3-4133-aed1-661cba8e1194 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7800,7 +7695,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (e8b088a8-7da0-480b-a2dc-75ffef068ece)
 
 > inventory-generate
-generated inventory collection 7349431d-718a-4353-a1ee-357ce2aeeb28 from configured sleds
+generated inventory collection 74b742c1-01da-4461-a011-785e2e11a5b2 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -7938,7 +7833,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (810ea95a-4730-43dd-867e-1984aeb9d873)
 
 > inventory-generate
-generated inventory collection 5ffc4b23-0e6e-40e9-bacd-f83ca33f9792 from configured sleds
+generated inventory collection 78486156-ea1a-42a2-adc3-658ccd94ccd1 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -8094,7 +7989,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (67c074ef-c52e-4ff1-851a-598c04dc2c8d)
 
 > inventory-generate
-generated inventory collection 2c0e8abf-b92d-4682-be5f-f0fa1e9e5b2a from configured sleds
+generated inventory collection 0f80a0f2-360f-4c64-9c35-3dc067dd2620 from configured sleds
 
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -8251,7 +8146,7 @@ external DNS:
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (0a8d2f87-1d3e-4296-ba07-108940a7a57e)
 
 > inventory-generate
-generated inventory collection a838e97f-3fe3-475a-9dcf-760577308807 from configured sleds
+generated inventory collection c0548a65-0ee4-4876-a5e0-3384187c88cc from configured sleds
 
 
 > # Start the Nexus handoff process: A planning step here should place three new
@@ -8574,7 +8469,7 @@ set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest bluepri
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (d69e1109-06be-4469-8876-4292dc7885d7)
 
 > inventory-generate
-generated inventory collection 70b80a63-ba91-427d-ac02-b4b245c70e76 from configured sleds
+generated inventory collection 7349431d-718a-4353-a1ee-357ce2aeeb28 from configured sleds
 
 
 > # Planning now should bump the top-level `nexus_generation` to 2, indicating
@@ -8723,24 +8618,15 @@ external DNS:
 
 
 > # If we expunge one of the OLD nexuses, we should observe
-> # that it is re-created. Apply the latest blueprint to the affected sled's
-> # inventory so the noop check on the next plan isn't blocked by the
-> # inventory-stale path on the bumped generation.
+> # that it is re-created.
 > blueprint-edit latest expunge-zones 0c71b3b2-6ceb-4e8f-b020-b08675e83038
 blueprint 6d830d26-547e-492b-adfe-c5c4ad9c3751 created from latest blueprint (4713f6c4-e8ba-4a28-87a0-df75ebf7b8b6): expunged zone 0c71b3b2-6ceb-4e8f-b020-b08675e83038 from sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 
 
-> sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (6d830d26-547e-492b-adfe-c5c4ad9c3751)
-
-> inventory-generate
-generated inventory collection 1330e9de-5cee-4ddc-ae6b-1981b87ac78b from configured sleds
-
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 10, num_already_artifact: 10, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (16) that is older than the generation in the parent blueprint (17)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
@@ -8828,24 +8714,23 @@ to:   blueprint 8e0cc787-e068-4a45-97ed-21029cbe4ddf
 
 
     omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
-    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
-    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
-    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service       fd00:1122:3344:101::c
-    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::6
-    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service       fd00:1122:3344:101::b
-    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::5
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:2::1  
-    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
-    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::3
-    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
-    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service       fd00:1122:3344:101::d
-*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::4
-     └─                                                                                + expunged ✓                          
-+   nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   in service       fd00:1122:3344:101::e
+    -----------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition    underlay IP          
+    -----------------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service     fd00:1122:3344:101::9
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service     fd00:1122:3344:101::7
+    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service     fd00:1122:3344:101::8
+    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service     fd00:1122:3344:101::c
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:101::6
+    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service     fd00:1122:3344:101::b
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:101::5
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:2::1  
+    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service     fd00:1122:3344:2::1  
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:101::3
+    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service     fd00:1122:3344:101::a
+    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   expunged ⏳     fd00:1122:3344:101::4
+    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service     fd00:1122:3344:101::d
++   nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   in service     fd00:1122:3344:101::e
 
 
  COCKROACHDB SETTINGS:
@@ -8877,7 +8762,7 @@ external DNS:
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (8e0cc787-e068-4a45-97ed-21029cbe4ddf)
 
 > inventory-generate
-generated inventory collection 18ad5141-06e0-4aeb-9033-c7cc49474f82 from configured sleds
+generated inventory collection 5ffc4b23-0e6e-40e9-bacd-f83ca33f9792 from configured sleds
 
 
 > # Bump the set of active Nexus zones; this simulates Nexus handoff.
@@ -8885,9 +8770,7 @@ generated inventory collection 18ad5141-06e0-4aeb-9033-c7cc49474f82 from configu
 will use active Nexus zones from generation 2
 
 
-> # Planning should now expunge one of the old Nexus zones. After each plan,
-> # apply the latest blueprint to all sleds' inventories so subsequent plans see
-> # fresh sled-agent generations rather than firing the inventory-stale path.
+> # Planning should now expunge one of the old Nexus zones.
 > blueprint-plan latest latest
 INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 10, num_already_artifact: 10, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
@@ -9002,6 +8885,92 @@ to:   blueprint e31c9054-8549-4c68-acf9-a01f68d1fc9b
      └─                                                                                + expunged ⏳                          
 
 
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 18):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    ------------------------------
+    slot   boot image source      
+    ------------------------------
+    A      current contents       
+    B      artifact: version 1.0.0
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    d7f95803-df03-49e0-9ad2-37de73f01417   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    68e4149e-114c-460e-8f33-54dd5f9a274e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_7e83b92d-6b02-47f3-a5ab-125a6bb44e29   7562b5c7-041c-44e8-9ae7-e453b63f5b03   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_26bdd109-c842-43a9-95cb-15aba9b0832b      16a8c618-d062-4bde-8ca4-301b5f14ccf2   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_abd27551-4027-4084-8b52-13a575b035b4      6119babc-cdc9-4b6b-afa4-9037eee05728   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_b9fc779e-e127-4a3b-8c6c-3294d6749a34             cf8e3f19-fd6d-4f81-9bb7-f4e2bb8d2c9d   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_d516d61b-fd96-46ad-a743-78eec814ee90             d2707e9c-d793-4a6c-8f77-2d3aa5a98390   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_e14f91b0-0c41-48a0-919d-e5078d2b89b0               312286f1-e378-464d-97cb-6fa06ba2dab7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
+    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
+    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service       fd00:1122:3344:101::c
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::6
+    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service       fd00:1122:3344:101::b
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::5
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:2::1  
+    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::3
+    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
+    nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   in service       fd00:1122:3344:101::e
+    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service       fd00:1122:3344:101::d
+*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::4
+     └─                                                                                + expunged ✓                          
+
+
  COCKROACHDB SETTINGS:
     state fingerprint:::::::::::::::::   (none) (unchanged)
     cluster.preserve_downgrade_option:   (do not modify) (unchanged)
@@ -9027,24 +8996,11 @@ external DNS:
 
 
 
-> sled-set 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (e31c9054-8549-4c68-acf9-a01f68d1fc9b)
-
-> sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (e31c9054-8549-4c68-acf9-a01f68d1fc9b)
-
-> sled-set d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (e31c9054-8549-4c68-acf9-a01f68d1fc9b)
-
-> inventory-generate
-generated inventory collection b8392284-b0b2-4c3b-b6f0-42e03911e111 from configured sleds
-
 
 > # Two more planning iterations should expunge the remaining two old 0.0.1
 > # version Nexus zones.
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (17) that is older than the generation in the parent blueprint (18)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
@@ -9067,93 +9023,6 @@ from: blueprint e31c9054-8549-4c68-acf9-a01f68d1fc9b
 to:   blueprint 3e332949-6785-4aff-ad86-6134f5ce6152
 
  MODIFIED SLEDS:
-
-  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 18):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    ------------------------------
-    slot   boot image source      
-    ------------------------------
-    A      current contents       
-    B      artifact: version 1.0.0
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
-    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
-    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              feecfda1-9966-43d4-aaef-440b77f0b26d   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              956966b9-8201-437b-81ba-3c8ad2032080   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    22a4acd6-9d38-43e2-a3bf-c85f5c2f3246   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    bccbe44f-bcf8-4868-b086-c8901f896cdc   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          6e218d0a-13fd-4f70-884e-47e960fa8bb8   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          9073fb6b-f973-4bbd-b7cc-ba1abf6cb238   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          0582030b-aab6-4d0e-b1d2-64562ee712cd   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_156bfcde-e3fa-4abe-a93e-eb4a408b4e5e   7f2ba73c-1f57-4f92-8059-738059808061   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_4ab0ec67-b27e-42b5-af22-9117ad11113b      75ffc8e6-b071-4f51-966d-4a6e6b01b432   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_698d1d82-0620-4978-93ac-0ba5d40f3da9      dfe5586b-e4a8-4b98-ad72-eabc34988177   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   expunged      none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_nexus_9ae90740-7fdb-4073-ae43-048f2fca3d69             91f7f766-931f-43ef-99b4-2399f58c946b   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_ba87399e-e9b7-4ee4-8cb7-0032822630e9               484f151e-c290-48bd-99b2-c97ef85c9844   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    100 GiB   none          gzip-9     
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/local_storage                                                   2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/local_storage                                                   09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/local_storage                                                   c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/local_storage_unencrypted                                             775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/local_storage_unencrypted                                             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/local_storage_unencrypted                                             2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
-
-
-    omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   artifact: version 1.0.0   in service       fd00:1122:3344:102::5
-    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   artifact: version 1.0.0   in service       fd00:1122:3344:102::a
-    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   artifact: version 1.0.0   in service       fd00:1122:3344:102::8
-    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 1.0.0   in service       fd00:1122:3344:102::9
-    crucible_pantry   156bfcde-e3fa-4abe-a93e-eb4a408b4e5e   artifact: version 1.0.0   in service       fd00:1122:3344:102::d
-    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::7
-    external_dns      4ab0ec67-b27e-42b5-af22-9117ad11113b   artifact: version 1.0.0   in service       fd00:1122:3344:102::c
-    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::6
-    internal_dns      698d1d82-0620-4978-93ac-0ba5d40f3da9   artifact: version 1.0.0   in service       fd00:1122:3344:1::1  
-    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:1::1  
-    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::3
-    internal_ntp      ba87399e-e9b7-4ee4-8cb7-0032822630e9   artifact: version 1.0.0   in service       fd00:1122:3344:102::b
-    nexus             9ae90740-7fdb-4073-ae43-048f2fca3d69   artifact: version 1.0.0   in service       fd00:1122:3344:102::e
-*   nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:102::4
-     └─                                                                                + expunged ✓                          
-
 
   sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 18 -> 19):
 
@@ -9267,23 +9136,9 @@ external DNS:
 
 
 
-> sled-set 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (3e332949-6785-4aff-ad86-6134f5ce6152)
-
-> sled-set 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (3e332949-6785-4aff-ad86-6134f5ce6152)
-
-> sled-set d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (3e332949-6785-4aff-ad86-6134f5ce6152)
-
-> inventory-generate
-generated inventory collection 2b99b4d7-debb-4b8c-b00e-a623f9f5714c from configured sleds
-
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (17) that is older than the generation in the parent blueprint (18)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (18) that is older than the generation in the parent blueprint (19)
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO skipping board for MGS-driven update (no update necessary), serial_number: serial0, part_number: 913-0000019
@@ -9304,92 +9159,6 @@ from: blueprint 3e332949-6785-4aff-ad86-6134f5ce6152
 to:   blueprint 05685571-d61f-4754-a2b2-604ea8c45dff
 
  MODIFIED SLEDS:
-
-  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 19):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    ------------------------------
-    slot   boot image source      
-    ------------------------------
-    A      current contents       
-    B      artifact: version 1.0.0
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
-    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
-    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    d7f95803-df03-49e0-9ad2-37de73f01417   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    68e4149e-114c-460e-8f33-54dd5f9a274e   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_7e83b92d-6b02-47f3-a5ab-125a6bb44e29   7562b5c7-041c-44e8-9ae7-e453b63f5b03   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_26bdd109-c842-43a9-95cb-15aba9b0832b      16a8c618-d062-4bde-8ca4-301b5f14ccf2   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_abd27551-4027-4084-8b52-13a575b035b4      6119babc-cdc9-4b6b-afa4-9037eee05728   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_b9fc779e-e127-4a3b-8c6c-3294d6749a34             cf8e3f19-fd6d-4f81-9bb7-f4e2bb8d2c9d   expunged      none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_d516d61b-fd96-46ad-a743-78eec814ee90             d2707e9c-d793-4a6c-8f77-2d3aa5a98390   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   expunged      none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_e14f91b0-0c41-48a0-919d-e5078d2b89b0               312286f1-e378-464d-97cb-6fa06ba2dab7   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
-
-
-    omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
-    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
-    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
-    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service       fd00:1122:3344:101::c
-    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::6
-    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service       fd00:1122:3344:101::b
-    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::5
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:2::1  
-    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
-    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::3
-    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
-    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::4
-    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service       fd00:1122:3344:101::d
-*   nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::e
-     └─                                                                                + expunged ✓                          
-
 
   sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 16 -> 17):
 
@@ -9513,7 +9282,7 @@ set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest bluepri
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (05685571-d61f-4754-a2b2-604ea8c45dff)
 
 > inventory-generate
-generated inventory collection 85b886b3-77f1-448f-b80b-b519a7209328 from configured sleds
+generated inventory collection 2c0e8abf-b92d-4682-be5f-f0fa1e9e5b2a from configured sleds
 
 
 > # Planning now should note that the old zones are gone, but do nothing else:
@@ -9541,6 +9310,179 @@ from: blueprint 05685571-d61f-4754-a2b2-604ea8c45dff
 to:   blueprint 008e1541-3d9d-4a50-a877-eed4a3cf86ab
 
  MODIFIED SLEDS:
+
+  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 18):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    ------------------------------
+    slot   boot image source      
+    ------------------------------
+    A      current contents       
+    B      artifact: version 1.0.0
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
+    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
+    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              feecfda1-9966-43d4-aaef-440b77f0b26d   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              956966b9-8201-437b-81ba-3c8ad2032080   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    22a4acd6-9d38-43e2-a3bf-c85f5c2f3246   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    bccbe44f-bcf8-4868-b086-c8901f896cdc   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          6e218d0a-13fd-4f70-884e-47e960fa8bb8   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          9073fb6b-f973-4bbd-b7cc-ba1abf6cb238   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          0582030b-aab6-4d0e-b1d2-64562ee712cd   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_156bfcde-e3fa-4abe-a93e-eb4a408b4e5e   7f2ba73c-1f57-4f92-8059-738059808061   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_4ab0ec67-b27e-42b5-af22-9117ad11113b      75ffc8e6-b071-4f51-966d-4a6e6b01b432   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_698d1d82-0620-4978-93ac-0ba5d40f3da9      dfe5586b-e4a8-4b98-ad72-eabc34988177   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   expunged      none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_nexus_9ae90740-7fdb-4073-ae43-048f2fca3d69             91f7f766-931f-43ef-99b4-2399f58c946b   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_ba87399e-e9b7-4ee4-8cb7-0032822630e9               484f151e-c290-48bd-99b2-c97ef85c9844   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    100 GiB   none          gzip-9     
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/local_storage                                                   2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/local_storage                                                   09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/local_storage                                                   c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/local_storage_unencrypted                                             775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/local_storage_unencrypted                                             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/local_storage_unencrypted                                             2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   artifact: version 1.0.0   in service       fd00:1122:3344:102::5
+    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   artifact: version 1.0.0   in service       fd00:1122:3344:102::a
+    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   artifact: version 1.0.0   in service       fd00:1122:3344:102::8
+    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 1.0.0   in service       fd00:1122:3344:102::9
+    crucible_pantry   156bfcde-e3fa-4abe-a93e-eb4a408b4e5e   artifact: version 1.0.0   in service       fd00:1122:3344:102::d
+    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::7
+    external_dns      4ab0ec67-b27e-42b5-af22-9117ad11113b   artifact: version 1.0.0   in service       fd00:1122:3344:102::c
+    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::6
+    internal_dns      698d1d82-0620-4978-93ac-0ba5d40f3da9   artifact: version 1.0.0   in service       fd00:1122:3344:1::1  
+    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:1::1  
+    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:102::3
+    internal_ntp      ba87399e-e9b7-4ee4-8cb7-0032822630e9   artifact: version 1.0.0   in service       fd00:1122:3344:102::b
+    nexus             9ae90740-7fdb-4073-ae43-048f2fca3d69   artifact: version 1.0.0   in service       fd00:1122:3344:102::e
+*   nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:102::4
+     └─                                                                                + expunged ✓                          
+
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 19):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    ------------------------------
+    slot   boot image source      
+    ------------------------------
+    A      current contents       
+    B      artifact: version 1.0.0
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    d7f95803-df03-49e0-9ad2-37de73f01417   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    68e4149e-114c-460e-8f33-54dd5f9a274e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_7e83b92d-6b02-47f3-a5ab-125a6bb44e29   7562b5c7-041c-44e8-9ae7-e453b63f5b03   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_26bdd109-c842-43a9-95cb-15aba9b0832b      16a8c618-d062-4bde-8ca4-301b5f14ccf2   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_abd27551-4027-4084-8b52-13a575b035b4      6119babc-cdc9-4b6b-afa4-9037eee05728   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_b9fc779e-e127-4a3b-8c6c-3294d6749a34             cf8e3f19-fd6d-4f81-9bb7-f4e2bb8d2c9d   expunged      none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_d516d61b-fd96-46ad-a743-78eec814ee90             d2707e9c-d793-4a6c-8f77-2d3aa5a98390   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   expunged      none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_e14f91b0-0c41-48a0-919d-e5078d2b89b0               312286f1-e378-464d-97cb-6fa06ba2dab7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 1.0.0   in service       fd00:1122:3344:101::9
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 1.0.0   in service       fd00:1122:3344:101::7
+    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 1.0.0   in service       fd00:1122:3344:101::8
+    crucible_pantry   7e83b92d-6b02-47f3-a5ab-125a6bb44e29   artifact: version 1.0.0   in service       fd00:1122:3344:101::c
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::6
+    external_dns      26bdd109-c842-43a9-95cb-15aba9b0832b   artifact: version 1.0.0   in service       fd00:1122:3344:101::b
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::5
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:2::1  
+    internal_dns      abd27551-4027-4084-8b52-13a575b035b4   artifact: version 1.0.0   in service       fd00:1122:3344:2::1  
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::3
+    internal_ntp      e14f91b0-0c41-48a0-919d-e5078d2b89b0   artifact: version 1.0.0   in service       fd00:1122:3344:101::a
+    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   expunged ✓       fd00:1122:3344:101::4
+    nexus             d516d61b-fd96-46ad-a743-78eec814ee90   artifact: version 1.0.0   in service       fd00:1122:3344:101::d
+*   nexus             b9fc779e-e127-4a3b-8c6c-3294d6749a34   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:101::e
+     └─                                                                                + expunged ✓                          
+
 
   sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 17):
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-unknown-measurements-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-unknown-measurements-stdout
@@ -337,15 +337,9 @@ external DNS:
 generated inventory collection 61f451b3-2121-4ed6-91c7-a550054f6c21 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 7, num_already_artifact: 7, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
 generated blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4 based on parent blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
 blueprint source: planner with report:
 planning report:

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-unknown-measurements-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-unknown-measurements-stdout
@@ -341,9 +341,9 @@ external DNS:
 generated inventory collection 61f451b3-2121-4ed6-91c7-a550054f6c21 from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: for sled, inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)
 generated blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4 based on parent blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
 blueprint source: planner with report:
 planning report:

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-unknown-measurements-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-unknown-measurements-stdout
@@ -332,7 +332,11 @@ external DNS:
 
 
 
-> # Next plan should show waiting on inventory to have the measurements
+> # The previous plan bumped each sled's sled-agent generation, but inventory
+> # hasn't been advanced via `sled-set ... omicron-config latest` yet. The next
+> # plan should therefore mark each sled's noop check as ineligible due to
+> # stale inventory, and the planning report should still show that we're
+> # waiting on measurements to converge.
 > inventory-generate
 generated inventory collection 61f451b3-2121-4ed6-91c7-a550054f6c21 from configured sleds
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
@@ -1665,28 +1665,10 @@ external DNS:
 
 
 
-> # The expungement above bumped the host sled's sled-agent generation. Apply
-> # the latest blueprint to all sleds so the noop check on subsequent plans
-> # doesn't fire the inventory-stale path for the affected sled.
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (df06bb57-ad42-4431-9206-abff322896c7)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (df06bb57-ad42-4431-9206-abff322896c7)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (df06bb57-ad42-4431-9206-abff322896c7)
-
-> inventory-generate
-generated inventory collection a71f7a73-35a6-45e8-acbe-f1c5925eed69 from configured sleds
-
-
 > # Attempt to upgrade one RoT bootloader. This should successfully plan the
 > # pending RoT bootloader update
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1700,9 +1682,7 @@ blueprint source: planner with report:
 planning report:
 * 1 pending MGS update:
   * 913-0000019:serial0: RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: NoValidVersion })
-* discretionary zones placed:
-  * internal_dns zone on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c from source artifact: version 0.0.1
-* zone updates waiting on discretionary zones
+* zone updates waiting on pending MGS updates (RoT bootloader / RoT / SP / Host OS)
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
 
 
@@ -1710,86 +1690,6 @@ planning report:
 > blueprint-diff latest
 from: blueprint df06bb57-ad42-4431-9206-abff322896c7
 to:   blueprint 7f976e0d-d2a5-4eeb-9e82-c82bc2824aba
-
- MODIFIED SLEDS:
-
-  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 4 -> 5):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    ------------------------
-    slot   boot image source
-    ------------------------
-    A      current contents 
-    B      current contents 
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
-    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
-    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              feecfda1-9966-43d4-aaef-440b77f0b26d   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              956966b9-8201-437b-81ba-3c8ad2032080   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          6e218d0a-13fd-4f70-884e-47e960fa8bb8   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          9073fb6b-f973-4bbd-b7cc-ba1abf6cb238   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          0582030b-aab6-4d0e-b1d2-64562ee712cd   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    100 GiB   none          gzip-9     
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/local_storage                                                   2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/local_storage                                                   09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/local_storage                                                   c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/local_storage_unencrypted                                             775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/local_storage_unencrypted                                             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/local_storage_unencrypted                                             2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
-+   oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    0e04c3b5-47fc-412c-b352-dbf09a6bfac8   in service    none      none          off        
-+   oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_ff6dceb4-84c5-4e0e-afe1-3c884cb656cb      71d27157-3ff7-4806-be2e-1ad6d6b5bfa2   in service    none      none          off        
-
-
-    omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition      underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   artifact: version 0.0.1   in service       fd00:1122:3344:102::5
-    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   artifact: version 0.0.1   in service       fd00:1122:3344:102::a
-    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   artifact: version 0.0.1   in service       fd00:1122:3344:102::8
-    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 0.0.1   in service       fd00:1122:3344:102::9
-    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 0.0.1   in service       fd00:1122:3344:102::7
-    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 0.0.1   in service       fd00:1122:3344:102::6
-    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 0.0.1   in service       fd00:1122:3344:102::3
-    nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   in service       fd00:1122:3344:102::4
-*   internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:1::1  
-     └─                                                                                + expunged ✓                          
-+   internal_dns      ff6dceb4-84c5-4e0e-afe1-3c884cb656cb   artifact: version 0.0.1   in service       fd00:1122:3344:1::1  
-
 
  COCKROACHDB SETTINGS:
     state fingerprint:::::::::::::::::   (none) (unchanged)
@@ -1815,30 +1715,8 @@ to:   blueprint 7f976e0d-d2a5-4eeb-9e82-c82bc2824aba
 
 
 internal DNS:
-* DNS zone: "control-plane.oxide.internal": 
-*   name: @                                                  (records: 2 -> 3)
--       NS   ns1.control-plane.oxide.internal
--       NS   ns2.control-plane.oxide.internal
-+       NS   ns1.control-plane.oxide.internal
-+       NS   ns2.control-plane.oxide.internal
-+       NS   ns3.control-plane.oxide.internal
-*   name: _nameservice._tcp                                  (records: 2 -> 3)
--       SRV  port  5353 427ec88f-f467-42fa-9bbb-66a91a36103c.host.control-plane.oxide.internal
--       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
-+       SRV  port  5353 427ec88f-f467-42fa-9bbb-66a91a36103c.host.control-plane.oxide.internal
-+       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
-+       SRV  port  5353 ff6dceb4-84c5-4e0e-afe1-3c884cb656cb.host.control-plane.oxide.internal
-+   name: ff6dceb4-84c5-4e0e-afe1-3c884cb656cb.host          (records: 1)
-+       AAAA fd00:1122:3344:1::1
-*   name: ns1                                                (records: 1 -> 1)
--       AAAA fd00:1122:3344:2::1
-+       AAAA fd00:1122:3344:1::1
-*   name: ns2                                                (records: 1 -> 1)
--       AAAA fd00:1122:3344:3::1
-+       AAAA fd00:1122:3344:2::1
-+   name: ns3                                                (records: 1)
-+       AAAA fd00:1122:3344:3::1
-    unchanged names: 46 (records: 58)
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    unchanged names: 50 (records: 64)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
@@ -1847,27 +1725,9 @@ external DNS:
 
 
 
-> # Apply the latest blueprint to all sleds' inventories so the noop check on
-> # the next plan doesn't fire the inventory-stale path for whichever sled the
-> # above plan bumped.
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (7f976e0d-d2a5-4eeb-9e82-c82bc2824aba)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (7f976e0d-d2a5-4eeb-9e82-c82bc2824aba)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (7f976e0d-d2a5-4eeb-9e82-c82bc2824aba)
-
-> inventory-generate
-generated inventory collection 0b5efbb3-0b1b-4bbf-b7d8-a2d6fca074c6 from configured sleds
-
-
 > # We generate another plan, there should be no changes
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1907,7 +1767,7 @@ to:   blueprint 9034c710-3e57-45f3-99e5-4316145e87ac
 
 internal DNS:
   DNS zone: "control-plane.oxide.internal" (unchanged)
-    unchanged names: 52 (records: 68)
+    unchanged names: 50 (records: 64)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
@@ -1931,12 +1791,10 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT bootloader versions: stage0 ->
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT bootloader versions: stage0 -> 1.0.0
 
 > inventory-generate
-generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
+generated inventory collection a71f7a73-35a6-45e8-acbe-f1c5925eed69 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1986,28 +1844,13 @@ to:   blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976
 
 internal DNS:
   DNS zone: "control-plane.oxide.internal" (unchanged)
-    unchanged names: 52 (records: 68)
+    unchanged names: 50 (records: 64)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
     unchanged names: 5 (records: 9)
 
 
-
-
-> # Apply the latest blueprint again before the next sled-update steps so each
-> # subsequent plan starts from a fresh sled-agent generation.
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
-
-> inventory-generate
-generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
 
 
 > # We repeat the same process with the RoT, but now expecting to see a single
@@ -2023,12 +1866,10 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT settings: slot b -> 1.0.0, act
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.0.0, active slot -> B, persistent boot preference -> B
 
 > inventory-generate
-generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configured sleds
+generated inventory collection 0b5efbb3-0b1b-4bbf-b7d8-a2d6fca074c6 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -2036,13 +1877,16 @@ INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-495
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO MGS-driven update completed (will remove it and re-evaluate board), artifact_version: 1.0.0, artifact_hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, expected_transient_boot_preference: None, expected_pending_persistent_boot_preference: None, expected_persistent_boot_preference: A, expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, component: rot, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: 913-0000019
-INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: 913-0000019
+INFO skipping board for MGS-driven update (found issues), serial_number: serial0, part_number: 913-0000019
+INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: 913-0000019
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736 based on parent blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976
 blueprint source: planner with report:
 planning report:
 * 1 pending MGS update:
-  * 913-0000019:serial0: Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })
+  * 913-0000019:serial1: Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })
+* 1 blocked MGS update:
+  * 913-0000019:serial0: failed to plan an SP update: sled contains zones that are unsafe to shut down: "427ec88f-f467-42fa-9bbb-66a91a36103c: only 2/2 internal DNS zones are synchronized; require at least 3"
 * zone updates waiting on pending MGS updates (RoT bootloader / RoT / SP / Host OS)
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
 
@@ -2069,36 +1913,22 @@ to:   blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736
  PENDING MGS UPDATES:
 
     Pending MGS-managed updates (all baseboards):
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    sp_type   slot   part_number   serial_number   artifact_hash                                                        artifact_version   details                                                                                                                                                                                                                                                                                                         
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-*   sled      0      913-0000019   serial0         - d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02   1.0.0              - Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, expected_persistent_boot_preference: A, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: None })
-     └─                                            + 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4                      + Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })                                                                                                                                                                                
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_hash                                                      artifact_version   details                                                                                                                                                                                                                                                                                                       
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   sled      0      913-0000019   serial0         d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02   1.0.0              Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, expected_persistent_boot_preference: A, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: None })
++   sled      1      913-0000019   serial1         68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4   1.0.0              Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })                                                                                                                                                                                
 
 
 internal DNS:
   DNS zone: "control-plane.oxide.internal" (unchanged)
-    unchanged names: 52 (records: 68)
+    unchanged names: 50 (records: 64)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
     unchanged names: 5 (records: 9)
 
 
-
-
-> # Apply the latest blueprint again before the next sled-update steps.
-> sled-set serial0 omicron-config latest
-set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (a5a8f242-ffa5-473c-8efd-2acf2dc0b736)
-
-> sled-set serial1 omicron-config latest
-set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (a5a8f242-ffa5-473c-8efd-2acf2dc0b736)
-
-> sled-set serial2 omicron-config latest
-set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (a5a8f242-ffa5-473c-8efd-2acf2dc0b736)
-
-> inventory-generate
-generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configured sleds
 
 
 > # Since there was a blocked update on serial0, the planner has moved on to
@@ -2114,34 +1944,35 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c SP versions: active -> 1.0.0
 > sled-update-sp serial2 --active 1.0.0
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 SP versions: active -> 1.0.0
 
-> sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
+> sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47 
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 2 details: boot_disk -> B, B -> d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
 
-> sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
+> sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b 
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 1 details: active -> B, B -> b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 
 > inventory-generate
-generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configured sleds
+generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
-INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO MGS-driven update completed (will remove it and re-evaluate board), artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: 913-0000019
-INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b, sled_agent_address: [fd00:1122:3344:101::1]:12345, expected_inactive_phase_2_hash: d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: 913-0000019
-INFO reached maximum number of pending MGS-driven updates, max: 1
+INFO MGS-driven update completed (will remove it and re-evaluate board), artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: 913-0000019
+INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
+INFO skipping board for MGS-driven update (found issues), serial_number: serial0, part_number: 913-0000019
+INFO skipping board for MGS-driven update (found issues), serial_number: serial2, part_number: 913-0000019
+INFO ran out of boards for MGS-driven update
 generated blueprint 626487fa-7139-45ec-8416-902271fc730b based on parent blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736
 blueprint source: planner with report:
 planning report:
-* noop converting host phase 2 slot B to Artifact on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
-* 1 pending MGS update:
-  * 913-0000019:serial0: HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47"), sled_agent_address: [fd00:1122:3344:101::1]:12345 })
-* zone updates waiting on pending MGS updates (RoT bootloader / RoT / SP / Host OS)
+* 2 blocked MGS updates:
+  * 913-0000019:serial0: failed to plan a Host OS update: sled contains zones that are unsafe to shut down: "427ec88f-f467-42fa-9bbb-66a91a36103c: only 2/2 internal DNS zones are synchronized; require at least 3"
+  * 913-0000019:serial2: failed to plan a Host OS update: sled contains zones that are unsafe to shut down: "ea5b4030-b52f-44b2-8d70-45f15f987d01: only 2/2 internal DNS zones are synchronized; require at least 3"
+* zone updates waiting on blocked MGS updates (RoT bootloader / RoT / SP / Host OS)
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
 
 
@@ -2149,158 +1980,6 @@ planning report:
 > blueprint-diff latest
 from: blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736
 to:   blueprint 626487fa-7139-45ec-8416-902271fc730b
-
- MODIFIED SLEDS:
-
-  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 5 -> 6):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    --------------------------------
-    slot   boot image source        
-    --------------------------------
-    A      current contents         
-*   B      - current contents       
-     └─    + artifact: version 1.0.0
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
-    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
-    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              feecfda1-9966-43d4-aaef-440b77f0b26d   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              956966b9-8201-437b-81ba-3c8ad2032080   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    0e04c3b5-47fc-412c-b352-dbf09a6bfac8   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          6e218d0a-13fd-4f70-884e-47e960fa8bb8   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          9073fb6b-f973-4bbd-b7cc-ba1abf6cb238   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          0582030b-aab6-4d0e-b1d2-64562ee712cd   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   expunged      none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_ff6dceb4-84c5-4e0e-afe1-3c884cb656cb      71d27157-3ff7-4806-be2e-1ad6d6b5bfa2   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    100 GiB   none          gzip-9     
-    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/local_storage                                                   2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/local_storage                                                   09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/local_storage                                                   c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
-    oxp_727522a7-934f-494d-b5b3-160968e74463/local_storage_unencrypted                                             775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
-    oxp_72c59873-31ff-4e36-8d76-ff834009349a/local_storage_unencrypted                                             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
-    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/local_storage_unencrypted                                             2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
-
-
-    omicron zones:
-    -----------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition    underlay IP          
-    -----------------------------------------------------------------------------------------------------------------------
-    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   artifact: version 0.0.1   in service     fd00:1122:3344:102::5
-    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   artifact: version 0.0.1   in service     fd00:1122:3344:102::a
-    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   artifact: version 0.0.1   in service     fd00:1122:3344:102::8
-    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 0.0.1   in service     fd00:1122:3344:102::9
-    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 0.0.1   in service     fd00:1122:3344:102::7
-    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 0.0.1   in service     fd00:1122:3344:102::6
-    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:1::1  
-    internal_dns      ff6dceb4-84c5-4e0e-afe1-3c884cb656cb   artifact: version 0.0.1   in service     fd00:1122:3344:1::1  
-    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 0.0.1   in service     fd00:1122:3344:102::3
-    nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   in service     fd00:1122:3344:102::4
-
-
-  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 3 -> 4):
-
-    measurements:
-    --------------------------------------------------------------------------------
-    hash                                                               version      
-    --------------------------------------------------------------------------------
-    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
-
-
-    host phase 2 contents:
-    --------------------------------
-    slot   boot image source        
-    --------------------------------
-    A      current contents         
-*   B      - current contents       
-     └─    + artifact: version 1.0.0
-
-
-    physical disks:
-    ------------------------------------------------------------------------------------
-    vendor        model        serial                                        disposition
-    ------------------------------------------------------------------------------------
-    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
-    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
-    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
-
-
-    datasets:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
-    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
-    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
-    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
-
-
-    omicron zones:
-    ----------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source              disposition   underlay IP          
-    ----------------------------------------------------------------------------------------------------------------------
-    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 0.0.1   in service    fd00:1122:3344:101::9
-    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 0.0.1   in service    fd00:1122:3344:101::7
-    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 0.0.1   in service    fd00:1122:3344:101::8
-    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   in service    fd00:1122:3344:101::6
-    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   in service    fd00:1122:3344:101::5
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   in service    fd00:1122:3344:2::1  
-    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   in service    fd00:1122:3344:101::3
-    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   in service    fd00:1122:3344:101::4
-
 
  COCKROACHDB SETTINGS:
     state fingerprint:::::::::::::::::   (none) (unchanged)
@@ -2319,16 +1998,15 @@ to:   blueprint 626487fa-7139-45ec-8416-902271fc730b
  PENDING MGS UPDATES:
 
     Pending MGS-managed updates (all baseboards):
-    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    sp_type   slot   part_number   serial_number   artifact_hash                                                        artifact_version   details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
-    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-*   sled      0      913-0000019   serial0         - 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4   1.0.0              - Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
-     └─                                            + b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b                      + HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47"), sled_agent_address: [fd00:1122:3344:101::1]:12345 })
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_hash                                                      artifact_version   details                                                                                                                       
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   sled      1      913-0000019   serial1         68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4   1.0.0              Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })
 
 
 internal DNS:
   DNS zone: "control-plane.oxide.internal" (unchanged)
-    unchanged names: 52 (records: 68)
+    unchanged names: 50 (records: 64)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
@@ -1528,8 +1528,15 @@ blueprint source: edited directly with reconfigurator-cli
 > #
 > # Note that since we are not running the command to emulate the sled-agent
 > # performing an inventory collection and seeing the DNS zone has gone away, the
-> # planner will not attemt to restore the internal DNS zone. This is intentional
-> # as we want the zone to stay in this state for the purposes of this test
+> # planner will not attempt to restore the internal DNS zone. This is intentional
+> # as we want the zone to stay in this state for the purposes of this test.
+> #
+> # A secondary effect of pinning inventory this way is that the noop image source
+> # check on serial1 will be skipped with reason "inventory stale" for the rest
+> # of this test: the expunge bumps serial1's blueprint sled-agent generation,
+> # but inventory still reports the prior generation. That's the correct
+> # behavior; see `cmds-noop-stale-inventory.txt` for a focused test of the
+> # inventory-staleness guarantee.
 > blueprint-edit latest expunge-zones 99e2f30b-3174-40bf-a78a-90da8abba8ca
 blueprint df06bb57-ad42-4431-9206-abff322896c7 created from latest blueprint (af934083-59b5-4bf6-8966-6fb5292c29e1): expunged zone 99e2f30b-3174-40bf-a78a-90da8abba8ca from sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 
@@ -1668,7 +1675,7 @@ external DNS:
 > # Attempt to upgrade one RoT bootloader. This should successfully plan the
 > # pending RoT bootloader update
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1727,7 +1734,7 @@ external DNS:
 
 > # We generate another plan, there should be no changes
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1794,7 +1801,7 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT bootloader versions: stage0 ->
 generated inventory collection a71f7a73-35a6-45e8-acbe-f1c5925eed69 from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1869,7 +1876,7 @@ set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.0.0, act
 generated inventory collection 0b5efbb3-0b1b-4bbf-b7d8-a2d6fca074c6 from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -1944,17 +1951,17 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c SP versions: active -> 1.0.0
 > sled-update-sp serial2 --active 1.0.0
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 SP versions: active -> 1.0.0
 
-> sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47 
+> sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 2 details: boot_disk -> B, B -> d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
 
-> sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b 
+> sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 1 details: active -> B, B -> b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 
 > inventory-generate
 generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
 
 > blueprint-plan latest latest
-INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: for sled, inventory reported generation (3) that is older than the generation in the parent blueprint (4)
+INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (3) that is older than the generation in the parent blueprint (4)
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
@@ -1665,6 +1665,22 @@ external DNS:
 
 
 
+> # The expungement above bumped the host sled's sled-agent generation. Apply
+> # the latest blueprint to all sleds so the noop check on subsequent plans
+> # doesn't fire the inventory-stale path for the affected sled.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (df06bb57-ad42-4431-9206-abff322896c7)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (df06bb57-ad42-4431-9206-abff322896c7)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (df06bb57-ad42-4431-9206-abff322896c7)
+
+> inventory-generate
+generated inventory collection a71f7a73-35a6-45e8-acbe-f1c5925eed69 from configured sleds
+
+
 > # Attempt to upgrade one RoT bootloader. This should successfully plan the
 > # pending RoT bootloader update
 > blueprint-plan latest latest
@@ -1684,7 +1700,9 @@ blueprint source: planner with report:
 planning report:
 * 1 pending MGS update:
   * 913-0000019:serial0: RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: NoValidVersion })
-* zone updates waiting on pending MGS updates (RoT bootloader / RoT / SP / Host OS)
+* discretionary zones placed:
+  * internal_dns zone on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c from source artifact: version 0.0.1
+* zone updates waiting on discretionary zones
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
 
 
@@ -1692,6 +1710,86 @@ planning report:
 > blueprint-diff latest
 from: blueprint df06bb57-ad42-4431-9206-abff322896c7
 to:   blueprint 7f976e0d-d2a5-4eeb-9e82-c82bc2824aba
+
+ MODIFIED SLEDS:
+
+  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 4 -> 5):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
+    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
+    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              feecfda1-9966-43d4-aaef-440b77f0b26d   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              956966b9-8201-437b-81ba-3c8ad2032080   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          6e218d0a-13fd-4f70-884e-47e960fa8bb8   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          9073fb6b-f973-4bbd-b7cc-ba1abf6cb238   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          0582030b-aab6-4d0e-b1d2-64562ee712cd   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    100 GiB   none          gzip-9     
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/local_storage                                                   2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/local_storage                                                   09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/local_storage                                                   c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/local_storage_unencrypted                                             775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/local_storage_unencrypted                                             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/local_storage_unencrypted                                             2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
++   oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    0e04c3b5-47fc-412c-b352-dbf09a6bfac8   in service    none      none          off        
++   oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_ff6dceb4-84c5-4e0e-afe1-3c884cb656cb      71d27157-3ff7-4806-be2e-1ad6d6b5bfa2   in service    none      none          off        
+
+
+    omicron zones:
+    -------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition      underlay IP          
+    -------------------------------------------------------------------------------------------------------------------------
+    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   artifact: version 0.0.1   in service       fd00:1122:3344:102::5
+    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   artifact: version 0.0.1   in service       fd00:1122:3344:102::a
+    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   artifact: version 0.0.1   in service       fd00:1122:3344:102::8
+    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 0.0.1   in service       fd00:1122:3344:102::9
+    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 0.0.1   in service       fd00:1122:3344:102::7
+    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 0.0.1   in service       fd00:1122:3344:102::6
+    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 0.0.1   in service       fd00:1122:3344:102::3
+    nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   in service       fd00:1122:3344:102::4
+*   internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 0.0.1   - expunged ⏳     fd00:1122:3344:1::1  
+     └─                                                                                + expunged ✓                          
++   internal_dns      ff6dceb4-84c5-4e0e-afe1-3c884cb656cb   artifact: version 0.0.1   in service       fd00:1122:3344:1::1  
+
 
  COCKROACHDB SETTINGS:
     state fingerprint:::::::::::::::::   (none) (unchanged)
@@ -1717,8 +1815,30 @@ to:   blueprint 7f976e0d-d2a5-4eeb-9e82-c82bc2824aba
 
 
 internal DNS:
-  DNS zone: "control-plane.oxide.internal" (unchanged)
-    unchanged names: 50 (records: 64)
+* DNS zone: "control-plane.oxide.internal": 
+*   name: @                                                  (records: 2 -> 3)
+-       NS   ns1.control-plane.oxide.internal
+-       NS   ns2.control-plane.oxide.internal
++       NS   ns1.control-plane.oxide.internal
++       NS   ns2.control-plane.oxide.internal
++       NS   ns3.control-plane.oxide.internal
+*   name: _nameservice._tcp                                  (records: 2 -> 3)
+-       SRV  port  5353 427ec88f-f467-42fa-9bbb-66a91a36103c.host.control-plane.oxide.internal
+-       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
++       SRV  port  5353 427ec88f-f467-42fa-9bbb-66a91a36103c.host.control-plane.oxide.internal
++       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
++       SRV  port  5353 ff6dceb4-84c5-4e0e-afe1-3c884cb656cb.host.control-plane.oxide.internal
++   name: ff6dceb4-84c5-4e0e-afe1-3c884cb656cb.host          (records: 1)
++       AAAA fd00:1122:3344:1::1
+*   name: ns1                                                (records: 1 -> 1)
+-       AAAA fd00:1122:3344:2::1
++       AAAA fd00:1122:3344:1::1
+*   name: ns2                                                (records: 1 -> 1)
+-       AAAA fd00:1122:3344:3::1
++       AAAA fd00:1122:3344:2::1
++   name: ns3                                                (records: 1)
++       AAAA fd00:1122:3344:3::1
+    unchanged names: 46 (records: 58)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
@@ -1727,9 +1847,25 @@ external DNS:
 
 
 
+> # Apply the latest blueprint to all sleds' inventories so the noop check on
+> # the next plan doesn't fire the inventory-stale path for whichever sled the
+> # above plan bumped.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (7f976e0d-d2a5-4eeb-9e82-c82bc2824aba)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (7f976e0d-d2a5-4eeb-9e82-c82bc2824aba)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (7f976e0d-d2a5-4eeb-9e82-c82bc2824aba)
+
+> inventory-generate
+generated inventory collection 0b5efbb3-0b1b-4bbf-b7d8-a2d6fca074c6 from configured sleds
+
+
 > # We generate another plan, there should be no changes
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
+INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
@@ -1771,7 +1907,7 @@ to:   blueprint 9034c710-3e57-45f3-99e5-4316145e87ac
 
 internal DNS:
   DNS zone: "control-plane.oxide.internal" (unchanged)
-    unchanged names: 50 (records: 64)
+    unchanged names: 52 (records: 68)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
@@ -1795,10 +1931,10 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT bootloader versions: stage0 ->
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT bootloader versions: stage0 -> 1.0.0
 
 > inventory-generate
-generated inventory collection a71f7a73-35a6-45e8-acbe-f1c5925eed69 from configured sleds
+generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
+INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
@@ -1850,13 +1986,28 @@ to:   blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976
 
 internal DNS:
   DNS zone: "control-plane.oxide.internal" (unchanged)
-    unchanged names: 50 (records: 64)
+    unchanged names: 52 (records: 68)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
     unchanged names: 5 (records: 9)
 
 
+
+
+> # Apply the latest blueprint again before the next sled-update steps so each
+> # subsequent plan starts from a fresh sled-agent generation.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (d60afc57-f15d-476c-bd0f-b1071e2bb976)
+
+> inventory-generate
+generated inventory collection 39363465-89ae-4ac2-9be1-099068da9d45 from configured sleds
 
 
 > # We repeat the same process with the RoT, but now expecting to see a single
@@ -1872,10 +2023,10 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c RoT settings: slot b -> 1.0.0, act
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 RoT settings: slot b -> 1.0.0, active slot -> B, persistent boot preference -> B
 
 > inventory-generate
-generated inventory collection 0b5efbb3-0b1b-4bbf-b7d8-a2d6fca074c6 from configured sleds
+generated inventory collection 04bc9001-0836-4fec-b9cb-9d4760caf8b4 from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
+INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
@@ -1885,16 +2036,13 @@ INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-495
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO MGS-driven update completed (will remove it and re-evaluate board), artifact_version: 1.0.0, artifact_hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, expected_transient_boot_preference: None, expected_pending_persistent_boot_preference: None, expected_persistent_boot_preference: A, expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, component: rot, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: 913-0000019
-INFO skipping board for MGS-driven update (found issues), serial_number: serial0, part_number: 913-0000019
-INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: 913-0000019
+INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: 913-0000019
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736 based on parent blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976
 blueprint source: planner with report:
 planning report:
 * 1 pending MGS update:
-  * 913-0000019:serial1: Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })
-* 1 blocked MGS update:
-  * 913-0000019:serial0: failed to plan an SP update: sled contains zones that are unsafe to shut down: "427ec88f-f467-42fa-9bbb-66a91a36103c: only 2/2 internal DNS zones are synchronized; require at least 3"
+  * 913-0000019:serial0: Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT bootloader / RoT / SP / Host OS)
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
 
@@ -1921,22 +2069,36 @@ to:   blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736
  PENDING MGS UPDATES:
 
     Pending MGS-managed updates (all baseboards):
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    sp_type   slot   part_number   serial_number   artifact_hash                                                      artifact_version   details                                                                                                                                                                                                                                                                                                       
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   sled      0      913-0000019   serial0         d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02   1.0.0              Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, expected_persistent_boot_preference: A, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: None })
-+   sled      1      913-0000019   serial1         68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4   1.0.0              Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })                                                                                                                                                                                
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_hash                                                        artifact_version   details                                                                                                                                                                                                                                                                                                         
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+*   sled      0      913-0000019   serial0         - d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02   1.0.0              - Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, expected_persistent_boot_preference: A, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: None })
+     └─                                            + 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4                      + Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })                                                                                                                                                                                
 
 
 internal DNS:
   DNS zone: "control-plane.oxide.internal" (unchanged)
-    unchanged names: 50 (records: 64)
+    unchanged names: 52 (records: 68)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
     unchanged names: 5 (records: 9)
 
 
+
+
+> # Apply the latest blueprint again before the next sled-update steps.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (a5a8f242-ffa5-473c-8efd-2acf2dc0b736)
+
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (a5a8f242-ffa5-473c-8efd-2acf2dc0b736)
+
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (a5a8f242-ffa5-473c-8efd-2acf2dc0b736)
+
+> inventory-generate
+generated inventory collection 08abe624-4b5f-491c-90cb-d74a84e4ba3e from configured sleds
 
 
 > # Since there was a blocked update on serial0, the planner has moved on to
@@ -1952,17 +2114,17 @@ set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c SP versions: active -> 1.0.0
 > sled-update-sp serial2 --active 1.0.0
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 SP versions: active -> 1.0.0
 
-> sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47 
+> sled-update-host-phase2 serial1 --boot-disk B --slot-b d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 2 details: boot_disk -> B, B -> d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47
 
-> sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b 
+> sled-update-host-phase1 serial1 --active B --slot-b b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c host phase 1 details: active -> B, B -> b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b
 
 > inventory-generate
-generated inventory collection 78f72e8d-46a9-40a9-8618-602f54454d80 from configured sleds
+generated inventory collection 005f6a30-7f65-4593-9f78-ee68f766f42b from configured sleds
 
 > blueprint-plan latest latest
-INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
+INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 9, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO performed noop zone image source checks on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
@@ -1970,19 +2132,16 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 8, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
-INFO MGS-driven update completed (will remove it and re-evaluate board), artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: 913-0000019
-INFO skipping board for MGS-driven update (no update necessary), serial_number: serial1, part_number: 913-0000019
-INFO skipping board for MGS-driven update (found issues), serial_number: serial0, part_number: 913-0000019
-INFO skipping board for MGS-driven update (found issues), serial_number: serial2, part_number: 913-0000019
-INFO ran out of boards for MGS-driven update
+INFO MGS-driven update completed (will remove it and re-evaluate board), artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: 913-0000019
+INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b, sled_agent_address: [fd00:1122:3344:101::1]:12345, expected_inactive_phase_2_hash: d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: 913-0000019
+INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 626487fa-7139-45ec-8416-902271fc730b based on parent blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736
 blueprint source: planner with report:
 planning report:
 * noop converting host phase 2 slot B to Artifact on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
-* 2 blocked MGS updates:
-  * 913-0000019:serial0: failed to plan a Host OS update: sled contains zones that are unsafe to shut down: "427ec88f-f467-42fa-9bbb-66a91a36103c: only 2/2 internal DNS zones are synchronized; require at least 3"
-  * 913-0000019:serial2: failed to plan a Host OS update: sled contains zones that are unsafe to shut down: "ea5b4030-b52f-44b2-8d70-45f15f987d01: only 2/2 internal DNS zones are synchronized; require at least 3"
-* zone updates waiting on blocked MGS updates (RoT bootloader / RoT / SP / Host OS)
+* 1 pending MGS update:
+  * 913-0000019:serial0: HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47"), sled_agent_address: [fd00:1122:3344:101::1]:12345 })
+* zone updates waiting on pending MGS updates (RoT bootloader / RoT / SP / Host OS)
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
 
 
@@ -1993,7 +2152,7 @@ to:   blueprint 626487fa-7139-45ec-8416-902271fc730b
 
  MODIFIED SLEDS:
 
-  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 4 -> 5):
+  sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 5 -> 6):
 
     measurements:
     --------------------------------------------------------------------------------
@@ -2029,6 +2188,7 @@ to:   blueprint 626487fa-7139-45ec-8416-902271fc730b
     oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              4b0b09bf-94b7-45bf-a6b3-d46af53ae44a   in service    none      none          off        
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    3e0d6188-c503-49cf-a441-fa7df40ceb43   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    0e04c3b5-47fc-412c-b352-dbf09a6bfac8   in service    none      none          off        
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    b8f2a09f-8bd2-4418-872b-a4457a3f958c   expunged      none      none          off        
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
     oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
@@ -2040,6 +2200,7 @@ to:   blueprint 626487fa-7139-45ec-8416-902271fc730b
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   1640adb6-70bf-44cf-b05c-bff6dd300cf3   in service    none      none          off        
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      78f34ce7-42f1-41da-995f-318f32054ad2   in service    none      none          off        
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      2f204c50-a327-479c-8852-f53ec7a19c1f   expunged      none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_ff6dceb4-84c5-4e0e-afe1-3c884cb656cb      71d27157-3ff7-4806-be2e-1ad6d6b5bfa2   in service    none      none          off        
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   in service    none      none          off        
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               8c4fa711-1d5d-4e93-85f0-d17bff47b063   in service    none      none          off        
     oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
@@ -2063,9 +2224,82 @@ to:   blueprint 626487fa-7139-45ec-8416-902271fc730b
     crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   artifact: version 0.0.1   in service     fd00:1122:3344:102::9
     crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   artifact: version 0.0.1   in service     fd00:1122:3344:102::7
     external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   artifact: version 0.0.1   in service     fd00:1122:3344:102::6
-    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 0.0.1   expunged ⏳     fd00:1122:3344:1::1  
+    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   artifact: version 0.0.1   expunged ✓     fd00:1122:3344:1::1  
+    internal_dns      ff6dceb4-84c5-4e0e-afe1-3c884cb656cb   artifact: version 0.0.1   in service     fd00:1122:3344:1::1  
     internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   artifact: version 0.0.1   in service     fd00:1122:3344:102::3
     nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   artifact: version 0.0.1   in service     fd00:1122:3344:102::4
+
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 3 -> 4):
+
+    measurements:
+    --------------------------------------------------------------------------------
+    hash                                                               version      
+    --------------------------------------------------------------------------------
+    8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f   version 1.0.0
+
+
+    host phase 2 contents:
+    --------------------------------
+    slot   boot image source        
+    --------------------------------
+    A      current contents         
+*   B      - current contents       
+     └─    + artifact: version 1.0.0
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              335e1dc3-b610-48dd-90bb-9ca5cce1a6d0   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              d5fef28b-4ee8-4443-8c06-7e872c2502f3   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              6477f019-088c-43cf-8508-aa93f868830f   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    02c56a30-7d97-406d-bd34-1eb437fd517d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    4d7e3e8e-06bd-414c-a468-779e056a9b75   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          55a2a61a-1471-49b2-a6d0-b191ed94e057   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          90b46084-4238-45ba-9e26-d3f2623e640e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          bcdc7bf3-bbae-4e7f-81b2-4d94c8f752a4   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   50b029e3-96aa-41e5-bf39-023193a4355e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             832fd140-d467-4bad-b5e9-63171634087c   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               42430c80-7836-4191-a4f6-bcee749010fe   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    100 GiB   none          gzip-9     
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/local_storage                                                   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/local_storage_unencrypted                                             4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
+
+
+    omicron zones:
+    ----------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition   underlay IP          
+    ----------------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   artifact: version 0.0.1   in service    fd00:1122:3344:101::9
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   artifact: version 0.0.1   in service    fd00:1122:3344:101::7
+    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   artifact: version 0.0.1   in service    fd00:1122:3344:101::8
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   artifact: version 0.0.1   in service    fd00:1122:3344:101::6
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   artifact: version 0.0.1   in service    fd00:1122:3344:101::5
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 0.0.1   in service    fd00:1122:3344:2::1  
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   artifact: version 0.0.1   in service    fd00:1122:3344:101::3
+    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   artifact: version 0.0.1   in service    fd00:1122:3344:101::4
 
 
  COCKROACHDB SETTINGS:
@@ -2085,15 +2319,16 @@ to:   blueprint 626487fa-7139-45ec-8416-902271fc730b
  PENDING MGS UPDATES:
 
     Pending MGS-managed updates (all baseboards):
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    sp_type   slot   part_number   serial_number   artifact_hash                                                      artifact_version   details                                                                                                                       
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   sled      1      913-0000019   serial1         68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4   1.0.0              Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_hash                                                        artifact_version   details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+*   sled      0      913-0000019   serial0         - 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4   1.0.0              - Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+     └─                                            + b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b                      + HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47"), sled_agent_address: [fd00:1122:3344:101::1]:12345 })
 
 
 internal DNS:
   DNS zone: "control-plane.oxide.internal" (unchanged)
-    unchanged names: 50 (records: 64)
+    unchanged names: 52 (records: 68)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -884,6 +884,8 @@ impl<'a> BlueprintBuilder<'a> {
         Either::Right(editor.all_in_service_and_expunged_zones(reason))
     }
 
+    /// For a sled, return the sled agent generation recorded in the parent
+    /// blueprint, or generation 1 if the sled is newly added.
     pub fn current_sled_incoming_sled_agent_generation(
         &self,
         sled_id: SledUuid,

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -884,6 +884,18 @@ impl<'a> BlueprintBuilder<'a> {
         Either::Right(editor.all_in_service_and_expunged_zones(reason))
     }
 
+    pub fn current_sled_incoming_sled_agent_generation(
+        &self,
+        sled_id: SledUuid,
+    ) -> Result<Generation, Error> {
+        let editor = self.sled_editors.get(&sled_id).ok_or_else(|| {
+            Error::Planner(anyhow!(
+                "tried to get incoming generation for unknown sled {sled_id}"
+            ))
+        })?;
+        Ok(editor.incoming_sled_agent_generation())
+    }
+
     pub fn current_sled_disks<F>(
         &self,
         sled_id: SledUuid,

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -377,6 +377,10 @@ impl SledEditor {
         self.zones.all_in_service_and_expunged_zones(reason)
     }
 
+    pub fn incoming_sled_agent_generation(&self) -> Generation {
+        self.incoming_sled_agent_generation
+    }
+
     pub fn host_phase_2(&self) -> BlueprintHostPhase2DesiredSlots {
         self.host_phase_2.value()
     }

--- a/nexus/reconfigurator/planning/src/planner/image_source.rs
+++ b/nexus/reconfigurator/planning/src/planner/image_source.rs
@@ -93,7 +93,12 @@ impl NoopConvertInfo {
                 .current_sled_incoming_sled_agent_generation(sled_id)?;
             let inventory_gen =
                 last_reconciliation.last_reconciled_config.generation;
-            // TODO check/explain < vs <=
+            // If the inventory's reported generation is behind the blueprint,
+            // then the inventory is stale. We should not:
+            //
+            // * clear the "will remove mupdate override" field in the blueprint
+            // * noop convert any sleds to Artifact data sources based on this
+            //   inventory
             if inventory_gen < parent_bp_gen {
                 sleds
                     .insert_unique(NoopConvertSledInfo {
@@ -540,8 +545,8 @@ impl fmt::Display for NoopConvertSledIneligibleReason {
             Self::InventoryStale { parent_bp_gen, inventory_gen } => {
                 write!(
                     f,
-                    "inventory stale: for sled, inventory reported \
-                     generation ({inventory_gen}) that is older than the \
+                    "inventory stale: inventory reported generation \
+                     ({inventory_gen}) that is older than the \
                      generation in the parent blueprint ({parent_bp_gen})",
                 )
             }

--- a/nexus/reconfigurator/planning/src/planner/image_source.rs
+++ b/nexus/reconfigurator/planning/src/planner/image_source.rs
@@ -19,7 +19,7 @@ use nexus_types::{
     },
     inventory::Collection,
 };
-use omicron_common::api::external::TufArtifactMeta;
+use omicron_common::api::external::{Generation, TufArtifactMeta};
 use omicron_uuid_kinds::{MupdateOverrideUuid, OmicronZoneUuid, SledUuid};
 use sled_agent_types::inventory::{
     BootPartitionContents, BootPartitionDetails, ManifestBootInventory,
@@ -75,6 +75,39 @@ impl NoopConvertInfo {
                     .expect("sled IDs are unique");
                 continue;
             };
+
+            let Some(last_reconciliation) = &inv_sled.last_reconciliation
+            else {
+                sleds
+                    .insert_unique(NoopConvertSledInfo {
+                        sled_id,
+                        status: NoopConvertSledStatus::Ineligible(
+                            NoopConvertSledIneligibleReason::NoLastReconciliation,
+                        ),
+                    })
+                    .expect("sled IDs are unique");
+                continue;
+            };
+
+            let parent_bp_gen = blueprint
+                .current_sled_incoming_sled_agent_generation(sled_id)?;
+            let inventory_gen =
+                last_reconciliation.last_reconciled_config.generation;
+            // TODO check/explain < vs <=
+            if inventory_gen < parent_bp_gen {
+                sleds
+                    .insert_unique(NoopConvertSledInfo {
+                        sled_id,
+                        status: NoopConvertSledStatus::Ineligible(
+                            NoopConvertSledIneligibleReason::InventoryStale {
+                                parent_bp_gen,
+                                inventory_gen,
+                            },
+                        ),
+                    })
+                    .expect("sled IDs are unique");
+                continue;
+            }
 
             let zone_manifest = match &inv_sled
                 .file_source_resolver
@@ -339,6 +372,10 @@ impl NoopConvertSledStatus {
                 // be logged at different levels. Hence this mess.
                 match reason {
                     NoopConvertSledIneligibleReason::NotInInventory
+                    | NoopConvertSledIneligibleReason::NoLastReconciliation
+                    | NoopConvertSledIneligibleReason::InventoryStale {
+                        ..
+                    }
                     | NoopConvertSledIneligibleReason::MupdateOverride {
                         ..
                     } => {
@@ -451,6 +488,13 @@ pub(crate) enum NoopConvertSledIneligibleReason {
     /// This sled is missing from inventory.
     NotInInventory,
 
+    /// This sled doesn't have a last reconciliation.
+    NoLastReconciliation,
+
+    /// The inventory is stale, as indicated by its generation number: it has an
+    /// older generation for this sled than the parent blueprint.
+    InventoryStale { parent_bp_gen: Generation, inventory_gen: Generation },
+
     /// An error occurred retrieving the sled's install dataset zone manifest.
     ManifestError { message: String },
 
@@ -490,6 +534,17 @@ impl fmt::Display for NoopConvertSledIneligibleReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotInInventory => write!(f, "sled not found in inventory"),
+            Self::NoLastReconciliation => {
+                write!(f, "sled doesn't have a last reconciled config")
+            }
+            Self::InventoryStale { parent_bp_gen, inventory_gen } => {
+                write!(
+                    f,
+                    "inventory stale: for sled, inventory reported \
+                     generation ({inventory_gen}) that is older than the \
+                     generation in the parent blueprint ({parent_bp_gen})",
+                )
+            }
             Self::ManifestError { message } => {
                 write!(f, "error retrieving zone manifest: {}", message)
             }

--- a/nexus/reconfigurator/planning/src/planner/image_source.rs
+++ b/nexus/reconfigurator/planning/src/planner/image_source.rs
@@ -97,7 +97,7 @@ impl NoopConvertInfo {
             // then the inventory is stale. We should not:
             //
             // * clear the "will remove mupdate override" field in the blueprint
-            // * noop convert any sleds to Artifact data sources based on this
+            // * noop convert any sleds to Artifact image sources based on this
             //   inventory
             if inventory_gen < parent_bp_gen {
                 sleds


### PR DESCRIPTION
In https://github.com/oxidecomputer/omicron/issues/10392, we found while progressing along the MUPdate recovery state machine ([RFD 556](https://rfd.shared.oxide.computer/rfd/0556)), duelling Nexuses might trample over each other based on stale inventory.

The specific reproduction is covered in the added reconfigurator-cli test, but to recap: Let's say there are two inventory collections, C1 and C2. C1 was collected right before the MUPdate, and C2 right after. Then, the failure happens if:

* Nexus 1 reads C2 and starts processing the MUPdate override, creating a blueprint B1.
* Nexus 2 has C1 cached, and creates a blueprint B2 with parent B1 but based on collection C1.
* In C1, the mupdate override is not present, so Nexus 2 believes (based on this outdated collection) that more progress has been made along the MUPdate recovery state machine.

The fix in this PR is to use the Sled Agent generation number stored in the parent blueprint as an indicator. If the Sled Agent generation gathered from inventory is older than that, then that is a sign that inventory is stale, and we shouldn't clear the "will remove mupdate override" field as a result.

We're hoping to cherry-pick this PR onto the r19 release branch. There is a very similar bug around setting the "will remove mupdate override" field as well. We believe the downsides of that bug are not as bad (i.e. the planner doesn't end up along a path which makes things worse), so we're currently not planning to pick that for 19.3. (We would like to get this bug fixed for release 20 though -- expect a PR for it soon.)