### PR TITLE
proof of concept, do not merge: macro-based parent-selector validation

### DIFF
--- a/nexus/db-lookup/src/lookup.rs
+++ b/nexus/db-lookup/src/lookup.rs
@@ -95,8 +95,9 @@ impl<'a> LookupPath<'a> {
     /// Select an Instance by id, validating that it lives in `expected_project`
     /// rather than rejecting the combined `id + project` selector (#10517).
     ///
-    /// The mismatch is reported as a 404 (the same error as a nonexistent
-    /// instance), consistent with the by-name path and leaking nothing.
+    /// A mismatch against a real project is reported as a 400 (after the
+    /// instance's own authz check, so a caller who can't see the instance still
+    /// gets a 404 and learns nothing).
     pub fn instance_id_validated(
         self,
         id: Uuid,

--- a/nexus/db-lookup/src/lookup.rs
+++ b/nexus/db-lookup/src/lookup.rs
@@ -92,6 +92,23 @@ impl<'a> LookupPath<'a> {
         Instance::PrimaryKey(Root { lookup_root: self }, id)
     }
 
+    /// Select an Instance by id, validating that it lives in `expected_project`
+    /// rather than rejecting the combined `id + project` selector (#10517).
+    ///
+    /// The mismatch is reported as a 404 (the same error as a nonexistent
+    /// instance), consistent with the by-name path and leaking nothing.
+    pub fn instance_id_validated(
+        self,
+        id: Uuid,
+        expected_project: Project<'a>,
+    ) -> Instance<'a> {
+        Instance::PrimaryKeyWithParents(
+            Root { lookup_root: self },
+            id,
+            Some(Box::new(expected_project)),
+        )
+    }
+
     /// Select a resource of type AffinityGroup, identified by its id
     pub fn affinity_group_id(self, id: Uuid) -> AffinityGroup<'a> {
         AffinityGroup::PrimaryKey(Root { lookup_root: self }, id)
@@ -147,9 +164,43 @@ impl<'a> LookupPath<'a> {
         Vpc::PrimaryKey(Root { lookup_root: self }, id)
     }
 
+    /// Select a Vpc by id, validating that it lives in `expected_project`
+    /// rather than rejecting the combined `id + project` selector (#10517).
+    pub fn vpc_id_validated(
+        self,
+        id: Uuid,
+        expected_project: Project<'a>,
+    ) -> Vpc<'a> {
+        Vpc::PrimaryKeyWithParents(
+            Root { lookup_root: self },
+            id,
+            Some(Box::new(expected_project)),
+        )
+    }
+
     /// Select a resource of type VpcSubnet, identified by its id
     pub fn vpc_subnet_id(self, id: Uuid) -> VpcSubnet<'a> {
         VpcSubnet::PrimaryKey(Root { lookup_root: self }, id)
+    }
+
+    /// Select a VpcSubnet by id, validating any supplied ancestors against the
+    /// subnet's real ancestors rather than rejecting the combined selector
+    /// (#10517). Either or both of `expected_project` and `expected_vpc` may be
+    /// given; a `None` simply isn't constrained. When `expected_vpc` is itself
+    /// a validated lookup, its project is checked too, so the whole supplied
+    /// chain is validated.
+    pub fn vpc_subnet_id_validated(
+        self,
+        id: Uuid,
+        expected_project: Option<Project<'a>>,
+        expected_vpc: Option<Vpc<'a>>,
+    ) -> VpcSubnet<'a> {
+        VpcSubnet::PrimaryKeyWithParents(
+            Root { lookup_root: self },
+            id,
+            expected_project.map(Box::new),
+            expected_vpc.map(Box::new),
+        )
     }
 
     /// Select a resource of type VpcRouter, identified by its id
@@ -639,7 +690,10 @@ lookup_resource! {
     ancestors = [ "Silo", "Project" ],
     lookup_by_name = true,
     soft_deletes = true,
-    primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
+    primary_key_columns = [ { column_name = "id", rust_type = Uuid } ],
+    // Spike (#10517): opt in to the by-id path that validates a supplied
+    // project against the instance's real project instead of rejecting it.
+    validate_by_id_parent = true
 }
 
 lookup_resource! {
@@ -671,7 +725,9 @@ lookup_resource! {
     ancestors = [ "Silo", "Project" ],
     lookup_by_name = true,
     soft_deletes = true,
-    primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
+    primary_key_columns = [ { column_name = "id", rust_type = Uuid } ],
+    // Spike (#10517): validate a supplied project against the vpc's real one.
+    validate_by_id_parent = true
 }
 
 lookup_resource! {
@@ -695,7 +751,12 @@ lookup_resource! {
     ancestors = [ "Silo", "Project", "Vpc" ],
     lookup_by_name = true,
     soft_deletes = true,
-    primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
+    primary_key_columns = [ { column_name = "id", rust_type = Uuid } ],
+    // Spike (#10517): validate a supplied vpc (which itself validates the
+    // project, recursively) against the subnet's real vpc. Demonstrates the
+    // two-parent case: the macro's immediate-parent comparison composes with
+    // the validated Vpc lookup to cover the whole chain.
+    validate_by_id_parent = true
 }
 
 lookup_resource! {

--- a/nexus/db-macros/src/lookup.rs
+++ b/nexus/db-macros/src/lookup.rs
@@ -604,68 +604,83 @@ fn generate_lookup_methods(config: &Config) -> TokenStream {
             (quote! {}, quote! {})
         };
 
-    // Generate the by-id-with-validated-parent arms (see #10517). The by-id
-    // walk-up already resolves the resource's real parent for free; we compare
-    // the caller-supplied parent against it and 404 on mismatch (consistent
-    // with the by-name path, where a wrong parent simply doesn't resolve). The
-    // resource's own authz check happens before the comparison is reached
-    // (`fetch_by_id_for` authorizes; `lookup_for` authorizes after `lookup`),
-    // so a caller who can't see the resource never learns whether the parent
-    // matched.
-    let (validated_fetch_arm, validated_lookup_arm) = if config
-        .validate_by_id_parent
-    {
-        let (_, ancestor_authz_names, supplied_args) =
-            config.validated_ancestors();
-        // For each supplied ancestor, resolve it (its `lookup_for` walks up and
-        // yields its own authz chain; the last element is that ancestor's
-        // authz) and compare its id to the resource's real ancestor at that
-        // level. A mismatch is reported as the resource's own not-found, so it
-        // is indistinguishable from a nonexistent resource. Because ids are
-        // globally unique, comparing a single level transitively validates
-        // everything above it — and a supplied ancestor that is itself a
-        // validated lookup checks its own parents in turn.
-        let compare = quote! {
-            use nexus_auth::authz::ApiResource;
-            #(
-                if let Some(#supplied_args) = #supplied_args {
-                    let (.., supplied_authz) =
-                        #supplied_args.lookup_for(authz::Action::Read).await?;
-                    if #ancestor_authz_names.id() != supplied_authz.id() {
-                        return Err(#resource_authz_name.not_found());
+    // Generate the by-id-with-validated-parents machinery (see #10517). For
+    // each caller-supplied ancestor we resolve it (its `lookup_for` walks up and
+    // yields its own authz chain, whose last element is that ancestor's authz)
+    // and compare its id to the resource's real ancestor at that level. A
+    // mismatch is a contradictory request, so it's a 400. Because ids are
+    // globally unique, comparing a single level transitively validates
+    // everything above it — and a supplied ancestor that is itself a validated
+    // lookup checks its own parents in turn.
+    //
+    // The comparison only runs *after* the resource's own authz check has
+    // passed (`fetch_by_id_for` authorizes; in `lookup_for` we run it after the
+    // `authorize` call below), so a caller who can't see the resource gets the
+    // usual 404 and never learns from a 400 whether the parent matched.
+    let (validated_fetch_arm, validated_lookup_arm, validated_lookup_for_check) =
+        if config.validate_by_id_parent {
+            let (ancestor_types, ancestor_authz_names, supplied_args) =
+                config.validated_ancestors();
+            let compare = quote! {
+                use nexus_auth::authz::ApiResource;
+                #(
+                    if let Some(#supplied_args) = #supplied_args {
+                        let (.., supplied_authz) =
+                            #supplied_args.lookup_for(authz::Action::Read).await?;
+                        if #ancestor_authz_names.id() != supplied_authz.id() {
+                            return Err(Error::invalid_request(format!(
+                                "{} with id \"{}\" does not belong to the \
+                                 specified {}",
+                                ResourceType::#resource_name,
+                                #resource_authz_name.id(),
+                                ResourceType::#ancestor_types,
+                            )));
+                        }
                     }
-                }
-            )*
+                )*
+            };
+            (
+                // fetch_for: fetch_by_id_for has already authorized `action`.
+                quote! {
+                    #resource_name::PrimaryKeyWithParents(
+                        _, #(#pkey_names,)* #(#supplied_args,)*
+                    ) => {
+                        let (#(#path_authz_names,)* db_row) =
+                            Self::fetch_by_id_for(
+                                opctx, datastore, #(#pkey_names,)* action
+                            ).await?;
+                        { #compare }
+                        Ok((#(#path_authz_names,)* db_row))
+                    }
+                },
+                // lookup(): just resolve the path (no authz here, so no
+                // comparison either — that would leak before the authz check in
+                // lookup_for). The supplied ancestors are validated in
+                // lookup_for, after authorize.
+                quote! {
+                    #resource_name::PrimaryKeyWithParents(
+                        _, #(#pkey_names,)* ..
+                    ) => {
+                        let (#(#path_authz_names,)* _) =
+                            Self::lookup_by_id_no_authz(
+                                opctx, datastore, #(#pkey_names,)*
+                            ).await?;
+                        Ok((#(#path_authz_names,)*))
+                    }
+                },
+                // lookup_for: runs after `authorize`, so the 400 is only
+                // reachable by a caller allowed to do `action` on the resource.
+                quote! {
+                    if let #resource_name::PrimaryKeyWithParents(
+                        _, .., #(#supplied_args,)*
+                    ) = self {
+                        #compare
+                    }
+                },
+            )
+        } else {
+            (quote! {}, quote! {}, quote! {})
         };
-        (
-            quote! {
-                #resource_name::PrimaryKeyWithParents(
-                    _, #(#pkey_names,)* #(#supplied_args,)*
-                ) => {
-                    let (#(#path_authz_names,)* db_row) =
-                        Self::fetch_by_id_for(
-                            opctx, datastore, #(#pkey_names,)* action
-                        ).await?;
-                    { #compare }
-                    Ok((#(#path_authz_names,)* db_row))
-                }
-            },
-            quote! {
-                #resource_name::PrimaryKeyWithParents(
-                    _, #(#pkey_names,)* #(#supplied_args,)*
-                ) => {
-                    let (#(#path_authz_names,)* _) =
-                        Self::lookup_by_id_no_authz(
-                            opctx, datastore, #(#pkey_names,)*
-                        ).await?;
-                    { #compare }
-                    Ok((#(#path_authz_names,)*))
-                }
-            },
-        )
-    } else {
-        (quote! {}, quote! {})
-    };
 
     // Generate the by-name branch of the match arm in "fetch_for()"
     let fetch_for_name_variant = if config.lookup_by_name {
@@ -837,6 +852,7 @@ fn generate_lookup_methods(config: &Config) -> TokenStream {
             let opctx = &lookup.opctx;
             let (#(#path_authz_names,)*) = self.lookup().await?;
             opctx.authorize(action, &#resource_authz_name).await?;
+            #validated_lookup_for_check
             Ok((#(#path_authz_names,)*))
             #silo_check_lookup
         }

--- a/nexus/db-macros/src/lookup.rs
+++ b/nexus/db-macros/src/lookup.rs
@@ -51,6 +51,19 @@ pub struct Input {
     /// on whether it's nested under a `Silo`.
     #[serde(default)]
     visible_outside_silo: bool,
+    /// Generate an extra by-id selection path that *validates* a
+    /// caller-supplied parent against the resource's real parent instead of
+    /// rejecting `id + parent` (see #10517).
+    ///
+    /// This is "false" by default. When enabled (only meaningful for a
+    /// resource that has a parent), the macro emits a `PrimaryKeyWithParents`
+    /// variant carrying an optional supplied lookup per validatable ancestor,
+    /// plus the match arms that compare each supplied ancestor's id to the real
+    /// one resolved by the existing by-id walk-up. This is an opt-in flag so the
+    /// approach can be rolled out one resource at a time without touching every
+    /// `lookup_resource!` invocation at once.
+    #[serde(default)]
+    validate_by_id_parent: bool,
 }
 
 struct PrimaryKeyColumn {
@@ -135,6 +148,9 @@ pub struct Config {
 
     /// Description of the primary key columns
     primary_key_columns: Vec<PrimaryKeyColumn>,
+
+    /// Generate the parent-validating by-id path (see [`Input::validate_by_id_parent`])
+    validate_by_id_parent: bool,
 }
 
 impl Config {
@@ -155,6 +171,8 @@ impl Config {
         path_authz_names.push(resource.authz_name.clone());
 
         let parent = ancestors.last().cloned();
+        let validate_by_id_parent =
+            input.validate_by_id_parent && parent.is_some();
         let silo_restricted = !input.visible_outside_silo
             && ancestors.iter().any(|r| r.name == "Silo");
 
@@ -173,7 +191,40 @@ impl Config {
             lookup_by_name: input.lookup_by_name,
             primary_key_columns,
             soft_deletes: input.soft_deletes,
+            validate_by_id_parent,
         })
+    }
+
+    /// The ancestors whose selector a caller may supply alongside a by-id
+    /// lookup and that we therefore validate (see #10517), as parallel lists of
+    /// `(resource type ident, authz binding ident, supplied-arg ident)`.
+    ///
+    /// This excludes `Silo`: for these resources the silo is always the actor's
+    /// own (taken from the auth context), never a caller-supplied value, so
+    /// there's nothing to validate. (A silo-scoped resource that *does* take an
+    /// explicit silo selector would need different treatment.)
+    fn validated_ancestors(
+        &self,
+    ) -> (Vec<syn::Ident>, Vec<syn::Ident>, Vec<syn::Ident>) {
+        let nancestors = self.path_types.len() - 1;
+        let mut types = Vec::new();
+        let mut authz_names = Vec::new();
+        let mut supplied_args = Vec::new();
+        for (ty, authz) in self.path_types[..nancestors]
+            .iter()
+            .zip(&self.path_authz_names[..nancestors])
+        {
+            if ty == "Silo" {
+                continue;
+            }
+            types.push(ty.clone());
+            authz_names.push(authz.clone());
+            supplied_args.push(format_ident!(
+                "supplied_{}",
+                heck::AsSnakeCase(ty.to_string()).to_string()
+            ));
+        }
+        (types, authz_names, supplied_args)
     }
 }
 
@@ -253,6 +304,34 @@ fn generate_struct(config: &Config) -> TokenStream {
     );
     let pkey_types = config.primary_key_columns.iter().map(|c| c.ty.external());
 
+    // Optional by-id-with-validated-parents variant (see #10517). Carries the
+    // primary key plus, for each validatable ancestor, an optional
+    // caller-supplied lookup for that ancestor (boxed to keep the enum small).
+    // A `Some` ancestor must match the resource's real ancestor at that level;
+    // `None` means the caller didn't constrain that level. This shape supports
+    // partial selectors (e.g. a project but no vpc) uniformly.
+    let validated_variant = if config.validate_by_id_parent {
+        let pkey_types = config
+            .primary_key_columns
+            .iter()
+            .map(|c| c.ty.external())
+            .collect::<Vec<_>>();
+        let (ancestor_types, _, _) = config.validated_ancestors();
+        quote! {
+            /// We're looking for a resource with the given primary key, but the
+            /// caller also supplied one or more ancestor selectors that must
+            /// match the resource's real ancestors (rather than being
+            /// rejected). See #10517.
+            PrimaryKeyWithParents(
+                Root<'a>
+                #(,#pkey_types)*
+                #(, Option<::std::boxed::Box<#ancestor_types<'a>>>)*
+            ),
+        }
+    } else {
+        quote! {}
+    };
+
     /* configure the lookup enum */
     let name_variant = if config.lookup_by_name {
         let root_sym = format_ident!("Root");
@@ -286,6 +365,8 @@ fn generate_struct(config: &Config) -> TokenStream {
             ///
             /// This has no parent container -- a by-id lookup is always global
             PrimaryKey(Root<'a> #(,#pkey_types)*),
+
+            #validated_variant
         }
     }
 }
@@ -369,6 +450,14 @@ fn generate_misc_helpers(config: &Config) -> TokenStream {
         quote! {
             #resource_name::Name(parent, _)
             | #resource_name::OwnedName(parent, _) => parent.lookup_root(),
+        }
+    } else {
+        quote! {}
+    };
+
+    let validated_root_variant = if config.validate_by_id_parent {
+        quote! {
+            #resource_name::PrimaryKeyWithParents(root, ..) => root.lookup_root(),
         }
     } else {
         quote! {}
@@ -478,6 +567,8 @@ fn generate_misc_helpers(config: &Config) -> TokenStream {
                 #name_variant
 
                 #resource_name::PrimaryKey(root, ..) => root.lookup_root(),
+
+                #validated_root_variant
             }
         }
 
@@ -512,6 +603,69 @@ fn generate_lookup_methods(config: &Config) -> TokenStream {
         } else {
             (quote! {}, quote! {})
         };
+
+    // Generate the by-id-with-validated-parent arms (see #10517). The by-id
+    // walk-up already resolves the resource's real parent for free; we compare
+    // the caller-supplied parent against it and 404 on mismatch (consistent
+    // with the by-name path, where a wrong parent simply doesn't resolve). The
+    // resource's own authz check happens before the comparison is reached
+    // (`fetch_by_id_for` authorizes; `lookup_for` authorizes after `lookup`),
+    // so a caller who can't see the resource never learns whether the parent
+    // matched.
+    let (validated_fetch_arm, validated_lookup_arm) = if config
+        .validate_by_id_parent
+    {
+        let (_, ancestor_authz_names, supplied_args) =
+            config.validated_ancestors();
+        // For each supplied ancestor, resolve it (its `lookup_for` walks up and
+        // yields its own authz chain; the last element is that ancestor's
+        // authz) and compare its id to the resource's real ancestor at that
+        // level. A mismatch is reported as the resource's own not-found, so it
+        // is indistinguishable from a nonexistent resource. Because ids are
+        // globally unique, comparing a single level transitively validates
+        // everything above it — and a supplied ancestor that is itself a
+        // validated lookup checks its own parents in turn.
+        let compare = quote! {
+            use nexus_auth::authz::ApiResource;
+            #(
+                if let Some(#supplied_args) = #supplied_args {
+                    let (.., supplied_authz) =
+                        #supplied_args.lookup_for(authz::Action::Read).await?;
+                    if #ancestor_authz_names.id() != supplied_authz.id() {
+                        return Err(#resource_authz_name.not_found());
+                    }
+                }
+            )*
+        };
+        (
+            quote! {
+                #resource_name::PrimaryKeyWithParents(
+                    _, #(#pkey_names,)* #(#supplied_args,)*
+                ) => {
+                    let (#(#path_authz_names,)* db_row) =
+                        Self::fetch_by_id_for(
+                            opctx, datastore, #(#pkey_names,)* action
+                        ).await?;
+                    { #compare }
+                    Ok((#(#path_authz_names,)* db_row))
+                }
+            },
+            quote! {
+                #resource_name::PrimaryKeyWithParents(
+                    _, #(#pkey_names,)* #(#supplied_args,)*
+                ) => {
+                    let (#(#path_authz_names,)* _) =
+                        Self::lookup_by_id_no_authz(
+                            opctx, datastore, #(#pkey_names,)*
+                        ).await?;
+                    { #compare }
+                    Ok((#(#path_authz_names,)*))
+                }
+            },
+        )
+    } else {
+        (quote! {}, quote! {})
+    };
 
     // Generate the by-name branch of the match arm in "fetch_for()"
     let fetch_for_name_variant = if config.lookup_by_name {
@@ -641,6 +795,8 @@ fn generate_lookup_methods(config: &Config) -> TokenStream {
                         action
                     ).await
                 }
+
+                #validated_fetch_arm
             }
             #silo_check_fetch
         }
@@ -743,6 +899,8 @@ fn generate_lookup_methods(config: &Config) -> TokenStream {
                         ).await?;
                     Ok((#(#path_authz_names,)*))
                 }
+
+                #validated_lookup_arm
             }
         }
     }

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -348,8 +348,14 @@ async fn normalize_anti_affinity_groups(
 impl super::Nexus {
     /// Look up an instance by name or UUID.
     ///
-    /// The `project` parameter is required for name-based lookup (provides scope)
-    /// and must NOT be specified for UUID-based lookup.
+    /// The `project` parameter is required for name-based lookup (provides
+    /// scope). For UUID-based lookup the project is optional; if it is
+    /// supplied, it is validated against the instance's actual project rather
+    /// than rejected (see #10517).
+    ///
+    /// Note this function stays synchronous: the `id + project` validation is
+    /// deferred into the (already-async) `lookup_for`/`fetch_for` on the
+    /// returned builder, so none of the ~40 callers need to change.
     pub fn instance_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
@@ -365,6 +371,24 @@ impl super::Nexus {
                 Ok(instance)
             }
             instance::InstanceSelector {
+                instance: NameOrId::Id(id),
+                project: Some(project),
+            } => {
+                // Instance addressed by ID with a project also supplied: build
+                // a lookup that validates the supplied project against the
+                // instance's real project when it's resolved, rather than
+                // rejecting the request (#10517). The comparison happens lazily
+                // inside the builder, so this arm — and `instance_lookup` —
+                // remain synchronous.
+                let expected_project = self.project_lookup(
+                    opctx,
+                    project::ProjectSelector { project },
+                )?;
+                let instance = LookupPath::new(opctx, &self.db_datastore)
+                    .instance_id_validated(id, expected_project);
+                Ok(instance)
+            }
+            instance::InstanceSelector {
                 instance: NameOrId::Name(name),
                 project: Some(project),
             } => {
@@ -376,11 +400,6 @@ impl super::Nexus {
                     .instance_name_owned(name.into());
                 Ok(instance)
             }
-            instance::InstanceSelector {
-                instance: NameOrId::Id(_), ..
-            } => Err(Error::invalid_request(
-                "when providing instance as an ID project should not be specified",
-            )),
             _ => Err(Error::invalid_request(
                 "instance should either be UUID or project should be specified",
             )),

--- a/nexus/src/app/vpc.rs
+++ b/nexus/src/app/vpc.rs
@@ -60,10 +60,18 @@ impl super::Nexus {
                     .vpc_name_owned(name.into());
                 Ok(v)
             }
-            vpc::VpcSelector { vpc: NameOrId::Id(_), project: Some(_) } => {
-                Err(Error::invalid_request(
-                    "when providing vpc as an ID, project should not be specified",
-                ))
+            vpc::VpcSelector { vpc: NameOrId::Id(id), project: Some(proj) } => {
+                // vpc by id with a project also supplied: validate the project
+                // against the vpc's real project rather than rejecting (#10517).
+                // The comparison is deferred into the builder, so this stays
+                // synchronous.
+                let expected_project = self.project_lookup(
+                    opctx,
+                    project::ProjectSelector { project: proj },
+                )?;
+                let v = LookupPath::new(opctx, &self.db_datastore)
+                    .vpc_id_validated(id, expected_project);
+                Ok(v)
             }
             _ => Err(Error::invalid_request(
                 "vpc should either be an ID or project should be specified",

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -13,6 +13,7 @@ use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
 use nexus_db_queries::db::model::VpcSubnet;
+use nexus_types::external_api::project;
 use nexus_types::external_api::vpc;
 use omicron_common::api::external;
 use omicron_common::api::external::CreateResult;
@@ -53,12 +54,36 @@ impl super::Nexus {
                 Ok(subnet)
             }
             vpc::SubnetSelector {
-                subnet: NameOrId::Id(_),
-                vpc: _,
-                project: _,
-            } => Err(Error::invalid_request(
-                "when providing subnet as an ID, vpc and project should not be specified",
-            )),
+                subnet: NameOrId::Id(id),
+                vpc: Some(vpc),
+                project,
+            } => {
+                // subnet by id with a vpc also supplied: validate the supplied
+                // vpc (which validates the project too, recursively) against
+                // the subnet's real vpc rather than rejecting (#10517). Stays
+                // synchronous: the comparison is deferred into the builder.
+                let expected_vpc =
+                    self.vpc_lookup(opctx, vpc::VpcSelector { project, vpc })?;
+                let subnet = LookupPath::new(opctx, &self.db_datastore)
+                    .vpc_subnet_id_validated(id, None, Some(expected_vpc));
+                Ok(subnet)
+            }
+            vpc::SubnetSelector {
+                subnet: NameOrId::Id(id),
+                vpc: None,
+                project: Some(project),
+            } => {
+                // subnet by id with only a project supplied (no vpc): validate
+                // the project alone, for leniency/consistency. Nothing forces
+                // a caller to also name the vpc just to scope by project.
+                let expected_project = self.project_lookup(
+                    opctx,
+                    project::ProjectSelector { project },
+                )?;
+                let subnet = LookupPath::new(opctx, &self.db_datastore)
+                    .vpc_subnet_id_validated(id, Some(expected_project), None);
+                Ok(subnet)
+            }
             _ => Err(Error::invalid_request(
                 "subnet should either be an ID or vpc should be specified",
             )),

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -115,7 +115,7 @@ use dropshot::{HttpErrorResponseBody, ResultsPage};
 use nexus_test_utils::identity_eq;
 use nexus_test_utils::resource_helpers::{
     create_instance, create_instance_with, create_instance_with_error,
-    create_project, create_vpc, create_vpc_subnet,
+    create_project, create_vpc, create_vpc_subnet, object_get_error,
 };
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::policy::{ProjectRole, SiloRole};
@@ -335,6 +335,81 @@ async fn test_instance_access(cptestctx: &ControlPlaneTestContext) {
     )
     .await;
     assert_eq!(fetched_instance.identity.id, instance.identity.id);
+
+    // When the instance is addressed by id, a project selector that matches the
+    // instance's actual project is now accepted (previously a 400). See
+    // https://github.com/oxidecomputer/omicron/issues/10517. This is the
+    // approach-B (macro) spike: the validation happens lazily inside the
+    // builder, so `instance_lookup` stayed synchronous.
+
+    // by id + matching project name
+    let fetched_instance = instance_get(
+        &client,
+        format!(
+            "/v1/instances/{}?project={}",
+            instance.identity.id, project.identity.name
+        )
+        .as_str(),
+    )
+    .await;
+    assert_eq!(fetched_instance.identity.id, instance.identity.id);
+
+    // by id + matching project id
+    let fetched_instance = instance_get(
+        &client,
+        format!(
+            "/v1/instances/{}?project={}",
+            instance.identity.id, project.identity.id
+        )
+        .as_str(),
+    )
+    .await;
+    assert_eq!(fetched_instance.identity.id, instance.identity.id);
+
+    // A project selector that does NOT match the instance's project yields a
+    // 404 (the same error as a nonexistent instance), regardless of whether the
+    // mismatching project is given by name or id, and whether or not it exists.
+    let other_project = create_project(client, "other-project").await;
+
+    // by id + wrong (but existing) project name
+    let error = object_get_error(
+        client,
+        format!(
+            "/v1/instances/{}?project={}",
+            instance.identity.id, other_project.identity.name
+        )
+        .as_str(),
+        StatusCode::NOT_FOUND,
+    )
+    .await;
+    assert_eq!(
+        error.message,
+        format!("not found: instance with id \"{}\"", instance.identity.id)
+    );
+
+    // by id + wrong (but existing) project id
+    object_get_error(
+        client,
+        format!(
+            "/v1/instances/{}?project={}",
+            instance.identity.id, other_project.identity.id
+        )
+        .as_str(),
+        StatusCode::NOT_FOUND,
+    )
+    .await;
+
+    // by id + nonexistent project name
+    object_get_error(
+        client,
+        format!(
+            "/v1/instances/{}?project=does-not-exist",
+            instance.identity.id
+        )
+        .as_str(),
+        StatusCode::NOT_FOUND,
+    )
+    .await;
 }
 
 #[nexus_test]

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -366,10 +366,15 @@ async fn test_instance_access(cptestctx: &ControlPlaneTestContext) {
     .await;
     assert_eq!(fetched_instance.identity.id, instance.identity.id);
 
-    // A project selector that does NOT match the instance's project yields a
-    // 404 (the same error as a nonexistent instance), regardless of whether the
-    // mismatching project is given by name or id, and whether or not it exists.
+    // A project selector that names a real project the instance does NOT belong
+    // to is a contradictory request: a 400, whether given by name or id. (The
+    // resource's own authz check runs first, so a caller who can't see the
+    // instance still gets a 404 and learns nothing.)
     let other_project = create_project(client, "other-project").await;
+    let mismatch_msg = format!(
+        "instance with id \"{}\" does not belong to the specified project",
+        instance.identity.id
+    );
 
     // by id + wrong (but existing) project name
     let error = object_get_error(
@@ -379,27 +384,28 @@ async fn test_instance_access(cptestctx: &ControlPlaneTestContext) {
             instance.identity.id, other_project.identity.name
         )
         .as_str(),
-        StatusCode::NOT_FOUND,
+        StatusCode::BAD_REQUEST,
     )
     .await;
-    assert_eq!(
-        error.message,
-        format!("not found: instance with id \"{}\"", instance.identity.id)
-    );
+    assert_eq!(error.message, mismatch_msg);
 
     // by id + wrong (but existing) project id
-    object_get_error(
+    let error = object_get_error(
         client,
         format!(
             "/v1/instances/{}?project={}",
             instance.identity.id, other_project.identity.id
         )
         .as_str(),
-        StatusCode::NOT_FOUND,
+        StatusCode::BAD_REQUEST,
     )
     .await;
+    assert_eq!(error.message, mismatch_msg);
 
-    // by id + nonexistent project name
+    // by id + nonexistent project name: the supplied project simply doesn't
+    // resolve, so this is a 404 about the project (it isn't treated as a
+    // mismatch). This is the one case that differs from a unified "always 400"
+    // policy.
     object_get_error(
         client,
         format!(

--- a/nexus/tests/integration_tests/vpc_subnets.rs
+++ b/nexus/tests/integration_tests/vpc_subnets.rs
@@ -484,9 +484,9 @@ async fn test_vpc_subnet_id_parent_validation(
         let url = format!("/v1/vpc-subnets/{sid}?{query}");
         async move { object_get::<VpcSubnet>(client, &url).await }
     };
-    let get_404 = |query: String| {
+    let get_400 = |query: String| {
         let url = format!("/v1/vpc-subnets/{sid}?{query}");
-        async move { object_get_error(client, &url, StatusCode::NOT_FOUND).await }
+        async move { object_get_error(client, &url, StatusCode::BAD_REQUEST).await }
     };
 
     // --- Accepted: matching selectors, in every form ---
@@ -516,35 +516,45 @@ async fn test_vpc_subnet_id_parent_validation(
         sid
     );
 
-    // --- Rejected with 404: any mismatching ancestor ---
+    // --- Rejected with 400: any mismatching, but real, ancestor ---
 
-    let subnet_not_found = format!("not found: vpc-subnet with id \"{sid}\"");
+    let wrong_vpc = format!(
+        "vpc-subnet with id \"{sid}\" does not belong to the specified vpc"
+    );
+    let wrong_project = format!(
+        "vpc-subnet with id \"{sid}\" does not belong to the specified project"
+    );
 
     // id + wrong vpc by id -> subnet's real vpc doesn't match
-    let error = get_404(format!("vpc={}", vpc2.identity.id)).await;
-    assert_eq!(error.message, subnet_not_found);
+    let error = get_400(format!("vpc={}", vpc2.identity.id)).await;
+    assert_eq!(error.message, wrong_vpc);
 
     // id + matching vpc by id + WRONG project by id: the supplied vpc is real
     // and matches the subnet, but it doesn't live in project2, so the recursive
-    // vpc validation rejects it. (404 reported at the vpc level.)
-    let error = get_404(format!(
+    // vpc->project validation rejects it. The 400 is reported at the vpc level
+    // (its message names the vpc and project), demonstrating that the inner
+    // validated lookup's error propagates out.
+    let error = get_400(format!(
         "vpc={}&project={}",
         vpc1.identity.id, project2.identity.id
     ))
     .await;
     assert_eq!(
         error.message,
-        format!("not found: vpc with id \"{}\"", vpc1.identity.id)
+        format!(
+            "vpc with id \"{}\" does not belong to the specified project",
+            vpc1.identity.id
+        )
     );
 
     // id + wrong project only (no vpc) -> project-level mismatch
-    let error = get_404(format!("project={}", project2.identity.id)).await;
-    assert_eq!(error.message, subnet_not_found);
+    let error = get_400(format!("project={}", project2.identity.id)).await;
+    assert_eq!(error.message, wrong_project);
 
     // id + wrong vpc by name + its (real) project: vpc2 exists in project2 but
     // isn't the subnet's vpc
-    let error = get_404("vpc=vpc2&project=project2".into()).await;
-    assert_eq!(error.message, subnet_not_found);
+    let error = get_400("vpc=vpc2&project=project2".into()).await;
+    assert_eq!(error.message, wrong_vpc);
 }
 
 fn subnets_eq(sn1: &VpcSubnet, sn2: &VpcSubnet) {

--- a/nexus/tests/integration_tests/vpc_subnets.rs
+++ b/nexus/tests/integration_tests/vpc_subnets.rs
@@ -16,6 +16,7 @@ use nexus_test_utils::identity_eq;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
 use nexus_test_utils::resource_helpers::{
     create_default_ip_pools, create_instance, create_project, create_vpc,
+    create_vpc_subnet, object_get, object_get_error,
 };
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::vpc::{
@@ -449,6 +450,101 @@ async fn test_vpc_subnets(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(subnet_same_name.vpc_id, vpc2.identity.id);
     assert_eq!(subnet_same_name.ipv4_block, "192.168.0.0/16".parse().unwrap());
     assert!(subnet_same_name.ipv6_block.is_unique_local());
+}
+
+// Spike (#10517), two-parent case: when a subnet is addressed by id, supplied
+// `vpc`/`project` selectors are validated against the subnet's real ancestors
+// instead of being rejected. Exercises the recursive validation (vpc-by-id
+// also validates its project) and the lenient project-only selector.
+#[nexus_test]
+async fn test_vpc_subnet_id_parent_validation(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+
+    // project1/vpc1/subnet1 is the resource under test; project2/vpc2 are
+    // unrelated and used as mismatching ancestors.
+    let project1 = create_project(client, "project1").await;
+    let vpc1 = create_vpc(client, "project1", "vpc1").await;
+    let subnet = create_vpc_subnet(
+        client,
+        "project1",
+        "vpc1",
+        "subnet1",
+        "10.0.0.0/24".parse().unwrap(),
+        None,
+        None,
+    )
+    .await;
+    let project2 = create_project(client, "project2").await;
+    let vpc2 = create_vpc(client, "project2", "vpc2").await;
+
+    let sid = subnet.identity.id;
+    let get = |query: String| {
+        let url = format!("/v1/vpc-subnets/{sid}?{query}");
+        async move { object_get::<VpcSubnet>(client, &url).await }
+    };
+    let get_404 = |query: String| {
+        let url = format!("/v1/vpc-subnets/{sid}?{query}");
+        async move { object_get_error(client, &url, StatusCode::NOT_FOUND).await }
+    };
+
+    // --- Accepted: matching selectors, in every form ---
+
+    // bare id
+    assert_eq!(get(String::new()).await.identity.id, sid);
+    // id + matching vpc by name + matching project by name
+    assert_eq!(get("vpc=vpc1&project=project1".into()).await.identity.id, sid);
+    // id + matching vpc by id (no project needed)
+    assert_eq!(get(format!("vpc={}", vpc1.identity.id)).await.identity.id, sid);
+    // id + matching vpc by id + matching project by id (recursive vpc->project
+    // validation, all succeeding)
+    assert_eq!(
+        get(format!(
+            "vpc={}&project={}",
+            vpc1.identity.id, project1.identity.id
+        ))
+        .await
+        .identity
+        .id,
+        sid
+    );
+    // id + matching project only, no vpc (the lenient case)
+    assert_eq!(get("project=project1".into()).await.identity.id, sid);
+    assert_eq!(
+        get(format!("project={}", project1.identity.id)).await.identity.id,
+        sid
+    );
+
+    // --- Rejected with 404: any mismatching ancestor ---
+
+    let subnet_not_found = format!("not found: vpc-subnet with id \"{sid}\"");
+
+    // id + wrong vpc by id -> subnet's real vpc doesn't match
+    let error = get_404(format!("vpc={}", vpc2.identity.id)).await;
+    assert_eq!(error.message, subnet_not_found);
+
+    // id + matching vpc by id + WRONG project by id: the supplied vpc is real
+    // and matches the subnet, but it doesn't live in project2, so the recursive
+    // vpc validation rejects it. (404 reported at the vpc level.)
+    let error = get_404(format!(
+        "vpc={}&project={}",
+        vpc1.identity.id, project2.identity.id
+    ))
+    .await;
+    assert_eq!(
+        error.message,
+        format!("not found: vpc with id \"{}\"", vpc1.identity.id)
+    );
+
+    // id + wrong project only (no vpc) -> project-level mismatch
+    let error = get_404(format!("project={}", project2.identity.id)).await;
+    assert_eq!(error.message, subnet_not_found);
+
+    // id + wrong vpc by name + its (real) project: vpc2 exists in project2 but
+    // isn't the subnet's vpc
+    let error = get_404("vpc=vpc2&project=project2".into()).await;
+    assert_eq!(error.message, subnet_not_found);
 }
 
 fn subnets_eq(sn1: &VpcSubnet, sn2: &VpcSubnet) {


### PR DESCRIPTION
Prototype for #10517, similar to #10526 but does it the real way by modifying the lookup macro. 

<details>
<summary>Claude: how it works and what full-API coverage would take</summary>

Today, looking up a resource by id while *also* supplying a parent selector
(`GET /v1/instances/{id}?project=...`) is rejected with a 400. This validates
the supplied parent against the resource's real parent instead (#10517).

The check lives in the `lookup_resource!` macro, gated behind an opt-in
`validate_by_id_parent = true` flag, so resources convert one at a time without
touching the other ~30 `lookup_resource!` invocations.

When the flag is set, the macro emits an extra builder variant:

```rust
PrimaryKeyWithParents(Root, <pkey>, Option<Box<Project>>, Option<Box<Vpc>>, …)
```

— one `Option` per validatable ancestor (`Silo` is excluded: it's always the
actor's own silo from the auth context, never caller-supplied). Each `Some`
ancestor is a fully-built lookup the caller already knows how to construct.

The validation reuses the existing by-id resolution, which already walks up and
resolves every real ancestor for free. For each supplied ancestor it resolves
the supplied lookup and compares ids; a real-but-wrong ancestor is a 400:

```rust
let (.., supplied_authz) = supplied.lookup_for(Read).await?;
if real_ancestor_authz.id() != supplied_authz.id() {
    return Err(Error::invalid_request(format!(
        "{resource} with id \"{id}\" does not belong to the specified {ancestor}"
    )));
}
```

The comparison runs **only after the resource's own authz check passes** — in
`fetch_for` that's `fetch_by_id_for`; in `lookup_for` it's after the `authorize`
call. So a caller who can't see the resource gets the usual 404 and never learns
from a 400 whether the parent matched.

Four properties fall out of this design:

- **No call-site churn.** The app-layer `*_lookup` functions stay *synchronous* —
  the comparison is deferred into the already-`async` `lookup_for`/`fetch_for`.
  None of the existing callers change (vs. ~130 `.await` edits for the
  app-layer alternative).
- **Multi-parent works for free.** Comparing a single level is sufficient
  because ids are globally unique, so a matching child implies a matching
  parent chain. A supplied `vpc` that is itself a validated lookup checks its
  own `project` in turn (recursive), and its 400 propagates out with a precise
  message.
- **Lenient partial selectors.** Any subset of ancestors can be supplied —
  e.g. subnet by id + `project` with no `vpc` validates just the project.
- **No info leak.** Mismatch is reachable only after the resource's authz check,
  so it's a 400 the caller could already have gotten from a plain by-id GET.

### Status codes

| selector                                       | result                             |
| ---------------------------------------------- | ---------------------------------- |
| matching parent (by name or id)                | 200                                |
| real parent the resource doesn't belong to     | **400** `… does not belong to …`   |
| caller can't see the resource                  | 404 (authz, before the comparison) |
| supplied parent doesn't resolve (unknown name) | 404 about that parent              |

The last row is the one place this differs from a strict "always 400" policy:
an unresolvable parent surfaces its own 404 rather than being folded into a
mismatch. (Switching to unified-400 is a one-line change in the generated
comparison.)

This PR opts in `instance`, `vpc`, and `vpc_subnet` as a proof of the approach
(single-parent, plus the two-parent + recursive + partial-selector cases).

## What full-API coverage would take

Per resource that opts in:

1. Add `validate_by_id_parent = true` to its `lookup_resource!` invocation.
2. Add one hand-written builder in `nexus/db-lookup/src/lookup.rs` taking an
   `Option<Ancestor>` per validatable level (~12 lines).
3. Rewrite the app-layer `*_lookup` arms that currently reject `id + parent` to
   build the validated lookup instead (no `async`, no new queries on the
   accepted paths).
4. Tests: the per-resource matrix is ~6–10 assertions (match/mismatch by name
   and id, per supplied level), reusing existing setup helpers.

Scope: ~17 selectors across 13 files (9 single-parent, ~5 two-parent, 3
three-parent). The macro change is paid **once** regardless of how many
resources opt in.

Known follow-ups before generalizing:

- **`Silo` exclusion is a real boundary.** Silo-scoped resources that take an
  *explicit* silo selector (e.g. `saml_identity_provider`) aren't covered by
  the current rule and need it revisited.
- **One unoptimized query.** The `id + id` path resolves the supplied parent
  via `lookup_for` rather than comparing ids directly. Harmless (it only runs
  on a combo that's a hard 400 today), but worth the direct-compare
  optimization before the 3-parent resources.
- **Decide the unresolvable-parent case once, API-wide** (404 about the parent,
  as here, vs. folding it into a 400 mismatch).

</details>