### PR TITLE
[1/n] [reconfigurator-cli] in cmds-mupdate-update-flow, apply sled agent configs

### DIFF
--- a/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
@@ -245,8 +245,10 @@ blueprint-diff latest
 # This *will* generate the datasets and internal NTP zone on the new sled.
 set planner-config --add-zones-with-mupdate-override true
 blueprint-plan latest latest
-# TODO: This blippy run produces two FATAL notes due to
-# https://github.com/oxidecomputer/omicron/issues/10420.
+# TODO: This blippy run produces two FATAL notes, due to, respectively:
+#
+# * https://github.com/oxidecomputer/omicron/issues/10420
+# * https://github.com/oxidecomputer/omicron/pull/10363
 blueprint-blippy latest
 blueprint-diff latest
 

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
@@ -20,6 +20,11 @@ blueprint-edit latest set-sp-update serial0 e3b0c44298fc1c149afbf4c8996fb92427ae
 blueprint-edit latest set-host-phase2 serial0 A artifact 1.0.0 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
 blueprint-edit latest set-host-phase2 serial0 B artifact 1.0.0 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
 
+# Model sled 0 reconciling the blueprint edits above, so its reported
+# sled-agent generation matches the parent blueprint when the next
+# inventory is generated.
+sled-set serial0 omicron-config latest
+
 # Simulate a mupdate on sled 0 by setting the mupdate override field to a
 # new UUID (generated using uuidgen).
 sled-set serial0 mupdate-override 6123eac1-ec5b-42ba-b73f-9845105a9971
@@ -80,6 +85,12 @@ blueprint-diff latest
 sled-set serial0 mupdate-override unset
 sled-set serial0 inventory-visible
 sled-set serial0 omicron-config latest
+
+# Model sled 2 having processed the recovery blueprint emitted by the first
+# plan (which set remove_mupdate_override = 203fa72c on sled 2): advance the
+# reported sled-agent generation. (The marker is overwritten below, so we
+# don't need to unset it first.)
+sled-set serial2 omicron-config latest
 
 # But simulate a second mupdate on sled 2. This should invalidate the existing
 # mupdate override on sled 2 and cause another target release minimum
@@ -206,6 +217,13 @@ blueprint-diff latest
 # With the option disabled (the current state), the planner will
 # not proceed with adding new zones. But with the option enabled,
 # new zones will be added.
+
+# Advance serial0's reported sled-agent generation to match the latest
+# blueprint, modeling the sled having reconciled prior planning steps
+# before the new mupdate below. This also lets the planner confirm a
+# previously soft-expunged internal_dns zone, transitioning it to
+# hard-expunged and unblocking a replacement.
+sled-set serial0 omicron-config latest
 sled-set serial0 mupdate-override c8fba912-63ae-473a-9115-0495d10fb3bc
 sled-add c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 inventory-generate
@@ -224,6 +242,10 @@ blueprint-diff latest
 # test that the planner bails if it attempts a rollback of the target release
 # minimum generation.
 blueprint-edit latest set-target-release-min-gen 1000
+
+# Advance serial1's reported sled-agent generation to match the latest
+# blueprint before the new mupdate below.
+sled-set serial1 omicron-config latest
 sled-set serial1 mupdate-override cc724abe-80c1-47e6-9771-19e6540531a9
 inventory-generate
 blueprint-plan latest latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-mupdate-update-flow.txt
@@ -20,9 +20,7 @@ blueprint-edit latest set-sp-update serial0 e3b0c44298fc1c149afbf4c8996fb92427ae
 blueprint-edit latest set-host-phase2 serial0 A artifact 1.0.0 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
 blueprint-edit latest set-host-phase2 serial0 B artifact 1.0.0 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
 
-# Model sled 0 reconciling the blueprint edits above, so its reported
-# sled-agent generation matches the parent blueprint when the next
-# inventory is generated.
+# Apply the blueprint edits to sled 0.
 sled-set serial0 omicron-config latest
 
 # Simulate a mupdate on sled 0 by setting the mupdate override field to a
@@ -86,10 +84,8 @@ sled-set serial0 mupdate-override unset
 sled-set serial0 inventory-visible
 sled-set serial0 omicron-config latest
 
-# Model sled 2 having processed the recovery blueprint emitted by the first
-# plan (which set remove_mupdate_override = 203fa72c on sled 2): advance the
-# reported sled-agent generation. (The marker is overwritten below, so we
-# don't need to unset it first.)
+# Apply this config (which sets remove_mupdate_override to 203fa72c)
+# on sled 2.
 sled-set serial2 omicron-config latest
 
 # But simulate a second mupdate on sled 2. This should invalidate the existing
@@ -218,11 +214,9 @@ blueprint-diff latest
 # not proceed with adding new zones. But with the option enabled,
 # new zones will be added.
 
-# Advance serial0's reported sled-agent generation to match the latest
-# blueprint, modeling the sled having reconciled prior planning steps
-# before the new mupdate below. This also lets the planner confirm a
-# previously soft-expunged internal_dns zone, transitioning it to
-# hard-expunged and unblocking a replacement.
+# Apply the blueprint edits to sled 0. This also lets the planner see
+# that the internal_dns zone is expunged, setting up a replacement
+# internal_dns zone.
 sled-set serial0 omicron-config latest
 sled-set serial0 mupdate-override c8fba912-63ae-473a-9115-0495d10fb3bc
 sled-add c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
@@ -243,8 +237,7 @@ blueprint-diff latest
 # minimum generation.
 blueprint-edit latest set-target-release-min-gen 1000
 
-# Advance serial1's reported sled-agent generation to match the latest
-# blueprint before the new mupdate below.
+# Apply this config to sled 1 before the new MUPdate below.
 sled-set serial1 omicron-config latest
 sled-set serial1 mupdate-override cc724abe-80c1-47e6-9771-19e6540531a9
 inventory-generate

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -78,6 +78,13 @@ blueprint df06bb57-ad42-4431-9206-abff322896c7 created from latest blueprint (af
 warn: no validation is done on the requested source
 
 
+> # Model sled 0 reconciling the blueprint edits above, so its reported
+> # sled-agent generation matches the parent blueprint when the next
+> # inventory is generated.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (df06bb57-ad42-4431-9206-abff322896c7)
+
+
 > # Simulate a mupdate on sled 0 by setting the mupdate override field to a
 > # new UUID (generated using uuidgen).
 > sled-set serial0 mupdate-override 6123eac1-ec5b-42ba-b73f-9845105a9971
@@ -383,10 +390,10 @@ sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
         reservation: None, quota: None
 
 LEDGERED SLED CONFIG
-    generation: 2
+    generation: 5
     remove_mupdate_override: None
-    desired host phase 2 slot a: keep current contents
-    desired host phase 2 slot b: keep current contents
+    desired host phase 2 slot a: artifact 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
+    desired host phase 2 slot b: artifact 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
     DISKS: 1
         ID                                       ZPOOL_ID                                 VENDOR          MODEL          SERIAL                                      
         3f399219-7701-414c-9f07-8e97f688765c     c6d33b64-fb96-4129-bab1-7878a06a5f9b     fake-vendor     fake-model     serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b 
@@ -406,13 +413,13 @@ LEDGERED SLED CONFIG
         ad41be71-6c15-4428-b510-20ceacde4fa6     oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/external_dns                                                      off             none        none        
         cdf3684f-a6cf-4449-b9ec-e696b2c663e2     oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                     off             none        none        
     ZONES: 6
-        ID                                       KIND                IMAGE_SOURCE    
-        0c71b3b2-6ceb-4e8f-b020-b08675e83038     nexus               install-dataset 
-        427ec88f-f467-42fa-9bbb-66a91a36103c     internal_dns        install-dataset 
-        5199c033-4cf9-4ab6-8ae7-566bd7606363     crucible            install-dataset 
-        6444f8a5-6465-4f0b-a549-1993c113569c     internal_ntp        install-dataset 
-        803bfb63-c246-41db-b0da-d3b87ddfc63d     external_dns        install-dataset 
-        ba4994a8-23f9-4b1a-a84f-a08d74591389     crucible_pantry     install-dataset 
+        ID                                       KIND                IMAGE_SOURCE                                                               
+        0c71b3b2-6ceb-4e8f-b020-b08675e83038     nexus               artifact: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 
+        427ec88f-f467-42fa-9bbb-66a91a36103c     internal_dns        install-dataset                                                            
+        5199c033-4cf9-4ab6-8ae7-566bd7606363     crucible            install-dataset                                                            
+        6444f8a5-6465-4f0b-a549-1993c113569c     internal_ntp        install-dataset                                                            
+        803bfb63-c246-41db-b0da-d3b87ddfc63d     external_dns        install-dataset                                                            
+        ba4994a8-23f9-4b1a-a84f-a08d74591389     crucible_pantry     install-dataset                                                            
     measurement empty
     zone image resolver status:
         zone manifest:
@@ -639,7 +646,7 @@ INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupda
 INFO no previous MGS update found as part of updating blueprint mupdate override to match inventory, phase: do_plan_mupdate_override, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763
 INFO updating target release minimum generation based on new set-override actions, phase: do_plan_mupdate_override, current_generation: 1, new_generation: 3
 WARN skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: error retrieving mupdate override information: reconfigurator-cli simulated mupdate-override error
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (5)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (6123eac1-ec5b-42ba-b73f-9845105a9971)
 INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: remove_mupdate_override is set in the blueprint (203fa72c-85c1-466a-8ed3-338ee029530d)
 generated blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736 based on parent blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976
 blueprint source: planner with report:
@@ -1027,6 +1034,14 @@ set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 inventory visibility: hidden -> vi
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (626487fa-7139-45ec-8416-902271fc730b)
 
 
+> # Model sled 2 having processed the recovery blueprint emitted by the first
+> # plan (which set remove_mupdate_override = 203fa72c on sled 2): advance the
+> # reported sled-agent generation. (The marker is overwritten below, so we
+> # don't need to unset it first.)
+> sled-set serial2 omicron-config latest
+set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (626487fa-7139-45ec-8416-902271fc730b)
+
+
 > # But simulate a second mupdate on sled 2. This should invalidate the existing
 > # mupdate override on sled 2 and cause another target release minimum
 > # generation bump.
@@ -1105,7 +1120,7 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO measurement is eligible for noop image source conversion, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, new_measurement_source: 8a0e23157bae655fceec7376926c9758efee6511c7b7ff8355bbb49545a2257f version 1.0.0
 
-INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: inventory stale: inventory reported generation (2) that is older than the generation in the parent blueprint (3)
+INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: remove_mupdate_override is set in the blueprint (1c0ce176-6dc8-4a90-adea-d4a8000751da)
 generated blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b based on parent blueprint 626487fa-7139-45ec-8416-902271fc730b
 blueprint source: planner with report:
 planning report:
@@ -3235,6 +3250,15 @@ external DNS:
 > # With the option disabled (the current state), the planner will
 > # not proceed with adding new zones. But with the option enabled,
 > # new zones will be added.
+
+> # Advance serial0's reported sled-agent generation to match the latest
+> # blueprint, modeling the sled having reconciled prior planning steps
+> # before the new mupdate below. This also lets the planner confirm a
+> # previously soft-expunged internal_dns zone, transitioning it to
+> # hard-expunged and unblocking a replacement.
+> sled-set serial0 omicron-config latest
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (27e755bc-dc10-4647-853c-f89bb3a15a2c)
+
 > sled-set serial0 mupdate-override c8fba912-63ae-473a-9115-0495d10fb3bc
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 mupdate override: unset -> c8fba912-63ae-473a-9115-0495d10fb3bc
 
@@ -3264,7 +3288,7 @@ INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupda
 INFO no previous MGS update found as part of updating blueprint mupdate override to match inventory, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 INFO updating target release minimum generation based on new set-override actions, phase: do_plan_mupdate_override, current_generation: 4, new_generation: 5
 INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (6) that is older than the generation in the parent blueprint (7)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (8) that is older than the generation in the parent blueprint (9)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (c8fba912-63ae-473a-9115-0495d10fb3bc)
 INFO performed noop zone image source checks on sled, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, num_total: 0, num_already_artifact: 0, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -3344,20 +3368,21 @@ to:   blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f
 
 
     omicron zones:
-    -------------------------------------------------------------------------------------------------------------------------
-    zone type         zone id                                image source                disposition    underlay IP          
-    -------------------------------------------------------------------------------------------------------------------------
-    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0     expunged ⏳     fd00:1122:3344:2::1  
-*   crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   - artifact: version 1.0.0   in service     fd00:1122:3344:101::7
-     └─                                                      + install dataset                                               
-*   crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   - artifact: version 1.0.0   in service     fd00:1122:3344:101::6
-     └─                                                      + install dataset                                               
-*   external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   - artifact: version 1.0.0   in service     fd00:1122:3344:101::5
-     └─                                                      + install dataset                                               
-*   internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   - artifact: version 1.0.0   in service     fd00:1122:3344:101::3
-     └─                                                      + install dataset                                               
-*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   - artifact: version 1.0.0   in service     fd00:1122:3344:101::4
-     └─                                                      + install dataset                                               
+    ---------------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source                disposition      underlay IP          
+    ---------------------------------------------------------------------------------------------------------------------------
+*   crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   - artifact: version 1.0.0   in service       fd00:1122:3344:101::7
+     └─                                                      + install dataset                                                 
+*   crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   - artifact: version 1.0.0   in service       fd00:1122:3344:101::6
+     └─                                                      + install dataset                                                 
+*   external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   - artifact: version 1.0.0   in service       fd00:1122:3344:101::5
+     └─                                                      + install dataset                                                 
+*   internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0     - expunged ⏳     fd00:1122:3344:2::1  
+     └─                                                                                  + expunged ✓                          
+*   internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   - artifact: version 1.0.0   in service       fd00:1122:3344:101::3
+     └─                                                      + install dataset                                                 
+*   nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   - artifact: version 1.0.0   in service       fd00:1122:3344:101::4
+     └─                                                      + install dataset                                                 
 
 
  ADDED SLEDS:
@@ -3413,7 +3438,7 @@ planner config updated:
 
 > blueprint-plan latest latest
 INFO skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, reason: inventory stale: inventory reported generation (6) that is older than the generation in the parent blueprint (7)
-INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (8) that is older than the generation in the parent blueprint (10)
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: inventory stale: inventory reported generation (9) that is older than the generation in the parent blueprint (10)
 INFO performed noop zone image source checks on sled, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, num_total: 0, num_already_artifact: 0, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
@@ -3439,7 +3464,9 @@ planner config:
 * discretionary zone placement waiting for NTP zones on sleds: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * missing NTP zone on sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * only placed 0/1 desired nexus zones
-* zone updates waiting on zone add blockers
+* discretionary zones placed:
+  * internal_dns zone on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 from source artifact: version 2.0.0
+* zone updates waiting on discretionary zones
 * waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
 Measurement updates:
 Waiting on zone add/update blockers
@@ -3451,6 +3478,65 @@ from: blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f
 to:   blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35
 
  MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 10 -> 11):
+    will remove mupdate override:   c8fba912-63ae-473a-9115-0495d10fb3bc (unchanged)
+
+    measurements:
+    ------------------------------
+    hash              version     
+    ------------------------------
+    install dataset   (no version)
+
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              42430c80-7836-4191-a4f6-bcee749010fe   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/external_dns                                                    ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/internal_dns                                                    a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   expunged      none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      3ac089c9-9dec-465b-863a-188e80d71fb4   expunged      none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               686c19cf-a0d7-45f6-866f-c564612b2664   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/local_storage                                                   cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/local_storage_unencrypted                                             793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
++   oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/internal_dns                                                    b8ba4bea-893b-42e9-a034-c7283d15c2b7   in service    none      none          off        
++   oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_internal_dns_cfc72ddd-fd83-4396-b1ad-d53f69182a09      64c1c086-6866-4a94-b9bf-1d022312d587   in service    none      none          off        
+
+
+    omicron zones:
+    -----------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source              disposition    underlay IP          
+    -----------------------------------------------------------------------------------------------------------------------
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   install dataset           in service     fd00:1122:3344:101::7
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   install dataset           in service     fd00:1122:3344:101::6
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   install dataset           in service     fd00:1122:3344:101::5
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   artifact: version 1.0.0   expunged ✓     fd00:1122:3344:2::1  
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   install dataset           in service     fd00:1122:3344:101::3
+    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   install dataset           in service     fd00:1122:3344:101::4
++   internal_dns      cfc72ddd-fd83-4396-b1ad-d53f69182a09   artifact: version 2.0.0   in service     fd00:1122:3344:2::1  
+
 
   sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b (active, config generation 1 -> 2):
 
@@ -3556,6 +3642,12 @@ to:   blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35
 
 internal DNS:
 * DNS zone: "control-plane.oxide.internal": 
+*   name: @                                                  (records: 2 -> 3)
+-       NS   ns1.control-plane.oxide.internal
+-       NS   ns2.control-plane.oxide.internal
++       NS   ns1.control-plane.oxide.internal
++       NS   ns2.control-plane.oxide.internal
++       NS   ns3.control-plane.oxide.internal
 *   name: _internal-ntp._tcp                                 (records: 3 -> 4)
 -       SRV  port   123 62620961-fc4a-481e-968b-f5acbac0dc63.host.control-plane.oxide.internal
 -       SRV  port   123 6444f8a5-6465-4f0b-a549-1993c113569c.host.control-plane.oxide.internal
@@ -3564,9 +3656,22 @@ internal DNS:
 +       SRV  port   123 6444f8a5-6465-4f0b-a549-1993c113569c.host.control-plane.oxide.internal
 +       SRV  port   123 cee5d0c6-412c-49e9-a9a8-dab9addaa182.host.control-plane.oxide.internal
 +       SRV  port   123 f10a4fb9-759f-4a65-b25e-5794ad2d07d8.host.control-plane.oxide.internal
+*   name: _nameservice._tcp                                  (records: 2 -> 3)
+-       SRV  port  5353 99e2f30b-3174-40bf-a78a-90da8abba8ca.host.control-plane.oxide.internal
+-       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
++       SRV  port  5353 99e2f30b-3174-40bf-a78a-90da8abba8ca.host.control-plane.oxide.internal
++       SRV  port  5353 cfc72ddd-fd83-4396-b1ad-d53f69182a09.host.control-plane.oxide.internal
++       SRV  port  5353 ea5b4030-b52f-44b2-8d70-45f15f987d01.host.control-plane.oxide.internal
 +   name: cee5d0c6-412c-49e9-a9a8-dab9addaa182.host          (records: 1)
 +       AAAA fd00:1122:3344:104::3
-    unchanged names: 38 (records: 51)
++   name: cfc72ddd-fd83-4396-b1ad-d53f69182a09.host          (records: 1)
++       AAAA fd00:1122:3344:2::1
+*   name: ns2                                                (records: 1 -> 1)
+-       AAAA fd00:1122:3344:3::1
++       AAAA fd00:1122:3344:2::1
++   name: ns3                                                (records: 1)
++       AAAA fd00:1122:3344:3::1
+    unchanged names: 35 (records: 46)
 
 external DNS:
   DNS zone: "oxide.example" (unchanged)
@@ -3580,6 +3685,12 @@ external DNS:
 > # minimum generation.
 > blueprint-edit latest set-target-release-min-gen 1000
 blueprint 13cfdd24-52ba-4e94-8c83-02e3a48fc746 created from latest blueprint (9a9e6c32-5a84-4020-a159-33dceff18d35): set target release minimum generation to 1000
+
+
+> # Advance serial1's reported sled-agent generation to match the latest
+> # blueprint before the new mupdate below.
+> sled-set serial1 omicron-config latest
+set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (13cfdd24-52ba-4e94-8c83-02e3a48fc746)
 
 > sled-set serial1 mupdate-override cc724abe-80c1-47e6-9771-19e6540531a9
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c mupdate override: unset -> cc724abe-80c1-47e6-9771-19e6540531a9

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -78,9 +78,7 @@ blueprint df06bb57-ad42-4431-9206-abff322896c7 created from latest blueprint (af
 warn: no validation is done on the requested source
 
 
-> # Model sled 0 reconciling the blueprint edits above, so its reported
-> # sled-agent generation matches the parent blueprint when the next
-> # inventory is generated.
+> # Apply the blueprint edits to sled 0.
 > sled-set serial0 omicron-config latest
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (df06bb57-ad42-4431-9206-abff322896c7)
 
@@ -1034,10 +1032,8 @@ set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 inventory visibility: hidden -> vi
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (626487fa-7139-45ec-8416-902271fc730b)
 
 
-> # Model sled 2 having processed the recovery blueprint emitted by the first
-> # plan (which set remove_mupdate_override = 203fa72c on sled 2): advance the
-> # reported sled-agent generation. (The marker is overwritten below, so we
-> # don't need to unset it first.)
+> # Apply this config (which sets remove_mupdate_override to 203fa72c)
+> # on sled 2.
 > sled-set serial2 omicron-config latest
 set sled d81c6a84-79b8-4958-ae41-ea46c9b19763 omicron config from latest blueprint (626487fa-7139-45ec-8416-902271fc730b)
 
@@ -3251,11 +3247,9 @@ external DNS:
 > # not proceed with adding new zones. But with the option enabled,
 > # new zones will be added.
 
-> # Advance serial0's reported sled-agent generation to match the latest
-> # blueprint, modeling the sled having reconciled prior planning steps
-> # before the new mupdate below. This also lets the planner confirm a
-> # previously soft-expunged internal_dns zone, transitioning it to
-> # hard-expunged and unblocking a replacement.
+> # Apply the blueprint edits to sled 0. This also lets the planner see
+> # that the internal_dns zone is expunged, setting up a replacement
+> # internal_dns zone.
 > sled-set serial0 omicron-config latest
 set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 omicron config from latest blueprint (27e755bc-dc10-4647-853c-f89bb3a15a2c)
 
@@ -3687,8 +3681,7 @@ external DNS:
 blueprint 13cfdd24-52ba-4e94-8c83-02e3a48fc746 created from latest blueprint (9a9e6c32-5a84-4020-a159-33dceff18d35): set target release minimum generation to 1000
 
 
-> # Advance serial1's reported sled-agent generation to match the latest
-> # blueprint before the new mupdate below.
+> # Apply this config to sled 1 before the new MUPdate below.
 > sled-set serial1 omicron-config latest
 set sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c omicron config from latest blueprint (13cfdd24-52ba-4e94-8c83-02e3a48fc746)
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -3482,8 +3482,10 @@ Waiting on zone add/update blockers
 
 
 
-> # TODO: This blippy run produces two FATAL notes due to
-> # https://github.com/oxidecomputer/omicron/issues/10420.
+> # TODO: This blippy run produces two FATAL notes, due to, respectively:
+> #
+> # * https://github.com/oxidecomputer/omicron/issues/10420
+> # * https://github.com/oxidecomputer/omicron/pull/10363
 > blueprint-blippy latest
 blippy report for blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35: 2 notes
   FATAL note: sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: Nexus zones 466a9f29-62bf-4e63-924a-b9efdb86afec and 0c71b3b2-6ceb-4e8f-b020-b08675e83038 both have generation 1 but different image sources (Artifact { version: Available { version: ArtifactVersion("2.0.0") }, hash: ArtifactHash("e9b7035f41848a987a798c15ac424cc91dd662b1af0920d58d8aa1ebad7467b6") } vs InstallDataset)


### PR DESCRIPTION
In `cmds-mupdate-update-flow.txt`, add `sled-set omicron-config latest` commands before setting the mupdate override field for these sleds. Without these, the simulated sled-agent's reported reconciled generation lags behind the parent blueprint's per-sled generation, which ends up breaking forthcoming work to detect stale inventory collections while initially setting the "will remove mupdate override" field within blueprints.

This test-only PR is separated out into its own commit to try and minimize the diff for the forthcoming functional change.

As a result of this change, within the test, sled 0 now applies a previously-pending zone expungement (`internal_dns 427ec88f`). As a result, the planner confirms the expungement and adds a replacement zone (`cfc72ddd`, artifact 2.0.0). But this is actually a bug -- on a sled with a mupdate override, replacement zones should come from the install dataset. See #10420.