### PR TITLE
Omit query logs for fast clickhouse queries.

### DIFF
--- a/smf/clickhouse/config.xml
+++ b/smf/clickhouse/config.xml
@@ -26,6 +26,9 @@
         itself one of the largest tables in terms of compressed disk use.
         This block truncates this long query pattern, since it's not
         operationally useful and consumes a significant amount of disk.
+
+        Note: this rule will become irrelevant if we change the metrics
+        data model in clickhouse.
     -->
     <query_masking_rules>
         <rule>
@@ -86,7 +89,42 @@
     </users>
 
     <profiles>
-        <default/>
+        <default>
+            <!--
+                Omit logs for fast queries. As of this writing, the vast
+                majority of clickhouse queries are INSERTS that succeed in
+                <5ms, and aren't operationally interesting. From a test rack:
+
+                    SELECT
+                        roundToExp2(greatest(query_duration_ms, 1)) AS bucket_start,
+                        bucket_start * 2 AS bucket_end,
+                        count() AS count,
+                        round((100 * count()) / (
+                            SELECT count()
+                            FROM system.query_log
+                        ), 4) AS pct
+                    FROM system.query_log
+                    GROUP BY bucket_start, bucket_end
+                    ORDER BY bucket_start ASC
+
+                        ┌─bucket_start─┬─bucket_end─┬───count─┬─────pct─┐
+                     1. │            1 │          2 │ 3590120 │ 62.6491 │
+                     2. │            2 │          4 │ 1206074 │ 21.0465 │
+                     3. │            4 │          8 │  298972 │  5.2172 │
+                     4. │            8 │         16 │  109739 │   1.915 │
+                     5. │           16 │         32 │  114881 │  2.0047 │
+                     6. │           32 │         64 │  121448 │  2.1193 │
+                     7. │           64 │        128 │  130456 │  2.2765 │
+                     8. │          128 │        256 │   87336 │  1.5241 │
+                     9. │          256 │        512 │   57767 │  1.0081 │
+                    10. │          512 │       1024 │   12327 │  0.2151 │
+                    11. │         1024 │       2048 │    1341 │  0.0234 │
+                    12. │         2048 │       4096 │      56 │   0.001 │
+                    13. │         4096 │       8192 │       1 │       0 │
+                        └──────────────┴────────────┴─────────┴─────────┘
+            -->
+            <log_queries_min_query_duration_ms>5</log_queries_min_query_duration_ms>
+        </default>
     </profiles>
 
     <quotas>


### PR DESCRIPTION
As described in #10444, we use a significant amount of space storing logs for fast clickhouse queries that aren't operationally useful. This patch configures clickhouse to only log queries that take >5ms, which excludes about 80% of observed queries.

h/t @JustinAzoff 