### PR TITLE
Fix flaky test: wait for an inventory collection to be loaded

### DIFF
--- a/nexus/tests/integration_tests/target_release.rs
+++ b/nexus/tests/integration_tests/target_release.rs
@@ -26,8 +26,6 @@ use nexus_types::deployment::BlueprintHostPhase2DesiredContents;
 use nexus_types::deployment::BlueprintZoneImageSource;
 use nexus_types::external_api::update;
 use nexus_types::external_api::update::SetTargetReleaseParams;
-use omicron_test_utils::dev::poll::CondCheckError;
-use omicron_test_utils::dev::poll::wait_for_condition;
 use omicron_uuid_kinds::{BlueprintUuid, GenericUuid};
 use semver::Version;
 use std::sync::Arc;
@@ -47,27 +45,10 @@ async fn get_set_target_release() -> Result<()> {
     let client = &ctx.external_client;
     let logctx = &ctx.logctx;
 
-    // During high contention the inventory might not be ready yet, which will
-    // cause the call to /v1/system/update/status to 500. We thus query the
-    // database to make sure we have an inventory before proceeding.
-    {
-        let datastore = ctx.server.server_context().nexus.datastore();
-        let opctx =
-            OpContext::for_tests(logctx.log.new(o!()), datastore.clone());
-        wait_for_condition(
-            || async {
-                datastore
-                    .inventory_get_latest_collection(&opctx)
-                    .await
-                    .expect("failed to get inventory collection")
-                    .ok_or(CondCheckError::<()>::NotYet)
-            },
-            &Duration::from_millis(100),
-            &Duration::from_secs(30),
-        )
-        .await
-        .expect("no inventory collection available");
-    }
+    // Interacting with the target release fails until an inventory collection
+    // is loaded, so wait for that before running the test.
+    ctx.wait_for_at_least_one_inventory_collection(Duration::from_secs(60))
+        .await;
 
     // There is no target release before one has ever been specified
     let status: update::UpdateStatus =


### PR DESCRIPTION
This test was _almost_ doing the right thing: it was waiting for an inventory collection to exist in the DB, but that's not sufficient - we need Nexus to have actually loaded it.

Fixes #10490.