### PR TITLE
omdb: one ereport pretty-printer to rule them all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "rats-corim 0.1.0 (git+https://github.com/oxidecomputer/rats-corim)",
  "salty",
  "serde",
- "serde_with",
+ "serde_with 3.17.0",
  "sha3",
  "static_assertions",
  "thiserror 2.0.18",
@@ -419,7 +419,7 @@ dependencies = [
  "rats-corim 0.1.0 (git+https://github.com/oxidecomputer/rats-corim)",
  "salty",
  "serde",
- "serde_with",
+ "serde_with 3.17.0",
  "sha3",
  "static_assertions",
  "thiserror 2.0.18",
@@ -438,7 +438,7 @@ dependencies = [
  "rats-corim 0.1.0 (git+https://github.com/oxidecomputer/rats-corim)",
  "salty",
  "serde",
- "serde_with",
+ "serde_with 3.17.0",
  "sha3",
  "static_assertions",
  "thiserror 2.0.18",
@@ -830,7 +830,7 @@ dependencies = [
  "rand 0.8.6",
  "secrecy 0.10.3",
  "serde",
- "serde_with",
+ "serde_with 3.17.0",
  "sha3",
  "sled-hardware-types",
  "slog",
@@ -1419,7 +1419,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
  "terminal_size 0.4.3",
 ]
 
@@ -2364,6 +2364,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -2394,6 +2404,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -2402,7 +2426,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -2416,7 +2440,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -2429,8 +2453,19 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3609,6 +3644,15 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "erebor"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/erebor?rev=eff27fb3a652e993a62c8babe327108538fcde53#eff27fb3a652e993a62c8babe327108538fcde53"
+dependencies = [
+ "pmbus",
+ "serde_json",
 ]
 
 [[package]]
@@ -5617,7 +5661,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.17.0",
  "test-strategy",
  "thiserror 2.0.18",
  "tokio",
@@ -6867,7 +6911,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.17.0",
  "sled-agent-types",
  "tokio-postgres",
  "toml 0.8.23",
@@ -7065,7 +7109,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.17.0",
  "sha2",
  "sled-agent-client",
  "sled-agent-types",
@@ -7812,7 +7856,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.17.0",
  "sled-agent-types",
  "sled-agent-types-versions",
  "sled-hardware-types",
@@ -8415,7 +8459,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_with",
+ "serde_with 3.17.0",
  "slog",
  "slog-error-chain",
  "strum 0.27.2",
@@ -8807,7 +8851,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_with",
+ "serde_with 3.17.0",
  "sha2",
  "similar-asserts",
  "sled-agent-client",
@@ -8909,6 +8953,7 @@ dependencies = [
  "diesel",
  "dropshot 0.17.0",
  "dyn-clone",
+ "erebor",
  "ereport-types",
  "expectorate",
  "fmd-adm-sys",
@@ -9035,7 +9080,7 @@ dependencies = [
  "schemars 0.8.22",
  "secrecy 0.10.3",
  "serde",
- "serde_with",
+ "serde_with 3.17.0",
  "thiserror 2.0.18",
 ]
 
@@ -9478,8 +9523,8 @@ dependencies = [
  "serde",
  "serde_core",
  "serde_json",
- "serde_with",
- "serde_with_macros",
+ "serde_with 3.17.0",
+ "serde_with_macros 3.17.0",
  "sha1",
  "sha2",
  "sha3",
@@ -10851,6 +10896,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pmbus"
+version = "0.1.7"
+source = "git+https://github.com/oxidecomputer/pmbus?rev=3e681b17aafce32e80e06aff2dd841c9153cf069#3e681b17aafce32e80e06aff2dd841c9153cf069"
+dependencies = [
+ "anyhow",
+ "convert_case 0.4.0",
+ "libm",
+ "num-derive 0.4.2",
+ "num-traits",
+ "ron",
+ "serde",
+ "serde_with 1.14.0",
+]
+
+[[package]]
 name = "polar-core"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11845,7 +11905,7 @@ dependencies = [
  "clap",
  "hex",
  "serde",
- "serde_with",
+ "serde_with 3.17.0",
  "strum 0.26.3",
  "thiserror 2.0.18",
 ]
@@ -11860,7 +11920,7 @@ dependencies = [
  "clap",
  "hex",
  "serde",
- "serde_with",
+ "serde_with 3.17.0",
  "strum 0.26.3",
  "thiserror 2.0.18",
 ]
@@ -13305,6 +13365,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
@@ -13319,8 +13389,20 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 3.17.0",
  "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -13845,7 +13927,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.17.0",
  "sha3",
  "sled-hardware-types",
  "slog",
@@ -14477,6 +14559,12 @@ checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
 dependencies = [
  "vte",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -15770,7 +15858,7 @@ dependencies = [
  "secrecy 0.10.3",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.17.0",
  "sha3",
  "sled-agent-measurements",
  "sled-agent-types",
@@ -15817,7 +15905,7 @@ dependencies = [
  "secrecy 0.10.3",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.17.0",
  "sha3",
  "sled-agent-types",
  "sled-hardware-types",
@@ -15877,7 +15965,7 @@ dependencies = [
  "rand 0.9.2",
  "schemars 0.8.22",
  "serde",
- "serde_with",
+ "serde_with 3.17.0",
  "sled-hardware-types",
  "slog",
  "slog-error-chain",
@@ -16368,7 +16456,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.17.0",
  "slog",
  "supports-color 3.0.2",
  "swrite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "erebor"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/erebor?rev=d41644dc6ec8396415712a2863edbee73d6e7ab9#d41644dc6ec8396415712a2863edbee73d6e7ab9"
+source = "git+https://github.com/oxidecomputer/erebor?rev=48512bf970474ff0fd0868c833fd504c8d169064#48512bf970474ff0fd0868c833fd504c8d169064"
 dependencies = [
  "pmbus",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "erebor"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/erebor?rev=eff27fb3a652e993a62c8babe327108538fcde53#eff27fb3a652e993a62c8babe327108538fcde53"
+source = "git+https://github.com/oxidecomputer/erebor?rev=d41644dc6ec8396415712a2863edbee73d6e7ab9#d41644dc6ec8396415712a2863edbee73d6e7ab9"
 dependencies = [
  "pmbus",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,7 +507,7 @@ dropshot-api-manager = "0.7.1"
 dropshot-api-manager-types = "0.7.1"
 dyn-clone = "1.0.20"
 either = "1.15.0"
-erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "eff27fb3a652e993a62c8babe327108538fcde53" }
+erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "d41644dc6ec8396415712a2863edbee73d6e7ab9" }
 ereport-types = { path = "ereport/types" }
 expectorate = "1.2.0"
 fatfs = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,6 +507,7 @@ dropshot-api-manager = "0.7.1"
 dropshot-api-manager-types = "0.7.1"
 dyn-clone = "1.0.20"
 either = "1.15.0"
+erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "eff27fb3a652e993a62c8babe327108538fcde53" }
 ereport-types = { path = "ereport/types" }
 expectorate = "1.2.0"
 fatfs = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,7 +507,7 @@ dropshot-api-manager = "0.7.1"
 dropshot-api-manager-types = "0.7.1"
 dyn-clone = "1.0.20"
 either = "1.15.0"
-erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "d41644dc6ec8396415712a2863edbee73d6e7ab9" }
+erebor = { git = "https://github.com/oxidecomputer/erebor", rev = "48512bf970474ff0fd0868c833fd504c8d169064" }
 ereport-types = { path = "ereport/types" }
 expectorate = "1.2.0"
 fatfs = "0.3.6"

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -30,6 +30,7 @@ daft.workspace = true
 diesel.workspace = true
 dropshot.workspace = true
 dyn-clone.workspace = true
+erebor = { workspace = true, features = ["pmbus"] }
 ereport-types.workspace = true
 futures.workspace = true
 gateway-client.workspace = true

--- a/dev-tools/omdb/src/bin/omdb/db/ereport.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/ereport.rs
@@ -480,8 +480,8 @@ async fn cmd_db_ereport_info(
 
         println!("\n{:=<80}", "== EREPORT ");
         println!("{}", erebor::Displayer::new(&report));
-        println!()
     }
+    println!();
 
     Ok(())
 }

--- a/dev-tools/omdb/src/bin/omdb/db/ereport.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/ereport.rs
@@ -56,11 +56,6 @@ enum Commands {
     #[clap(alias = "show")]
     Info(InfoArgs),
 
-    /// Dump an ereport as JSON.
-    ///
-    /// This is an alias for `omdb db ereport info --json --raw`.
-    Dump(EreportIdArgs),
-
     /// List ereport reporters
     Reporters(ReportersArgs),
 
@@ -84,8 +79,10 @@ struct ClassesArgs {
 
 #[derive(Debug, Args, Clone)]
 struct InfoArgs {
-    #[clap(flatten)]
-    ereport: EreportIdArgs,
+    /// The reporter restart UUID of the ereport to show
+    restart_id: EreporterRestartUuid,
+    /// The ENA of the ereport within the reporter restart
+    ena: Ena,
 
     /// If set, output the ereport as JSON, rather than using the default
     /// human-readable format.
@@ -102,14 +99,6 @@ struct InfoArgs {
     /// from the database.
     #[clap(long, short, requires("json"))]
     raw: bool,
-}
-
-#[derive(Debug, Args, Clone, Copy)]
-struct EreportIdArgs {
-    /// The reporter restart UUID of the ereport to show
-    restart_id: EreporterRestartUuid,
-    /// The ENA of the ereport within the reporter restart
-    ena: Ena,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -188,11 +177,6 @@ pub(super) async fn cmd_db_ereport(
 
         Commands::Info(ref args) => {
             cmd_db_ereport_info(datastore, fetch_opts, args).await
-        }
-
-        Commands::Dump(ereport) => {
-            let args = InfoArgs { ereport, raw: true, json: true };
-            cmd_db_ereport_info(datastore, fetch_opts, &args).await
         }
 
         Commands::Reporters(ref args) => {
@@ -376,8 +360,7 @@ async fn cmd_db_ereport_info(
     fetch_opts: &DbFetchOptions,
     args: &InfoArgs,
 ) -> anyhow::Result<()> {
-    let &InfoArgs { ereport: EreportIdArgs { restart_id, ena }, json, raw } =
-        args;
+    let &InfoArgs { restart_id, ena, json, raw } = args;
     let ereport_id = ereport_types::EreportId { restart_id, ena };
     let conn = datastore.pool_connection_for_tests().await?;
     let ereport = ereport_fetch(&conn, fetch_opts, ereport_id).await?;
@@ -412,17 +395,29 @@ async fn cmd_db_ereport_info(
                 format!("failed to serialize raw ereport: {ereport:?}")
             })?;
     } else if json {
-        let ereport = nexus_types::fm::Ereport::try_from(ereport).context(
-            "failed to interpret ereport database row as domain type\n\
-             note: use `omdb db ereport info --raw` to display the raw \
-             JSON for this ereport",
-        )?;
-        serde_json::to_writer_pretty(std::io::stdout(), &ereport)
-            .with_context(|| {
-                format!(
-                    "failed to serialize ereport with metadata: {ereport:?}"
-                )
-            })?;
+        let raw_report = ereport.report.clone();
+        match nexus_types::fm::Ereport::try_from(ereport) {
+            Ok(ereport) => {
+                serde_json::to_writer_pretty(std::io::stdout(), &ereport)
+                    .with_context(|| {
+                        format!(
+                            "failed to serialize ereport with metadata: {ereport:?}"
+                        )
+                    })?;
+            }
+            Err(e) => {
+                eprintln!(
+                    "WARNING: failed to interpret ereport metadata, falling \
+                     back to raw JSON: {e}"
+                );
+                serde_json::to_writer_pretty(std::io::stdout(), &raw_report)
+                    .with_context(|| {
+                        format!(
+                            "failed to serialize raw ereport: {raw_report:?}"
+                        )
+                    })?;
+            }
+        }
     } else {
         let db::model::Ereport {
             ena: DbEna(ena),

--- a/dev-tools/omdb/src/bin/omdb/db/ereport.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/ereport.rs
@@ -56,6 +56,11 @@ enum Commands {
     #[clap(alias = "show")]
     Info(InfoArgs),
 
+    /// Dump an ereport as JSON.
+    ///
+    /// This is an alias for `omdb db ereport info --json --raw`.
+    Dump(EreportIdArgs),
+
     /// List ereport reporters
     Reporters(ReportersArgs),
 
@@ -79,6 +84,28 @@ struct ClassesArgs {
 
 #[derive(Debug, Args, Clone)]
 struct InfoArgs {
+    #[clap(flatten)]
+    ereport: EreportIdArgs,
+
+    /// If set, output the ereport as JSON, rather than using the default
+    /// human-readable format.
+    ///
+    /// Note that this will output a JSON object containing the raw ereport data
+    /// along with additional metadata from the database record for this
+    /// ereport. To emit *only* the original JSON received from the reporter,
+    /// add the `--raw` flag in addition to `--json`.
+    #[clap(long, short)]
+    json: bool,
+
+    /// If outputting the ereport as JSON, output *only* the raw JSON received
+    /// from the reporter in its original form, omitting additional metadata
+    /// from the database.
+    #[clap(long, short, requires("json"))]
+    raw: bool,
+}
+
+#[derive(Debug, Args, Clone, Copy)]
+struct EreportIdArgs {
     /// The reporter restart UUID of the ereport to show
     restart_id: EreporterRestartUuid,
     /// The ENA of the ereport within the reporter restart
@@ -158,8 +185,14 @@ pub(super) async fn cmd_db_ereport(
         Commands::List(ref args) => {
             cmd_db_ereport_list(datastore, fetch_opts, args).await
         }
+
         Commands::Info(ref args) => {
             cmd_db_ereport_info(datastore, fetch_opts, args).await
+        }
+
+        Commands::Dump(ereport) => {
+            let args = InfoArgs { ereport, raw: true, json: true };
+            cmd_db_ereport_info(datastore, fetch_opts, &args).await
         }
 
         Commands::Reporters(ref args) => {
@@ -343,7 +376,8 @@ async fn cmd_db_ereport_info(
     fetch_opts: &DbFetchOptions,
     args: &InfoArgs,
 ) -> anyhow::Result<()> {
-    let &InfoArgs { restart_id, ena } = args;
+    let &InfoArgs { ereport: EreportIdArgs { restart_id, ena }, json, raw } =
+        args;
     let ereport_id = ereport_types::EreportId { restart_id, ena };
     let conn = datastore.pool_connection_for_tests().await?;
     let ereport = ereport_fetch(&conn, fetch_opts, ereport_id).await?;
@@ -370,63 +404,84 @@ async fn cmd_db_ereport_info(
         SERIAL_NUMBER,
         MARKED_SEEN_IN,
     ]);
-    let db::model::Ereport {
-        ena: DbEna(ena),
-        restart_id,
-        time_deleted,
-        time_collected,
-        collector_id,
-        ref part_number,
-        ref serial_number,
-        ref class,
-        ref report,
-        reporter,
-        marked_seen_in,
-    } = ereport;
-    println!("\n{:=<80}", "== EREPORT METADATA ");
-    println!("    {ENA:>WIDTH$}: {ena}");
-    match class {
-        Some(class) => println!("    {CLASS:>WIDTH$}: {class}"),
-        None => println!("/!\\ {CLASS:>WIDTH$}: <unknown>"),
-    }
-    if let Some(time_deleted) = time_deleted {
-        println!("(i) {TIME_DELETED:>WIDTH$}: {time_deleted}");
-    }
-    println!("    {TIME_COLLECTED:>WIDTH$}: {time_collected}");
-    println!("    {COLLECTOR_ID:>WIDTH$}: {collector_id}");
-    match Reporter::try_from(reporter) {
-        Err(err) => eprintln!("{err}"),
-        Ok(Reporter::Sp { sp_type, slot }) => {
-            println!(
-                "    {REPORTER:>WIDTH$}: {sp_type:?} {slot} (service processor)"
-            )
-        }
-        Ok(Reporter::HostOs { sled, slot }) => {
-            if let Some(slot) = slot {
-                println!("    {REPORTER:>WIDTH$}: sled {slot} (host OS)");
-            } else {
-                println!(
-                    "    {REPORTER:>WIDTH$}: <unknown sled slot> (host OS)"
-                );
-            }
-            println!("    {SLED_ID:>WIDTH$}: {sled:?}")
-        }
-    }
-    println!("    {RESTART_ID:>WIDTH$}: {restart_id}");
-    println!(
-        "    {PART_NUMBER:>WIDTH$}: {}",
-        part_number.as_deref().unwrap_or("<unknown>")
-    );
-    println!(
-        "    {SERIAL_NUMBER:>WIDTH$}: {}",
-        serial_number.as_deref().unwrap_or("<unknown>")
-    );
-    println!("    {MARKED_SEEN_IN:>WIDTH$}: {marked_seen_in:?}",);
 
-    println!("\n{:=<80}", "== EREPORT ");
-    serde_json::to_writer_pretty(std::io::stdout(), &report)
-        .with_context(|| format!("failed to serialize ereport: {report:?}"))?;
-    println!();
+    if json && raw {
+        let ereport = ereport.report;
+        serde_json::to_writer_pretty(std::io::stdout(), &ereport)
+            .with_context(|| {
+                format!("failed to serialize raw ereport: {ereport:?}")
+            })?;
+    } else if json {
+        let ereport = nexus_types::fm::Ereport::try_from(ereport).context(
+            "failed to interpret ereport database row as domain type\n\
+             note: use `omdb db ereport info --raw` to display the raw \
+             JSON for this ereport",
+        )?;
+        serde_json::to_writer_pretty(std::io::stdout(), &ereport)
+            .with_context(|| {
+                format!(
+                    "failed to serialize ereport with metadata: {ereport:?}"
+                )
+            })?;
+    } else {
+        let db::model::Ereport {
+            ena: DbEna(ena),
+            restart_id,
+            time_deleted,
+            time_collected,
+            collector_id,
+            ref part_number,
+            ref serial_number,
+            ref class,
+            ref report,
+            reporter,
+            marked_seen_in,
+        } = ereport;
+        println!("\n{:=<80}", "== EREPORT METADATA ");
+        println!("    {ENA:>WIDTH$}: {ena}");
+        match class {
+            Some(class) => println!("    {CLASS:>WIDTH$}: {class}"),
+            None => println!("/!\\ {CLASS:>WIDTH$}: <unknown>"),
+        }
+        if let Some(time_deleted) = time_deleted {
+            println!("(i) {TIME_DELETED:>WIDTH$}: {time_deleted}");
+        }
+        println!("    {TIME_COLLECTED:>WIDTH$}: {time_collected}");
+        println!("    {COLLECTOR_ID:>WIDTH$}: {collector_id}");
+        match Reporter::try_from(reporter) {
+            Err(err) => eprintln!("{err}"),
+            Ok(Reporter::Sp { sp_type, slot }) => {
+                println!(
+                    "    {REPORTER:>WIDTH$}: {sp_type:?} {slot} \
+                     (service processor)"
+                )
+            }
+            Ok(Reporter::HostOs { sled, slot }) => {
+                if let Some(slot) = slot {
+                    println!("    {REPORTER:>WIDTH$}: sled {slot} (host OS)");
+                } else {
+                    println!(
+                        "    {REPORTER:>WIDTH$}: <unknown sled slot> (host OS)"
+                    );
+                }
+                println!("    {SLED_ID:>WIDTH$}: {sled:?}")
+            }
+        }
+        println!("    {RESTART_ID:>WIDTH$}: {restart_id}");
+        println!(
+            "    {PART_NUMBER:>WIDTH$}: {}",
+            part_number.as_deref().unwrap_or("<unknown>")
+        );
+        println!(
+            "    {SERIAL_NUMBER:>WIDTH$}: {}",
+            serial_number.as_deref().unwrap_or("<unknown>")
+        );
+        println!("    {MARKED_SEEN_IN:>WIDTH$}: {marked_seen_in:?}",);
+
+        println!("\n{:=<80}", "== EREPORT ");
+        println!("{}", erebor::Displayer::new(&report));
+        println!()
+    }
 
     Ok(())
 }

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -536,7 +536,6 @@ Usage: omdb db ereport [OPTIONS] <COMMAND>
 Commands:
   list       List ereports
   info       Show an ereport
-  dump       Dump an ereport as JSON
   reporters  List ereport reporters
   classes    Summarize ereports by class, marking which classes a diagnosis engine in Nexus consumes
              (fetched from Nexus's lockstep API; falls back to `?` if Nexus is unreachable)

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -536,6 +536,7 @@ Usage: omdb db ereport [OPTIONS] <COMMAND>
 Commands:
   list       List ereports
   info       Show an ereport
+  dump       Dump an ereport as JSON
   reporters  List ereport reporters
   classes    Summarize ereports by class, marking which classes a diagnosis engine in Nexus consumes
              (fetched from Nexus's lockstep API; falls back to `?` if Nexus is unreachable)
@@ -543,7 +544,7 @@ Commands:
 
 Options:
       --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
-      --color <COLOR>          Color output [default: auto] [possible values: auto, always, never]
+      --color <COLOR>          Color output [default: auto] [possible values: auto, always, never
   -h, --help                   Print help
 
 Connection Options:
@@ -682,26 +683,61 @@ Show an ereport
 Usage: omdb db ereport info [OPTIONS] <RESTART_ID> <ENA>
 
 Arguments:
-  <RESTART_ID>  The reporter restart UUID of the ereport to show
-  <ENA>         The ENA of the ereport within the reporter restart
+  <RESTART_ID>
+          The reporter restart UUID of the ereport to show
+
+  <ENA>
+          The ENA of the ereport within the reporter restart
 
 Options:
-      --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
-      --color <COLOR>          Color output [default: auto] [possible values: auto, always, never]
-  -h, --help                   Print help
+  -j, --json
+          If set, output the ereport as JSON, rather than using the default human-readable format.
+          
+          Note that this will output a JSON object containing the raw ereport data along with
+          additional metadata from the database record for this ereport. To emit *only* the original
+          JSON received from the reporter, add the `--raw` flag in addition to `--json`.
+
+      --log-level <LOG_LEVEL>
+          log level filter
+          
+          [env: LOG_LEVEL=]
+          [default: warn]
+
+  -r, --raw
+          If outputting the ereport as JSON, output *only* the raw JSON received from the reporter
+          in its original form, omitting additional metadata from the database
+
+      --color <COLOR>
+          Color output
+          
+          [default: auto]
+          [possible values: auto, always, never]
+
+  -h, --help
+          Print help (see a summary with '-h')
 
 Connection Options:
-      --db-url <DB_URL>          URL of the database SQL interface [env: OMDB_DB_URL=]
-      --dns-server <DNS_SERVER>  [env: OMDB_DNS_SERVER=]
+      --db-url <DB_URL>
+          URL of the database SQL interface
+          
+          [env: OMDB_DB_URL=]
+
+      --dns-server <DNS_SERVER>
+          [env: OMDB_DNS_SERVER=]
 
 Database Options:
-      --fetch-limit <FETCH_LIMIT>  limit to apply to queries that fetch rows [env:
-                                   OMDB_FETCH_LIMIT=] [default: 500]
-      --include-deleted            whether to include soft-deleted records when enumerating objects
-                                   that can be soft-deleted
+      --fetch-limit <FETCH_LIMIT>
+          limit to apply to queries that fetch rows
+          
+          [env: OMDB_FETCH_LIMIT=]
+          [default: 500]
+
+      --include-deleted
+          whether to include soft-deleted records when enumerating objects that can be soft-deleted
 
 Safety Options:
-  -w, --destructive  Allow potentially-destructive subcommands
+  -w, --destructive
+          Allow potentially-destructive subcommands
 ---------------------------------------------
 stderr:
 =============================================

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -544,7 +544,7 @@ Commands:
 
 Options:
       --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
-      --color <COLOR>          Color output [default: auto] [possible values: auto, always, never
+      --color <COLOR>          Color output [default: auto] [possible values: auto, always, never]
   -h, --help                   Print help
 
 Connection Options:


### PR DESCRIPTION
As seen in [today's Demo Friday][1], I have put together a little pretty-printer for formatting ereport JSON in a human-focused way. The format it outputs is a little less full of delimiters than the JSON object, as it's indentation delimited, and should look pretty familiar to anyone who's used `fmdump -eV` or similar. More importantly, though, giving us a custom formatter gives us opportunities to prettify and enrich specific fields and structures which commonly occur in ereports by convention. Currently, the most interesting example of this is PMBus status registers from ereports that SPs emit about PMBus devices.

For example, let's consider an ereport that I harvested from the dogfood rack's PSC. In the current (JSON) format, it looks like this:

```console
root@oxz_switch1:~# omdb db ereport show e9674d6e-cd4b-0cf3-ee6d-0c062720b868 0x5
note: database URL not specified.  Will search DNS.
note: (override with --db-url or OMDB_DB_URL)
note: using DNS from system config (typically /etc/resolv.conf)
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using database URL postgresql://root@[fd00:1122:3344:109::3]:32221,[fd00:1122:3344:105::3]:32221,[fd00:1122:3344:10b::3]:32221,[fd00:1122:3344:107::3]:32221,[fd00:1122:3344:108::3]:32221/omicron?sslmode=disable
note: database schema version matches expected (257.0.0)

== EREPORT METADATA ============================================================
                      ENA: 0x5
                    class: hw.pwr.pwr_good.bad
             collected at: 2025-11-14 20:38:20.177799 UTC
             collected by: 8af5baf2-7611-43fc-817c-283cb25e149f
              reported by: Power 0 (service processor)
               restart ID: e9674d6e-cd4b-0cf3-ee6d-0c062720b868
              part number: 913-0000003
            serial number: BRM45220004
    marked seen in sitrep: None

== EREPORT =====================================================================
{
  "baseboard_part_number": "913-0000003",
  "baseboard_rev": 8,
  "baseboard_serial_number": "BRM45220004",
  "ereport_message_version": 0,
  "fruid": {
    "fw_rev": "0701",
    "mfr": "Murata-PS",
    "mpn": "MWOCP68-3600-D-RM",
    "serial": "LL2216RB003Z"
  },
  "hubris_archive_id": "qSm4IUtvQe0",
  "hubris_task_gen": 0,
  "hubris_task_name": "sequencer",
  "hubris_uptime_ms": 1197408566,
  "k": "hw.pwr.pwr_good.bad",
  "pmbus_status": {
    "cml": 0,
    "input": 48,
    "iout": 0,
    "mfr": 0,
    "temp": 0,
    "vout": 0,
    "word": 10312
  },
  "rail": "V54_PSU4",
  "refdes": "PSU4",
  "slot": 4,
  "v": 0
}
root@oxz_switch1:~#
```

With the new formatter, it looks like this:

```console
root@oxz_switch1:~# /tmp/omdb-erebor db ereport show e9674d6e-cd4b-0cf3-ee6d-0c062720b868 0x5
note: database URL not specified.  Will search DNS.
note: (override with --db-url or OMDB_DB_URL)
note: using DNS from system config (typically /etc/resolv.conf)
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using database URL postgresql://root@[fd00:1122:3344:109::3]:32221,[fd00:1122:3344:105::3]:32221,[fd00:1122:3344:10b::3]:32221,[fd00:1122:3344:107::3]:32221,[fd00:1122:3344:108::3]:32221/omicron?sslmode=disable
WARN: found schema version 257.0.0, expected 261.0.0
It's possible the database is running a version that's different from what this
tool understands.  This may result in errors or incorrect output.

== EREPORT METADATA ============================================================
                      ENA: 0x5
                    class: hw.pwr.pwr_good.bad
             collected at: 2025-11-14 20:38:20.177799 UTC
             collected by: 8af5baf2-7611-43fc-817c-283cb25e149f
              reported by: Power 0 (service processor)
               restart ID: e9674d6e-cd4b-0cf3-ee6d-0c062720b868
              part number: 913-0000003
            serial number: BRM45220004
    marked seen in sitrep: None

== EREPORT =====================================================================
baseboard_part_number = 913-0000003
baseboard_rev = 0x8
baseboard_serial_number = BRM45220004
ereport_message_version = 0x0
fruid = (object)
    fw_rev = 0701
    mfr = Murata-PS
    mpn = MWOCP68-3600-D-RM
    serial = LL2216RB003Z
(end fruid)

hubris_archive_id = qSm4IUtvQe0
hubris_task_gen = 0x0
hubris_task_name = sequencer
hubris_uptime_ms = 1197408566 (1197408.566s)
class = hw.pwr.pwr_good.bad
pmbus_status = (PMBus status)
    STATUS_WORD         = 0x2848 (InputFault | PowerGoodStatus | Off | InputUndervoltageFault)
    STATUS_VOUT         = 0x00
    STATUS_IOUT         = 0x00
    STATUS_INPUT        = 0x30 (InputUndervoltageWarning | InputUndervoltageFault)
    STATUS_TEMPERATURE  = 0x00
    STATUS_CML          = 0x00
    STATUS_MFR_SPECIFIC = 0x00
(end PMBus status)

rail = V54_PSU4
refdes = PSU4
slot = 0x4
version = 0


root@oxz_switch1:~#
```

Note that Bryan's `pmbus` crate is used to decode the PMBus status registers, which should allow folks to get a sense for what happened here without having to manually interpret the status register bitflags.

I've put this new formatter in a crate, named [`erebor`](github.com/oxidecomputer/erebor) --- this is either a portmanteau of "ereport" and "CBOR", or a reference to the Lonely Mountain of Middle-Earth, named "Erebor" in Sindarin; where Smaug destroyed the Dwarves' kingdom in an event that one assumes must have produced a great deal of ereports. This is intended to allow reusing it in `omdb`, in the `faux-mgs ereports` command, and perhaps elsewhere, eventually.

This branch adds it to `omdb`. Since I am sure there are situations where one would want to get the output as JSON, I've also added new `--json` adn `--raw` flags for doing that.

[1]: https://drive.google.com/file/d/16Snam3jJBQ5vyGoeji0zYaeMKrR3q1me/view?usp=sharing&t=827.273