### PR TITLE
Add zfs pool and dataset usage metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9991,14 +9991,18 @@ dependencies = [
 name = "oximeter-instruments"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "chrono",
  "dropshot 0.17.0",
  "futures",
  "http",
  "hyper",
+ "illumos-utils",
  "kstat-rs",
  "libc",
+ "omicron-common",
+ "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oximeter 0.1.0",
  "rand 0.9.2",

--- a/common/src/zpool_name.rs
+++ b/common/src/zpool_name.rs
@@ -51,6 +51,15 @@ pub enum ZpoolName {
     Internal(InternalZpoolUuid),
 }
 
+impl fmt::Display for ZpoolKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ZpoolKind::External => write!(f, "external"),
+            ZpoolKind::Internal => write!(f, "internal"),
+        }
+    }
+}
+
 const ZPOOL_NAME_REGEX: &str = r"^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$";
 
 /// Custom JsonSchema implementation to encode the constraints on Name.

--- a/illumos-utils/src/zpool.rs
+++ b/illumos-utils/src/zpool.rs
@@ -287,6 +287,21 @@ impl Zpool {
         Ok(zpool)
     }
 
+    pub async fn list_with_info() -> Result<Vec<ZpoolInfo>, ListError> {
+        let mut command = Command::new(ZPOOL);
+        let cmd =
+            command.args(&["list", "-Hpo", "name,size,allocated,free,health"]);
+
+        let output = execute_async(cmd).await.map_err(Error::from)?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        let zpools = stdout
+            .lines()
+            .filter_map(|line| line.parse::<ZpoolInfo>().ok())
+            .collect();
+        Ok(zpools)
+    }
+
     #[cfg_attr(test, allow(dead_code))]
     pub async fn get_info(name: &str) -> Result<ZpoolInfo, GetInfoError> {
         let mut command = Command::new(ZPOOL);

--- a/oximeter/collector/src/results_sink.rs
+++ b/oximeter/collector/src/results_sink.rs
@@ -12,6 +12,7 @@
 use crate::collection_task::CollectionTaskOutput;
 use crate::probes;
 use oximeter::Sample;
+use oximeter::queue::BoundedQueue;
 use oximeter::types::ProducerResultsItem;
 use oximeter_db::Client;
 use oximeter_db::DbWrite as _;
@@ -151,14 +152,16 @@ const MAX_BUFFER_SIZE_MULTIPLIER: usize = 100;
 #[derive(Clone)]
 struct BatchHandoff<T> {
     notify: Arc<Notify>,
-    batch: Arc<Mutex<VecDeque<T>>>,
+    batch: Arc<Mutex<BoundedQueue<T>>>,
 }
 
 impl<T> BatchHandoff<T> {
     fn new(batch_size: usize) -> Self {
         Self {
             notify: Arc::new(Notify::new()),
-            batch: Arc::new(Mutex::new(VecDeque::with_capacity(batch_size))),
+            batch: Arc::new(Mutex::new(BoundedQueue::new(
+                batch_size * MAX_BUFFER_SIZE_MULTIPLIER,
+            ))),
         }
     }
 }
@@ -168,19 +171,11 @@ struct BatchSender<T> {
     handoff: BatchHandoff<T>,
     // Minimum size of the buffer before inserting into the database.
     batch_size: usize,
-    // Maximum size we let the ring buffer grow before starting to drop older
-    // samples. This is a relief value, in the case where the database is
-    // completely partitioned or insertions have slowed dramatically.
-    max_buffer_size: usize,
 }
 
 impl<T> BatchSender<T> {
     fn new(handoff: BatchHandoff<T>, batch_size: usize) -> Self {
-        Self {
-            handoff,
-            batch_size,
-            max_buffer_size: batch_size * MAX_BUFFER_SIZE_MULTIPLIER,
-        }
+        Self { handoff, batch_size }
     }
 
     // Notify the insertion task that it should insert the batch of results.
@@ -205,44 +200,7 @@ impl<T> BatchSender<T> {
     ) -> usize {
         let mut batch = self.handoff.batch.lock().unwrap();
 
-        // Append the new samples, ensuring we never exceed the maximum buffer
-        // size.
-        let n_current_samples = batch.len();
-        let n_new_samples = samples.len();
-        let n_total_samples = n_current_samples + n_new_samples;
-
-        // The easy case is when all the samples fit. Just append them and
-        // return 0, since we've not dropped anything.
-        let n_dropped = if n_total_samples <= self.max_buffer_size {
-            batch.extend(samples);
-            0
-        } else {
-            // Now, drop samples first from the existing batch, then the new set of
-            // samples, until we're under our limit. Start by computing the total
-            // number to be dropped.
-            //
-            // NOTE: This can't underflow, we're in the branch where
-            // `n_total_samples > self.max_buffer size`.
-            let n_dropped = n_total_samples - self.max_buffer_size;
-
-            // We want to drop from the existing batch first. We can drop the
-            // minimum of the number to be dropped and the batch length. If
-            // we're only dropping part of the batch, we'll take `n_dropped` off
-            // the front. If we need to drop the whole batch and then some,
-            // we'll take the batch length and drop the whole thing.
-            let n_to_drop_from_batch = n_dropped.min(batch.len());
-            drop(batch.drain(..n_to_drop_from_batch));
-
-            // At this point, we've dropped something (potentially everything)
-            // from the existing batch. We need to figure out how many, if any,
-            // to drop from the _incoming_ set of samples. Subtract whatever we
-            // dropped immediately above to compute the number left to drop.
-            let n_left_to_drop = n_dropped - n_to_drop_from_batch;
-
-            // Append whatever we don't want to drop.
-            batch.extend(samples.into_iter().skip(n_left_to_drop));
-            n_dropped
-        };
+        let n_dropped = batch.extend(samples);
 
         // Notify the insertion task if needed.
         if was_forced_collection || batch.len() >= self.batch_size {
@@ -254,7 +212,6 @@ impl<T> BatchSender<T> {
 
 struct BatchReceiver<T> {
     handoff: BatchHandoff<T>,
-    batch_size: usize,
 }
 
 impl<T> BatchReceiver<T> {
@@ -264,10 +221,7 @@ impl<T> BatchReceiver<T> {
     // a contiguous `&[Sample]` without an additional heap allocation.
     async fn wait_for_batch(&self) -> VecDeque<T> {
         self.handoff.notify.notified().await;
-        let mut stolen = VecDeque::with_capacity(self.batch_size);
-        let mut batch = self.handoff.batch.lock().unwrap();
-        std::mem::swap(&mut stolen, &mut *batch);
-        stolen
+        self.handoff.batch.lock().unwrap().drain()
     }
 }
 
@@ -276,7 +230,7 @@ fn batch_handoff<T: Clone>(
 ) -> (BatchSender<T>, BatchReceiver<T>) {
     let handoff = BatchHandoff::new(batch_size);
     let sender = BatchSender::new(handoff.clone(), batch_size);
-    let receiver = BatchReceiver { handoff, batch_size };
+    let receiver = BatchReceiver { handoff };
     (sender, receiver)
 }
 
@@ -379,7 +333,7 @@ mod tests {
                 .await
                 .expect("Should be notified with force collection");
         assert_eq!(batch.len(), n_samples);
-        assert!(batch_tx.handoff.batch.lock().unwrap().is_empty());
+        assert_eq!(batch_tx.handoff.batch.lock().unwrap().len(), 0);
     }
 
     proptest! {
@@ -407,7 +361,7 @@ mod tests {
             {
                 let buf = batch_tx.handoff.batch.lock().unwrap();
                 assert_eq!(buf.len(), expected_n_samples);
-                assert_eq!(*buf, tail);
+                assert!(buf.iter().eq(tail.iter()));
             }
 
             // Check that we're either notified, or not, if the current batch is
@@ -422,7 +376,7 @@ mod tests {
                 rt.block_on(async {
                     timeout(TIMEOUT, fut).await
                 }).expect("Should be notified");
-                assert_eq!(*batch_rx.handoff.batch.lock().unwrap(), tail);
+                assert!(batch_rx.handoff.batch.lock().unwrap().iter().eq(tail.iter()));
             } else {
                 rt.block_on(async {
                     timeout(TIMEOUT, fut).await
@@ -453,7 +407,7 @@ mod tests {
             {
                 let buf = batch_tx.handoff.batch.lock().unwrap();
                 assert_eq!(buf.len(), expected_n_samples);
-                assert_eq!(*buf, tail);
+                assert!(buf.iter().eq(tail.iter()));
             }
 
             // And check we've notified the receiver again.

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -8,14 +8,18 @@ license = "MPL-2.0"
 workspace = true
 
 [dependencies]
+anyhow = { workspace = true, optional = true }
 cfg-if = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 dropshot = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
+illumos-utils = { workspace = true, optional = true }
 kstat-rs = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
+omicron-common= { workspace = true, optional = true }
+omicron-uuid-kinds= { workspace = true, optional = true }
 oximeter = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -27,7 +31,7 @@ uuid = { workspace = true, optional = true }
 omicron-workspace-hack.workspace = true
 
 [features]
-default = ["http-instruments", "cpu", "datalink", "zone"]
+default = ["http-instruments", "cpu", "datalink", "zfs", "zone"]
 http-instruments = [
     "dep:chrono",
     "dep:dropshot",
@@ -55,6 +59,17 @@ kstat = [
 ]
 cpu = ["kstat"]
 datalink = ["kstat"]
+zfs = [
+    "dep:anyhow",
+    "dep:illumos-utils",
+    "dep:omicron-common",
+    "dep:omicron-uuid-kinds",
+    "dep:oximeter",
+    "dep:slog",
+    "dep:tokio",
+    "dep:thiserror",
+    "dep:uuid"
+]
 zone = ["kstat"]
 
 [dev-dependencies]

--- a/oximeter/instruments/src/kstat/sampler.rs
+++ b/oximeter/instruments/src/kstat/sampler.rs
@@ -20,6 +20,7 @@ use kstat_rs::Kstat;
 use oximeter::Metric;
 use oximeter::MetricsError;
 use oximeter::Sample;
+use oximeter::queue::BoundedQueue;
 use oximeter::types::Cumulative;
 use slog::Logger;
 use slog::debug;
@@ -342,7 +343,7 @@ struct KstatSamplerWorker {
 
     /// The per-target queue of samples, pulled by the main `KstatSampler` type
     /// when producing metrics.
-    samples: Arc<Mutex<BTreeMap<TargetId, Vec<Sample>>>>,
+    samples: Arc<Mutex<BTreeMap<TargetId, BoundedQueue<Sample>>>>,
 
     /// Inbox channel on which the `KstatSampler` sends messages.
     inbox: mpsc::Receiver<Request>,
@@ -397,7 +398,7 @@ impl KstatSamplerWorker {
         log: Logger,
         inbox: mpsc::Receiver<Request>,
         self_stat_queue: broadcast::Sender<Sample>,
-        samples: Arc<Mutex<BTreeMap<TargetId, Vec<Sample>>>>,
+        samples: Arc<Mutex<BTreeMap<TargetId, BoundedQueue<Sample>>>>,
         sample_limit: usize,
     ) -> Result<Self, Error> {
         let ctl = Some(Ctl::new().map_err(Error::Kstat)?);
@@ -590,7 +591,7 @@ impl KstatSamplerWorker {
                 if let Some(remaining_samples) =
                     self.samples.lock().unwrap().remove(&id)
                 {
-                    if !remaining_samples.is_empty() {
+                    if remaining_samples.len() > 0 {
                         warn!(
                             self.log,
                             "target removed with queued samples";
@@ -766,7 +767,7 @@ impl KstatSamplerWorker {
     fn append_per_target_samples(
         &self,
         id: TargetId,
-        mut samples: Vec<Sample>,
+        samples: Vec<Sample>,
     ) -> Option<usize> {
         // Limit the number of samples we actually contain
         // in the sample queue. This is to avoid huge
@@ -785,36 +786,17 @@ impl KstatSamplerWorker {
         };
         let n_new_samples = samples.len();
         let n_current_samples = current_samples.len();
-        let n_total_samples = n_new_samples + n_current_samples;
-        let n_overflow_samples =
-            n_total_samples.saturating_sub(self.sample_limit);
-        if n_overflow_samples > 0 {
+        let n_dropped_samples = current_samples.extend(samples);
+        if n_dropped_samples > 0 {
             warn!(
                 self.log,
                 "sample queue is too full, dropping oldest samples";
                 "n_new_samples" => n_new_samples,
                 "n_current_samples" => n_current_samples,
-                "n_overflow_samples" => n_overflow_samples,
+                "n_dropped_samples" => n_dropped_samples,
             );
-            // It's possible that the number of new samples
-            // is big enough to overflow the current
-            // capacity, and also require removing new
-            // samples.
-            if n_overflow_samples < n_current_samples {
-                let _ = current_samples.drain(..n_overflow_samples);
-            } else {
-                // Clear all the current samples, and some
-                // of the new ones. The subtraction below
-                // cannot panic, because
-                // `n_overflow_samples` is computed above by
-                // adding `n_current_samples`.
-                current_samples.clear();
-                let _ =
-                    samples.drain(..(n_overflow_samples - n_current_samples));
-            }
         }
-        current_samples.extend(samples);
-        Some(n_overflow_samples)
+        Some(n_dropped_samples)
     }
 
     /// Add samples for one target to the internal queue.
@@ -1174,8 +1156,13 @@ impl KstatSamplerWorker {
         // were already there previously. This would be a bit odd, since it
         // means that the target expired, but we hadn't been polled by oximeter.
         // Nonetheless keep these samples anyway.
-        let n_samples =
-            self.samples.lock().unwrap().entry(id).or_default().len();
+        let n_samples = self
+            .samples
+            .lock()
+            .unwrap()
+            .entry(id)
+            .or_insert_with(|| BoundedQueue::new(self.sample_limit))
+            .len();
         match n_samples {
             0 => debug!(
                 self.log,
@@ -1198,7 +1185,7 @@ impl KstatSamplerWorker {
 #[derive(Clone, Debug)]
 pub struct KstatSampler {
     log: Logger,
-    samples: Arc<Mutex<BTreeMap<TargetId, Vec<Sample>>>>,
+    samples: Arc<Mutex<BTreeMap<TargetId, BoundedQueue<Sample>>>>,
     outbox: mpsc::Sender<Request>,
     // NOTE: We're using a broadcast MPMC channel here intentionally, even
     // though there is only one receiver. That's to make use of its ring-buffer
@@ -1378,7 +1365,7 @@ impl oximeter::Producer for KstatSampler {
         // keys.
         let mut samples = Vec::new();
         for (_id, queue) in self.samples.lock().unwrap().iter_mut() {
-            samples.append(queue);
+            samples.extend(queue.drain());
         }
 
         // Append any self-stat samples as well.

--- a/oximeter/instruments/src/kstat/zone.rs
+++ b/oximeter/instruments/src/kstat/zone.rs
@@ -94,7 +94,7 @@ impl KstatTarget for Zone {
 
             /* Parse zone kstats into cpu samples.
 
-            States for the zone module look like this (stats we don't use elided):
+            Stats for the zone module look like this (stats we don't use elided):
 
             ...
             zones:26:oxz_cockroachdb_8bbea076-ff60-:nsec_sys        112675830670973

--- a/oximeter/instruments/src/lib.rs
+++ b/oximeter/instruments/src/lib.rs
@@ -11,3 +11,6 @@ pub mod http;
 
 #[cfg(feature = "kstat")]
 pub mod kstat;
+
+#[cfg(feature = "zfs")]
+pub mod zfs;

--- a/oximeter/instruments/src/zfs/mod.rs
+++ b/oximeter/instruments/src/zfs/mod.rs
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+pub mod usage;

--- a/oximeter/instruments/src/zfs/usage.rs
+++ b/oximeter/instruments/src/zfs/usage.rs
@@ -1,0 +1,371 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Report metrics about zfs pool and dataset usage on the host system
+
+use illumos_utils::zfs::DatasetProperties;
+use illumos_utils::zfs::Zfs;
+use illumos_utils::zpool::Zpool;
+use illumos_utils::zpool::ZpoolInfo;
+use omicron_common::api::internal::shared::SledIdentifiers;
+use omicron_common::disk::{DatasetKind, DatasetName};
+use omicron_common::zpool_name::ZpoolName;
+use omicron_uuid_kinds::GenericUuid;
+use oximeter::MetricsError;
+use oximeter::Sample;
+use oximeter::queue::BoundedQueue;
+use slog::Logger;
+use slog::warn;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio::time::interval;
+use uuid::Uuid;
+
+oximeter::use_timeseries!("zfs_pool.toml");
+oximeter::use_timeseries!("zfs_dataset.toml");
+
+const POLL_INTERVAL: Duration = Duration::from_secs(60);
+const POLL_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_QUEUE_LENGTH: usize = 1000;
+
+#[derive(Clone, Debug)]
+pub struct ZfsUsageProducer {
+    samples: Arc<Mutex<BoundedQueue<Sample>>>,
+    _worker: Arc<JoinHandle<()>>,
+}
+
+impl ZfsUsageProducer {
+    pub fn new(log: Logger, sled: &SledIdentifiers) -> Self {
+        let samples = Arc::new(Mutex::new(BoundedQueue::new(MAX_QUEUE_LENGTH)));
+
+        let pool = zfs_pool::ZfsPool {
+            rack_id: sled.rack_id,
+            sled_id: sled.sled_id,
+            sled_model: sled.model.clone().into(),
+            sled_revision: sled.revision,
+            sled_serial: sled.serial.clone().into(),
+        };
+        let dataset = zfs_dataset::ZfsDataset {
+            rack_id: sled.rack_id,
+            sled_id: sled.sled_id,
+            sled_model: sled.model.clone().into(),
+            sled_revision: sled.revision,
+            sled_serial: sled.serial.clone().into(),
+        };
+
+        let worker = tokio::spawn(worker(samples.clone(), pool, dataset, log));
+
+        Self { samples, _worker: Arc::new(worker) }
+    }
+}
+
+impl oximeter::Producer for ZfsUsageProducer {
+    fn produce(
+        &mut self,
+    ) -> Result<Box<dyn Iterator<Item = Sample>>, MetricsError> {
+        let samples = self.samples.lock().unwrap().drain();
+        Ok(Box::new(samples.into_iter()))
+    }
+}
+
+async fn worker(
+    samples: Arc<Mutex<BoundedQueue<Sample>>>,
+    pool: zfs_pool::ZfsPool,
+    dataset: zfs_dataset::ZfsDataset,
+    log: Logger,
+) {
+    let mut tick = interval(POLL_INTERVAL);
+    loop {
+        tick.tick().await;
+
+        let mut new_samples = Vec::new();
+
+        match tokio::time::timeout(POLL_TIMEOUT, collect_zpools(&pool)).await {
+            Ok(Ok(samples)) => new_samples.extend(samples),
+            Ok(Err(err)) => {
+                warn!(log, "failed to collect zpool samples"; "err" => %err)
+            }
+            Err(_) => warn!(log, "zpool collection timed out"),
+        }
+
+        match tokio::time::timeout(POLL_TIMEOUT, collect_datasets(&dataset))
+            .await
+        {
+            Ok(Ok(samples)) => new_samples.extend(samples),
+            Ok(Err(err)) => {
+                warn!(log, "failed to collect dataset samples"; "err" => %err);
+            }
+            Err(_) => warn!(log, "dataset collection timed out"),
+        }
+
+        let mut q = samples.lock().unwrap();
+        let n_dropped = q.extend(new_samples);
+        if n_dropped > 0 {
+            warn!(log, "sample queue overflow; dropping samples"; "dropped" => n_dropped);
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Failed to list zpools")]
+    ListZpools(#[from] illumos_utils::zpool::ListError),
+
+    #[error("Failed to fetch dataset properties")]
+    GetDatasetProperties(#[from] anyhow::Error),
+
+    #[error("Failed to build sample")]
+    MetricsError(#[from] oximeter::MetricsError),
+}
+
+async fn collect_zpools(
+    target: &zfs_pool::ZfsPool,
+) -> Result<Vec<Sample>, Error> {
+    let pools = Zpool::list_with_info().await?;
+    let samples = pools
+        .iter()
+        .map(|pool| zpool_samples(target, pool))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+    Ok(samples)
+}
+
+async fn collect_datasets(
+    target: &zfs_dataset::ZfsDataset,
+) -> Result<Vec<Sample>, Error> {
+    let pools = Zpool::list_with_info().await?;
+    let anchors: Vec<String> =
+        pools.iter().flat_map(|pool| dataset_anchors(pool.name())).collect();
+    let datasets = Zfs::get_dataset_properties(
+        &anchors,
+        illumos_utils::zfs::WhichDatasets::SelfAndChildren,
+    )
+    .await
+    .map_err(Error::GetDatasetProperties)?;
+    let samples = datasets
+        .iter()
+        .map(|dataset| dataset_samples(target, dataset))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+    Ok(samples)
+}
+
+fn dataset_anchors(pool_name: &str) -> Vec<String> {
+    vec![
+        pool_name.to_string(),
+        format!("{pool_name}/crypt"),
+        format!("{pool_name}/crypt/zone"),
+    ]
+}
+
+// Parse a zpool into bytes_allocated and bytes_total metrics.
+//
+// Note: we extract zpool kind and uuid for pools named ox(i|p)_<uuid>.
+// Otherwise, we leave those fields empty.
+fn zpool_samples(
+    target: &zfs_pool::ZfsPool,
+    info: &ZpoolInfo,
+) -> Result<Vec<Sample>, Error> {
+    let (pool_kind, pool_id) = match ZpoolName::from_str(info.name()) {
+        Ok(parsed) => {
+            (parsed.kind().to_string(), parsed.id().into_untyped_uuid())
+        }
+        Err(_) => (String::new(), Uuid::nil()),
+    };
+    let allocated = zfs_pool::BytesAllocated {
+        pool_name: info.name().to_string().into(),
+        pool_kind: pool_kind.clone().into(),
+        pool_id,
+        datum: info.allocated(),
+    };
+    let total = zfs_pool::BytesTotal {
+        pool_name: info.name().to_string().into(),
+        pool_kind: pool_kind.into(),
+        pool_id,
+        datum: info.size(),
+    };
+    Ok(vec![Sample::new(target, &allocated)?, Sample::new(target, &total)?])
+}
+
+// Parse a dataset into a bytes_used metric.
+//
+// Note: we omit bytes_quota because no datasets currently set quotas;
+// we'll add this metric if it becomes relevant in the future.
+//
+// Note: we extract dataset, zpool, and zone metadata (kind, id) if
+// encoded in the dataset name as
+// ox(i|p)_<pool_uuid>/crypt/zone/<zone_uuid>. For datasets that don't
+// follow this naming pattern, we omit this metadata.
+fn dataset_samples(
+    target: &zfs_dataset::ZfsDataset,
+    props: &DatasetProperties,
+) -> Result<Vec<Sample>, Error> {
+    let mut dataset_kind = String::new();
+
+    let mut pool_kind = String::new();
+    let mut pool_id = Uuid::nil();
+
+    let mut zone_name = String::new();
+
+    let dataset_id =
+        props.id.map(|id| id.into_untyped_uuid()).unwrap_or(Uuid::nil());
+
+    let maybe_dataset = DatasetName::from_str(&props.name).ok();
+    if let Some(dataset) = &maybe_dataset {
+        dataset_kind = match dataset.kind() {
+            DatasetKind::TransientZoneRoot => "transient_zone_root".to_string(),
+            DatasetKind::TransientZone { .. } => "transient_zone".to_string(),
+            other => other.to_string(),
+        };
+        zone_name = match dataset.kind() {
+            DatasetKind::TransientZone { name } => name.to_string(),
+            _ => zone_name,
+        };
+    };
+
+    // Best-effort attempt at parsing the zpool. If we parsed the DatasetName,
+    // look up its associated zpool metadata. Otherwise, split the dataset name
+    // by /, and attempt to parse the 0th part as a ZpoolName. This allows us
+    // to extract pool metadata from datasets like
+    // ox(i|p)_<uuid>/(crypt|install|...), which don't parse to a DatasetName.
+    let maybe_pool =
+        maybe_dataset.as_ref().map(|dataset| *dataset.pool()).or_else(|| {
+            let prefix = props
+                .name
+                .split_once('/')
+                .map(|(part, _)| part)
+                .unwrap_or(&props.name);
+            ZpoolName::from_str(prefix).ok()
+        });
+    if let Some(pool) = maybe_pool {
+        pool_kind = pool.kind().to_string();
+        pool_id = pool.id().into_untyped_uuid();
+    }
+
+    let used = zfs_dataset::BytesUsed {
+        dataset_name: props.name.clone().into(),
+        dataset_id,
+        dataset_kind: dataset_kind.into(),
+        pool_kind: pool_kind.clone().into(),
+        pool_id,
+        zone_name: zone_name.into(),
+        datum: props.used.to_bytes(),
+    };
+    Ok(vec![Sample::new(target, &used)?])
+}
+
+#[cfg(test)]
+mod tests {
+    use omicron_uuid_kinds::DatasetUuid;
+
+    use super::*;
+
+    #[test]
+    fn test_dataset_samples() {
+        let target = zfs_dataset::ZfsDataset {
+            rack_id: uuid::Uuid::nil(),
+            sled_id: uuid::Uuid::nil(),
+            sled_model: "test".into(),
+            sled_revision: 0,
+            sled_serial: "test".into(),
+        };
+        let dataset_id = DatasetUuid::new_v4();
+        let props = DatasetProperties {
+            id: Some(dataset_id),
+            name: "oxp_0e485ad3-04e6-404b-b619-87d4fea9f5ae/crypt/zone/oxz_clickhouse_aa646c82-c6d7-4d0c-8401-150130927759".into(),
+            mounted: true,
+            avail: 0u32.into(),
+            used: 12345u32.into(),
+            quota: None,
+            reservation: None,
+            compression: String::new(),
+            epoch: None,
+        };
+        let samples = dataset_samples(&target, &props).unwrap();
+        assert_eq!(samples.len(), 1);
+
+        let sample = &samples[0];
+        assert_eq!(sample.timeseries_name, "zfs_dataset:bytes_used");
+
+        let fields = sample.sorted_metric_fields();
+        assert_eq!(fields["dataset_name"].value, props.name.clone().into());
+        assert_eq!(fields["dataset_kind"].value, "transient_zone".into());
+        assert_eq!(
+            fields["dataset_id"].value,
+            dataset_id.into_untyped_uuid().into(),
+        );
+        assert_eq!(fields["pool_kind"].value, "external".into());
+        assert_eq!(
+            fields["pool_id"].value,
+            uuid::uuid!("0e485ad3-04e6-404b-b619-87d4fea9f5ae").into(),
+        );
+        assert_eq!(
+            fields["zone_name"].value,
+            "oxz_clickhouse_aa646c82-c6d7-4d0c-8401-150130927759".into(),
+        );
+
+        assert_eq!(sample.measurement.datum(), &oximeter::Datum::U64(12345));
+    }
+
+    #[cfg(target_os = "illumos")]
+    #[tokio::test]
+    async fn test_collect_zpools() {
+        let target = zfs_pool::ZfsPool {
+            rack_id: uuid::Uuid::nil(),
+            sled_id: uuid::Uuid::nil(),
+            sled_model: "test".into(),
+            sled_revision: 0,
+            sled_serial: "test".into(),
+        };
+        let samples =
+            collect_zpools(&target).await.expect("collect should succeed");
+
+        assert!(
+            samples
+                .iter()
+                .filter(|s| s.timeseries_name == "zfs_pool:bytes_allocated")
+                .count()
+                >= 1,
+            "expected at least one sample for bytes_allocated"
+        );
+        assert!(
+            samples
+                .iter()
+                .filter(|s| s.timeseries_name == "zfs_pool:bytes_total")
+                .count()
+                >= 1,
+            "expected at least one sample for bytes_total"
+        );
+    }
+
+    #[cfg(target_os = "illumos")]
+    #[tokio::test]
+    async fn test_collect_datasets() {
+        let target = zfs_dataset::ZfsDataset {
+            rack_id: uuid::Uuid::nil(),
+            sled_id: uuid::Uuid::nil(),
+            sled_model: "test".into(),
+            sled_revision: 0,
+            sled_serial: "test".into(),
+        };
+        let samples =
+            collect_datasets(&target).await.expect("collect should succeed");
+
+        assert!(
+            samples
+                .iter()
+                .filter(|s| s.timeseries_name == "zfs_dataset:bytes_used")
+                .count()
+                >= 1,
+            "expected at least one sample for bytes_used"
+        );
+    }
+}

--- a/oximeter/oximeter/schema/zfs_dataset.toml
+++ b/oximeter/oximeter/schema/zfs_dataset.toml
@@ -1,0 +1,62 @@
+format_version = 1
+
+[target]
+name = "zfs_dataset"
+description = "Disk usage for a zfs dataset"
+authz_scope = "fleet"
+versions = [
+  { version = 1, fields = [ "rack_id", "sled_id", "sled_model", "sled_revision", "sled_serial"] },
+]
+
+[fields.rack_id]
+type = "uuid"
+description = "ID for the rack"
+
+[fields.sled_id]
+type = "uuid"
+description = "ID for the sled"
+
+[fields.sled_model]
+type = "string"
+description = "Model number of the sled"
+
+[fields.sled_revision]
+type = "u32"
+description = "Revision number of the sled"
+
+[fields.sled_serial]
+type = "string"
+description = "Serial number of the sled"
+
+[fields.pool_kind]
+type = "string"
+description = "Control plane kind of the parent zpool"
+
+[fields.pool_id]
+type = "uuid"
+description = "Control plane UUID of the parent zpool"
+
+[fields.dataset_name]
+type = "string"
+description = "Name of the dataset"
+
+[fields.dataset_kind]
+type = "string"
+description = "Control plane kind of the dataset"
+
+[fields.dataset_id]
+type = "uuid"
+description = "Control plane UUID of the dataset"
+
+[fields.zone_name]
+type = "string"
+description = "Name of the associated zone"
+
+[[metrics]]
+name = "bytes_used"
+description = "Bytes used for the dataset"
+units = "bytes"
+datum_type = "u64"
+versions = [
+  { added_in = 1, fields = [ "dataset_name", "pool_kind", "pool_id", "dataset_kind", "dataset_id", "zone_name" ] }
+]

--- a/oximeter/oximeter/schema/zfs_pool.toml
+++ b/oximeter/oximeter/schema/zfs_pool.toml
@@ -1,0 +1,59 @@
+format_version = 1
+
+[target]
+name = "zfs_pool"
+description = "Disk usage for a zfs pool"
+authz_scope = "fleet"
+versions = [
+  { version = 1, fields = [ "rack_id", "sled_id", "sled_model", "sled_revision", "sled_serial"] },
+]
+
+[fields.rack_id]
+type = "uuid"
+description = "ID for the rack"
+
+[fields.sled_id]
+type = "uuid"
+description = "ID for the sled"
+
+[fields.sled_model]
+type = "string"
+description = "Model number of the sled"
+
+[fields.sled_revision]
+type = "u32"
+description = "Revision number of the sled"
+
+[fields.sled_serial]
+type = "string"
+description = "Serial number of the sled"
+
+[fields.pool_name]
+type = "string"
+description = "Name of the zpool"
+
+[fields.pool_kind]
+type = "string"
+description = "Control plane kind of the zpool"
+
+[fields.pool_id]
+type = "uuid"
+description = "Control plane UUID of the zpool"
+
+[[metrics]]
+name = "bytes_allocated"
+description = "Bytes allocated for the pool"
+units = "bytes"
+datum_type = "u64"
+versions = [
+  { added_in = 1, fields = [ "pool_name", "pool_kind", "pool_id" ] }
+]
+
+[[metrics]]
+name = "bytes_total"
+description = "Total size for the pool"
+units = "bytes"
+datum_type = "u64"
+versions = [
+  { added_in = 1, fields = [ "pool_name", "pool_kind", "pool_id" ] }
+]

--- a/oximeter/types/src/lib.rs
+++ b/oximeter/types/src/lib.rs
@@ -16,6 +16,7 @@ pub mod collector;
 pub mod histogram;
 pub mod producer;
 pub mod quantile;
+pub mod queue;
 pub mod schema;
 pub mod traits;
 pub mod types;

--- a/oximeter/types/src/queue.rs
+++ b/oximeter/types/src/queue.rs
@@ -1,0 +1,100 @@
+use std::collections::VecDeque;
+
+#[derive(Debug)]
+pub struct BoundedQueue<T> {
+    queue: VecDeque<T>,
+    max_size: usize,
+}
+
+impl<T> BoundedQueue<T> {
+    pub fn new(max_size: usize) -> Self {
+        Self { queue: VecDeque::new(), max_size }
+    }
+
+    pub fn extend(&mut self, samples: Vec<T>) -> usize {
+        // Append the new samples, ensuring we never exceed `max_size`.
+        let n_current_samples = self.queue.len();
+        let n_new_samples = samples.len();
+        let n_total_samples = n_current_samples + n_new_samples;
+
+        // The easy case is when all the samples fit. Just append them and
+        // return 0, since we've not dropped anything.
+        let n_dropped = if n_total_samples <= self.max_size {
+            self.queue.extend(samples);
+            0
+        } else {
+            // Now, drop samples first from the queue, then the new set
+            // of samples, until we're under our limit. Start by computing
+            // the total number to be dropped.
+            //
+            // NOTE: This can't underflow, we're in the branch where
+            // `n_total_samples > self.max_size`.
+            let n_dropped = n_total_samples - self.max_size;
+
+            // We want to drop from the queue first. We can drop the
+            // minimum of the number to be dropped and the queue size. If
+            // we're only dropping part of the queue, we'll take `n_dropped` off
+            // the front. If we need to drop the whole queue and then some,
+            // we'll take the queue size and drop the whole thing.
+            let n_to_drop = n_dropped.min(self.queue.len());
+            drop(self.queue.drain(..n_to_drop));
+
+            // At this point, we've dropped something (potentially everything)
+            // from the queue. We need to figure out how many, if any,
+            // to drop from the _incoming_ set of samples. Subtract whatever we
+            // dropped immediately above to compute the number left to drop.
+            let n_left_to_drop = n_dropped - n_to_drop;
+
+            // Append whatever we don't want to drop.
+            self.queue.extend(samples.into_iter().skip(n_left_to_drop));
+            n_dropped
+        };
+        n_dropped
+    }
+
+    pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, T> {
+        self.queue.iter()
+    }
+
+    pub fn drain(&mut self) -> VecDeque<T> {
+        std::mem::take(&mut self.queue)
+    }
+
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bounded_queue() {
+        let mut bq = BoundedQueue::new(5);
+        let n_dropped = bq.extend(vec![0, 1, 2, 3, 4]);
+        assert_eq!(bq.len(), 5);
+        assert_eq!(n_dropped, 0);
+        let drained = bq.drain();
+        assert_eq!(drained, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_bounded_queue_overflow() {
+        let mut bq = BoundedQueue::new(5);
+        bq.extend(vec![0, 1, 2, 3, 4]);
+        let n_dropped = bq.extend(vec![5, 6, 7]);
+        assert_eq!(n_dropped, 3);
+        let drained = bq.drain();
+        assert_eq!(drained, vec![3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn test_bounded_queue_sample_overflow() {
+        let mut bq = BoundedQueue::new(5);
+        let n_dropped = bq.extend(vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(n_dropped, 3);
+        let drained = bq.drain();
+        assert_eq!(drained, vec![3, 4, 5, 6, 7]);
+    }
+}

--- a/sled-agent/src/metrics.rs
+++ b/sled-agent/src/metrics.rs
@@ -21,6 +21,7 @@ use oximeter_instruments::kstat::link::SledDataLink;
 use oximeter_instruments::kstat::link::SledDataLinkTarget;
 use oximeter_instruments::kstat::zone::Zone;
 use oximeter_instruments::kstat::zone::ZoneTarget;
+use oximeter_instruments::zfs::usage::ZfsUsageProducer;
 use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
 use slog::Logger;
@@ -144,7 +145,7 @@ fn get_collection_details(kind: &str) -> CollectionDetails {
 async fn metrics_task(
     sled_identifiers: SledIdentifiers,
     kstat_sampler: KstatSampler,
-    _server: ProducerServer,
+    server: ProducerServer,
     log: Logger,
     mut rx: mpsc::Receiver<Message>,
 ) {
@@ -250,6 +251,13 @@ async fn metrics_task(
                     sync_zone(&log, &mut tracked_zone, &kstat_sampler).await;
                     sync_sled_cpu(&log, &mut tracked_sled_cpu, &kstat_sampler)
                         .await;
+
+                    let zfs_producer =
+                        ZfsUsageProducer::new(log.clone(), &sled_identifiers);
+                    server
+                        .registry()
+                        .register_producer(zfs_producer.clone())
+                        .expect("actually infallible");
                 }
             }
         }


### PR DESCRIPTION
Collect zpool and dataset usage metrics from sled-agent, using a background worker to collect stats and a producer to expose them to oximeter. To be used to monitor and alert on disk use of internal applications.

Context: we had an escalation related to an internal service filling up its disk. We shipped a mitigation in #10366, but the mitigation still requires the user to take action before the disk fills up. This patch adds metrics that the user can monitor and alert on proactively, and that we can use to understand storage use of internal services (and eventually set quotas).