### PR TITLE
bump Propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=58ab73bde89ade637b0ca8118682ee9575da6c2a#58ab73bde89ade637b0ca8118682ee9575da6c2a"
+source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=58ab73bde89ade637b0ca8118682ee9575da6c2a#58ab73bde89ade637b0ca8118682ee9575da6c2a"
+source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -11332,7 +11332,7 @@ dependencies = [
 [[package]]
 name = "propolis-api-types-versions"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=58ab73bde89ade637b0ca8118682ee9575da6c2a#58ab73bde89ade637b0ca8118682ee9575da6c2a"
+source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -11345,7 +11345,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=58ab73bde89ade637b0ca8118682ee9575da6c2a#58ab73bde89ade637b0ca8118682ee9575da6c2a"
+source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -11369,7 +11369,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=58ab73bde89ade637b0ca8118682ee9575da6c2a#58ab73bde89ade637b0ca8118682ee9575da6c2a"
+source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
 dependencies = [
  "anyhow",
  "atty",
@@ -11402,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=58ab73bde89ade637b0ca8118682ee9575da6c2a#58ab73bde89ade637b0ca8118682ee9575da6c2a"
+source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
 dependencies = [
  "crucible-client-types",
  "propolis-api-types-versions",
@@ -11411,7 +11411,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=58ab73bde89ade637b0ca8118682ee9575da6c2a#58ab73bde89ade637b0ca8118682ee9575da6c2a"
+source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
 dependencies = [
  "schemars 0.8.22",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -732,11 +732,11 @@ progenitor-client010 = { package = "progenitor-client", version = "0.10.0" }
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "58ab73bde89ade637b0ca8118682ee9575da6c2a" }
-propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "58ab73bde89ade637b0ca8118682ee9575da6c2a" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "58ab73bde89ade637b0ca8118682ee9575da6c2a" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "58ab73bde89ade637b0ca8118682ee9575da6c2a" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "58ab73bde89ade637b0ca8118682ee9575da6c2a" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
+propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.1"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -667,10 +667,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "58ab73bde89ade637b0ca8118682ee9575da6c2a"
+source.commit = "6873add79b835f7932d9fe928340886df8e49676"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "7344b58d0243a293d0eceb4e323c7f4efdce3e5effb549c593478662de24add5"
+source.sha256 = "ccac586c3ed1e996d9554fb1db1b1096c0bcd0dd5712c14579924ea85dd16a34"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
since last time:

* update example of patching Omicron (Propolis#1142)
* [meta] update dropshot-api-manager to 0.7.2 (Propolis#1145)
* viona worker LWPs should not be CPU-pinned (Propolis#1146)

The only one that should affect anything is the last one: we haven't measured this carefully on systems with high-throughput NICs *yet*, but this may help explain why we've observed VMs having a network bandwidth ceiling when those VMs have enough vCPUs to have CPU pinning in place.

I have some testing notes around this in Propolis#1146 and there's no reason we shouldn't pull this change in even if it turns out net-neutral.