### PR TITLE
Document the -s flag in help output (one liner)

### DIFF
--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -26,6 +26,7 @@ function usage
   echo "   -y: Assume 'yes' instead of showing confirmation prompts"
   echo "   -p: Skip checking paths"
   echo "   -r: Number of retries to perform for network operations (default: 3)"
+  echo "   -s: Skip using sudo on Linux systems"
   exit 1
 }
 


### PR DESCRIPTION
The script supports a "-s" flag to skip using sudo on Linux systems, but the flag is not documented in the output of the -h command.

This PR adds it in.