### PR TITLE
Improve error reporting when omdb tries to fetch the inventory for a collection that doesn't exist

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -957,6 +957,7 @@ pub enum ResourceType {
     IdentityProvider,
     Image,
     Instance,
+    InventoryCollection,
     InstanceNetworkInterface,
     InternetGateway,
     InternetGatewayIpAddress,

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -5238,6 +5238,28 @@ mod test {
         logctx.cleanup_successful();
     }
 
+    #[tokio::test]
+    async fn test_inventory_collection_read_missing_returns_not_found() {
+        let logctx = dev::test_setup_log("inventory_collection_read_missing");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let missing_id = CollectionUuid::new_v4();
+
+        let err = datastore
+            .inventory_collection_read(&opctx, missing_id)
+            .await
+            .expect_err("expected error for missing collection");
+
+        assert!(
+            matches!(err, Error::ObjectNotFound { .. }),
+            "expected ObjectNotFound error, got: {err:?}"
+        );
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
     /// Tests inserting several collections, reading them back, and making sure
     /// they look the same.
     #[tokio::test]

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -4738,8 +4738,20 @@ impl DataStore {
                 .map_err(|e| {
                     public_error_from_diesel(e, ErrorHandler::Server)
                 })?;
-            bail_unless!(collections.len() == 1);
-            let collection = collections.into_iter().next().unwrap();
+            let collection = match collections.len() {
+                0 => {
+                    return Err(Error::ObjectNotFound {
+                        type_name: ResourceType::InventoryCollection,
+                        lookup_type: LookupType::ById(id.into_untyped_uuid()),
+                    });
+                },
+                1 => collections.into_iter().next().unwrap(),
+                n => {
+                    return Err(Error::internal_error(&format!(
+                        "expected 1 collection row, got {n}"
+                    )));
+                },
+            };
             (
                 collection.time_started,
                 collection.time_done,


### PR DESCRIPTION
This simple PR adds a three-way discrimination for handling the return value when trying to fetch a specific collection from CockroachDB.

1. Found -> All good, return it
2. Not found -> Return an ObjectNotFound error to make it clear that the collection doesn't exist
3. Multiple matches found -> Return a generic error, as this is unexpected behavior.

Fixes #8336 

@davepacheco I am not sure if, for case 3, multiple entries found, it would be better to return a specific error informing of the unexpected state. I lack enough context to understand how unlikely that possibility is.