### PR TITLE
update MGS to pick up oxidecomputer/management-gateway-service#491

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,7 +4069,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4096,7 +4096,7 @@ dependencies = [
  "chrono",
  "daft",
  "ereport-types",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-types",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4115,36 +4115,9 @@ dependencies = [
 [[package]]
 name = "gateway-ereport-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=0d7a8992f914ad6a5947409048779969bbe80e3d#0d7a8992f914ad6a5947409048779969bbe80e3d"
-dependencies = [
- "serde",
- "zerocopy 0.8.40",
-]
-
-[[package]]
-name = "gateway-ereport-messages"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d#745a508cb97b7ca9b4c10ec9592c980eb769b10d"
 dependencies = [
  "serde",
- "zerocopy 0.8.40",
-]
-
-[[package]]
-name = "gateway-messages"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=0d7a8992f914ad6a5947409048779969bbe80e3d#0d7a8992f914ad6a5947409048779969bbe80e3d"
-dependencies = [
- "bitflags 2.11.0",
- "hubpack",
- "serde",
- "serde-big-array",
- "serde_repr",
- "smoltcp 0.9.1",
- "static_assertions",
- "strum 0.27.2",
- "strum_macros 0.27.2",
- "uuid",
  "zerocopy 0.8.40",
 ]
 
@@ -4176,8 +4149,8 @@ dependencies = [
  "base64 0.22.1",
  "futures",
  "fxhash",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-ereport-messages",
+ "gateway-messages",
  "hex",
  "hubpack",
  "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
@@ -4212,7 +4185,7 @@ dependencies = [
  "camino",
  "dropshot 0.17.0",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-types",
  "omicron-gateway",
  "omicron-test-utils",
@@ -4239,7 +4212,7 @@ version = "0.1.0"
 dependencies = [
  "daft",
  "dropshot 0.17.0",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "hex",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -6594,7 +6567,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-test-utils",
  "libc",
  "omicron-gateway",
@@ -7234,7 +7207,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "httpmock",
@@ -7364,7 +7337,7 @@ dependencies = [
  "dropshot 0.17.0",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -7734,7 +7707,7 @@ dependencies = [
  "dropshot 0.17.0",
  "fmd-adm-sys",
  "futures",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-test-utils",
  "headers",
  "hickory-resolver 0.25.2",
@@ -8572,7 +8545,7 @@ dependencies = [
  "futures",
  "gateway-api",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-sp-comms",
  "gateway-test-utils",
  "gateway-types",
@@ -8724,7 +8697,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "headers",
@@ -8941,7 +8914,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -9433,8 +9406,8 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=0d7a8992f914ad6a5947409048779969bbe80e3d)",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=0d7a8992f914ad6a5947409048779969bbe80e3d)",
+ "gateway-ereport-messages",
+ "gateway-messages",
  "generic-array",
  "getrandom 0.2.17",
  "getrandom 0.4.1",
@@ -14252,8 +14225,8 @@ dependencies = [
  "clap",
  "dropshot 0.17.0",
  "futures",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-ereport-messages",
+ "gateway-messages",
  "gateway-types",
  "hex",
  "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
@@ -17084,7 +17057,7 @@ dependencies = [
  "fs-err 3.3.0",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,7 +4069,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4096,7 +4096,7 @@ dependencies = [
  "chrono",
  "daft",
  "ereport-types",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-types",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4122,6 +4122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway-ereport-messages"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d#745a508cb97b7ca9b4c10ec9592c980eb769b10d"
+dependencies = [
+ "serde",
+ "zerocopy 0.8.40",
+]
+
+[[package]]
 name = "gateway-messages"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=0d7a8992f914ad6a5947409048779969bbe80e3d#0d7a8992f914ad6a5947409048779969bbe80e3d"
@@ -4140,17 +4149,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway-messages"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d#745a508cb97b7ca9b4c10ec9592c980eb769b10d"
+dependencies = [
+ "bitflags 2.11.0",
+ "hubpack",
+ "serde",
+ "serde-big-array",
+ "serde_repr",
+ "smoltcp 0.9.1",
+ "static_assertions",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "uuid",
+ "zerocopy 0.8.40",
+]
+
+[[package]]
 name = "gateway-sp-comms"
 version = "0.1.2"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=0d7a8992f914ad6a5947409048779969bbe80e3d#0d7a8992f914ad6a5947409048779969bbe80e3d"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d#745a508cb97b7ca9b4c10ec9592c980eb769b10d"
 dependencies = [
  "async-trait",
  "backoff",
  "base64 0.22.1",
  "futures",
  "fxhash",
- "gateway-ereport-messages",
- "gateway-messages",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "hex",
  "hubpack",
  "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
@@ -4185,7 +4212,7 @@ dependencies = [
  "camino",
  "dropshot 0.17.0",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-types",
  "omicron-gateway",
  "omicron-test-utils",
@@ -4212,7 +4239,7 @@ version = "0.1.0"
 dependencies = [
  "daft",
  "dropshot 0.17.0",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "hex",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -6567,7 +6594,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-test-utils",
  "libc",
  "omicron-gateway",
@@ -7207,7 +7234,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-test-utils",
  "gateway-types",
  "httpmock",
@@ -7337,7 +7364,7 @@ dependencies = [
  "dropshot 0.17.0",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -7707,7 +7734,7 @@ dependencies = [
  "dropshot 0.17.0",
  "fmd-adm-sys",
  "futures",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-test-utils",
  "headers",
  "hickory-resolver 0.25.2",
@@ -8545,7 +8572,7 @@ dependencies = [
  "futures",
  "gateway-api",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-sp-comms",
  "gateway-test-utils",
  "gateway-types",
@@ -8697,7 +8724,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-test-utils",
  "gateway-types",
  "headers",
@@ -8914,7 +8941,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -9406,8 +9433,8 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
- "gateway-ereport-messages",
- "gateway-messages",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=0d7a8992f914ad6a5947409048779969bbe80e3d)",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=0d7a8992f914ad6a5947409048779969bbe80e3d)",
  "generic-array",
  "getrandom 0.2.17",
  "getrandom 0.4.1",
@@ -14225,8 +14252,8 @@ dependencies = [
  "clap",
  "dropshot 0.17.0",
  "futures",
- "gateway-ereport-messages",
- "gateway-messages",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-types",
  "hex",
  "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
@@ -17057,7 +17084,7 @@ dependencies = [
  "fs-err 3.3.0",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "gateway-test-utils",
  "gateway-types",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -530,9 +530,9 @@ gateway-client = { path = "clients/gateway-client" }
 # compatibility, but will mean that faux-mgs might be missing new
 # functionality.)
 #
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0d7a8992f914ad6a5947409048779969bbe80e3d", default-features = false, features = ["debug-impls"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0d7a8992f914ad6a5947409048779969bbe80e3d", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0d7a8992f914ad6a5947409048779969bbe80e3d" }
+gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", default-features = false, features = ["debug-impls"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", default-features = false, features = ["std"] }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d" }
 gateway-test-utils = { path = "gateway-test-utils" }
 gateway-types = { path = "gateway-types" }
 gateway-types-versions = { path = "gateway-types/versions" }

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -605,8 +605,8 @@ source.type = "prebuilt"
 source.repo = "management-gateway-service"
 # In general, this commit should match the pinned revision of `gateway-sp-comms`
 # in `Cargo.toml`.
-source.commit = "0d7a8992f914ad6a5947409048779969bbe80e3d"
-source.sha256 = "ebd8e0edd3551bcc397dfbc72b0b1e35a032c5fcae925447eeb40279b3adbc84"
+source.commit = "745a508cb97b7ca9b4c10ec9592c980eb769b10d"
+source.sha256 = "24368fb049c3bcdda56c5e4b1f18e2371aa5699ac73f161e12d1ebd842293b71"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -59,8 +59,8 @@ futures-core = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
 futures-task = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.32", features = ["channel", "io", "sink"] }
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0d7a8992f914ad6a5947409048779969bbe80e3d", default-features = false, features = ["debug-impls", "serde"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0d7a8992f914ad6a5947409048779969bbe80e3d", features = ["std"] }
+gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", default-features = false, features = ["debug-impls", "serde"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["js", "rdrand", "std"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }
@@ -206,8 +206,8 @@ futures-core = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
 futures-task = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.32", features = ["channel", "io", "sink"] }
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0d7a8992f914ad6a5947409048779969bbe80e3d", default-features = false, features = ["debug-impls", "serde"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0d7a8992f914ad6a5947409048779969bbe80e3d", features = ["std"] }
+gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", default-features = false, features = ["debug-impls", "serde"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["js", "rdrand", "std"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This updates the MGS dep to
oxidecomputer/management-gateway-service@745a508cb97b7ca9b4c10ec9592c980eb769b10d. Along with #10452, this is necessary for #10437.

I had considered waiting to get oxidecomputer/management-gateway-service#494 in the update as well, and may still do so depending on when I hear back from people about various things. But, I did want to [take a moment to get some feedback](https://github.com/oxidecomputer/management-gateway-service/pull/494#issuecomment-4479795690) from potential actual users of the faux-mgs interface on whether they actually like my (perhaps unnecessarily cutesy) output format before merging it.