### PR TITLE
Update crucible to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 name = "bootstrap-agent-api"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "omicron-common",
  "omicron-uuid-kinds",
@@ -886,7 +886,7 @@ name = "bootstrap-agent-lockstep-api"
 version = "0.1.0"
 dependencies = [
  "bootstrap-agent-lockstep-types",
- "dropshot 0.17.0",
+ "dropshot",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
 ]
@@ -1066,15 +1066,6 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
@@ -1106,20 +1097,6 @@ dependencies = [
  "toml 0.8.23",
  "unicode-xid",
  "url",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform 0.1.9",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1270,7 +1247,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "libc",
  "omicron-common",
@@ -1451,7 +1428,7 @@ dependencies = [
  "clap",
  "clickhouse-admin-server-client",
  "clickhouse-admin-types",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "omicron-common",
  "omicron-workspace-hack",
@@ -1473,7 +1450,7 @@ name = "clickhouse-admin-api"
 version = "0.1.0"
 dependencies = [
  "clickhouse-admin-types-versions",
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "omicron-common",
  "omicron-uuid-kinds",
@@ -1535,7 +1512,7 @@ dependencies = [
  "camino",
  "clickhouse-admin-types",
  "clickward",
- "dropshot 0.17.0",
+ "dropshot",
  "omicron-workspace-hack",
 ]
 
@@ -1635,7 +1612,7 @@ name = "cockroach-admin-api"
 version = "0.1.0"
 dependencies = [
  "cockroach-admin-types-versions",
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "http",
  "omicron-common",
@@ -2020,7 +1997,7 @@ name = "crdb-seed"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dropshot 0.17.0",
+ "dropshot",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "slog",
@@ -2150,14 +2127,14 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=7103cd3a3d7b0112d2949dd135db06fef0c156bb#7103cd3a3d7b0112d2949dd135db06fef0c156bb"
+source = "git+https://github.com/oxidecomputer/crucible?rev=fefccc0623038371dbded0458f0645bee6b141cb#fefccc0623038371dbded0458f0645bee6b141cb"
 dependencies = [
  "anyhow",
  "chrono",
  "crucible-workspace-hack",
  "percent-encoding",
- "progenitor 0.10.0",
- "reqwest 0.12.28",
+ "progenitor 0.14.0",
+ "reqwest 0.13.2",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -2179,13 +2156,13 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=7103cd3a3d7b0112d2949dd135db06fef0c156bb#7103cd3a3d7b0112d2949dd135db06fef0c156bb"
+source = "git+https://github.com/oxidecomputer/crucible?rev=fefccc0623038371dbded0458f0645bee6b141cb#fefccc0623038371dbded0458f0645bee6b141cb"
 dependencies = [
  "anyhow",
  "atty",
  "crucible-workspace-hack",
- "dropshot 0.16.7",
- "nix 0.29.0",
+ "dropshot",
+ "nix 0.31.2",
  "rustls-pemfile 1.0.4",
  "schemars 0.8.22",
  "serde",
@@ -2199,7 +2176,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.24.1",
- "toml 0.8.23",
+ "toml 1.0.6+spec-1.1.0",
  "twox-hash",
  "uuid",
  "vergen",
@@ -2209,14 +2186,14 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=7103cd3a3d7b0112d2949dd135db06fef0c156bb#7103cd3a3d7b0112d2949dd135db06fef0c156bb"
+source = "git+https://github.com/oxidecomputer/crucible?rev=fefccc0623038371dbded0458f0645bee6b141cb#fefccc0623038371dbded0458f0645bee6b141cb"
 dependencies = [
  "anyhow",
  "chrono",
  "crucible-workspace-hack",
  "percent-encoding",
- "progenitor 0.10.0",
- "reqwest 0.12.28",
+ "progenitor 0.14.0",
+ "reqwest 0.13.2",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -2226,7 +2203,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=7103cd3a3d7b0112d2949dd135db06fef0c156bb#7103cd3a3d7b0112d2949dd135db06fef0c156bb"
+source = "git+https://github.com/oxidecomputer/crucible?rev=fefccc0623038371dbded0458f0645bee6b141cb#fefccc0623038371dbded0458f0645bee6b141cb"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -2957,7 +2934,7 @@ dependencies = [
  "clap",
  "dns-server-api",
  "dns-service-client",
- "dropshot 0.17.0",
+ "dropshot",
  "git-stub-vcs",
  "hickory-client",
  "hickory-proto 0.25.2",
@@ -2989,7 +2966,7 @@ name = "dns-server-api"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "internal-dns-types-versions",
  "omicron-workspace-hack",
@@ -3024,7 +3001,7 @@ dependencies = [
  "clap",
  "dns-server",
  "dns-service-client",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "internal-dns-types",
  "omicron-test-utils",
@@ -3169,57 +3146,6 @@ dependencies = [
 
 [[package]]
 name = "dropshot"
-version = "0.16.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69fd85c8dfc67252d02f260595f6b62b5abceb1b88b4b9722369d27936e5fa4"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "camino",
- "chrono",
- "debug-ignore",
- "dropshot_endpoint 0.16.7",
- "form_urlencoded",
- "futures",
- "hostname 0.4.2",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "indexmap 2.14.0",
- "multer",
- "openapiv3",
- "paste",
- "percent-encoding",
- "rustls 0.22.4",
- "rustls-pemfile 2.2.0",
- "schemars 0.8.22",
- "scopeguard",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sha1",
- "slog",
- "slog-async",
- "slog-bunyan",
- "slog-json",
- "slog-term",
- "thiserror 2.0.18",
- "tokio",
- "tokio-rustls 0.25.0",
- "toml 0.9.12+spec-1.1.0",
- "usdt 0.6.0",
- "uuid",
- "version_check",
- "waitgroup",
-]
-
-[[package]]
-name = "dropshot"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "409eb76c7ea1623d270393248ff55ec436841fcd724c2e1c9de294291edd35f5"
@@ -3232,7 +3158,7 @@ dependencies = [
  "camino",
  "chrono",
  "debug-ignore",
- "dropshot_endpoint 0.17.0",
+ "dropshot_endpoint",
  "form_urlencoded",
  "futures",
  "hostname 0.4.2",
@@ -3283,7 +3209,7 @@ dependencies = [
  "clap",
  "debug-ignore",
  "drift",
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "fs-err 3.3.0",
  "git-stub",
@@ -3315,21 +3241,6 @@ dependencies = [
  "paste",
  "semver 1.0.28",
  "serde_json",
-]
-
-[[package]]
-name = "dropshot_endpoint"
-version = "0.16.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d106478e4a4782556981d028a667f41c4845cdaa6e2d3a9f58c5d15e725401"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "semver 1.0.28",
- "serde",
- "serde_tokenstream",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3613,7 +3524,7 @@ dependencies = [
 name = "ereport-types"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.17.0",
+ "dropshot",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "schemars 0.8.22",
@@ -4029,7 +3940,7 @@ dependencies = [
 name = "gateway-api"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "ereport-types",
  "gateway-types-versions",
@@ -4164,7 +4075,7 @@ name = "gateway-test-utils"
 version = "0.1.0"
 dependencies = [
  "camino",
- "dropshot 0.17.0",
+ "dropshot",
  "gateway-client",
  "gateway-messages",
  "gateway-types",
@@ -4192,7 +4103,7 @@ name = "gateway-types-versions"
 version = "0.1.0"
 dependencies = [
  "daft",
- "dropshot 0.17.0",
+ "dropshot",
  "gateway-messages",
  "hex",
  "omicron-uuid-kinds",
@@ -5308,7 +5219,7 @@ dependencies = [
  "chrono",
  "crucible-smf",
  "debug-ignore",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "http",
  "iddqd",
@@ -5537,7 +5448,7 @@ name = "installinator-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "hyper",
  "installinator-common-versions",
@@ -5616,7 +5527,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "hickory-resolver 0.25.2",
  "internal-dns-resolver",
  "internal-dns-types",
@@ -5636,7 +5547,7 @@ dependencies = [
  "dns-server",
  "dns-server-api",
  "dns-service-client",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "futures",
  "hickory-proto 0.25.2",
@@ -6755,7 +6666,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "cookie",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "headers",
  "http",
@@ -6822,7 +6733,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "ipnet",
  "libc",
@@ -6974,7 +6885,7 @@ dependencies = [
  "db-macros",
  "diesel",
  "diesel-dtrace",
- "dropshot 0.17.0",
+ "dropshot",
  "ereport-types",
  "expectorate",
  "futures",
@@ -7091,7 +7002,7 @@ dependencies = [
  "api_identity",
  "base64 0.22.1",
  "chrono",
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "http",
  "hyper",
@@ -7142,7 +7053,7 @@ dependencies = [
 name = "nexus-internal-api"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "http",
  "nexus-types",
@@ -7209,7 +7120,7 @@ dependencies = [
 name = "nexus-lockstep-api"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.17.0",
+ "dropshot",
  "http",
  "nexus-types",
  "nexus-types-versions",
@@ -7296,7 +7207,7 @@ dependencies = [
  "assert_matches",
  "camino",
  "chrono",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "gateway-client",
  "gateway-messages",
@@ -7477,7 +7388,7 @@ dependencies = [
  "cockroach-admin-types",
  "daft",
  "debug-ignore",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "gateway-client",
  "gateway-types",
@@ -7663,7 +7574,7 @@ dependencies = [
  "crucible-agent-client",
  "dns-service-client",
  "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=187aee7de2e50f907099ea06c04aac96c3455665)",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "gateway-messages",
  "gateway-test-utils",
@@ -7736,7 +7647,7 @@ dependencies = [
  "daft",
  "derive-where",
  "derive_more 0.99.20",
- "dropshot 0.17.0",
+ "dropshot",
  "either",
  "ereport-types",
  "expectorate",
@@ -7804,7 +7715,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "daft",
- "dropshot 0.17.0",
+ "dropshot",
  "http",
  "mg-admin-client",
  "omicron-common",
@@ -7866,18 +7777,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases 0.2.1",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
@@ -7921,7 +7820,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 name = "ntp-admin-api"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "http",
  "ntp-admin-types-versions",
@@ -8221,7 +8120,7 @@ dependencies = [
  "clickhouse-admin-test-utils",
  "clickhouse-admin-types",
  "clickward",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "flume",
  "http",
@@ -8265,7 +8164,7 @@ dependencies = [
  "cockroach-admin-types",
  "cockroach-admin-types-versions",
  "csv",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "http",
  "illumos-utils",
@@ -8330,7 +8229,7 @@ dependencies = [
  "camino-tempfile",
  "chrono",
  "daft",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "futures",
  "hex",
@@ -8345,7 +8244,6 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "parse-display",
- "progenitor-client 0.10.0",
  "progenitor-client 0.14.0",
  "progenitor-extras",
  "proptest",
@@ -8406,7 +8304,7 @@ dependencies = [
  "anyhow",
  "camino",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "futures",
  "gateway-client",
@@ -8481,7 +8379,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "ereport-types",
  "expectorate",
  "futures",
@@ -8533,7 +8431,7 @@ dependencies = [
  "async-trait",
  "camino",
  "camino-tempfile",
- "dropshot 0.17.0",
+ "dropshot",
  "omicron-workspace-hack",
  "serde",
  "serde_json",
@@ -8550,7 +8448,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "dns-service-client",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "internal-dns-resolver",
  "internal-dns-types",
@@ -8632,7 +8530,7 @@ dependencies = [
  "dns-server",
  "dns-service-client",
  "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=187aee7de2e50f907099ea06c04aac96c3455665)",
- "dropshot 0.17.0",
+ "dropshot",
  "ereport-types",
  "expectorate",
  "fatfs",
@@ -8734,7 +8632,6 @@ dependencies = [
  "rdb-types",
  "ref-cast",
  "regex",
- "reqwest 0.12.28",
  "reqwest 0.13.2",
  "ring",
  "rustls 0.22.4",
@@ -8793,7 +8690,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "http",
  "nexus-test-utils",
@@ -8847,7 +8744,7 @@ dependencies = [
  "csv",
  "daft",
  "diesel",
- "dropshot 0.17.0",
+ "dropshot",
  "dyn-clone",
  "ereport-types",
  "expectorate",
@@ -8997,7 +8894,7 @@ dependencies = [
  "anyhow",
  "camino",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "internal-dns-resolver",
  "internal-dns-types",
  "nexus-db-model",
@@ -9076,7 +8973,7 @@ dependencies = [
  "bytes",
  "camino",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "libc",
  "omicron-common",
@@ -9127,7 +9024,7 @@ dependencies = [
  "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?branch=main)",
  "display-error-chain",
  "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=cc8e02a0800034c431c8cf96b889ea638da3d194)",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "flate2",
  "flume",
@@ -9179,7 +9076,6 @@ dependencies = [
  "regress 0.10.5",
  "repo-depot-api",
  "repo-depot-client",
- "reqwest 0.12.28",
  "reqwest 0.13.2",
  "schemars 0.8.22",
  "secrecy 0.10.3",
@@ -9245,7 +9141,7 @@ dependencies = [
  "camino",
  "camino-tempfile",
  "chrono",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "filetime",
  "futures",
@@ -9442,7 +9338,6 @@ dependencies = [
  "tokio-util",
  "toml 0.7.8",
  "toml_datetime 0.6.11",
- "toml_datetime 0.7.5+spec-1.1.0",
  "toml_edit 0.19.15",
  "toml_edit 0.22.27",
  "toml_parser",
@@ -9454,7 +9349,7 @@ dependencies = [
  "usdt-impl 0.6.0",
  "uuid",
  "vergen",
- "vergen-lib",
+ "vergen-lib 9.1.0",
  "winnow 0.7.14",
  "x509-cert",
  "zerocopy 0.8.40",
@@ -9780,7 +9675,7 @@ dependencies = [
 name = "oximeter-api"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "omicron-common",
  "omicron-workspace-hack",
@@ -9812,7 +9707,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "futures",
  "httpmock",
@@ -9875,7 +9770,7 @@ dependencies = [
  "crossterm 0.29.0",
  "debug-ignore",
  "display-error-chain",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "futures",
  "gethostname",
@@ -9930,7 +9825,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "chrono",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "http",
  "hyper",
@@ -9978,7 +9873,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "either",
  "internal-dns-resolver",
  "internal-dns-types",
@@ -10004,7 +9899,7 @@ dependencies = [
 name = "oximeter-producer-api"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.17.0",
+ "dropshot",
  "omicron-workspace-hack",
  "oximeter-types-versions 0.1.0",
 ]
@@ -11076,17 +10971,6 @@ dependencies = [
 
 [[package]]
 name = "progenitor"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced2eadb9776a201d0585b4b072fd44d7d2104e0f3452d967b5a78966f4855cf"
-dependencies = [
- "progenitor-client 0.10.0",
- "progenitor-impl 0.10.0",
- "progenitor-macro 0.10.0",
-]
-
-[[package]]
-name = "progenitor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2326f73d5326257514712436680ef8da4543ee47c0e9e0d501545c8909ee12e4"
@@ -11116,21 +11000,6 @@ dependencies = [
  "progenitor-client 0.14.0",
  "progenitor-impl 0.14.0",
  "progenitor-macro 0.14.0",
-]
-
-[[package]]
-name = "progenitor-client"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296003fd74e64c77aeb2c10eae850eb543211a8557dd3b3de6f4230b5071e44b"
-dependencies = [
- "bytes",
- "futures-core",
- "percent-encoding",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_urlencoded",
 ]
 
 [[package]]
@@ -11188,28 +11057,6 @@ dependencies = [
  "http",
  "progenitor-client 0.14.0",
  "tokio",
-]
-
-[[package]]
-name = "progenitor-impl"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17e5363daa50bf1cccfade6b0fb970d2278758fd5cfa9ab69f25028e4b1afa3"
-dependencies = [
- "heck 0.5.0",
- "http",
- "indexmap 2.14.0",
- "openapiv3",
- "proc-macro2",
- "quote",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "syn 2.0.117",
- "thiserror 2.0.18",
- "typify 0.4.3",
- "unicode-ident",
 ]
 
 [[package]]
@@ -11276,24 +11123,6 @@ dependencies = [
  "thiserror 2.0.18",
  "typify 0.6.2",
  "unicode-ident",
-]
-
-[[package]]
-name = "progenitor-macro"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4972aec926d1e06d6abc11ab3f063d2f7063be3dd46fd2839442c14d8e48f3ed"
-dependencies = [
- "openapiv3",
- "proc-macro2",
- "progenitor-impl 0.10.0",
- "quote",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "serde_yaml",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -11396,7 +11225,7 @@ dependencies = [
  "atty",
  "base64 0.21.7",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "hyper",
  "progenitor 0.13.0",
@@ -11738,7 +11567,7 @@ name = "range-requests"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "http",
  "http-body",
@@ -11866,7 +11695,7 @@ dependencies = [
  "colored 2.2.0",
  "daft",
  "datatest-stable",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "gateway-types",
  "humantime",
@@ -11913,7 +11742,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "gateway-client",
  "gateway-types",
@@ -12099,7 +11928,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 name = "repo-depot-api"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "omicron-workspace-hack",
  "schemars 0.8.22",
@@ -12177,6 +12006,7 @@ dependencies = [
  "bytes",
  "cookie",
  "cookie_store",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -12189,6 +12019,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -12860,7 +12691,7 @@ source = "git+https://github.com/oxidecomputer/scim2-rs?rev=018ae6f7bd752cd9b212
 dependencies = [
  "anyhow",
  "chrono",
- "dropshot 0.17.0",
+ "dropshot",
  "http",
  "iddqd",
  "schemars 0.8.22",
@@ -13452,7 +13283,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "chrono",
- "dropshot 0.17.0",
+ "dropshot",
  "dropshot-api-manager-types",
  "http",
  "iddqd",
@@ -13514,7 +13345,7 @@ dependencies = [
  "chrono",
  "debug-ignore",
  "derive_more 0.99.20",
- "dropshot 0.17.0",
+ "dropshot",
  "either",
  "expectorate",
  "futures",
@@ -13565,7 +13396,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "derive_more 0.99.20",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "illumos-utils",
  "omicron-common",
@@ -13664,7 +13495,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "camino-tempfile-ext",
- "dropshot 0.17.0",
+ "dropshot",
  "expectorate",
  "iddqd",
  "illumos-utils",
@@ -14140,7 +13971,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "gateway-ereport-messages",
  "gateway-messages",
@@ -15278,21 +15109,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
@@ -15649,7 +15465,7 @@ dependencies = [
  "anyhow",
  "dns-server",
  "dns-service-client",
- "dropshot 0.17.0",
+ "dropshot",
  "hickory-proto 0.25.2",
  "hickory-resolver 0.25.2",
  "internal-dns-types",
@@ -15673,7 +15489,7 @@ dependencies = [
  "daft",
  "debug-ignore",
  "derive_more 0.99.20",
- "dropshot 0.17.0",
+ "dropshot",
  "futures",
  "gfss",
  "hex",
@@ -15722,7 +15538,7 @@ dependencies = [
  "ciborium",
  "daft",
  "derive_more 0.99.20",
- "dropshot 0.17.0",
+ "dropshot",
  "gfss",
  "hex",
  "hkdf",
@@ -15758,7 +15574,7 @@ dependencies = [
  "bootstore",
  "camino",
  "daft",
- "dropshot 0.17.0",
+ "dropshot",
  "gfss",
  "iddqd",
  "omicron-uuid-kinds",
@@ -16233,7 +16049,7 @@ dependencies = [
  "clap",
  "debug-ignore",
  "display-error-chain",
- "dropshot 0.17.0",
+ "dropshot",
  "flate2",
  "fs-err 3.3.0",
  "futures",
@@ -16483,24 +16299,24 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.6"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.19.2",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustc_version 0.4.1",
  "rustversion",
- "vergen-lib",
+ "vergen-lib 9.1.0",
 ]
 
 [[package]]
 name = "vergen-git2"
-version = "1.0.7"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1"
+checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -16508,7 +16324,7 @@ dependencies = [
  "rustversion",
  "time",
  "vergen",
- "vergen-lib",
+ "vergen-lib 9.1.0",
 ]
 
 [[package]]
@@ -16522,7 +16338,7 @@ dependencies = [
  "rustversion",
  "time",
  "vergen",
- "vergen-lib",
+ "vergen-lib 0.1.6",
 ]
 
 [[package]]
@@ -16530,6 +16346,17 @@ name = "vergen-lib"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -16901,7 +16728,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=187aee7de2e50f907099ea06c04aac96c3455665)",
- "dropshot 0.17.0",
+ "dropshot",
  "gateway-client",
  "gateway-types",
  "maplit",
@@ -16966,7 +16793,7 @@ dependencies = [
  "debug-ignore",
  "display-error-chain",
  "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=187aee7de2e50f907099ea06c04aac96c3455665)",
- "dropshot 0.17.0",
+ "dropshot",
  "either",
  "expectorate",
  "flate2",
@@ -17045,7 +16872,7 @@ name = "wicketd-api"
 version = "0.1.0"
 dependencies = [
  "bootstrap-agent-lockstep-client",
- "dropshot 0.17.0",
+ "dropshot",
  "gateway-client",
  "omicron-common",
  "omicron-passwords",
@@ -17962,7 +17789,7 @@ dependencies = [
  "anyhow",
  "camino",
  "clap",
- "dropshot 0.17.0",
+ "dropshot",
  "illumos-utils",
  "omicron-common",
  "omicron-workspace-hack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -473,10 +473,10 @@ crossterm = { version = "0.29.0", features = ["event-stream"] }
 # NOTE: if you change the pinned revision of the `crucible` dependencies, you
 # must also update the references in package-manifest.toml to match the new
 # revision.
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "7103cd3a3d7b0112d2949dd135db06fef0c156bb" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "7103cd3a3d7b0112d2949dd135db06fef0c156bb" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "7103cd3a3d7b0112d2949dd135db06fef0c156bb" }
-crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "7103cd3a3d7b0112d2949dd135db06fef0c156bb" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "fefccc0623038371dbded0458f0645bee6b141cb" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "fefccc0623038371dbded0458f0645bee6b141cb" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "fefccc0623038371dbded0458f0645bee6b141cb" }
+crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "fefccc0623038371dbded0458f0645bee6b141cb" }
 # NOTE: See above!
 csv = "1.3.1"
 curve25519-dalek = "4"
@@ -717,7 +717,6 @@ proc-macro2 = "1.0"
 progenitor = "0.14.0"
 progenitor-client = "0.14.0"
 progenitor-extras = "0.2.0"
-progenitor-client010 = { package = "progenitor-client", version = "0.10.0" }
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
@@ -751,7 +750,6 @@ regress = "0.10.4"
 repo-depot-api = { path = "sled-agent/repo-depot-api" }
 repo-depot-client = { path = "clients/repo-depot-client" }
 reqwest = { version = "0.13", default-features = false }
-reqwest012 = { package = "reqwest", version = "0.12", default-features = false }
 ring = "0.17.14"
 rpassword = "7.4.0"
 rstest = "0.25.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -51,7 +51,6 @@ tokio = { workspace = true, features = ["full"] }
 uuid.workspace = true
 parse-display.workspace = true
 progenitor-client.workspace = true
-progenitor-client010.workspace = true
 progenitor-extras.workspace = true
 omicron-workspace-hack.workspace = true
 regress.workspace = true

--- a/common/src/api/external/error.rs
+++ b/common/src/api/external/error.rs
@@ -547,42 +547,6 @@ pub trait ClientError: std::fmt::Debug {
 // external client, others may require, for example, retries with an alternate
 // service instance or additional interpretation to sanitize the output error.
 // This should be removed to avoid leaking data.
-impl<T: ClientError> From<progenitor_client010::Error<T>> for Error {
-    fn from(e: progenitor_client010::Error<T>) -> Self {
-        match e {
-            // For most error variants, we delegate to the display impl for the
-            // Progenitor error type, but we pick apart an error response more
-            // carefully.
-            progenitor_client010::Error::InvalidRequest(_)
-            | progenitor_client010::Error::CommunicationError(_)
-            | progenitor_client010::Error::InvalidResponsePayload(..)
-            | progenitor_client010::Error::UnexpectedResponse(_)
-            | progenitor_client010::Error::InvalidUpgrade(_)
-            | progenitor_client010::Error::ResponseBodyError(_)
-            | progenitor_client010::Error::PreHookError(_)
-            | progenitor_client010::Error::PostHookError(_) => {
-                Error::internal_error(&e.to_string())
-            }
-            // This error represents an expected error from the remote service.
-            progenitor_client010::Error::ErrorResponse(rv) => {
-                let message = rv.message();
-
-                match rv.status() {
-                    http::StatusCode::SERVICE_UNAVAILABLE => {
-                        Error::unavail(&message)
-                    }
-                    status if status.is_client_error() => {
-                        Error::invalid_request(&message)
-                    }
-                    _ => Error::internal_error(&message),
-                }
-            }
-        }
-    }
-}
-
-// Equivalent From impl for progenitor-client 0.13. This coexists with the
-// progenitor_client010 impl above during the cross-repo upgrade window.
 impl<T: ClientError> From<progenitor_client::Error<T>> for Error {
     fn from(e: progenitor_client::Error<T>) -> Self {
         match e {

--- a/common/src/progenitor_operation_retry.rs
+++ b/common/src/progenitor_operation_retry.rs
@@ -25,14 +25,14 @@ pub enum ProgenitorOperationRetryError<E> {
 
     /// The retry loop progenitor operation saw a permanent client error
     #[error("permanent error")]
-    ProgenitorError(#[source] progenitor_client010::Error<E>),
+    ProgenitorError(#[source] progenitor_client::Error<E>),
 }
 
 impl<E> ProgenitorOperationRetryError<E> {
     pub fn is_not_found(&self) -> bool {
         match &self {
             ProgenitorOperationRetryError::ProgenitorError(e) => match e {
-                progenitor_client010::Error::ErrorResponse(rv) => {
+                progenitor_client::Error::ErrorResponse(rv) => {
                     match rv.status() {
                         http::StatusCode::NOT_FOUND => true,
 
@@ -70,7 +70,7 @@ pub struct ProgenitorOperationRetry<
     T,
     E: std::fmt::Debug,
     F: FnMut() -> Fut,
-    Fut: Future<Output = Result<T, progenitor_client010::Error<E>>>,
+    Fut: Future<Output = Result<T, progenitor_client::Error<E>>>,
     BF: FnMut() -> BFut,
     BFut: Future<Output = Result<bool, Error>>,
 > {
@@ -85,7 +85,7 @@ impl<T, E, F, Fut, BF, BFut> ProgenitorOperationRetry<T, E, F, Fut, BF, BFut>
 where
     E: std::fmt::Debug + 'static,
     F: FnMut() -> Fut,
-    Fut: Future<Output = Result<T, progenitor_client010::Error<E>>>,
+    Fut: Future<Output = Result<T, progenitor_client::Error<E>>>,
     BF: FnMut() -> BFut,
     BFut: Future<Output = Result<bool, Error>>,
 {
@@ -121,7 +121,7 @@ where
                     }
 
                     match f.await {
-                        Err(progenitor_client010::Error::CommunicationError(e)) => {
+                        Err(progenitor_client::Error::CommunicationError(e)) => {
                             warn!(
                                 log,
                                 "saw transient communication error, retrying...";
@@ -130,12 +130,12 @@ where
 
                             Err(BackoffError::transient(
                                 ProgenitorOperationRetryError::ProgenitorError(
-                                    progenitor_client010::Error::CommunicationError(e)
+                                    progenitor_client::Error::CommunicationError(e)
                                 )
                             ))
                         }
 
-                        Err(progenitor_client010::Error::ErrorResponse(
+                        Err(progenitor_client::Error::ErrorResponse(
                             response_value,
                         )) => {
                             match response_value.status() {
@@ -144,7 +144,7 @@ where
                                 | http::StatusCode::TOO_MANY_REQUESTS => {
                                     Err(BackoffError::transient(
                                         ProgenitorOperationRetryError::ProgenitorError(
-                                            progenitor_client010::Error::ErrorResponse(
+                                            progenitor_client::Error::ErrorResponse(
                                                 response_value
                                             )
                                         )
@@ -154,7 +154,7 @@ where
                                 // Anything else is a permanent error
                                 _ => Err(BackoffError::Permanent(
                                     ProgenitorOperationRetryError::ProgenitorError(
-                                        progenitor_client010::Error::ErrorResponse(
+                                        progenitor_client::Error::ErrorResponse(
                                             response_value
                                         )
                                     )

--- a/dev-tools/omdb/src/bin/omdb/crucible_pantry.rs
+++ b/dev-tools/omdb/src/bin/omdb/crucible_pantry.rs
@@ -101,7 +101,7 @@ async fn cmd_volume_info(
     args: &VolumeArgs,
 ) -> Result<(), anyhow::Error> {
     let volume = args.uuid.to_string();
-    let VolumeStatus { active, num_job_handles, seen_active } =
+    let VolumeStatus { active, num_job_handles, seen_active, info: _ } =
         *client.volume_status(&volume).await.context("listing volumes")?;
 
     println!("          active: {}", active);

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -99,7 +99,6 @@ ref-cast.workspace = true
 rdb-types.workspace = true
 regex.workspace = true
 reqwest = { workspace = true, features = ["http2", "json"] }
-reqwest012 = { workspace = true }
 ring.workspace = true
 samael.workspace = true
 schemars = { workspace = true, features = ["chrono", "uuid1"] }

--- a/nexus/src/app/crucible.rs
+++ b/nexus/src/app/crucible.rs
@@ -74,11 +74,9 @@ impl super::Nexus {
         &self,
         dataset: &db::model::CrucibleDataset,
     ) -> CrucibleAgentClient {
-        // Use reqwest012_client because the rev-pinned crucible-agent-client
-        // is still on reqwest 0.12.
         CrucibleAgentClient::new_with_client(
             &format!("http://{}", dataset.address()),
-            self.reqwest012_client.clone(),
+            self.reqwest_client.clone(),
         )
     }
 

--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -563,12 +563,9 @@ impl super::Nexus {
             // fails, then that failure would be propagated up to the user, and
             // that user's program can act accordingly. In a way, the user's
             // program is an externally driven saga instead.
-
-            // Use reqwest012_client because the rev-pinned
-            // crucible-pantry-client is still on reqwest 0.12.
             let client = crucible_pantry_client::Client::new_with_client(
                 &format!("http://{}", endpoint),
-                self.reqwest012_client.clone(),
+                self.reqwest_client.clone(),
             );
             let request = crucible_pantry_client::types::BulkWriteRequest {
                 offset: param.offset,

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -223,17 +223,7 @@ pub struct Nexus {
     ///
     /// (This does not need to be in an `Arc` because `reqwest::Client` uses
     /// `Arc` internally.)
-    ///
-    /// Currently unused because all `new_with_client` call sites use
-    /// `reqwest012_client` for cross-repo dependencies that are still on
-    /// reqwest 0.12. This field will be used again once rev pins are updated.
-    #[allow(dead_code)]
     reqwest_client: reqwest::Client,
-
-    /// `reqwest012::Client` for cross-repo dependencies where the rev-pinned
-    /// dependency is still on reqwest 0.12. Remove once all rev pins are
-    /// updated.
-    reqwest012_client: reqwest012::Client,
 
     /// Client to the timeseries database.
     timeseries_client: oximeter_db::Client,
@@ -436,14 +426,6 @@ impl Nexus {
             .build()
             .map_err(|e| InlineErrorChain::new(&e).to_string())?;
 
-        // reqwest 0.12 client for cross-repo dependencies still on reqwest
-        // 0.12. Remove once all rev pins are updated.
-        let reqwest012_client = reqwest012::ClientBuilder::new()
-            .connect_timeout(std::time::Duration::from_secs(15))
-            .timeout(std::time::Duration::from_secs(15))
-            .build()
-            .map_err(|e| InlineErrorChain::new(&e).to_string())?;
-
         // Client to the ClickHouse database.
         let timeseries_client = match &config.pkg.timeseries_db.address {
             None => {
@@ -548,7 +530,6 @@ impl Nexus {
             producer_server: std::sync::Mutex::new(None),
             populate_status,
             reqwest_client,
-            reqwest012_client,
             timeseries_client,
             webhook_delivery_client,
             tunables: config.pkg.tunables.clone(),

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -624,10 +624,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "7103cd3a3d7b0112d2949dd135db06fef0c156bb"
+source.commit = "fefccc0623038371dbded0458f0645bee6b141cb"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "8e245572e4b8d1c018884268a6afdf7f79efc22e61b4ed5b5526957bf61ccdcd"
+source.sha256 = "e4cbb6e0e5fa023f63a9c30ec9f9303521140ec6e5a6f4481bd89b8527f65b22"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -636,10 +636,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "7103cd3a3d7b0112d2949dd135db06fef0c156bb"
+source.commit = "fefccc0623038371dbded0458f0645bee6b141cb"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "7998ddb0bda4c97e3d5fec7c8079bbdfb27ef06dba69ab2867278dc2cd7544f4"
+source.sha256 = "060ae649f4ac6dbf94fcd7844df7b07f4570d74e4947229db7f177480eaf5253"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -653,10 +653,10 @@ service_name = "crucible_utils"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "7103cd3a3d7b0112d2949dd135db06fef0c156bb"
+source.commit = "fefccc0623038371dbded0458f0645bee6b141cb"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-utils.sha256.txt
-source.sha256 = "cc661b84fd258467ec1961e8c9879f76d2d07903fb9161012afa75c37490e24f"
+source.sha256 = "703b84d5d3a8fc5a1d4816cbeb096e035038c88ffa46bc56fb90dfe7b9a55511"
 output.type = "tarball"
 
 # Refer to

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -80,7 +80,6 @@ range-requests.workspace = true
 repo-depot-api.workspace = true
 repo-depot-client.workspace = true
 reqwest = { workspace = true, features = ["rustls", "stream"] }
-reqwest012 = { workspace = true }
 schemars = { workspace = true, features = ["chrono", "uuid1"] }
 serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -84,7 +84,7 @@ log = { version = "0.4.29", default-features = false, features = ["std"] }
 managed = { version = "0.8.0", default-features = false, features = ["alloc", "map"] }
 memchr = { version = "2.8.0" }
 newtype-uuid = { version = "1.3.2", features = ["proptest1"] }
-nix = { version = "0.31.2", features = ["fs", "net", "signal"] }
+nix = { version = "0.31.2", features = ["feature", "fs", "net", "signal", "uio"] }
 num-bigint-dig = { version = "0.8.6", default-features = false, features = ["i128", "prime", "serde", "u64_digit", "zeroize"] }
 num-integer = { version = "0.1.46", features = ["i128"] }
 num-iter = { version = "0.1.45", default-features = false, features = ["i128"] }
@@ -111,7 +111,7 @@ rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3.1", def
 regex = { version = "1.12.3" }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
-reqwest-594e8ee84c453af0 = { package = "reqwest", version = "0.13.2", default-features = false, features = ["blocking", "cookies", "http2", "json", "query", "rustls", "stream"] }
+reqwest-594e8ee84c453af0 = { package = "reqwest", version = "0.13.2", features = ["blocking", "cookies", "json", "query", "stream"] }
 reqwest-5ef9efb8ec2df382 = { package = "reqwest", version = "0.12.28", features = ["blocking", "json", "rustls-tls", "stream"] }
 rsa = { version = "0.9.10", features = ["serde", "sha2"] }
 rustc-hash = { version = "2.1.1" }
@@ -146,7 +146,6 @@ tokio-rustls = { version = "0.26.4", default-features = false, features = ["logg
 tokio-stream = { version = "0.1.18", features = ["net", "sync"] }
 tokio-util = { version = "0.7.18", features = ["codec", "io-util", "rt", "time"] }
 toml = { version = "0.7.8" }
-toml_datetime-ca01ad9e24f5d932 = { package = "toml_datetime", version = "0.7.5", features = ["serde"] }
 toml_edit-3c51e837cfc5589a = { package = "toml_edit", version = "0.22.27", features = ["serde"] }
 toml_parser = { version = "1.0.9" }
 tough = { version = "0.22.0", default-features = false, features = ["http"] }
@@ -232,7 +231,7 @@ log = { version = "0.4.29", default-features = false, features = ["std"] }
 managed = { version = "0.8.0", default-features = false, features = ["alloc", "map"] }
 memchr = { version = "2.8.0" }
 newtype-uuid = { version = "1.3.2", features = ["proptest1"] }
-nix = { version = "0.31.2", features = ["fs", "net", "signal"] }
+nix = { version = "0.31.2", features = ["feature", "fs", "net", "signal", "uio"] }
 num-bigint-dig = { version = "0.8.6", default-features = false, features = ["i128", "prime", "serde", "u64_digit", "zeroize"] }
 num-integer = { version = "0.1.46", features = ["i128"] }
 num-iter = { version = "0.1.45", default-features = false, features = ["i128"] }
@@ -259,7 +258,7 @@ rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3.1", def
 regex = { version = "1.12.3" }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
-reqwest-594e8ee84c453af0 = { package = "reqwest", version = "0.13.2", default-features = false, features = ["blocking", "cookies", "http2", "json", "query", "rustls", "stream"] }
+reqwest-594e8ee84c453af0 = { package = "reqwest", version = "0.13.2", features = ["blocking", "cookies", "json", "query", "stream"] }
 reqwest-5ef9efb8ec2df382 = { package = "reqwest", version = "0.12.28", features = ["blocking", "json", "rustls-tls", "stream"] }
 rsa = { version = "0.9.10", features = ["serde", "sha2"] }
 rustc-hash = { version = "2.1.1" }
@@ -297,7 +296,6 @@ tokio-rustls = { version = "0.26.4", default-features = false, features = ["logg
 tokio-stream = { version = "0.1.18", features = ["net", "sync"] }
 tokio-util = { version = "0.7.18", features = ["codec", "io-util", "rt", "time"] }
 toml = { version = "0.7.8" }
-toml_datetime-ca01ad9e24f5d932 = { package = "toml_datetime", version = "0.7.5", features = ["serde"] }
 toml_edit-3c51e837cfc5589a = { package = "toml_edit", version = "0.22.27", features = ["serde"] }
 toml_parser = { version = "1.0.9" }
 tough = { version = "0.22.0", default-features = false, features = ["http"] }
@@ -307,8 +305,8 @@ usdt = { version = "0.6.0" }
 usdt-impl-3b31131e45eafb45 = { package = "usdt-impl", version = "0.6.0", default-features = false, features = ["des"] }
 usdt-impl-d8f496e17d97b5cb = { package = "usdt-impl", version = "0.5.0", default-features = false, features = ["asm", "des"] }
 uuid = { version = "1.23.0", features = ["serde", "v4"] }
-vergen = { version = "9.0.6", features = ["cargo", "rustc"] }
-vergen-lib = { version = "0.1.6", features = ["cargo", "git", "rustc"] }
+vergen = { version = "9.1.0", features = ["cargo", "rustc"] }
+vergen-lib = { version = "9.1.0", features = ["cargo", "git", "rustc"] }
 winnow = { version = "0.7.14" }
 x509-cert = { version = "0.2.5" }
 zerocopy = { version = "0.8.40", default-features = false, features = ["derive", "simd"] }
@@ -406,7 +404,7 @@ object = { version = "0.37.3", default-features = false, features = ["read", "st
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38.44", features = ["fs", "stdio", "system", "termios"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["fs", "stdio", "termios"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
-toml_datetime-3b31131e45eafb45 = { package = "toml_datetime", version = "0.6.11", default-features = false, features = ["serde"] }
+toml_datetime = { version = "0.6.11", default-features = false, features = ["serde"] }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }
 
 [target.x86_64-unknown-illumos.build-dependencies]
@@ -423,7 +421,7 @@ object = { version = "0.37.3", default-features = false, features = ["read", "st
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38.44", features = ["fs", "stdio", "system", "termios"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["fs", "stdio", "termios"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
-toml_datetime-3b31131e45eafb45 = { package = "toml_datetime", version = "0.6.11", default-features = false, features = ["serde"] }
+toml_datetime = { version = "0.6.11", default-features = false, features = ["serde"] }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
note: depends on https://github.com/oxidecomputer/crucible/pull/1933, which must land first.  If it's rebased, I'll need to update the git & sha hashes here.