### PR TITLE
Return sentinels from `sled_insert_resource_query`

### DIFF
--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -1357,19 +1357,24 @@ impl DataStore {
                                 // instance we are trying to allocate due to
                                 // affinity / anti-affinity constraints.
                                 //
-                                // This isn't a problem when _not_ performing
-                                // local storage allocations because the insert
-                                // query will fail, and another sled_target will
-                                // be chosen right away. With local storage
+                                // Both of these cases are not a problem when
+                                // _not_ performing local storage allocations:
+                                // in that branch, when the insert query returns
+                                // that it inserted 0 rows or returned an error
+                                // sentinel, another sled_target will be chosen
+                                // right away.
+                                //
+                                // When local storage allocations are required
                                 // (just like the failure mode mentioned in a
                                 // previous block comment), the iterator will
                                 // erroneously keep returning different
                                 // permutations, meanwhile the insert query
-                                // isn't failing due to the available local
-                                // storage space.
-                                //
-                                // Bail out of the search right away and pick
-                                // another sled_target
+                                // isn't succeeding for reasons other than the
+                                // available space for local storage. In this
+                                // case, one of the sentinels will be returned,
+                                // and if we see those then bail out of the
+                                // search right away and pick another
+                                // sled_target.
 
                                 info!(
                                     &log,

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -1160,7 +1160,7 @@ impl DataStore {
         // In the uncontended case, however, we'll only iterate through this
         // loop once.
 
-        loop {
+        'sled_reservation: loop {
             // Pick a reservation target, given the constraints we previously
             // saw in the database.
             let sled_target = pick_sled_reservation_target(
@@ -1249,7 +1249,7 @@ impl DataStore {
                     unpreferred.remove(&sled_target);
                     preferred.remove(&sled_target);
 
-                    continue;
+                    continue 'sled_reservation;
                 };
 
                 let mut complete_allocation_lists =
@@ -1273,7 +1273,7 @@ impl DataStore {
                             unpreferred.remove(&sled_target);
                             preferred.remove(&sled_target);
 
-                            continue;
+                            continue 'sled_reservation;
                         }
                     };
 
@@ -1282,13 +1282,13 @@ impl DataStore {
                 // that particular set.
                 //
                 // If the `complate_allocation_lists` iterator returns None,
-                // control will pass to the end of the loop marked with 'outer,
+                // control will exit the `local_storage_allocation_search` loop,
                 // which will then try the next possible sled target. In the
                 // case where there were pre-existing local storage allocations
                 // there will _not_ be any more sleds to try and the user will
                 // see a capacity error.
 
-                loop {
+                'local_storage_allocation_search: loop {
                     // If other concurrent sled reservations are not taken into
                     // account, another sled reservation could allocate local
                     // storage onto the same pools that this one considers
@@ -1312,7 +1312,7 @@ impl DataStore {
                     else {
                         // All done searching, nothing worked. Try another
                         // sled!
-                        break;
+                        break 'local_storage_allocation_search;
                     };
 
                     info!(
@@ -1381,7 +1381,7 @@ impl DataStore {
                                     "reservation failed due to {sentinel}",
                                 );
 
-                                break;
+                                break 'local_storage_allocation_search;
                             } else {
                                 // The query failed, return this as an error
                                 return Err(

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -1218,7 +1218,7 @@ impl DataStore {
                             // The only part of the `insert_valid` section of
                             // the insertion query that can fail are the same
                             // places where these sentinels are cast and thrown
-                            // as errors as this branch does not have any
+                            // as errors, as this branch does not have any
                             // requested local storage allocations. Ignore these
                             // and proceed to the next sled_target.
                             info!(&log, "reservation failed due to {sentinel}");
@@ -1347,12 +1347,15 @@ impl DataStore {
                                 &SLED_INSERT_QUERY_SENTINELS,
                             ) {
                                 // Concurrent sled reservations could have
-                                // allocated enough hardware threads, rss ram,
-                                // and/ or reservoir ram that means this
+                                // allocated enough hardware threads, RSS RAM,
+                                // and/ or reservoir RAM that means this
                                 // sled_target is no longer valid.
-                                // Alternatively, checking affinity related
-                                // conditions could now also invalidate this
-                                // sled_target.
+                                //
+                                // Alternatively, a concurrent reservation could
+                                // have allocated another instance to this sled
+                                // target which makes it invalid for this
+                                // instance we are trying to allocate due to
+                                // affinity / anti-affinity constraints.
                                 //
                                 // This isn't a problem when _not_ performing
                                 // local storage allocations because the insert

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -1348,7 +1348,7 @@ impl DataStore {
                             ) {
                                 // Concurrent sled reservations could have
                                 // allocated enough hardware threads, RSS RAM,
-                                // and/ or reservoir RAM that means this
+                                // and/or reservoir RAM that means this
                                 // sled_target is no longer valid.
                                 //
                                 // Alternatively, a concurrent reservation could
@@ -1364,15 +1364,12 @@ impl DataStore {
                                 // sentinel, another sled_target will be chosen
                                 // right away.
                                 //
-                                // When local storage allocations are required
-                                // (just like the failure mode mentioned in a
-                                // previous block comment), the iterator will
-                                // erroneously keep returning different
-                                // permutations, meanwhile the insert query
+                                // If a sentinel is returned, the insert query
                                 // isn't succeeding for reasons other than the
-                                // available space for local storage. In this
-                                // case, one of the sentinels will be returned,
-                                // and if we see those then bail out of the
+                                // available space for local storage. If we
+                                // don't bail out here, the loop will keep
+                                // searching through permutations of local
+                                // storage allocations to try. Bail out of the
                                 // search right away and pick another
                                 // sled_target.
 

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -23,8 +23,14 @@ use crate::db::model::to_db_typed_uuid;
 use crate::db::pagination::Paginator;
 use crate::db::pagination::paginated;
 use crate::db::queries::disk::MAX_DISKS_PER_INSTANCE;
+use crate::db::queries::sled_reservation::BANNED_SLEDS_SENTINEL;
+use crate::db::queries::sled_reservation::BANNED_SLEDS_SENTINEL_REASON;
 use crate::db::queries::sled_reservation::LocalStorageAllocation;
 use crate::db::queries::sled_reservation::LocalStorageAllocationRequired;
+use crate::db::queries::sled_reservation::REQUIRED_SLEDS_SENTINEL;
+use crate::db::queries::sled_reservation::REQUIRED_SLEDS_SENTINEL_REASON;
+use crate::db::queries::sled_reservation::SLED_HAS_SPACE_SENTINEL;
+use crate::db::queries::sled_reservation::SLED_HAS_SPACE_SENTINEL_REASON;
 use crate::db::queries::sled_reservation::sled_find_targets_query;
 use crate::db::queries::sled_reservation::sled_insert_resource_query;
 use crate::db::true_or_cast_error::matches_sentinel;
@@ -661,7 +667,20 @@ impl<'a> Iterator for CompleteLocalStorageAllocationLists<'a> {
 /// to three of the conditions related to a sled's available hardware resources,
 /// or affinity rules.
 const SLED_INSERT_QUERY_SENTINELS: [&'static str; 3] =
-    ["SLED_HAS_SPACE", "BANNED_SLEDS", "REQUIRED_SLEDS"];
+    [SLED_HAS_SPACE_SENTINEL, BANNED_SLEDS_SENTINEL, REQUIRED_SLEDS_SENTINEL];
+
+/// Turn the returned sentinel into a human-readable error
+fn sentinel_to_reason(sentinel: &'static str) -> &'static str {
+    match sentinel {
+        SLED_HAS_SPACE_SENTINEL => SLED_HAS_SPACE_SENTINEL_REASON,
+
+        BANNED_SLEDS_SENTINEL => BANNED_SLEDS_SENTINEL_REASON,
+
+        REQUIRED_SLEDS_SENTINEL => REQUIRED_SLEDS_SENTINEL_REASON,
+
+        _ => unreachable!("unrecognized sentinel"),
+    }
+}
 
 impl DataStore {
     /// Stores a new sled in the database.
@@ -1221,7 +1240,12 @@ impl DataStore {
                             // as errors, as this branch does not have any
                             // requested local storage allocations. Ignore these
                             // and proceed to the next sled_target.
-                            info!(&log, "reservation failed due to {sentinel}");
+                            let reason = sentinel_to_reason(sentinel);
+                            info!(
+                                &log,
+                                "reservation failed: {reason}";
+                                "sentinel" => sentinel,
+                            );
                         } else {
                             // The query failed, return this as an error
                             return Err(
@@ -1376,9 +1400,11 @@ impl DataStore {
                                 // search right away and pick another
                                 // sled_target.
 
+                                let reason = sentinel_to_reason(sentinel);
                                 info!(
                                     &log,
-                                    "reservation failed due to {sentinel}",
+                                    "reservation failed: {reason}";
+                                    "sentinel" => sentinel,
                                 );
 
                                 break 'local_storage_allocation_search;

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -2380,16 +2380,27 @@ pub(in crate::db::datastore) mod test {
                 self.resources.clone(),
             );
 
-            sled_insert_resource_query(
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            match sled_insert_resource_query(
                 &resource,
                 &LocalStorageAllocationRequired::No,
             )
-            .execute_async(
-                &*datastore.pool_connection_for_tests().await.unwrap(),
-            )
+            .execute_async(&*conn)
             .await
-            .unwrap()
-                > 0
+            {
+                Ok(rows_inserted) => rows_inserted > 0,
+
+                Err(e) => {
+                    if matches_sentinel(&e, &SLED_INSERT_QUERY_SENTINELS)
+                        .is_some()
+                    {
+                        false
+                    } else {
+                        panic!("{e}")
+                    }
+                }
+            }
         }
 
         fn use_many_resources(mut self) -> Self {

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -23,14 +23,10 @@ use crate::db::model::to_db_typed_uuid;
 use crate::db::pagination::Paginator;
 use crate::db::pagination::paginated;
 use crate::db::queries::disk::MAX_DISKS_PER_INSTANCE;
-use crate::db::queries::sled_reservation::BANNED_SLEDS_SENTINEL;
-use crate::db::queries::sled_reservation::BANNED_SLEDS_SENTINEL_REASON;
 use crate::db::queries::sled_reservation::LocalStorageAllocation;
 use crate::db::queries::sled_reservation::LocalStorageAllocationRequired;
-use crate::db::queries::sled_reservation::REQUIRED_SLEDS_SENTINEL;
-use crate::db::queries::sled_reservation::REQUIRED_SLEDS_SENTINEL_REASON;
-use crate::db::queries::sled_reservation::SLED_HAS_SPACE_SENTINEL;
-use crate::db::queries::sled_reservation::SLED_HAS_SPACE_SENTINEL_REASON;
+use crate::db::queries::sled_reservation::SLED_INSERT_QUERY_SENTINELS;
+use crate::db::queries::sled_reservation::sentinel_to_reason;
 use crate::db::queries::sled_reservation::sled_find_targets_query;
 use crate::db::queries::sled_reservation::sled_insert_resource_query;
 use crate::db::true_or_cast_error::matches_sentinel;
@@ -659,26 +655,6 @@ impl<'a> Iterator for CompleteLocalStorageAllocationLists<'a> {
         }
 
         None
-    }
-}
-
-/// The sled insert query will return a sentinel (using the pattern of an
-/// erroneous cast of a string into a bool) if the insert is no longer valid due
-/// to three of the conditions related to a sled's available hardware resources,
-/// or affinity rules.
-const SLED_INSERT_QUERY_SENTINELS: [&'static str; 3] =
-    [SLED_HAS_SPACE_SENTINEL, BANNED_SLEDS_SENTINEL, REQUIRED_SLEDS_SENTINEL];
-
-/// Turn the returned sentinel into a human-readable error
-fn sentinel_to_reason(sentinel: &'static str) -> &'static str {
-    match sentinel {
-        SLED_HAS_SPACE_SENTINEL => SLED_HAS_SPACE_SENTINEL_REASON,
-
-        BANNED_SLEDS_SENTINEL => BANNED_SLEDS_SENTINEL_REASON,
-
-        REQUIRED_SLEDS_SENTINEL => REQUIRED_SLEDS_SENTINEL_REASON,
-
-        _ => unreachable!("unrecognized sentinel"),
     }
 }
 

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -27,6 +27,7 @@ use crate::db::queries::sled_reservation::LocalStorageAllocation;
 use crate::db::queries::sled_reservation::LocalStorageAllocationRequired;
 use crate::db::queries::sled_reservation::sled_find_targets_query;
 use crate::db::queries::sled_reservation::sled_insert_resource_query;
+use crate::db::true_or_cast_error::matches_sentinel;
 use crate::db::update_and_check::{UpdateAndCheck, UpdateStatus};
 use async_bb8_diesel::AsyncRunQueryDsl;
 use chrono::Utc;
@@ -655,6 +656,13 @@ impl<'a> Iterator for CompleteLocalStorageAllocationLists<'a> {
     }
 }
 
+/// The sled insert query will return a sentinel (using the pattern of an
+/// erroneous cast of a string into a bool) if the insert is no longer valid due
+/// to three of the conditions related to a sled's available hardware resources,
+/// or affinity rules.
+const SLED_INSERT_QUERY_SENTINELS: [&'static str; 3] =
+    ["SLED_HAS_SPACE", "BANNED_SLEDS", "REQUIRED_SLEDS"];
+
 impl DataStore {
     /// Stores a new sled in the database.
     ///
@@ -1151,6 +1159,7 @@ impl DataStore {
         //
         // In the uncontended case, however, we'll only iterate through this
         // loop once.
+
         loop {
             // Pick a reservation target, given the constraints we previously
             // saw in the database.
@@ -1187,18 +1196,40 @@ impl DataStore {
                 // Try to INSERT the record. If this is still a valid target,
                 // we'll use it. If it isn't a valid target, we'll shrink the
                 // set of viable sled targets and try again.
-                let rows_inserted = sled_insert_resource_query(
+
+                match sled_insert_resource_query(
                     &resource,
                     &LocalStorageAllocationRequired::No,
                 )
                 .execute_async(&*conn)
-                .await?;
+                .await
+                {
+                    Ok(rows_inserted) => {
+                        if rows_inserted > 0 {
+                            info!(&log, "reservation succeeded!");
+                            return Ok(resource);
+                        }
+                    }
 
-                if rows_inserted > 0 {
-                    info!(&log, "reservation succeeded!");
-                    return Ok(resource);
-                }
-                info!(&log, "reservation failed");
+                    Err(e) => {
+                        if let Some(sentinel) =
+                            matches_sentinel(&e, &SLED_INSERT_QUERY_SENTINELS)
+                        {
+                            // The only part of the `insert_valid` section of
+                            // the insertion query that can fail are the same
+                            // places where these sentinels are cast and thrown
+                            // as errors as this branch does not have any
+                            // requested local storage allocations. Ignore these
+                            // and proceed to the next sled_target.
+                            info!(&log, "reservation failed due to {sentinel}");
+                        } else {
+                            // The query failed, return this as an error
+                            return Err(
+                                SledReservationTransactionError::Diesel(e),
+                            );
+                        }
+                    }
+                };
             } else {
                 // If local storage allocation is required, match the requests
                 // with all the zpools of this sled that have available space.
@@ -1261,8 +1292,8 @@ impl DataStore {
                     // If other concurrent sled reservations are not taken into
                     // account, another sled reservation could allocate local
                     // storage onto the same pools that this one considers
-                    // candidates, and then this iterator will return an
-                    // allocation that will never work. Because the iterator
+                    // candidates, and then this iterator will return
+                    // allocations that will never work. Because the iterator
                     // searches for _every_ possible combination, this will end
                     // up searching for a long time. It's important to prune the
                     // list that we're searching from: using the _current_
@@ -1296,19 +1327,61 @@ impl DataStore {
                     // local storage allocations still fit, we'll use it. If it
                     // isn't a valid target, we'll shrink the set of viable sled
                     // targets and try again.
-                    let rows_inserted = sled_insert_resource_query(
+                    match sled_insert_resource_query(
                         &resource,
                         &LocalStorageAllocationRequired::Yes { allocations },
                     )
                     .execute_async(&*conn)
-                    .await?;
+                    .await
+                    {
+                        Ok(rows_inserted) => {
+                            if rows_inserted > 0 {
+                                info!(&log, "reservation succeeded!");
+                                return Ok(resource);
+                            }
+                        }
 
-                    if rows_inserted > 0 {
-                        info!(&log, "reservation succeeded!");
-                        return Ok(resource);
+                        Err(e) => {
+                            if let Some(sentinel) = matches_sentinel(
+                                &e,
+                                &SLED_INSERT_QUERY_SENTINELS,
+                            ) {
+                                // Concurrent sled reservations could have
+                                // allocated enough hardware threads, rss ram,
+                                // and/ or reservoir ram that means this
+                                // sled_target is no longer valid.
+                                // Alternatively, checking affinity related
+                                // conditions could now also invalidate this
+                                // sled_target.
+                                //
+                                // This isn't a problem when _not_ performing
+                                // local storage allocations because the insert
+                                // query will fail, and another sled_target will
+                                // be chosen right away. With local storage
+                                // (just like the failure mode mentioned in a
+                                // previous block comment), the iterator will
+                                // erroneously keep returning different
+                                // permutations, meanwhile the insert query
+                                // isn't failing due to the available local
+                                // storage space.
+                                //
+                                // Bail out of the search right away and pick
+                                // another sled_target
+
+                                info!(
+                                    &log,
+                                    "reservation failed due to {sentinel}",
+                                );
+
+                                break;
+                            } else {
+                                // The query failed, return this as an error
+                                return Err(
+                                    SledReservationTransactionError::Diesel(e),
+                                );
+                            }
+                        }
                     }
-
-                    info!(&log, "reservation failed");
                 }
             }
 
@@ -5830,6 +5903,149 @@ pub(in crate::db::datastore) mod test {
             vmms.into_iter().map(|vmm| vmm.sled_id).collect();
 
         assert_eq!(sleds.len(), 32);
+
+        validate_local_storage_allocations(&datastore).await;
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    /// Ensure that four sleds can have _many_ VMMs (enough to fully use all
+    /// cpus) allocate local storage, where the sled reservations happen
+    /// concurrently in chunks.
+    #[tokio::test]
+    async fn local_storage_allocation_four_sleds_concurrent_small() {
+        let logctx = dev::test_setup_log(
+            "local_storage_allocation_four_sleds_concurrent_small",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let mut config = LocalStorageTest {
+            sleds: vec![],
+            affinity_groups: vec![],
+            anti_affinity_groups: vec![],
+            instances: vec![],
+        };
+
+        const MAX_U2_PER_INSTANCE: usize = 10;
+
+        // Only define a few sleds, otherwise this test takes a considerable
+        // amount of time adding records to cockroach.
+
+        const NUM_SLEDS: usize = 4;
+
+        for i in 0..NUM_SLEDS {
+            let mut u2s = vec![];
+
+            for n in 0..MAX_U2_PER_INSTANCE {
+                u2s.push(LocalStorageTestSledU2 {
+                    physical_disk_id: PhysicalDiskUuid::new_v4(),
+                    physical_disk_serial: format!("phys_{i}_{n}"),
+
+                    zpool_id: ZpoolUuid::new_v4(),
+                    control_plane_storage_buffer:
+                        external::ByteCount::from_gibibytes_u32(250),
+
+                    inventory_total_size:
+                        external::ByteCount::from_gibibytes_u32(1024),
+
+                    crucible_dataset_id: DatasetUuid::new_v4(),
+                    crucible_dataset_addr: format!(
+                        "[fd00:1122:3344:{i}{n:02x}::1]:12345"
+                    )
+                    .parse()
+                    .unwrap(),
+
+                    local_storage_unencrypted_dataset_id: DatasetUuid::new_v4(),
+                });
+            }
+
+            config.sleds.push(LocalStorageTestSled {
+                sled_id: SledUuid::new_v4(),
+                sled_serial: format!("sled_{i}"),
+                u2s,
+            });
+        }
+
+        // Each instance requires 2 cpus. At 128 hardware threads per sled we
+        // need 64 instances to fully consume all available hardware threads.
+
+        for i in 0..(64 * NUM_SLEDS) {
+            let mut disks = vec![];
+
+            for n in 0..MAX_U2_PER_INSTANCE {
+                disks.push(LocalStorageTestInstanceDisk {
+                    id: Uuid::new_v4(),
+                    name: external::Name::try_from(format!("local-{i}-{n}"))
+                        .unwrap(),
+
+                    // 64 instances per sled, total provisionable size is 1024 -
+                    // 250 = 774, so roughly 12 G disks, minus overhead of about
+                    // 780M = drop to 10G
+                    size: external::ByteCount::from_gibibytes_u32(10),
+                });
+            }
+
+            config.instances.push(LocalStorageTestInstance {
+                id: InstanceUuid::new_v4(),
+                name: format!("inst{i}"),
+                affinity: None,
+                disks,
+            });
+        }
+
+        setup_local_storage_allocation_test(&opctx, datastore, &config).await;
+
+        let mut vmms = vec![];
+
+        // Reserve the instances concurrently in chunks - 8 at a time, because
+        // that's the maximum concurrent claims that qorb currently supports.
+        for chunk in config.instances.chunks(8) {
+            let mut jhs = vec![];
+
+            for (i, config_instance) in chunk.iter().enumerate() {
+                let instance = Instance::new_with_id(config_instance.id);
+
+                let datastore = datastore.clone();
+
+                let opctx = opctx.child(BTreeMap::from([(
+                    String::from("task"),
+                    format!("{i}"),
+                )]));
+
+                let jh = tokio::spawn(async move {
+                    datastore
+                        .sled_reservation_create_inner(
+                            &opctx,
+                            instance.id,
+                            PropolisUuid::new_v4(),
+                            db::model::Resources::new(
+                                2,
+                                ByteCount::try_from(1024).unwrap(),
+                                ByteCount::try_from(1024).unwrap(),
+                            ),
+                            db::model::SledReservationConstraints::none(),
+                        )
+                        .await
+                        .unwrap()
+                });
+
+                jhs.push(jh);
+            }
+
+            for jh in jhs {
+                let vmm = jh.await.unwrap();
+                vmms.push(vmm);
+            }
+        }
+
+        assert_eq!(vmms.len(), (64 * NUM_SLEDS));
+
+        let sleds: HashSet<_> =
+            vmms.into_iter().map(|vmm| vmm.sled_id).collect();
+
+        assert_eq!(sleds.len(), NUM_SLEDS);
 
         validate_local_storage_allocations(&datastore).await;
 

--- a/nexus/db-queries/src/db/queries/sled_reservation.rs
+++ b/nexus/db-queries/src/db/queries/sled_reservation.rs
@@ -286,6 +286,23 @@ pub const REQUIRED_SLEDS_SENTINEL: &'static str = "REQUIRED_SLEDS";
 pub const REQUIRED_SLEDS_SENTINEL_REASON: &'static str =
     "sled target does not host another instance in affinity group";
 
+/// The sled insert query will return a sentinel (using the pattern of an
+/// erroneous cast of a string into a bool) if the insert is no longer valid due
+/// to three of the conditions related to a sled's available hardware resources,
+/// or affinity rules.
+pub const SLED_INSERT_QUERY_SENTINELS: [&'static str; 3] =
+    [SLED_HAS_SPACE_SENTINEL, BANNED_SLEDS_SENTINEL, REQUIRED_SLEDS_SENTINEL];
+
+/// Turn the returned sentinel into a human-readable error
+pub fn sentinel_to_reason(sentinel: &'static str) -> &'static str {
+    match sentinel {
+        SLED_HAS_SPACE_SENTINEL => SLED_HAS_SPACE_SENTINEL_REASON,
+        BANNED_SLEDS_SENTINEL => BANNED_SLEDS_SENTINEL_REASON,
+        REQUIRED_SLEDS_SENTINEL => REQUIRED_SLEDS_SENTINEL_REASON,
+        _ => sentinel,
+    }
+}
+
 /// Attempts to:
 ///
 /// 1. Insert a sled_resource_vmm record, if it is still a valid reservation

--- a/nexus/db-queries/src/db/queries/sled_reservation.rs
+++ b/nexus/db-queries/src/db/queries/sled_reservation.rs
@@ -397,21 +397,51 @@ pub fn sled_insert_resource_query(
     //     allocation records with the existing ones and test each zpool.
     //   - the rendezvous local storage dataset is not tombstoned or marked
     //     no_provision
+    //
+    // In addition, use the "cast error string to bool" pattern to provide an
+    // error to the caller indicating what failed.
 
-    query
-        .sql(
-            "INSERT_VALID AS (
+    query.sql(
+        "INSERT_VALID AS (
               SELECT 1
               WHERE
-                  EXISTS(SELECT 1 FROM sled_has_space) AND
-                  NOT(EXISTS(SELECT 1 FROM banned_sleds WHERE sled_id = ",
-        )
-        .param()
-        .bind::<sql_types::Uuid, _>(resource.sled_id.into_untyped_uuid())
-        .sql(")) AND (EXISTS(SELECT 1 FROM required_sleds WHERE sled_id = ")
-        .param()
-        .bind::<sql_types::Uuid, _>(resource.sled_id.into_untyped_uuid())
-        .sql(") OR NOT EXISTS (SELECT 1 FROM required_sleds))");
+                  ",
+    );
+
+    query.true_or_cast_error(
+        |query| {
+            query.sql("EXISTS(SELECT 1 FROM sled_has_space)");
+        },
+        "SLED_HAS_SPACE",
+    );
+    query.sql(" AND ");
+
+    query.true_or_cast_error(
+        |query| {
+            query
+                .sql("NOT(EXISTS(SELECT 1 FROM banned_sleds WHERE sled_id = ")
+                .param()
+                .bind::<sql_types::Uuid, _>(
+                    resource.sled_id.into_untyped_uuid(),
+                )
+                .sql("))");
+        },
+        "BANNED_SLEDS",
+    );
+    query.sql(" AND ");
+
+    query.true_or_cast_error(
+        |query| {
+            query
+                .sql("(EXISTS(SELECT 1 FROM required_sleds WHERE sled_id = ")
+                .param()
+                .bind::<sql_types::Uuid, _>(
+                    resource.sled_id.into_untyped_uuid(),
+                )
+                .sql(") OR NOT EXISTS (SELECT 1 FROM required_sleds))");
+        },
+        "REQUIRED_SLEDS",
+    );
 
     match local_storage_allocation_required {
         LocalStorageAllocationRequired::No => {}

--- a/nexus/db-queries/src/db/queries/sled_reservation.rs
+++ b/nexus/db-queries/src/db/queries/sled_reservation.rs
@@ -274,6 +274,18 @@ pub fn sled_find_targets_query(
     query.query()
 }
 
+pub const SLED_HAS_SPACE_SENTINEL: &'static str = "SLED_HAS_SPACE";
+pub const SLED_HAS_SPACE_SENTINEL_REASON: &'static str =
+    "sled target does not have the available hardware resources";
+
+pub const BANNED_SLEDS_SENTINEL: &'static str = "BANNED_SLEDS";
+pub const BANNED_SLEDS_SENTINEL_REASON: &'static str =
+    "sled target hosts another instance in anti-affinity group";
+
+pub const REQUIRED_SLEDS_SENTINEL: &'static str = "REQUIRED_SLEDS";
+pub const REQUIRED_SLEDS_SENTINEL_REASON: &'static str =
+    "sled target does not host another instance in affinity group";
+
 /// Attempts to:
 ///
 /// 1. Insert a sled_resource_vmm record, if it is still a valid reservation
@@ -412,7 +424,7 @@ pub fn sled_insert_resource_query(
         |query| {
             query.sql("EXISTS(SELECT 1 FROM sled_has_space)");
         },
-        "SLED_HAS_SPACE",
+        SLED_HAS_SPACE_SENTINEL,
     );
     query.sql(" AND ");
 
@@ -426,7 +438,7 @@ pub fn sled_insert_resource_query(
                 )
                 .sql("))");
         },
-        "BANNED_SLEDS",
+        BANNED_SLEDS_SENTINEL,
     );
     query.sql(" AND ");
 
@@ -440,7 +452,7 @@ pub fn sled_insert_resource_query(
                 )
                 .sql(") OR NOT EXISTS (SELECT 1 FROM required_sleds))");
         },
-        "REQUIRED_SLEDS",
+        REQUIRED_SLEDS_SENTINEL,
     );
 
     match local_storage_allocation_required {

--- a/nexus/db-queries/src/db/raw_query_builder.rs
+++ b/nexus/db-queries/src/db/raw_query_builder.rs
@@ -139,6 +139,22 @@ impl QueryBuilder {
         self
     }
 
+    // [`TrueOrCastError`] exists but requires an expression that evaluates to
+    // sql_type::Bool. This function applies the same pattern but for the
+    // QueryBuilder.
+    pub fn true_or_cast_error<F>(&mut self, condition: F, error: &'static str)
+    where
+        F: FnOnce(&mut QueryBuilder),
+    {
+        self.sql("CAST(IF(");
+        self.sql("(");
+        condition(self);
+        self.sql("),");
+        self.sql("'TRUE', '");
+        self.sql(error);
+        self.sql("') AS BOOL)");
+    }
+
     /// Takes the final boxed query
     pub fn query<T>(self) -> TypedSqlQuery<T> {
         TypedSqlQuery { inner: self.query.unwrap(), _phantom: PhantomData }

--- a/nexus/db-queries/tests/output/sled_insert_resource_query.sql
+++ b/nexus/db-queries/tests/output/sled_insert_resource_query.sql
@@ -91,11 +91,27 @@ WITH
       SELECT
         1
       WHERE
-        EXISTS(SELECT 1 FROM sled_has_space)
-        AND NOT (EXISTS(SELECT 1 FROM banned_sleds WHERE sled_id = $9))
-        AND (
-            EXISTS(SELECT 1 FROM required_sleds WHERE sled_id = $10)
-            OR NOT EXISTS(SELECT 1 FROM required_sleds)
+        CAST(IF((EXISTS(SELECT 1 FROM sled_has_space)), 'TRUE', 'SLED_HAS_SPACE') AS BOOL)
+        AND CAST(
+            IF(
+              (NOT (EXISTS(SELECT 1 FROM banned_sleds WHERE sled_id = $9))),
+              'TRUE',
+              'BANNED_SLEDS'
+            )
+              AS BOOL
+          )
+        AND CAST(
+            IF(
+              (
+                (
+                  EXISTS(SELECT 1 FROM required_sleds WHERE sled_id = $10)
+                  OR NOT EXISTS(SELECT 1 FROM required_sleds)
+                )
+              ),
+              'TRUE',
+              'REQUIRED_SLEDS'
+            )
+              AS BOOL
           )
     )
 INSERT

--- a/nexus/db-queries/tests/output/sled_insert_resource_query_with_local_storage.sql
+++ b/nexus/db-queries/tests/output/sled_insert_resource_query_with_local_storage.sql
@@ -91,11 +91,27 @@ WITH
       SELECT
         1
       WHERE
-        EXISTS(SELECT 1 FROM sled_has_space)
-        AND NOT (EXISTS(SELECT 1 FROM banned_sleds WHERE sled_id = $9))
-        AND (
-            EXISTS(SELECT 1 FROM required_sleds WHERE sled_id = $10)
-            OR NOT EXISTS(SELECT 1 FROM required_sleds)
+        CAST(IF((EXISTS(SELECT 1 FROM sled_has_space)), 'TRUE', 'SLED_HAS_SPACE') AS BOOL)
+        AND CAST(
+            IF(
+              (NOT (EXISTS(SELECT 1 FROM banned_sleds WHERE sled_id = $9))),
+              'TRUE',
+              'BANNED_SLEDS'
+            )
+              AS BOOL
+          )
+        AND CAST(
+            IF(
+              (
+                (
+                  EXISTS(SELECT 1 FROM required_sleds WHERE sled_id = $10)
+                  OR NOT EXISTS(SELECT 1 FROM required_sleds)
+                )
+              ),
+              'TRUE',
+              'REQUIRED_SLEDS'
+            )
+              AS BOOL
           )
         AND (
             (


### PR DESCRIPTION
The failure mode seen in #10353 involves multiple contending sled reservations and lead to a sled reservation iterating over all possible potential allocation mappings, causing the instance-start to appear to hang when in reality it was exploring all potential permutations.

The fix for that was to update the iterator's stored information so that it could recognize when the sled insert query it was about to execute could never work. This fix was insufficient as further testing lead to more instance-start sagas that appeared stuck.

During contention, there are a few broad categories to how the sled reservation insert query could fail:

- the target sled could no longer have the available resources

- putting a VMM on the target sled would now violate affinity or anti-affinity rules

- the pools affected by requested local storage mapping no longer have the required available space

Updating the iterator's stored information would only let Nexus detect the last category where the instance-start saga hang seen today fell into the first. Nexus needs to know which part of the insert query failed so that it can decide what to do based on if local storage allocations are required or not, and this lead to this commit: using the "true or cast error" pattern, return sentinels from the sled insert resource query, and bail out of searching for a valid local storage allocation permutation if the sled target is no longer valid.

Fixes #10393