### PR TITLE
Store the UUID of the Nexus creator in Blueprints

### DIFF
--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -588,6 +588,7 @@ impl BackgroundTasksInitializer {
             reconfigurator_config_watcher.clone(),
             inventory_load_watcher.clone(),
             rx_blueprint.clone(),
+            nexus_id,
         );
         let rx_planner = blueprint_planner.watcher();
         driver.register(TaskDefinition {

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -98,7 +98,7 @@ impl BlueprintPlanner {
             rx_blueprint,
             tx_planned,
             blueprint_limit: DEFAULT_BLUEPRINT_LIMIT,
-            creator: nexus_id.to_string(),
+            creator: format!("nexus {}", nexus_id),
         }
     }
 
@@ -558,10 +558,10 @@ mod test {
         );
 
         // Verify the creator is the Nexus UUID, not the hardcoded string.
-        let nexus_id = nexus.id.to_string();
+        let expected_creator = format!("nexus {}", nexus.id);
         assert_eq!(
-            blueprint.creator, nexus_id,
-            "blueprint creator should be the Nexus UUID, not a hardcoded string"
+            blueprint.creator, expected_creator,
+            "blueprint creator should be the 'nexus UUID', not a hardcoded string"
         );
 
         // Planning again should not change the plan, because nothing has changed.

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -552,6 +552,13 @@ mod test {
             blueprint.diff_since_blueprint(&initial_blueprint).has_changes()
         );
 
+        // Verify the creator is the Nexus UUID, not the hardcoded string.
+        let nexus_id = nexus.id.to_string();
+        assert_eq!(
+            blueprint.creator, nexus_id,
+            "blueprint creator should be the Nexus UUID, not a hardcoded string"
+        );
+
         // Planning again should not change the plan, because nothing has changed.
         let status = serde_json::from_value::<BlueprintPlannerStatus>(
             planner.activate(&opctx).await,

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -25,6 +25,7 @@ use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupType;
 use omicron_uuid_kinds::BlueprintUuid;
 use omicron_uuid_kinds::GenericUuid as _;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use serde_json::json;
 use slog_error_chain::InlineErrorChain;
 use std::sync::Arc;
@@ -62,6 +63,7 @@ pub struct BlueprintPlanner {
     rx_blueprint: Receiver<Option<LoadedTargetBlueprint>>,
     tx_planned: Sender<Option<BlueprintUuid>>,
     blueprint_limit: u64,
+    creator: String,
 }
 
 /// The default number of blueprints, beyond which the auto-planner will stop
@@ -86,6 +88,7 @@ impl BlueprintPlanner {
         rx_config: Receiver<ReconfiguratorConfigLoaderState>,
         rx_inventory: Receiver<Option<Arc<Collection>>>,
         rx_blueprint: Receiver<Option<LoadedTargetBlueprint>>,
+        nexus_id: OmicronZoneUuid,
     ) -> Self {
         let (tx_planned, _) = watch::channel(None);
         Self {
@@ -95,6 +98,7 @@ impl BlueprintPlanner {
             rx_blueprint,
             tx_planned,
             blueprint_limit: DEFAULT_BLUEPRINT_LIMIT,
+            creator: nexus_id.to_string(),
         }
     }
 
@@ -205,7 +209,7 @@ impl BlueprintPlanner {
         let planner = Planner::new_based_on(
             opctx.log.clone(),
             &input,
-            "blueprint_planner",
+            &self.creator,
             &collection,
             PlannerRng::from_entropy(),
         )
@@ -517,6 +521,7 @@ mod test {
             rx_config_loader,
             rx_inventory,
             rx_loader.clone(),
+            nexus.id,
         );
 
         // On activation, the planner should run successfully and generate
@@ -694,11 +699,13 @@ mod test {
         let (_tx_inventory, rx_inventory) = watch::channel(None);
         let (_tx_blueprint, rx_blueprint) = watch::channel(None);
 
+        let test_nexus_id = OmicronZoneUuid::new_v4();
         let mut planner = BlueprintPlanner::new(
             datastore.clone(),
             rx_config_loader,
             rx_inventory,
             rx_blueprint,
+            test_nexus_id,
         );
 
         // This limit matches the loop above.

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -150,7 +150,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
     ) -> Result<PlanningContext, Error> {
-        let creator = format!("nexus {}", self.id.to_string());
+        let creator = format!("nexus {}", self.id);
         let datastore = self.datastore();
 
         let (_, parent_blueprint) =

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -150,7 +150,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
     ) -> Result<PlanningContext, Error> {
-        let creator = self.id.to_string();
+        let creator = format!("nexus {}", self.id.to_string());
         let datastore = self.datastore();
 
         let (_, parent_blueprint) =


### PR DESCRIPTION
This is a very simple PR that replaces the hardcoded "blueprint_planner" hardcoded string with the UUID of the Nexus instance that created it as reported in #10396.

I picked it up as it's labelled as `good first issue`, so I assumed it was OK to work on it as it's indeed quite simple.
Please let me know if I should proceed differently in the future.

The PR contains a unit tests that ensures that the value stored is indeed the Nexus UUID.

I am not sure if it's best to call the new structure element `creator` or `planner` for consistency, so any feedback in this direction would be helpful.

@davepacheco, tagging you as you originally reported the issue.

Fixes #10396 