### PR TITLE
update MGS dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4113,7 +4113,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4140,7 +4140,7 @@ dependencies = [
  "chrono",
  "daft",
  "ereport-types",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-types",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4159,9 +4159,36 @@ dependencies = [
 [[package]]
 name = "gateway-ereport-messages"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862#6c0aca2545a73fd75536e149d29faa7108be5862"
+dependencies = [
+ "serde",
+ "zerocopy 0.8.40",
+]
+
+[[package]]
+name = "gateway-ereport-messages"
+version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d#745a508cb97b7ca9b4c10ec9592c980eb769b10d"
 dependencies = [
  "serde",
+ "zerocopy 0.8.40",
+]
+
+[[package]]
+name = "gateway-messages"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862#6c0aca2545a73fd75536e149d29faa7108be5862"
+dependencies = [
+ "bitflags 2.11.0",
+ "hubpack",
+ "serde",
+ "serde-big-array",
+ "serde_repr",
+ "smoltcp 0.9.1",
+ "static_assertions",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "uuid",
  "zerocopy 0.8.40",
 ]
 
@@ -4186,15 +4213,15 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.2"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d#745a508cb97b7ca9b4c10ec9592c980eb769b10d"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862#6c0aca2545a73fd75536e149d29faa7108be5862"
 dependencies = [
  "async-trait",
  "backoff",
  "base64 0.22.1",
  "futures",
  "fxhash",
- "gateway-ereport-messages",
- "gateway-messages",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "hex",
  "hubpack",
  "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
@@ -4229,7 +4256,7 @@ dependencies = [
  "camino",
  "dropshot 0.17.0",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-types",
  "omicron-gateway",
  "omicron-test-utils",
@@ -4256,7 +4283,7 @@ version = "0.1.0"
 dependencies = [
  "daft",
  "dropshot 0.17.0",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "hex",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -6610,7 +6637,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-test-utils",
  "libc",
  "omicron-gateway",
@@ -7250,7 +7277,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-test-utils",
  "gateway-types",
  "httpmock",
@@ -7380,7 +7407,7 @@ dependencies = [
  "dropshot 0.17.0",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -7750,7 +7777,7 @@ dependencies = [
  "dropshot 0.17.0",
  "fmd-adm-sys",
  "futures",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-test-utils",
  "headers",
  "hickory-resolver 0.25.2",
@@ -8591,7 +8618,7 @@ dependencies = [
  "futures",
  "gateway-api",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-sp-comms",
  "gateway-test-utils",
  "gateway-types",
@@ -8743,7 +8770,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-test-utils",
  "gateway-types",
  "headers",
@@ -8962,7 +8989,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -9454,8 +9481,8 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
- "gateway-ereport-messages",
- "gateway-messages",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
  "generic-array",
  "getrandom 0.2.17",
  "getrandom 0.4.1",
@@ -14313,8 +14340,8 @@ dependencies = [
  "clap",
  "dropshot 0.17.0",
  "futures",
- "gateway-ereport-messages",
- "gateway-messages",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-types",
  "hex",
  "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
@@ -17191,7 +17218,7 @@ dependencies = [
  "fs-err 3.3.0",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "gateway-test-utils",
  "gateway-types",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4113,7 +4113,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4140,7 +4140,7 @@ dependencies = [
  "chrono",
  "daft",
  "ereport-types",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-types",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4166,36 +4166,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "gateway-ereport-messages"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d#745a508cb97b7ca9b4c10ec9592c980eb769b10d"
-dependencies = [
- "serde",
- "zerocopy 0.8.40",
-]
-
-[[package]]
 name = "gateway-messages"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862#6c0aca2545a73fd75536e149d29faa7108be5862"
-dependencies = [
- "bitflags 2.11.0",
- "hubpack",
- "serde",
- "serde-big-array",
- "serde_repr",
- "smoltcp 0.9.1",
- "static_assertions",
- "strum 0.27.2",
- "strum_macros 0.27.2",
- "uuid",
- "zerocopy 0.8.40",
-]
-
-[[package]]
-name = "gateway-messages"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d#745a508cb97b7ca9b4c10ec9592c980eb769b10d"
 dependencies = [
  "bitflags 2.11.0",
  "hubpack",
@@ -4220,8 +4193,8 @@ dependencies = [
  "base64 0.22.1",
  "futures",
  "fxhash",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-ereport-messages",
+ "gateway-messages",
  "hex",
  "hubpack",
  "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
@@ -4256,7 +4229,7 @@ dependencies = [
  "camino",
  "dropshot 0.17.0",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-types",
  "omicron-gateway",
  "omicron-test-utils",
@@ -4283,7 +4256,7 @@ version = "0.1.0"
 dependencies = [
  "daft",
  "dropshot 0.17.0",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "hex",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -6637,7 +6610,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-test-utils",
  "libc",
  "omicron-gateway",
@@ -7277,7 +7250,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "httpmock",
@@ -7407,7 +7380,7 @@ dependencies = [
  "dropshot 0.17.0",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -7777,7 +7750,7 @@ dependencies = [
  "dropshot 0.17.0",
  "fmd-adm-sys",
  "futures",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-test-utils",
  "headers",
  "hickory-resolver 0.25.2",
@@ -8618,7 +8591,7 @@ dependencies = [
  "futures",
  "gateway-api",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-sp-comms",
  "gateway-test-utils",
  "gateway-types",
@@ -8770,7 +8743,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "headers",
@@ -8989,7 +8962,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -9481,8 +9454,8 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=745a508cb97b7ca9b4c10ec9592c980eb769b10d)",
+ "gateway-ereport-messages",
+ "gateway-messages",
  "generic-array",
  "getrandom 0.2.17",
  "getrandom 0.4.1",
@@ -14340,8 +14313,8 @@ dependencies = [
  "clap",
  "dropshot 0.17.0",
  "futures",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-ereport-messages",
+ "gateway-messages",
  "gateway-types",
  "hex",
  "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
@@ -17218,7 +17191,7 @@ dependencies = [
  "fs-err 3.3.0",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -533,9 +533,9 @@ gateway-client = { path = "clients/gateway-client" }
 # compatibility, but will mean that faux-mgs might be missing new
 # functionality.)
 #
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", default-features = false, features = ["debug-impls"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d" }
+gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", default-features = false, features = ["debug-impls"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", default-features = false, features = ["std"] }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862" }
 gateway-test-utils = { path = "gateway-test-utils" }
 gateway-types = { path = "gateway-types" }
 gateway-types-versions = { path = "gateway-types/versions" }

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -605,8 +605,8 @@ source.type = "prebuilt"
 source.repo = "management-gateway-service"
 # In general, this commit should match the pinned revision of `gateway-sp-comms`
 # in `Cargo.toml`.
-source.commit = "745a508cb97b7ca9b4c10ec9592c980eb769b10d"
-source.sha256 = "24368fb049c3bcdda56c5e4b1f18e2371aa5699ac73f161e12d1ebd842293b71"
+source.commit = "6c0aca2545a73fd75536e149d29faa7108be5862"
+source.sha256 = "48748a5090ed9c7b4d61cc127d9c6959b228864b75a4ab111468dc22ae20d656"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -59,8 +59,8 @@ futures-core = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
 futures-task = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.32", features = ["channel", "io", "sink"] }
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", default-features = false, features = ["debug-impls", "serde"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", features = ["std"] }
+gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", default-features = false, features = ["debug-impls", "serde"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["js", "rdrand", "std"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }
@@ -205,8 +205,8 @@ futures-core = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
 futures-task = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.32", features = ["channel", "io", "sink"] }
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", default-features = false, features = ["debug-impls", "serde"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "745a508cb97b7ca9b4c10ec9592c980eb769b10d", features = ["std"] }
+gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", default-features = false, features = ["debug-impls", "serde"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["js", "rdrand", "std"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This updates our dep on the MGS repo to
oxidecomputer/management-gateway-service@6c0aca2545a73fd75536e149d29faa7108be5862. The only additional change that this picks up is
oxidecomputer/management-gateway-service#494, which I wanted to have now that #10486 is in. This way, we will format ereports consistently regardless of how they are being read.