### PR TITLE
Proof of concept, do not merge: allow parent name or ID when child is specified by ID

### DIFF
--- a/nexus/src/app/external_ip.rs
+++ b/nexus/src/app/external_ip.rs
@@ -215,7 +215,7 @@ impl super::Nexus {
                 };
 
                 let instance =
-                    self.instance_lookup(opctx, instance_selector)?;
+                    self.instance_lookup(opctx, instance_selector).await?;
 
                 let ip_version = match db_fip.ip {
                     ipnetwork::IpNetwork::V4(_) => IpVersion::V4,
@@ -255,7 +255,7 @@ impl super::Nexus {
             project: None,
             instance: parent_id.into(),
         };
-        let instance = self.instance_lookup(opctx, instance_selector)?;
+        let instance = self.instance_lookup(opctx, instance_selector).await?;
         let attach_params = &instance::ExternalIpDetach::Floating {
             floating_ip: authz_fip.id().into(),
         };

--- a/nexus/src/app/external_subnet.rs
+++ b/nexus/src/app/external_subnet.rs
@@ -159,7 +159,8 @@ impl super::Nexus {
             },
         };
         let (.., authz_instance, db_instance) = self
-            .instance_lookup(opctx, instance_selector)?
+            .instance_lookup(opctx, instance_selector)
+            .await?
             .fetch_for(authz::Action::Modify)
             .await?;
         if db_instance.project_id != db_subnet.project_id {
@@ -204,7 +205,8 @@ impl super::Nexus {
             instance: NameOrId::Id(instance_id.into_untyped_uuid()),
         };
         let (.., authz_instance, _db_instance) = self
-            .instance_lookup(opctx, instance_selector)?
+            .instance_lookup(opctx, instance_selector)
+            .await?
             .fetch_for(authz::Action::Modify)
             .await?;
         let params = subnet_detach::Params {

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -348,9 +348,11 @@ async fn normalize_anti_affinity_groups(
 impl super::Nexus {
     /// Look up an instance by name or UUID.
     ///
-    /// The `project` parameter is required for name-based lookup (provides scope)
-    /// and must NOT be specified for UUID-based lookup.
-    pub fn instance_lookup<'a>(
+    /// The `project` parameter is required for name-based lookup (provides
+    /// scope). For UUID-based lookup the project is optional; if it is
+    /// supplied, it is validated against the instance's actual project rather
+    /// than rejected (see #10517).
+    pub async fn instance_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
         instance_selector: instance::InstanceSelector,
@@ -365,6 +367,47 @@ impl super::Nexus {
                 Ok(instance)
             }
             instance::InstanceSelector {
+                instance: NameOrId::Id(id),
+                project: Some(project),
+            } => {
+                // Instance addressed by ID with a project also supplied:
+                // validate that the project matches the instance's actual
+                // project rather than rejecting the request (#10517).
+                //
+                // The by-id lookup already resolves the full ancestor chain, so
+                // `lookup_for` hands us the instance's real project's authz id
+                // at no extra query. We resolve the supplied project to an id
+                // (free if it's already an id) and compare. On mismatch we
+                // return the same "instance not found by id" error the caller
+                // would see for a nonexistent instance, so we don't leak which
+                // half of the selector was wrong.
+                let instance =
+                    LookupPath::new(opctx, &self.db_datastore).instance_id(id);
+                let (_, authz_project, _) =
+                    instance.lookup_for(authz::Action::Read).await?;
+                let expected_project_id = match project {
+                    NameOrId::Id(project_id) => project_id,
+                    NameOrId::Name(name) => self
+                        .project_lookup(
+                            opctx,
+                            project::ProjectSelector {
+                                project: NameOrId::Name(name),
+                            },
+                        )?
+                        .lookup_for(authz::Action::Read)
+                        .await?
+                        .1
+                        .id(),
+                };
+                if authz_project.id() != expected_project_id {
+                    return Err(Error::not_found_by_id(
+                        omicron_common::api::external::ResourceType::Instance,
+                        &id,
+                    ));
+                }
+                Ok(instance)
+            }
+            instance::InstanceSelector {
                 instance: NameOrId::Name(name),
                 project: Some(project),
             } => {
@@ -376,11 +419,6 @@ impl super::Nexus {
                     .instance_name_owned(name.into());
                 Ok(instance)
             }
-            instance::InstanceSelector {
-                instance: NameOrId::Id(_), ..
-            } => Err(Error::invalid_request(
-                "when providing instance as an ID project should not be specified",
-            )),
             _ => Err(Error::invalid_request(
                 "instance should either be UUID or project should be specified",
             )),

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -374,36 +374,42 @@ impl super::Nexus {
                 // validate that the project matches the instance's actual
                 // project rather than rejecting the request (#10517).
                 //
-                // The by-id lookup already resolves the full ancestor chain, so
-                // `lookup_for` hands us the instance's real project's authz id
-                // at no extra query. We resolve the supplied project to an id
-                // (free if it's already an id) and compare. On mismatch we
-                // return the same "instance not found by id" error the caller
-                // would see for a nonexistent instance, so we don't leak which
-                // half of the selector was wrong.
+                // Resolve the instance by ID first. If the caller can't access
+                // it (or it doesn't exist), `lookup_for` returns the usual 404,
+                // so we never reveal the existence of an instance the caller
+                // isn't allowed to see. The by-id lookup also resolves the full
+                // ancestor chain, so it hands us the instance's real project's
+                // authz id at no extra query.
                 let instance =
                     LookupPath::new(opctx, &self.db_datastore).instance_id(id);
                 let (_, authz_project, _) =
                     instance.lookup_for(authz::Action::Read).await?;
-                let expected_project_id = match project {
-                    NameOrId::Id(project_id) => project_id,
-                    NameOrId::Name(name) => self
+
+                // The instance exists and is accessible. Require the supplied
+                // project to match the instance's actual project; a mismatch is
+                // a contradictory request, so it's a 400. We treat a project
+                // that doesn't resolve (unknown name, or one the caller can't
+                // see) as a mismatch too, since it likewise can't be the
+                // instance's project.
+                let supplied_project_id = match &project {
+                    NameOrId::Id(project_id) => Some(*project_id),
+                    NameOrId::Name(_) => self
                         .project_lookup(
                             opctx,
                             project::ProjectSelector {
-                                project: NameOrId::Name(name),
+                                project: project.clone(),
                             },
                         )?
                         .lookup_for(authz::Action::Read)
-                        .await?
-                        .1
-                        .id(),
+                        .await
+                        .ok()
+                        .map(|(_, authz_project)| authz_project.id()),
                 };
-                if authz_project.id() != expected_project_id {
-                    return Err(Error::not_found_by_id(
-                        omicron_common::api::external::ResourceType::Instance,
-                        &id,
-                    ));
+                if supplied_project_id != Some(authz_project.id()) {
+                    return Err(Error::invalid_request(format!(
+                        "instance with ID \"{id}\" does not belong to \
+                         project \"{project}\""
+                    )));
                 }
                 Ok(instance)
             }

--- a/nexus/src/app/network_interface.rs
+++ b/nexus/src/app/network_interface.rs
@@ -27,7 +27,7 @@ use nexus_db_queries::authz;
 use nexus_db_queries::db;
 
 impl super::Nexus {
-    pub fn instance_network_interface_lookup<'a>(
+    pub async fn instance_network_interface_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
         network_interface_selector: instance::InstanceNetworkInterfaceSelector,
@@ -52,7 +52,8 @@ impl super::Nexus {
                     .instance_lookup(
                         opctx,
                         instance::InstanceSelector { project, instance: inst },
-                    )?
+                    )
+                    .await?
                     .instance_network_interface_name_owned(name.into());
                 Ok(network_interface)
             }

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -55,7 +55,7 @@ pub(crate) async fn instance_start(
         };
 
     let instance_lookup =
-        nexus.instance_lookup(&opctx, instance_selector).unwrap();
+        nexus.instance_lookup(&opctx, instance_selector).await.unwrap();
     nexus
         .instance_start(&opctx, &instance_lookup, instance_start::Reason::User)
         .await
@@ -75,7 +75,7 @@ pub(crate) async fn instance_stop(
         };
 
     let instance_lookup =
-        nexus.instance_lookup(&opctx, instance_selector).unwrap();
+        nexus.instance_lookup(&opctx, instance_selector).await.unwrap();
     nexus
         .instance_stop(&opctx, &instance_lookup)
         .await
@@ -96,7 +96,7 @@ pub(crate) async fn instance_stop_by_name(
         };
 
     let instance_lookup =
-        nexus.instance_lookup(&opctx, instance_selector).unwrap();
+        nexus.instance_lookup(&opctx, instance_selector).await.unwrap();
     nexus
         .instance_stop(&opctx, &instance_lookup)
         .await
@@ -117,7 +117,7 @@ pub(crate) async fn instance_delete_by_name(
         };
 
     let instance_lookup =
-        nexus.instance_lookup(&opctx, instance_selector).unwrap();
+        nexus.instance_lookup(&opctx, instance_selector).await.unwrap();
     nexus
         .project_destroy_instance(&opctx, &instance_lookup)
         .await
@@ -181,7 +181,7 @@ pub(crate) async fn instance_simulate_by_name(
         };
 
     let instance_lookup =
-        nexus.instance_lookup(&opctx, instance_selector).unwrap();
+        nexus.instance_lookup(&opctx, instance_selector).await.unwrap();
     let (.., instance) = instance_lookup.fetch().await.unwrap();
     let instance_id = InstanceUuid::from_untyped_uuid(instance.id());
     let VmmAndSledIds { vmm_id, sled_id } =
@@ -274,7 +274,7 @@ pub async fn instance_fetch_by_name(
         };
 
     let instance_lookup =
-        nexus.instance_lookup(&opctx, instance_selector).unwrap();
+        nexus.instance_lookup(&opctx, instance_selector).await.unwrap();
     let (_, _, authz_instance, ..) = instance_lookup.fetch().await.unwrap();
 
     let db_state = datastore
@@ -322,7 +322,7 @@ pub async fn instance_wait_for_state_by_name(
         };
 
     let instance_lookup =
-        nexus.instance_lookup(&opctx, instance_selector).unwrap();
+        nexus.instance_lookup(&opctx, instance_selector).await.unwrap();
     let (_, _, authz_instance, ..) = instance_lookup.fetch().await.unwrap();
 
     instance_poll_state(cptestctx, &opctx, authz_instance, desired_state).await

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2748,7 +2748,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let (.., authz_instance) =
                 instance_lookup.lookup_for(authz::Action::Read).await?;
             let instance_and_vmm = nexus
@@ -2777,7 +2777,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             nexus.project_destroy_instance(&opctx, &instance_lookup).await?;
             Ok(HttpResponseDeleted())
         })
@@ -2799,7 +2799,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
         };
         audit_and_time(&rqctx, |opctx, nexus| async move {
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let instance = nexus
                 .instance_reconfigure(
                     &opctx,
@@ -2825,7 +2825,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
         };
         audit_and_time(&rqctx, |opctx, nexus| async move {
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let instance =
                 nexus.instance_reboot(&opctx, &instance_lookup).await?;
             Ok(HttpResponseAccepted(instance.into()))
@@ -2846,7 +2846,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
         };
         audit_and_time(&rqctx, |opctx, nexus| async move {
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let instance = nexus
                 .instance_start(
                     &opctx,
@@ -2872,7 +2872,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
         };
         audit_and_time(&rqctx, |opctx, nexus| async move {
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let instance =
                 nexus.instance_stop(&opctx, &instance_lookup).await?;
             Ok(HttpResponseAccepted(instance.into()))
@@ -2898,7 +2898,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let data = nexus
                 .instance_serial_console_data(&opctx, &instance_lookup, &query)
                 .await?;
@@ -2932,7 +2932,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             None,
         )
         .await;
-        match nexus.instance_lookup(&opctx, instance_selector) {
+        match nexus.instance_lookup(&opctx, instance_selector).await {
             Ok(instance_lookup) => {
                 nexus
                     .instance_serial_console_stream(
@@ -2979,7 +2979,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let ssh_keys = nexus
                 .instance_ssh_keys_list(&opctx, &instance_lookup, &paginated_by)
                 .await?
@@ -3021,7 +3021,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let disks = nexus
                 .instance_list_disks(&opctx, &instance_lookup, &paginated_by)
                 .await?
@@ -3056,7 +3056,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let disk = nexus
                 .instance_attach_disk(&opctx, &instance_lookup, disk)
                 .await?;
@@ -3080,7 +3080,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let disk = nexus
                 .instance_detach_disk(&opctx, &instance_lookup, disk)
                 .await?;
@@ -3112,7 +3112,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let groups = nexus
                 .instance_list_affinity_groups(
                     &opctx,
@@ -3161,7 +3161,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let groups = nexus
                 .instance_list_anti_affinity_groups(
                     &opctx,
@@ -3323,7 +3323,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
 
             let group = nexus
                 .affinity_group_member_view(
@@ -3362,7 +3362,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
 
             let member = nexus
                 .affinity_group_member_add(
@@ -3396,7 +3396,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             nexus
                 .affinity_group_member_delete(
                     &opctx,
@@ -3616,7 +3616,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
 
             let group = nexus
                 .anti_affinity_group_member_instance_view(
@@ -3655,7 +3655,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
 
             let member = nexus
                 .anti_affinity_group_member_instance_add(
@@ -3689,7 +3689,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
 
             nexus
                 .anti_affinity_group_member_instance_delete(
@@ -4891,8 +4891,9 @@ impl NexusExternalApi for NexusExternalApiImpl {
             let pag_params = data_page_params_for(&rqctx, &query)?;
             let scan_params = ScanByNameOrId::from_query(&query)?;
             let paginated_by = name_or_id_pagination(&pag_params, scan_params)?;
-            let instance_lookup =
-                nexus.instance_lookup(&opctx, scan_params.selector.clone())?;
+            let instance_lookup = nexus
+                .instance_lookup(&opctx, scan_params.selector.clone())
+                .await?;
             let interfaces = nexus
                 .instance_network_interface_list(
                     &opctx,
@@ -4924,7 +4925,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
         audit_and_time(&rqctx, |opctx, nexus| async move {
             let query = query_params.into_inner();
             let interface_params = interface_params.into_inner();
-            let instance_lookup = nexus.instance_lookup(&opctx, query)?;
+            let instance_lookup = nexus.instance_lookup(&opctx, query).await?;
             let iface = nexus
                 .network_interface_create(
                     &opctx,
@@ -4951,10 +4952,9 @@ impl NexusExternalApi for NexusExternalApiImpl {
                     instance: query.instance,
                     network_interface: path.interface,
                 };
-            let interface_lookup = nexus.instance_network_interface_lookup(
-                &opctx,
-                interface_selector,
-            )?;
+            let interface_lookup = nexus
+                .instance_network_interface_lookup(&opctx, interface_selector)
+                .await?;
             nexus
                 .instance_network_interface_delete(&opctx, &interface_lookup)
                 .await?;
@@ -4982,7 +4982,8 @@ impl NexusExternalApi for NexusExternalApiImpl {
                     network_interface: path.interface,
                 };
             let (.., interface) = nexus
-                .instance_network_interface_lookup(&opctx, interface_selector)?
+                .instance_network_interface_lookup(&opctx, interface_selector)
+                .await?
                 .fetch()
                 .await?;
             interface.try_into().map(HttpResponseOk).map_err(HttpError::from)
@@ -5014,7 +5015,8 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 .instance_network_interface_lookup(
                     &opctx,
                     network_interface_selector,
-                )?;
+                )
+                .await?;
             let interface = nexus
                 .instance_network_interface_update(
                     &opctx,
@@ -5047,7 +5049,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let ips = nexus
                 .instance_list_external_ips(&opctx, &instance_lookup)
                 .await?;
@@ -5076,7 +5078,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let (pool, ip_version) = match pool_selector {
                 ip_pool::PoolSelector::Explicit { pool } => (Some(pool), None),
                 ip_pool::PoolSelector::Auto { ip_version } => {
@@ -5109,7 +5111,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             nexus
                 .instance_detach_external_ip(
                     &opctx,
@@ -5146,7 +5148,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let subnets = nexus
                 .instance_list_external_subnets(&opctx, &instance_lookup)
                 .await?;
@@ -5192,7 +5194,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance,
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let members = nexus
                 .instance_list_multicast_groups(
                     &opctx,
@@ -5238,7 +5240,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance.clone(),
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let result = nexus
                 .instance_join_multicast_group(
                     &opctx,
@@ -5271,7 +5273,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 instance: path.instance.clone(),
             };
             let instance_lookup =
-                nexus.instance_lookup(&opctx, instance_selector)?;
+                nexus.instance_lookup(&opctx, instance_selector).await?;
             let group_selector = multicast::MulticastGroupSelector {
                 multicast_group: path.multicast_group,
             };
@@ -5319,7 +5321,8 @@ impl NexusExternalApi for NexusExternalApiImpl {
             let instance_lookup = apictx
                 .context
                 .nexus
-                .instance_lookup(&opctx, instance_selector)?;
+                .instance_lookup(&opctx, instance_selector)
+                .await?;
             let result = apictx
                 .context
                 .nexus

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -115,7 +115,7 @@ use dropshot::{HttpErrorResponseBody, ResultsPage};
 use nexus_test_utils::identity_eq;
 use nexus_test_utils::resource_helpers::{
     create_instance, create_instance_with, create_instance_with_error,
-    create_project, create_vpc, create_vpc_subnet,
+    create_project, create_vpc, create_vpc_subnet, object_get_error,
 };
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::policy::{ProjectRole, SiloRole};
@@ -335,6 +335,79 @@ async fn test_instance_access(cptestctx: &ControlPlaneTestContext) {
     )
     .await;
     assert_eq!(fetched_instance.identity.id, instance.identity.id);
+
+    // When the instance is addressed by id, a project selector that matches the
+    // instance's actual project is now accepted (previously a 400). See
+    // https://github.com/oxidecomputer/omicron/issues/10517.
+
+    // Fetch instance by id and matching project_name
+    let fetched_instance = instance_get(
+        &client,
+        format!(
+            "/v1/instances/{}?project={}",
+            instance.identity.id, project.identity.name
+        )
+        .as_str(),
+    )
+    .await;
+    assert_eq!(fetched_instance.identity.id, instance.identity.id);
+
+    // Fetch instance by id and matching project_id
+    let fetched_instance = instance_get(
+        &client,
+        format!(
+            "/v1/instances/{}?project={}",
+            instance.identity.id, project.identity.id
+        )
+        .as_str(),
+    )
+    .await;
+    assert_eq!(fetched_instance.identity.id, instance.identity.id);
+
+    // A project selector that does NOT match the instance's project yields a
+    // 404, regardless of whether the mismatching project is given by name or
+    // id, and whether or not it actually exists.
+    let other_project = create_project(client, "other-project").await;
+
+    // by id + wrong (but existing) project name
+    let error = object_get_error(
+        client,
+        format!(
+            "/v1/instances/{}?project={}",
+            instance.identity.id, other_project.identity.name
+        )
+        .as_str(),
+        StatusCode::NOT_FOUND,
+    )
+    .await;
+    assert_eq!(
+        error.message,
+        format!("not found: instance with id \"{}\"", instance.identity.id)
+    );
+
+    // by id + wrong (but existing) project id
+    object_get_error(
+        client,
+        format!(
+            "/v1/instances/{}?project={}",
+            instance.identity.id, other_project.identity.id
+        )
+        .as_str(),
+        StatusCode::NOT_FOUND,
+    )
+    .await;
+
+    // by id + nonexistent project name
+    object_get_error(
+        client,
+        format!(
+            "/v1/instances/{}?project=does-not-exist",
+            instance.identity.id
+        )
+        .as_str(),
+        StatusCode::NOT_FOUND,
+    )
+    .await;
 }
 
 #[nexus_test]

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -364,10 +364,15 @@ async fn test_instance_access(cptestctx: &ControlPlaneTestContext) {
     .await;
     assert_eq!(fetched_instance.identity.id, instance.identity.id);
 
-    // A project selector that does NOT match the instance's project yields a
-    // 404, regardless of whether the mismatching project is given by name or
-    // id, and whether or not it actually exists.
+    // When the instance is found and accessible but the supplied project does
+    // not match its actual project, that's a contradictory request -> 400. This
+    // holds whether the mismatching project is given by name or id, and whether
+    // or not the supplied project even exists.
     let other_project = create_project(client, "other-project").await;
+    let expected_msg = format!(
+        "instance with ID \"{}\" does not belong to project",
+        instance.identity.id
+    );
 
     // by id + wrong (but existing) project name
     let error = object_get_error(
@@ -377,12 +382,13 @@ async fn test_instance_access(cptestctx: &ControlPlaneTestContext) {
             instance.identity.id, other_project.identity.name
         )
         .as_str(),
-        StatusCode::NOT_FOUND,
+        StatusCode::BAD_REQUEST,
     )
     .await;
-    assert_eq!(
-        error.message,
-        format!("not found: instance with id \"{}\"", instance.identity.id)
+    assert!(
+        error.message.starts_with(&expected_msg),
+        "unexpected message: {}",
+        error.message
     );
 
     // by id + wrong (but existing) project id
@@ -393,7 +399,7 @@ async fn test_instance_access(cptestctx: &ControlPlaneTestContext) {
             instance.identity.id, other_project.identity.id
         )
         .as_str(),
-        StatusCode::NOT_FOUND,
+        StatusCode::BAD_REQUEST,
     )
     .await;
 
@@ -405,9 +411,34 @@ async fn test_instance_access(cptestctx: &ControlPlaneTestContext) {
             instance.identity.id
         )
         .as_str(),
-        StatusCode::NOT_FOUND,
+        StatusCode::BAD_REQUEST,
     )
     .await;
+
+    // But if the caller can't access the instance, it must stay a 404 (the same
+    // as a nonexistent instance) -- we must not reveal the instance's existence,
+    // let alone whether the project matches. An unprivileged user can't see the
+    // instance, so even with the *correct* project they get a 404.
+    let error: HttpErrorResponseBody = NexusRequest::expect_failure(
+        client,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        format!(
+            "/v1/instances/{}?project={}",
+            instance.identity.id, project.identity.name
+        )
+        .as_str(),
+    )
+    .authn_as(AuthnMode::UnprivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
+    assert_eq!(
+        error.message,
+        format!("not found: instance with id \"{}\"", instance.identity.id)
+    );
 }
 
 #[nexus_test]


### PR DESCRIPTION
Quick test to back up my answer to #10517. Had Claude do this for the instance lookup and then see what it would take do it for all the lookups.

<details>
<summary>Claude: parent-selector validation across the whole external API</summary>

**Goal / prompt:** "How big would this get if we had to do it for every single resource in the external API?" — sizing the rollout of issue [#10517](https://github.com/oxidecomputer/omicron/issues/10517) option 2 (validate that a supplied parent selector matches the resource's real parent, instead of rejecting `id + parent`) across *all* resources, informed by a working single-resource prototype.

## What the prototype established

Two stacked commits on top of `main` (kept for review):

- `3f96a699` — `instance_lookup` validates `id + project`; **404** on mismatch.
- `3fefd813` — same, but **400** on mismatch when the instance is accessible
  (404 preserved when the caller can't see the instance).

Both compile (`cargo check -p omicron-nexus --all-targets`) and pass an extended
`test_instance_access` (`cargo nextest run ... test_instance_access` → 1 passed).

Concrete facts learned (these de-risk the estimate):

1. **The per-resource code change is small.** The instance match-arm rewrite is
   ~30–40 lines including comments. It uses approach A (app-layer): resolve the
   instance by id (`lookup_for(Read)` — which *already* yields the real
   project's authz id for free), resolve the supplied parent to an id, compare.
2. **`lookup_for(Read)` gives the no-access→404 behavior for free.** A caller who
   can't see the resource gets the usual 404 before the comparison is reached,
   so existence isn't leaked. Verified with an `UnprivilegedUser` test case
   (404 even with the correct project). This holds because instances are
   non-publicly-visible resources whose `on_unauthorized` converts Forbidden→404
   (`nexus/auth/src/authz/context.rs:142`). Most external-API resources are
   siloed/project-scoped and behave the same; fleet-level ones (silo, sled,
   ip_pool) differ but are mostly parent-less anyway.
3. **The async cascade is real.** Making `instance_lookup` async forced
   `instance_network_interface_lookup` async too, because the NIC builder calls
   `instance_lookup` in its name arm. This is the multiplier that makes approach
   A expensive at scale.
4. **The `.await` ripple is mechanical but wide.** `instance_lookup` alone has
   42 call sites; all took a mechanical `?`→`.await?` (done with `perl`).
5. **400 vs 404 is now a live per-resource policy choice** (see below).

## Scope: the target set

Selectors that currently reject `id + parent` and would need the change
(structural search for `NameOrId::Id(_)` catch-all arms, 13 files):

| # | Selector / builder                 | File                  | Parent chain (user-suppliable)      | Depth |
|---|------------------------------------|-----------------------|-------------------------------------|-------|
| 1 | instance ✅ (prototype)            | instance.rs           | project                             | 1 |
| 2 | disk                               | disk.rs               | project                             | 1 |
| 3 | snapshot                           | snapshot.rs           | project                             | 1 |
| 4 | image                              | image.rs              | project (or silo — special)         | 1 |
| 5 | vpc                                | vpc.rs                | project                             | 1 |
| 6 | affinity_group                     | affinity.rs           | project                             | 1 |
| 7 | anti_affinity_group                | affinity.rs           | project                             | 1 |
| 8 | floating_ip                        | external_ip.rs        | project                             | 1 |
| 9 | saml_identity_provider             | silo.rs               | silo                                | 1 |
|10 | external_subnet                    | external_subnet.rs    | (project / instance)                | 1–2 |
|11 | vpc_subnet                         | vpc_subnet.rs         | vpc, project                        | 2 |
|12 | vpc_router                         | vpc_router.rs         | vpc, project                        | 2 |
|13 | internet_gateway                   | internet_gateway.rs   | vpc, project                        | 2 |
|14 | instance_network_interface ⚠️      | network_interface.rs  | instance, project                   | 2 |
|15 | vpc_router_route                   | vpc_router.rs         | router, vpc, project                | 3 |
|16 | internet_gateway_ip_pool           | internet_gateway.rs   | gateway, vpc, project               | 3 |
|17 | internet_gateway_ip_address        | internet_gateway.rs   | gateway, vpc, project               | 3 |

✅ done. ⚠️ NIC is already async (cascade from the prototype) but still *rejects*
`id + parent` — it needs the validation logic added, just not the async
conversion.

**~17 selectors, 13 files. Depth: 9 single-parent, ~5 two-parent, 3
three-parent.** Parent-less builders (project, silo, sled, ip_pool, switch,
physical_disk, certificate, ssh_key, address_lot, alert, alert_receiver,
webhook_secret, user_builtin, current_silo, loopback_address) have no parent
selector to validate and are out of scope — but note several of them are
*called by* the in-scope builders.

## Approach A — app-layer (what the prototype does), scaled

Each in-scope builder gets the validate-on-id logic and **becomes `async`**.
Then every caller of every now-async builder takes `.await`, including the
cascade where one builder calls another.

**Async set ≈ the 17 in-scope builders** (every parented builder needs
validation, so it goes async regardless of the cascade). The cascade only
*adds* a builder if a parent-less, sync builder calls a parented one — which
doesn't happen here (the call direction is child→parent, and parent-less
builders like `project_lookup`/`silo_lookup` stay sync and are safe to call from
async code). So the cascade is contained: it doesn't pull in extra builders, it
just means the in-scope builders' internal calls to each other also need
`.await` (already counted).

**Total `.await` ripple = sum of the in-scope builders' call sites:**

| builder | sites |   | builder | sites |
|---|---|---|---|---|
| instance | 42 (done) | | internet_gateway | 8 |
| vpc | 15 | | affinity_group | 7 |
| disk | 11 | | anti_affinity_group | 7 |
| vpc_router | 9 | | vpc_subnet | 6 |
| image | 5 | | floating_ip | 5 |
| vpc_router_route | 3 | | nic | 3 (done) |
| snapshot | 2 | | gw_ip_pool / gw_ip_address | 1 each |
| saml_idp | 1 | | external_subnet | ~few |

**≈ 130–140 call sites** across `nexus/src/app/*.rs`,
`nexus/src/external_api/http_entrypoints.rs`, sagas, and test helpers. Mechanical
(`?`→`.await?`), but it touches a large fraction of the entrypoints file and is
prone to merge conflicts during the work.

- **Pros:** identical to the proven prototype; no macro risk; reuses existing
  recursive name/id parent resolution; each resource is independently
  reviewable.
- **Cons:** ~130 `.await` edits; **adds DB queries** on the `id + parent` path
  (re-resolves the child and resolves the supplied parent — only on a combo
  that's a hard 400 today, so no regression, but wasteful); spreads `async`
  across builders that didn't need to be.

## Approach B — macro (recommended at scale), scaled

Validate inside the `lookup_resource!` macro
(`nexus/db-macros/src/lookup.rs`): the by-id path already fetches every ancestor
row on its walk-up and discards them (the `_` in
`let (#(#ancestors,)* _) = Parent::lookup_by_id_no_authz(...)`). Retain those,
carry the supplied parents into the `PrimaryKey` variant, and compare against the
already-fetched rows.

- **Pros:** **zero added DB queries** (compares against rows already
  materialized); **no async ripple at all** — builders stay lazy/sync, so the
  ~130 `.await` edits vanish; the check rides on the fetch that already happens;
  multi-parent and name-vs-name comparison fall out uniformly (compare against
  the resolved chain — no scoping/uniqueness problem; see reference doc).
- **Cons:** concentrated risk in one generated file; the `PrimaryKey` variant
  gains fields, so the ~30 `LookupPath::*_id(id)` builders in
  `nexus/db-lookup/src/lookup.rs` must default them to "none" (one line each) so
  the **212** existing internal `.x_id()` callers stay untouched; regenerate 4
  expectorate snapshots (`nexus/db-macros/outputs/*.txt`); the ~17 app arms still
  change (to thread the supplied parents into the lazy lookup — but *without*
  `async`, so simpler than approach A).

The full-scope question actually **strengthens the case for B**: approach A's
single worst cost (the ~130-site async ripple) scales with the number of
resources and their call sites, while B's worst cost (the macro change) is paid
*once* regardless of how many resources opt in. At one resource, A and B are
comparable; across 17, B pulls ahead.

## Test surface

The prototype added ~6 assertions to one test (`test_instance_access`): match by
name, match by id, mismatch by name, mismatch by id, mismatch nonexistent
project, and no-access→404. Per resource the matrix is similar, plus extra
combinations for multi-parent selectors (which ancestor mismatches, and by which
form). Rough order: **~100–150 new assertions**, but most reuse existing
per-resource setup helpers in `resource_helpers.rs`, and the deep selectors
(route, gateway pool/address) carry the heaviest setup. There is little existing
coverage to flip — the reject messages aren't asserted in `nexus/tests` today
(grep returns nothing), so it's net-new tests rather than churn.

## The 400-vs-404 decision (now concrete, must be API-wide)

The prototype implements both. Findings:

- **No security difference here.** `lookup_for(Read)` runs first, so only callers
  who can already see the resource by id reach the comparison; a 400 leaks
  nothing they couldn't get from a plain by-id GET.
- **404** is consistent with the by-name path: `GET /instances/foo?project=wrong`
  is *unavoidably* 404 (a name is only meaningful within its project, so the
  scoped query finds nothing). Same logical error → same status.
- **400** is more debuggable (it's literally the "catch the client bug" goal from
  the 2022 review) and is semantically honest about contradictory inputs — but it
  diverges from the by-name path and introduces a new pattern.

Whichever is chosen, it should be decided **once and applied to all ~17
selectors** — the entire point is uniform behavior. This choice does not change
the size materially (it's one line in each mismatch arm), but it must be settled
before the rollout to avoid per-resource drift.

## Bottom line / estimate

This is **not a rewrite**, but it is a real cross-cutting, multi-day change —
roughly a **week of focused, agent-assisted work** either way, dominated by the
test matrix.

- **Approach A:** ~17 builders → async; ~130 mechanical `.await` edits; ~17
  match-arm rewrites (each like the proven ~30–40-line instance change, more for
  multi-parent); ~100–150 test assertions. Low conceptual risk (prototype
  proves it), high edit volume and merge-conflict surface. Adds avoidable
  queries. **~5–6 days.**
- **Approach B:** one macro change (~1–1.5 days, the only real risk) + ~30
  one-line db-lookup defaults + ~17 app arms (no async, simpler) + snapshot
  regen + the same ~100–150 tests. **~4–5 days**, zero async ripple, zero added
  queries, and the up-front macro cost amortizes across all resources.

**Recommendation:** prototype proved approach A works and is cheap *per
resource*; but for the full-API rollout, do approach B — its dominant cost is
paid once, it avoids the ~130-site async ripple, and it adds no queries. Use the
prototype's `test_instance_access` shape as the per-resource test template.

Single biggest unknown remaining: the macro change itself (plumbing N ancestor
rows out of the recursive by-id resolution and comparing per level). The logical
next derisking step would be a one-resource approach-B spike (instance again, via
the macro) to compare its diff against the approach-A prototype directly.

## Reference data (commands used)

- In-scope arms: `grep -rnE "NameOrId::Id\(_\)" nexus/src/app/*.rs`
- Call-site counts: `grep -rhoE "\.<builder>\(" nexus/src nexus/tests | wc -l`
- Internal `*_id` builder callers (must stay unchanged under B): **212**
  (`grep` over the `LookupPath::*_id(` builders).
- Macro: `nexus/db-macros/src/lookup.rs` (ancestor walk-up ~786–832, 991).
- Builders + `PrimaryKey` construction: `nexus/db-lookup/src/lookup.rs`.

</details>