### PR TITLE
Add system-version to omdb db 

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -190,7 +190,7 @@ mod db_metadata;
 mod ereport;
 mod saga;
 mod sitrep;
-mod system_version;
+mod target_release;
 mod user_data_export;
 mod whatis;
 
@@ -406,8 +406,8 @@ enum DbCommands {
     Sleds(SledsArgs),
     /// Show instances grouped by the sled they are running on
     SledInstances(SledInstancesArgs),
-    /// Print the current target system release and the update date (print all of the releases when `--all` is present)
-    SystemVersion(system_version::SystemVersionArgs),
+    /// Print the current target release and the update date
+    TargetRelease(target_release::TargetReleaseArgs),
     /// Print information about customer instances.
     Instance(InstanceArgs),
     /// Alias to `omdb instance list`.
@@ -1456,8 +1456,8 @@ impl DbArgs {
                         )
                         .await
                     }
-                    DbCommands::SystemVersion(args) => {
-                        system_version::cmd_db_system_version(&opctx, &datastore, &fetch_opts, args).await
+                    DbCommands::TargetRelease(args) => {
+                        target_release::cmd_db_target_release(&opctx, &datastore, &fetch_opts, args).await
                     }
                     DbCommands::Instance(InstanceArgs {
                         command: InstanceCommands::List(args),

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -190,6 +190,7 @@ mod db_metadata;
 mod ereport;
 mod saga;
 mod sitrep;
+mod system_version;
 mod user_data_export;
 mod whatis;
 
@@ -405,6 +406,8 @@ enum DbCommands {
     Sleds(SledsArgs),
     /// Show instances grouped by the sled they are running on
     SledInstances(SledInstancesArgs),
+    /// Print the current target system release and the update date (print all of the releases when `--all` is present)
+    SystemVersion(system_version::SystemVersionArgs),
     /// Print information about customer instances.
     Instance(InstanceArgs),
     /// Alias to `omdb instance list`.
@@ -1452,6 +1455,9 @@ impl DbArgs {
                             args,
                         )
                         .await
+                    }
+                    DbCommands::SystemVersion(args) => {
+                        system_version::cmd_db_system_version(&opctx, &datastore, &fetch_opts, args).await
                     }
                     DbCommands::Instance(InstanceArgs {
                         command: InstanceCommands::List(args),

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -1457,7 +1457,7 @@ impl DbArgs {
                         .await
                     }
                     DbCommands::TargetRelease(args) => {
-                        target_release::cmd_db_target_release(&opctx, &datastore, &fetch_opts, args).await
+                        target_release::cmd_db_target_release(&opctx, &datastore, args).await
                     }
                     DbCommands::Instance(InstanceArgs {
                         command: InstanceCommands::List(args),

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -1457,7 +1457,7 @@ impl DbArgs {
                         .await
                     }
                     DbCommands::TargetRelease(args) => {
-                        target_release::cmd_db_target_release(&opctx, &datastore, args).await
+                        target_release::cmd_db_target_release(&opctx, &datastore, &fetch_opts, args).await
                     }
                     DbCommands::Instance(InstanceArgs {
                         command: InstanceCommands::List(args),

--- a/dev-tools/omdb/src/bin/omdb/db/system_version.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/system_version.rs
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `omdb db system-version` subcommand
+//!
+//! Shows the current target release and date when update was requested.
+//! When `--all` option is used, lists all target release records.
+
+use crate::db::DbFetchOptions;
+use crate::db::check_limit;
+use crate::helpers::datetime_rfc3339_concise;
+use anyhow::Context;
+use async_bb8_diesel::AsyncRunQueryDsl;
+use clap::Args;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel::SelectableHelper;
+use nexus_db_model::TargetRelease;
+use nexus_db_model::TargetReleaseSource;
+use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::DataStore;
+use nexus_db_schema::schema::target_release::dsl;
+use tabled::Tabled;
+
+#[derive(Debug, Args, Clone)]
+pub(super) struct SystemVersionArgs {
+    /// List of target releases sorted from newest to oldest
+    #[clap(long)]
+    all: bool,
+}
+
+#[derive(Tabled)]
+#[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+struct SystemVersionRow {
+    system_version: String,
+    time_requested: String,
+}
+
+pub(super) async fn cmd_db_system_version(
+    opctx: &OpContext,
+    datastore: &DataStore,
+    fetch_opts: &DbFetchOptions,
+    args: &SystemVersionArgs,
+) -> Result<(), anyhow::Error> {
+    let releases = if args.all {
+        let limit = fetch_opts.fetch_limit;
+        let conn = datastore.pool_connection_for_tests().await?;
+        let releases: Vec<TargetRelease> = dsl::target_release
+            .select(TargetRelease::as_select())
+            .order_by(dsl::generation.desc())
+            .limit(i64::from(u32::from(limit)))
+            .load_async(&*conn)
+            .await
+            .context("listing target releases")?;
+        check_limit(&releases, limit, || String::from("listing target releases"));
+        releases
+    } else {
+        vec![
+            datastore
+                .target_release_get_current(opctx)
+                .await
+                .context("fetching current target release")?,
+        ]
+    };
+
+    let mut rows = Vec::with_capacity(releases.len());
+    for release in releases {
+        let system_version = match release
+            .release_source()
+            .context("interpreting target release source")?
+        {
+            TargetReleaseSource::Unspecified => "<unspecified>".to_string(),
+            TargetReleaseSource::SystemVersion(tuf_repo_id) => datastore
+                .tuf_repo_get_version(opctx, &tuf_repo_id)
+                .await
+                .with_context(|| format!("fetching TUF repo {tuf_repo_id}"))?
+                .to_string(),
+        };
+        rows.push(SystemVersionRow {
+            system_version,
+            time_requested: datetime_rfc3339_concise(&release.time_requested),
+        });
+    }
+
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(1, 1, 0, 0))
+        .to_string();
+
+    println!("{}", table);
+
+    Ok(())
+}

--- a/dev-tools/omdb/src/bin/omdb/db/system_version.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/system_version.rs
@@ -53,7 +53,9 @@ pub(super) async fn cmd_db_system_version(
             .load_async(&*conn)
             .await
             .context("listing target releases")?;
-        check_limit(&releases, limit, || String::from("listing target releases"));
+        check_limit(&releases, limit, || {
+            String::from("listing target releases")
+        });
         releases
     } else {
         vec![

--- a/dev-tools/omdb/src/bin/omdb/db/target_release.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/target_release.rs
@@ -7,25 +7,25 @@
 //! Shows the current target release and date when update was requested.
 //! When `--all` option is used, lists all target release records.
 
-use crate::db::DbFetchOptions;
-use crate::db::check_limit;
 use crate::helpers::datetime_rfc3339_concise;
 use anyhow::Context;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use clap::Args;
-use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use diesel::SelectableHelper;
 use nexus_db_model::TargetRelease;
 use nexus_db_model::TargetReleaseSource;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
+use nexus_db_queries::db::datastore::SQL_BATCH_SIZE;
+use nexus_db_queries::db::pagination::Paginator;
+use nexus_db_queries::db::pagination::paginated;
 use nexus_db_schema::schema::target_release::dsl;
 use tabled::Tabled;
 
 #[derive(Debug, Args, Clone)]
 pub(super) struct TargetReleaseArgs {
-    /// List of target releases sorted from newest to oldest
+    /// List of target releases sorted from oldest to newest
     #[clap(long)]
     all: bool,
 }
@@ -40,22 +40,29 @@ struct TargetReleaseRow {
 pub(super) async fn cmd_db_target_release(
     opctx: &OpContext,
     datastore: &DataStore,
-    fetch_opts: &DbFetchOptions,
     args: &TargetReleaseArgs,
 ) -> Result<(), anyhow::Error> {
     let releases = if args.all {
-        let limit = fetch_opts.fetch_limit;
         let conn = datastore.pool_connection_for_tests().await?;
-        let releases: Vec<TargetRelease> = dsl::target_release
+        let mut releases: Vec<TargetRelease> = Vec::new();
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
+        while let Some(p) = paginator.next() {
+            let batch = paginated(
+                dsl::target_release,
+                dsl::generation,
+                &p.current_pagparams(),
+            )
             .select(TargetRelease::as_select())
-            .order_by(dsl::generation.desc())
-            .limit(i64::from(u32::from(limit)))
             .load_async(&*conn)
             .await
             .context("listing target releases")?;
-        check_limit(&releases, limit, || {
-            String::from("listing target releases")
-        });
+            paginator =
+                p.found_batch(&batch, &|r: &TargetRelease| r.generation);
+            releases.extend(batch);
+        }
         releases
     } else {
         vec![

--- a/dev-tools/omdb/src/bin/omdb/db/target_release.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/target_release.rs
@@ -7,25 +7,25 @@
 //! Shows the current target release and date when update was requested.
 //! When `--all` option is used, lists all target release records.
 
+use crate::db::DbFetchOptions;
+use crate::db::check_limit;
 use crate::helpers::datetime_rfc3339_concise;
 use anyhow::Context;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use clap::Args;
+use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use diesel::SelectableHelper;
 use nexus_db_model::TargetRelease;
 use nexus_db_model::TargetReleaseSource;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
-use nexus_db_queries::db::datastore::SQL_BATCH_SIZE;
-use nexus_db_queries::db::pagination::Paginator;
-use nexus_db_queries::db::pagination::paginated;
 use nexus_db_schema::schema::target_release::dsl;
 use tabled::Tabled;
 
 #[derive(Debug, Args, Clone)]
 pub(super) struct TargetReleaseArgs {
-    /// List of target releases sorted from oldest to newest
+    /// List the most recent target releases, sorted from oldest to newest
     #[clap(long)]
     all: bool,
 }
@@ -33,36 +33,30 @@ pub(super) struct TargetReleaseArgs {
 #[derive(Tabled)]
 #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
 struct TargetReleaseRow {
-    system_version: String,
+    target_release: String,
     time_requested: String,
 }
 
 pub(super) async fn cmd_db_target_release(
     opctx: &OpContext,
     datastore: &DataStore,
+    fetch_opts: &DbFetchOptions,
     args: &TargetReleaseArgs,
 ) -> Result<(), anyhow::Error> {
     let releases = if args.all {
+        let limit = fetch_opts.fetch_limit;
         let conn = datastore.pool_connection_for_tests().await?;
-        let mut releases: Vec<TargetRelease> = Vec::new();
-        let mut paginator = Paginator::new(
-            SQL_BATCH_SIZE,
-            dropshot::PaginationOrder::Ascending,
-        );
-        while let Some(p) = paginator.next() {
-            let batch = paginated(
-                dsl::target_release,
-                dsl::generation,
-                &p.current_pagparams(),
-            )
+        let mut releases: Vec<TargetRelease> = dsl::target_release
             .select(TargetRelease::as_select())
+            .order_by(dsl::generation.desc())
+            .limit(i64::from(u32::from(limit)))
             .load_async(&*conn)
             .await
             .context("listing target releases")?;
-            paginator =
-                p.found_batch(&batch, &|r: &TargetRelease| r.generation);
-            releases.extend(batch);
-        }
+        check_limit(&releases, limit, || {
+            String::from("listing target releases")
+        });
+        releases.reverse();
         releases
     } else {
         vec![
@@ -75,7 +69,7 @@ pub(super) async fn cmd_db_target_release(
 
     let mut rows = Vec::with_capacity(releases.len());
     for release in releases {
-        let system_version = match release
+        let target_release = match release
             .release_source()
             .context("interpreting target release source")?
         {
@@ -87,7 +81,7 @@ pub(super) async fn cmd_db_target_release(
                 .to_string(),
         };
         rows.push(TargetReleaseRow {
-            system_version,
+            target_release,
             time_requested: datetime_rfc3339_concise(&release.time_requested),
         });
     }

--- a/dev-tools/omdb/src/bin/omdb/db/target_release.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/target_release.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! `omdb db system-version` subcommand
+//! `omdb db target-release` subcommand
 //!
 //! Shows the current target release and date when update was requested.
 //! When `--all` option is used, lists all target release records.
@@ -24,7 +24,7 @@ use nexus_db_schema::schema::target_release::dsl;
 use tabled::Tabled;
 
 #[derive(Debug, Args, Clone)]
-pub(super) struct SystemVersionArgs {
+pub(super) struct TargetReleaseArgs {
     /// List of target releases sorted from newest to oldest
     #[clap(long)]
     all: bool,
@@ -32,16 +32,16 @@ pub(super) struct SystemVersionArgs {
 
 #[derive(Tabled)]
 #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
-struct SystemVersionRow {
+struct TargetReleaseRow {
     system_version: String,
     time_requested: String,
 }
 
-pub(super) async fn cmd_db_system_version(
+pub(super) async fn cmd_db_target_release(
     opctx: &OpContext,
     datastore: &DataStore,
     fetch_opts: &DbFetchOptions,
-    args: &SystemVersionArgs,
+    args: &TargetReleaseArgs,
 ) -> Result<(), anyhow::Error> {
     let releases = if args.all {
         let limit = fetch_opts.fetch_limit;
@@ -79,7 +79,7 @@ pub(super) async fn cmd_db_system_version(
                 .with_context(|| format!("fetching TUF repo {tuf_repo_id}"))?
                 .to_string(),
         };
-        rows.push(SystemVersionRow {
+        rows.push(TargetReleaseRow {
             system_version,
             time_requested: datetime_rfc3339_concise(&release.time_requested),
         });

--- a/dev-tools/omdb/src/bin/omdb/db/target_release.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/target_release.rs
@@ -5,7 +5,7 @@
 //! `omdb db target-release` subcommand
 //!
 //! Shows the current target release and date when update was requested.
-//! When `--all` option is used, lists all target release records.
+//! When `--list` option is used, lists all target release records.
 
 use crate::db::DbFetchOptions;
 use crate::db::check_limit;
@@ -27,7 +27,7 @@ use tabled::Tabled;
 pub(super) struct TargetReleaseArgs {
     /// List the most recent target releases, sorted from oldest to newest
     #[clap(long)]
-    all: bool,
+    list: bool,
 }
 
 #[derive(Tabled)]
@@ -43,7 +43,7 @@ pub(super) async fn cmd_db_target_release(
     fetch_opts: &DbFetchOptions,
     args: &TargetReleaseArgs,
 ) -> Result<(), anyhow::Error> {
-    let releases = if args.all {
+    let releases = if args.list {
         let limit = fetch_opts.fetch_limit;
         let conn = datastore.pool_connection_for_tests().await?;
         let mut releases: Vec<TargetRelease> = dsl::target_release

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -142,8 +142,7 @@ Commands:
   sitreps                      Show the current history of fault management situation reports
   sleds                        Print information about sleds
   sled-instances               Show instances grouped by the sled they are running on
-  system-version               Print the current target system release and the update date (print
-                               all of the releases when `--all` is present)
+  target-release               Print the current target release and the update date
   instance                     Print information about customer instances
   instances                    Alias to `omdb instance list`
   network                      Print information about the network
@@ -212,8 +211,7 @@ Commands:
   sitreps                      Show the current history of fault management situation reports
   sleds                        Print information about sleds
   sled-instances               Show instances grouped by the sled they are running on
-  system-version               Print the current target system release and the update date (print
-                               all of the releases when `--all` is present)
+  target-release               Print the current target release and the update date
   instance                     Print information about customer instances
   instances                    Alias to `omdb instance list`
   network                      Print information about the network

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -142,6 +142,8 @@ Commands:
   sitreps                      Show the current history of fault management situation reports
   sleds                        Print information about sleds
   sled-instances               Show instances grouped by the sled they are running on
+  system-version               Print the current target system release and the update date (print
+                               all of the releases when `--all` is present)
   instance                     Print information about customer instances
   instances                    Alias to `omdb instance list`
   network                      Print information about the network
@@ -210,6 +212,8 @@ Commands:
   sitreps                      Show the current history of fault management situation reports
   sleds                        Print information about sleds
   sled-instances               Show instances grouped by the sled they are running on
+  system-version               Print the current target system release and the update date (print
+                               all of the releases when `--all` is present)
   instance                     Print information about customer instances
   instances                    Alias to `omdb instance list`
   network                      Print information about the network


### PR DESCRIPTION
Add `system-version` subcommand to `omdb db` to print the current system version and when this version update was requested. 
Also add `--all`, to print all system versions and their requested dates.