### PR TITLE
[fm] factor out `fmt_json_value` into its own module

### DIFF
--- a/nexus/types/src/fm.rs
+++ b/nexus/types/src/fm.rs
@@ -12,6 +12,7 @@ pub mod ereport;
 pub use ereport::{Ereport, EreportId};
 pub mod case;
 pub use case::Case;
+pub(crate) mod json_display;
 
 use case::AlertRequest;
 use chrono::{DateTime, Utc};

--- a/nexus/types/src/fm/analysis_reports.rs
+++ b/nexus/types/src/fm/analysis_reports.rs
@@ -7,6 +7,7 @@
 
 use super::case;
 use super::ereport::EreportId;
+use super::json_display::fmt_json_value;
 use iddqd::IdOrdMap;
 use omicron_uuid_kinds::{CaseUuid, CollectionUuid, SitrepUuid};
 use serde::{Deserialize, Serialize};
@@ -155,85 +156,6 @@ impl DebugLog {
     pub fn entry(&mut self, event: impl ToString) -> &mut LogEntry {
         self.0.push(LogEntry::new(event));
         self.0.last_mut().expect("we just pushed it")
-    }
-}
-
-/// Recursively format a JSON value as a bulleted list entry, nesting any
-/// object or array children as indented sub-bullets.
-fn fmt_json_value(
-    f: &mut fmt::Formatter<'_>,
-    key: &str,
-    value: &serde_json::Value,
-    indent: usize,
-) -> fmt::Result {
-    match value {
-        serde_json::Value::Object(map) => {
-            writeln!(f, "{:indent$}* {key}:", "")?;
-            for (k, v) in map {
-                fmt_json_value(f, k, v, indent + 2)?;
-            }
-            Ok(())
-        }
-        serde_json::Value::Array(arr) => {
-            writeln!(f, "{:indent$}* {key}:", "")?;
-            let indent = indent + 2;
-            for (i, v) in arr.iter().enumerate() {
-                fmt_json_array_item(f, i + 1, v, indent)?;
-            }
-            Ok(())
-        }
-        serde_json::Value::String(s) => {
-            writeln!(f, "{:indent$}* {key}: {s}", "")
-        }
-        serde_json::Value::Null => {
-            writeln!(f, "{:indent$}* {key}: <none>", "")
-        }
-        serde_json::Value::Bool(b) => {
-            writeln!(f, "{:indent$}* {key}: {b}", "")
-        }
-        serde_json::Value::Number(n) => {
-            writeln!(f, "{:indent$}* {key}: {n}", "")
-        }
-    }
-}
-
-/// Format a single element of a JSON array as a numbered list item,
-/// e.g. `1. value` for scalars or `1.` followed by indented children for
-/// objects and nested arrays.
-fn fmt_json_array_item(
-    f: &mut fmt::Formatter<'_>,
-    n: usize,
-    value: &serde_json::Value,
-    indent: usize,
-) -> fmt::Result {
-    match value {
-        serde_json::Value::Object(map) => {
-            writeln!(f, "{:indent$}{n}.", "")?;
-            for (k, v) in map {
-                fmt_json_value(f, k, v, indent + 2)?;
-            }
-            Ok(())
-        }
-        serde_json::Value::Array(arr) => {
-            writeln!(f, "{:indent$}{n}.", "")?;
-            let indent = indent + 2;
-            for (i, v) in arr.iter().enumerate() {
-                fmt_json_array_item(f, i + 1, v, indent)?;
-            }
-            Ok(())
-        }
-        serde_json::Value::String(s) => {
-            writeln!(f, "{:indent$}{n}. {s}", "")
-        }
-        serde_json::Value::Null => {
-            writeln!(f, "{:indent$}{n}. <none>", "")
-        }
-        serde_json::Value::Bool(b) => {
-            writeln!(f, "{:indent$}{n}. {b}", "")
-        }
-        serde_json::Value::Number(num) => {
-            writeln!(f, "{:indent$}{n}. {num}", "")
-        }
     }
 }
 

--- a/nexus/types/src/fm/json_display.rs
+++ b/nexus/types/src/fm/json_display.rs
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Shared helpers for rendering `serde_json::Value`s as bulleted lists in
+//! `Display` impls.
+
+use std::fmt;
+
+/// Recursively format a JSON value as a bulleted list entry, nesting any
+/// object or array children as indented sub-bullets.
+pub(crate) fn fmt_json_value(
+    f: &mut fmt::Formatter<'_>,
+    key: &str,
+    value: &serde_json::Value,
+    indent: usize,
+) -> fmt::Result {
+    match value {
+        serde_json::Value::Object(map) => {
+            writeln!(f, "{:indent$}* {key}:", "")?;
+            for (k, v) in map {
+                fmt_json_value(f, k, v, indent + 2)?;
+            }
+            Ok(())
+        }
+        serde_json::Value::Array(arr) => {
+            writeln!(f, "{:indent$}* {key}:", "")?;
+            let indent = indent + 2;
+            for (i, v) in arr.iter().enumerate() {
+                fmt_json_array_item(f, i + 1, v, indent)?;
+            }
+            Ok(())
+        }
+        serde_json::Value::String(s) => {
+            writeln!(f, "{:indent$}* {key}: {s}", "")
+        }
+        serde_json::Value::Null => {
+            writeln!(f, "{:indent$}* {key}: <none>", "")
+        }
+        serde_json::Value::Bool(b) => {
+            writeln!(f, "{:indent$}* {key}: {b}", "")
+        }
+        serde_json::Value::Number(n) => {
+            writeln!(f, "{:indent$}* {key}: {n}", "")
+        }
+    }
+}
+
+/// Format a single element of a JSON array as a numbered list item,
+/// e.g. `1. value` for scalars or `1.` followed by indented children for
+/// objects and nested arrays.
+pub(crate) fn fmt_json_array_item(
+    f: &mut fmt::Formatter<'_>,
+    n: usize,
+    value: &serde_json::Value,
+    indent: usize,
+) -> fmt::Result {
+    match value {
+        serde_json::Value::Object(map) => {
+            writeln!(f, "{:indent$}{n}.", "")?;
+            for (k, v) in map {
+                fmt_json_value(f, k, v, indent + 2)?;
+            }
+            Ok(())
+        }
+        serde_json::Value::Array(arr) => {
+            writeln!(f, "{:indent$}{n}.", "")?;
+            let indent = indent + 2;
+            for (i, v) in arr.iter().enumerate() {
+                fmt_json_array_item(f, i + 1, v, indent)?;
+            }
+            Ok(())
+        }
+        serde_json::Value::String(s) => {
+            writeln!(f, "{:indent$}{n}. {s}", "")
+        }
+        serde_json::Value::Null => {
+            writeln!(f, "{:indent$}{n}. <none>", "")
+        }
+        serde_json::Value::Bool(b) => {
+            writeln!(f, "{:indent$}{n}. {b}", "")
+        }
+        serde_json::Value::Number(num) => {
+            writeln!(f, "{:indent$}{n}. {num}", "")
+        }
+    }
+}


### PR DESCRIPTION
`nexus_types::fm` has a little utility for formatting `serde_json::Value`s as bulleted lists. Currently, this is only used for formatting sitrep analysis reports. #10460 factored it out of the `analysis_reports` module to use it for formatting case facts. While working on #10505, I realized it would also be useful to have this for use in `omdb` commands for reconstructing analysis reports from CRDB. Since #10460 isn't going to merge until after R20, I figured it would be helpful to just pull out the change to factor this out into its own commit that both our branches could depend on.