### PR TITLE
[fm] Introduce SitrepGuardedInsert.

### DIFF
--- a/nexus/db-queries/src/db/mod.rs
+++ b/nexus/db-queries/src/db/mod.rs
@@ -26,6 +26,7 @@ mod pool_connection;
 pub mod queries;
 mod raw_query_builder;
 mod sec_store;
+pub mod sitrep_guard;
 pub(crate) mod true_or_cast_error;
 mod update_and_check;
 

--- a/nexus/db-queries/src/db/sitrep_guard.rs
+++ b/nexus/db-queries/src/db/sitrep_guard.rs
@@ -1,0 +1,329 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Generic stale-execution-guarded inserts for resources created by fault
+//! management.
+//!
+//! The caller is expected to be a subtask of fm_rendezvous, executing either an
+//! [`AlertRequest`] or [`SupportBundleRequest`] in a sitrep. Given some
+//! unconditional Diesel `INSERT` statement for the requested alert or support
+//! bundle, the goal here is to wrap the statement such that it's conditional
+//! on a couple things:
+//!
+//!   - The generation number in `GENERATION_COLUMN` on the sitrep being
+//!     executed must be equal to the generation of the latest sitrep in
+//!     the database. This guards against stale execution.
+//!
+//!   - There is no entry in `MARKER_TABLE` for the requested resource id
+//!     indicating that the resource was previously created. This guards
+//!     against resurrection of resources that were already deleted.
+//!
+//! See detailed comments on trait [`SitrepGuardedResource`] and struct
+//! [`SitrepGuardedInsert`] for how this policy is implemented.
+//!
+//! [`AlertRequest`]: nexus_types::fm::case::AlertRequest
+//! [`SupportBundleRequest`]: nexus_types::fm::case::SupportBundleRequest
+
+use crate::db::true_or_cast_error::matches_sentinel;
+use async_bb8_diesel::AsyncRunQueryDsl;
+use diesel::QueryResult;
+use diesel::pg::Pg;
+use diesel::query_builder::AstPass;
+use diesel::query_builder::Query;
+use diesel::query_builder::QueryFragment;
+use diesel::query_builder::QueryId;
+use diesel::result::Error as DieselError;
+use diesel::sql_types;
+use nexus_db_lookup::DbConnection;
+use std::marker::PhantomData;
+use uuid::Uuid;
+
+/// Trait supplying the static SQL identifiers injected into
+/// [`SitrepGuardedInsert`]'s emitted SQL. This codifies the expectation that
+/// each guarded resource `R` will have some generation column on `fm_sitrep`,
+/// and some "marker" table (distinct from the resource) for tracking resource
+/// creation.
+///
+/// Example:
+///
+/// ```ignore
+/// impl SitrepGuardedResource for nexus_db_model::Alert {
+///    const GENERATION_COLUMN: &'static str = "alert_generation";
+///    const MARKER_TABLE: &'static str = "rendezvous_alert_created";
+///    const MARKER_ID_COLUMN: &'static str = "alert_id";
+/// }
+/// ```
+///
+/// All three constants here are hard-coded `&'static str`s, never user input,
+/// and safe to inject directly as text.
+pub trait SitrepGuardedResource {
+    /// Column on `fm_sitrep` carrying this resource's generation counter.
+    const GENERATION_COLUMN: &'static str;
+    /// Creation table tracked alongside the resource.
+    const MARKER_TABLE: &'static str;
+    /// Resource-id column in the marker table.
+    const MARKER_ID_COLUMN: &'static str;
+}
+
+/// CTE-wrapped stale-execution-guarded INSERT.
+///
+/// Type parameters:
+/// - `R` is the type of the resource being inserted, which must implement
+///   [`SitrepGuardedResource`] (see [`Self::walk_ast`] below).
+/// - `ISR` is the wrapped `INSERT` -- typically a Diesel-built
+///   `InsertStatement<...>`, inferred at the call site. It must include a
+///   `RETURNING` clause projecting to `R`.
+#[must_use = "Queries must be executed"]
+pub struct SitrepGuardedInsert<R, ISR> {
+    /// UUID of the resource being inserted. Used as the lookup key in the
+    /// `prior_marker_guard` CTE and as the row value written by the
+    /// `new_marker` CTE.
+    resource_id: Uuid,
+
+    /// Resource generation in the sitrep currently being executed by
+    /// fm_rendezvous. The `stale_guard` CTE requires this to equal the latest
+    /// sitrep's value of [`SitrepGuardedResource::GENERATION_COLUMN`].
+    expected_generation: i64,
+
+    /// Caller-built INSERT for the resource row itself, nested into the
+    /// `new_resource` CTE via [`QueryFragment::walk_ast`].
+    resource_insert: ISR,
+
+    /// Phantom data field carrying the `R` type parameter to make rustc happy.
+    _phantom: PhantomData<R>,
+}
+
+impl<R, ISR> SitrepGuardedInsert<R, ISR> {
+    /// Build a guarded insert for `resource_id` at `expected_generation`.
+    ///
+    /// The wrapped `resource_insert` statement should be built with
+    /// `ON CONFLICT DO NOTHING`. This combinator distinguishes "freshly
+    /// created" from "already exists" purely by whether the inner INSERT's
+    /// `RETURNING` produced a row: [`Self::execute_async`] maps an empty result
+    /// to [`SitrepGuardedInsertOutcome::AlreadyExists`]. An inner INSERT that
+    /// errored (rather than silently no-op'd) on a primary-key conflict would
+    /// turn the "row already exists" outcome into a hard error.
+    pub fn new(
+        resource_id: Uuid,
+        expected_generation: i64,
+        resource_insert: ISR,
+    ) -> Self {
+        Self {
+            resource_id,
+            expected_generation,
+            resource_insert,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Opt out of the prepared-statement cache. Because [`Self::walk_ast`] emits
+/// SQL with identifiers chosen from `R`'s `&'static str` consts, two distinct
+/// `R`s map to two different SQL strings even though they share a Rust type.
+/// Setting `HAS_STATIC_QUERY_ID = false` is what disables caching;
+/// [`Self::walk_ast`] does not need to call `out.unsafe_to_cache_prepared()`.
+impl<R, ISR> QueryId for SitrepGuardedInsert<R, ISR> {
+    type QueryId = ();
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+/// The combinator's projection mirrors the inner `INSERT`'s `RETURNING` clause.
+/// See [`Self::walk_ast`]'s outer `SELECT nr.* FROM new_resource nr`.
+impl<R, ISR> Query for SitrepGuardedInsert<R, ISR>
+where
+    ISR: Query,
+{
+    type SqlType = ISR::SqlType;
+}
+
+/// Sentinel string emitted by the `stale_guard` CTE on generation mismatch.
+/// Decoded back to [`SitrepGuardedInsertOutcome::StaleSitrep`].
+const STALE_GENERATION_SENTINEL: &str = "stale generation";
+
+/// Sentinel string emitted by the `prior_marker_guard` CTE when a creation
+/// marker already exists for this resource id. Decoded back to
+/// [`SitrepGuardedInsertOutcome::AlreadyExists`].
+const ALREADY_EXISTS_SENTINEL: &str = "marker already exists";
+
+impl<R, ISR> QueryFragment<Pg> for SitrepGuardedInsert<R, ISR>
+where
+    R: SitrepGuardedResource,
+    ISR: QueryFragment<Pg>,
+{
+    /// Executes a statement of the form:
+    ///
+    /// ```sql
+    /// WITH
+    ///   latest_history AS MATERIALIZED (...),
+    ///   stale_guard AS MATERIALIZED (...),
+    ///   prior_marker_guard AS MATERIALIZED (...),
+    ///   new_resource AS (...),
+    ///   new_marker AS (...)
+    /// SELECT nr.* FROM new_resource nr
+    /// ```
+    ///
+    /// The individual CTEs here are:
+    ///
+    /// 1. `latest_history`: the most-recent `fm_sitrep_history` row.
+    /// 2. `stale_guard`: compare `expected_generation` against the generation
+    ///    on the latest sitrep. If it doesn't match, it aborts with a
+    ///    non-retryable DB error that maps to
+    ///    [`SitrepGuardedInsertOutcome::StaleSitrep`].
+    /// 3. `prior_marker_guard`: checks whether a creation marker already exists
+    ///    for this resource id. If it does, aborts with a non-retryable DB
+    ///    error that maps to [`SitrepGuardedInsertOutcome::AlreadyExists`].
+    /// 4. `new_resource`: the caller's resource INSERT.
+    /// 5. `new_marker`: the marker INSERT, emitted inline by the
+    ///    combinator using R's `&'static str` consts. This only runs when
+    ///    `new_resource` actually produced a row.
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        // CTE 1: latest_history.
+        out.push_sql(
+            "WITH latest_history AS MATERIALIZED (\
+                SELECT sitrep_id FROM omicron.public.fm_sitrep_history \
+                 ORDER BY version DESC LIMIT 1\
+             )",
+        );
+
+        // CTE 2: stale_guard.
+        //
+        // A note on why Diesel has made us sad today: We'd have preferred to
+        // use `TrueOrCastError` here in `stale_guard` and `prior_marker_guard`
+        // below, rather than copy-pasting the `CAST(IF(...))` shape. We
+        // couldn't make it work.
+        //
+        // The crux of the problem was the signature of Diesel's
+        // `QueryFragment::walk_ast`, which ties the lifetimes of its `&'b self`
+        // and `out: AstPass<'_, 'b, Pg>` parameters to a single `'b`. If we try
+        // to write something here like:
+        //
+        // ```rust
+        // let guard = TrueOrCastError::new(...);
+        // guard.walk_ast(out.reborrow());
+        // ```
+        //
+        // ... the borrow checker would complain that `guard` doesn't have the
+        // same lifetime as `self`. We could certainly do this, lifting the
+        // guard clauses into fields of `SitrepGuardedInsert` to give them the
+        // correct lifetimes, but that would be way less readable than just
+        // writing the guards inline here.
+        out.push_sql(
+            ", stale_guard AS MATERIALIZED (SELECT CAST(IF(\
+                ((SELECT s.",
+        );
+        out.push_sql(R::GENERATION_COLUMN);
+        out.push_sql(
+            " FROM omicron.public.fm_sitrep s \
+                  JOIN latest_history lh ON lh.sitrep_id = s.id) = ",
+        );
+        out.push_bind_param::<sql_types::BigInt, _>(&self.expected_generation)?;
+        out.push_sql("), 'TRUE', '");
+        out.push_sql(STALE_GENERATION_SENTINEL);
+        out.push_sql("') AS BOOL) AS ok)");
+
+        // CTE 3: prior_marker_guard.
+        out.push_sql(
+            ", prior_marker_guard AS MATERIALIZED (SELECT CAST(IF(\
+                NOT EXISTS (SELECT 1 FROM omicron.public.",
+        );
+        out.push_sql(R::MARKER_TABLE);
+        out.push_sql(" WHERE ");
+        out.push_sql(R::MARKER_ID_COLUMN);
+        out.push_sql(" = ");
+        out.push_bind_param::<sql_types::Uuid, _>(&self.resource_id)?;
+        out.push_sql("), 'TRUE', '");
+        out.push_sql(ALREADY_EXISTS_SENTINEL);
+        out.push_sql("') AS BOOL) AS ok)");
+
+        // CTE 4: new_resource, the caller's INSERT statement.
+        //
+        // Note that unlike the guard CTEs, we're able to call walk_ast without
+        // lifetime issues here because resource_insert is a field of self.
+        out.push_sql(", new_resource AS (");
+        self.resource_insert.walk_ast(out.reborrow())?;
+        out.push_sql(")");
+
+        // CTE 5: new_marker.
+        //
+        // The `WHERE EXISTS (SELECT 1 FROM new_resource)` predicate gates the
+        // marker INSERT on the inner resource INSERT having produced a row.
+        out.push_sql(", new_marker AS (INSERT INTO omicron.public.");
+        out.push_sql(R::MARKER_TABLE);
+        out.push_sql(" (");
+        out.push_sql(R::MARKER_ID_COLUMN);
+        out.push_sql(", created_at_generation) SELECT ");
+        out.push_bind_param::<sql_types::Uuid, _>(&self.resource_id)?;
+        out.push_sql(", ");
+        out.push_bind_param::<sql_types::BigInt, _>(&self.expected_generation)?;
+        out.push_sql(
+            " WHERE EXISTS (SELECT 1 FROM new_resource) ON CONFLICT (",
+        );
+        out.push_sql(R::MARKER_ID_COLUMN);
+        out.push_sql(") DO NOTHING RETURNING ");
+        out.push_sql(R::MARKER_ID_COLUMN);
+        out.push_sql(")");
+
+        // Outer SELECT projects the inner INSERT's `RETURNING` columns through,
+        // so callers receive the inserted row.
+        out.push_sql(" SELECT nr.* FROM new_resource nr");
+
+        Ok(())
+    }
+}
+
+impl<R, ISR> diesel::RunQueryDsl<DbConnection> for SitrepGuardedInsert<R, ISR> {}
+
+/// Outcome of a [`SitrepGuardedInsert`] attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SitrepGuardedInsertOutcome<R> {
+    /// Both guards passed and the resource `INSERT` produced a row; the inner
+    /// statement's `RETURNING` clause is projected through and surfaced here.
+    /// The marker `INSERT` also wrote its row atomically.
+    Created(R),
+    /// The resource already exists. Either `prior_marker_guard`
+    /// short-circuited because a marker for this resource id was present, or
+    /// both guards passed but the inner INSERT `ON CONFLICT DO NOTHING` matched
+    /// a pre-existing row.
+    AlreadyExists,
+    /// The executor's expected generation does not match the current generation
+    /// on the latest sitrep; nothing was inserted.
+    StaleSitrep,
+}
+
+impl<R, ISR> SitrepGuardedInsert<R, ISR>
+where
+    R: Send + 'static,
+    ISR: Send + 'static,
+    Self:
+        Send + diesel::query_dsl::methods::LoadQuery<'static, DbConnection, R>,
+{
+    pub async fn execute_async(
+        self,
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+    ) -> Result<SitrepGuardedInsertOutcome<R>, DieselError> {
+        match self.get_result_async::<R>(conn).await {
+            Ok(row) => Ok(SitrepGuardedInsertOutcome::Created(row)),
+            // Both guards passed, but the outer SELECT returned zero rows. This
+            // is unlikely: the only way to reach this state is if the guards
+            // both passed but the wrapped `INSERT`'s `ON CONFLICT DO NOTHING`
+            // did nothing because there was a preexisting row with the same
+            // UUID.
+            Err(DieselError::NotFound) => {
+                Ok(SitrepGuardedInsertOutcome::AlreadyExists)
+            }
+            Err(e) => {
+                if matches_sentinel(&e, &[STALE_GENERATION_SENTINEL]).is_some()
+                {
+                    Ok(SitrepGuardedInsertOutcome::StaleSitrep)
+                } else if matches_sentinel(&e, &[ALREADY_EXISTS_SENTINEL])
+                    .is_some()
+                {
+                    Ok(SitrepGuardedInsertOutcome::AlreadyExists)
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+}

--- a/nexus/db-queries/src/db/sitrep_guard.rs
+++ b/nexus/db-queries/src/db/sitrep_guard.rs
@@ -459,14 +459,7 @@ mod tests {
         .unwrap();
     }
 
-    // Inserts a current sitrep via the production `fm_sitrep_insert` path, then
-    // sets the test-only `dummy_generation` column the combinator reads.
-    //
-    // Going through `fm_sitrep_insert` rather than a hand-written INSERT
-    // populates every real `fm_sitrep` column for us -- including the
-    // per-resource generation counters that later commits in this stack add.
-    // The sitrep is built from `SitrepMetadata::default()`, so those new columns
-    // are filled in without this test having to know about them.
+    // Inserts a current sitrep with a given `dummy_generation`.
     async fn insert_current_sitrep(
         datastore: &DataStore,
         opctx: &OpContext,
@@ -482,7 +475,7 @@ mod tests {
         datastore.fm_sitrep_insert(opctx, sitrep).await.unwrap();
 
         // `dummy_generation` is a test-only column that `fm_sitrep_insert`
-        // doesn't write, so set it directly; the combinator reads it as
+        // doesn't write, so set it directly; `SitrepGuardedInsert` reads it as
         // `DummyResource`'s generation column.
         conn.batch_execute_async(&format!(
             "UPDATE omicron.public.fm_sitrep \

--- a/nexus/db-queries/src/db/sitrep_guard.rs
+++ b/nexus/db-queries/src/db/sitrep_guard.rs
@@ -361,8 +361,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::pub_test_utils::TestDatabase;
     use crate::db::raw_query_builder::expectorate_query_contents;
+    use assert_matches::assert_matches;
+    use async_bb8_diesel::AsyncRunQueryDsl;
+    use async_bb8_diesel::AsyncSimpleConnection;
     use diesel::prelude::*;
+    use omicron_test_utils::dev;
+    use uuid::uuid;
 
     // Dummy schema standing in for a real resource. These tables exist only in
     // this test module (not in the real schema) so we can exercise the typed
@@ -387,7 +393,13 @@ mod tests {
         }
     }
 
-    struct DummyResource;
+    #[derive(Queryable, Selectable, Debug)]
+    #[diesel(table_name = dummy_resource)]
+    struct DummyResource {
+        id: Uuid,
+        name: String,
+    }
+
     impl SitrepGuardedResource for DummyResource {
         type GenerationColumn = dummy_sitrep::dsl::dummy_generation;
         type MarkerIdColumn = dummy_marker::dsl::dummy_id;
@@ -397,8 +409,7 @@ mod tests {
     // hand-assembled query are caught in review.
     #[tokio::test]
     async fn expectorate_sitrep_guarded_insert() {
-        let resource_id =
-            "11111111-1111-1111-1111-111111111111".parse().unwrap();
+        let resource_id = uuid!("11111111-1111-1111-1111-111111111111");
         let insert = diesel::insert_into(dummy_resource::table)
             .values((
                 dummy_resource::dsl::id.eq(resource_id),
@@ -406,7 +417,7 @@ mod tests {
             ))
             .on_conflict(dummy_resource::dsl::id)
             .do_nothing()
-            .returning(dummy_resource::dsl::id);
+            .returning(DummyResource::as_returning());
         let query = SitrepGuardedInsert::<DummyResource, _>::new(
             resource_id,
             Generation::try_from(3).unwrap(),
@@ -417,5 +428,228 @@ mod tests {
             "tests/output/sitrep_guarded_insert.sql",
         )
         .await;
+    }
+
+    // Fixed sitrep id used by the DB-backed tests below.
+    const SITREP_ID: &str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+    // Creates the tables the combinator's SQL references but which the real
+    // schema doesn't have: the dummy marker and resource tables, plus a
+    // `dummy_generation` column on the real `fm_sitrep` (the combinator reads
+    // the resource generation off `omicron.public.fm_sitrep`).
+    async fn setup_dummy_schema(
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+    ) {
+        conn.batch_execute_async(
+            "ALTER TABLE omicron.public.fm_sitrep \
+                 ADD COLUMN IF NOT EXISTS dummy_generation INT8; \
+             CREATE SCHEMA IF NOT EXISTS test_schema; \
+             CREATE TABLE IF NOT EXISTS test_schema.dummy_marker ( \
+                 dummy_id UUID PRIMARY KEY, \
+                 created_at_generation INT8 NOT NULL \
+             ); \
+             CREATE TABLE IF NOT EXISTS test_schema.dummy_resource ( \
+                 id UUID PRIMARY KEY, \
+                 name TEXT NOT NULL \
+             );",
+        )
+        .await
+        .unwrap();
+    }
+
+    // Inserts a current sitrep at `generation`, plus the `fm_sitrep_history`
+    // row that marks it as the latest sitrep.
+    async fn insert_current_sitrep(
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+        generation: i64,
+    ) {
+        conn.batch_execute_async(&format!(
+            "INSERT INTO omicron.public.fm_sitrep \
+                 (id, inv_collection_id, time_created, creator_id, comment, \
+                  next_inv_min_time_started, dummy_generation) \
+                 VALUES ('{SITREP_ID}', gen_random_uuid(), now(), \
+                         gen_random_uuid(), '', now(), {generation}); \
+             INSERT INTO omicron.public.fm_sitrep_history \
+                 (version, sitrep_id, time_made_current) \
+                 VALUES (1, '{SITREP_ID}', now());"
+        ))
+        .await
+        .unwrap();
+    }
+
+    // Builds and runs a guarded insert for `resource_id` at
+    // `expected_generation`.
+    async fn run_guarded_insert(
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+        resource_id: Uuid,
+        expected_generation: i64,
+    ) -> SitrepGuardedInsertOutcome<DummyResource> {
+        let insert = diesel::insert_into(dummy_resource::table)
+            .values((
+                dummy_resource::dsl::id.eq(resource_id),
+                dummy_resource::dsl::name.eq("test"),
+            ))
+            .on_conflict(dummy_resource::dsl::id)
+            .do_nothing()
+            .returning(DummyResource::as_returning());
+        SitrepGuardedInsert::<DummyResource, _>::new(
+            resource_id,
+            Generation::try_from(expected_generation).unwrap(),
+            insert,
+        )
+        .execute_async(conn)
+        .await
+        .unwrap()
+    }
+
+    // Whether a dummy resource row exists for `id`.
+    async fn resource_exists(
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+        id: Uuid,
+    ) -> bool {
+        diesel::select(diesel::dsl::exists(
+            dummy_resource::table.filter(dummy_resource::dsl::id.eq(id)),
+        ))
+        .get_result_async::<bool>(conn)
+        .await
+        .unwrap()
+    }
+
+    // The generation recorded in the marker row for `id`, if any.
+    async fn marker_generation(
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+        id: Uuid,
+    ) -> Option<i64> {
+        dummy_marker::table
+            .filter(dummy_marker::dsl::dummy_id.eq(id))
+            .select(dummy_marker::dsl::created_at_generation)
+            .first_async::<i64>(conn)
+            .await
+            .optional()
+            .unwrap()
+    }
+
+    // Both guards pass: the resource row is inserted and a marker is written
+    // with the executed generation.
+    #[tokio::test]
+    async fn sitrep_guarded_insert_created_writes_marker() {
+        let logctx =
+            dev::test_setup_log("sitrep_guarded_insert_created_writes_marker");
+        let db = TestDatabase::new_with_pool(&logctx.log).await;
+        let pool = db.pool();
+        let conn = pool.claim().await.unwrap();
+        setup_dummy_schema(&conn).await;
+        insert_current_sitrep(&conn, 2).await;
+
+        let resource_id = uuid!("22222222-2222-2222-2222-222222222222");
+        let outcome = run_guarded_insert(&conn, resource_id, 2).await;
+
+        assert_matches!(
+            outcome,
+            SitrepGuardedInsertOutcome::Created(row)
+                if row.id == resource_id && row.name == "test"
+        );
+        // The marker was written with the executed generation.
+        assert_eq!(marker_generation(&conn, resource_id).await, Some(2));
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // A pre-existing marker short-circuits `prior_marker_guard`: the insert
+    // reports `AlreadyExists` and the resource row is not written.
+    #[tokio::test]
+    async fn sitrep_guarded_insert_already_exists_via_marker() {
+        let logctx = dev::test_setup_log(
+            "sitrep_guarded_insert_already_exists_via_marker",
+        );
+        let db = TestDatabase::new_with_pool(&logctx.log).await;
+        let pool = db.pool();
+        let conn = pool.claim().await.unwrap();
+        setup_dummy_schema(&conn).await;
+        insert_current_sitrep(&conn, 2).await;
+
+        let resource_id = uuid!("33333333-3333-3333-3333-333333333333");
+        // Seed a marker for this resource id.
+        diesel::insert_into(dummy_marker::table)
+            .values((
+                dummy_marker::dsl::dummy_id.eq(resource_id),
+                dummy_marker::dsl::created_at_generation.eq(2i64),
+            ))
+            .execute_async(&*conn)
+            .await
+            .unwrap();
+
+        let outcome = run_guarded_insert(&conn, resource_id, 2).await;
+
+        assert_matches!(outcome, SitrepGuardedInsertOutcome::AlreadyExists);
+        // The resource row was not inserted; the seeded marker is unchanged.
+        assert!(!resource_exists(&conn, resource_id).await);
+        assert_eq!(marker_generation(&conn, resource_id).await, Some(2));
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // Both guards pass, but the inner `ON CONFLICT DO NOTHING` matches a
+    // pre-existing resource row, so no row is returned and no marker is
+    // written. This is also surfaced as `AlreadyExists`.
+    #[tokio::test]
+    async fn sitrep_guarded_insert_already_exists_via_conflict() {
+        let logctx = dev::test_setup_log(
+            "sitrep_guarded_insert_already_exists_via_conflict",
+        );
+        let db = TestDatabase::new_with_pool(&logctx.log).await;
+        let pool = db.pool();
+        let conn = pool.claim().await.unwrap();
+        setup_dummy_schema(&conn).await;
+        insert_current_sitrep(&conn, 2).await;
+
+        let resource_id = uuid!("44444444-4444-4444-4444-444444444444");
+        // Seed the resource row, but no marker.
+        diesel::insert_into(dummy_resource::table)
+            .values((
+                dummy_resource::dsl::id.eq(resource_id),
+                dummy_resource::dsl::name.eq("preexisting"),
+            ))
+            .execute_async(&*conn)
+            .await
+            .unwrap();
+
+        let outcome = run_guarded_insert(&conn, resource_id, 2).await;
+
+        assert_matches!(outcome, SitrepGuardedInsertOutcome::AlreadyExists);
+        // The pre-existing resource row is still there, and no marker was
+        // written (the marker INSERT is gated on the resource INSERT producing
+        // a row).
+        assert!(resource_exists(&conn, resource_id).await);
+        assert_eq!(marker_generation(&conn, resource_id).await, None);
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // The executed generation does not match the latest sitrep's generation:
+    // `stale_guard` aborts and nothing is written.
+    #[tokio::test]
+    async fn sitrep_guarded_insert_stale_sitrep() {
+        let logctx = dev::test_setup_log("sitrep_guarded_insert_stale_sitrep");
+        let db = TestDatabase::new_with_pool(&logctx.log).await;
+        let pool = db.pool();
+        let conn = pool.claim().await.unwrap();
+        setup_dummy_schema(&conn).await;
+        // Latest sitrep is at generation 2 ...
+        insert_current_sitrep(&conn, 2).await;
+
+        let resource_id = uuid!("55555555-5555-5555-5555-555555555555");
+        // ... but we execute expecting generation 1.
+        let outcome = run_guarded_insert(&conn, resource_id, 1).await;
+
+        assert_matches!(outcome, SitrepGuardedInsertOutcome::StaleSitrep);
+        assert!(!resource_exists(&conn, resource_id).await);
+        assert_eq!(marker_generation(&conn, resource_id).await, None);
+
+        db.terminate().await;
+        logctx.cleanup_successful();
     }
 }

--- a/nexus/db-queries/src/db/sitrep_guard.rs
+++ b/nexus/db-queries/src/db/sitrep_guard.rs
@@ -27,44 +27,49 @@
 
 use crate::db::true_or_cast_error::matches_sentinel;
 use async_bb8_diesel::AsyncRunQueryDsl;
+use diesel::Column;
 use diesel::QueryResult;
+use diesel::associations::HasTable;
 use diesel::pg::Pg;
 use diesel::query_builder::AstPass;
 use diesel::query_builder::Query;
 use diesel::query_builder::QueryFragment;
 use diesel::query_builder::QueryId;
+use diesel::query_source::QuerySource;
 use diesel::result::Error as DieselError;
 use diesel::sql_types;
 use nexus_db_lookup::DbConnection;
-use std::marker::PhantomData;
+use nexus_db_model::Generation;
 use uuid::Uuid;
 
-/// Trait supplying the static SQL identifiers injected into
-/// [`SitrepGuardedInsert`]'s emitted SQL. This codifies the expectation that
-/// each guarded resource `R` will have some generation column on `fm_sitrep`,
-/// and some "marker" table (distinct from the resource) for tracking resource
-/// creation.
+/// Trait supplying the types injected into [`SitrepGuardedInsert`]'s emitted
+/// SQL. This codifies the expectation that each guarded resource `R` will have
+/// some generation column on `fm_sitrep`, and some "marker" table (distinct
+/// from the resource) for tracking resource creation.
 ///
 /// Example:
 ///
 /// ```ignore
-/// impl SitrepGuardedResource for nexus_db_model::Alert {
-///    const GENERATION_COLUMN: &'static str = "alert_generation";
-///    const MARKER_TABLE: &'static str = "rendezvous_alert_created";
-///    const MARKER_ID_COLUMN: &'static str = "alert_id";
+/// use schema::fm_sitrep::dsl::my_resource_generation;
+/// use schema::rendezvous_my_resource_created::dsl::my_resource_id;
+///
+/// impl SitrepGuardedResource for MyResource {
+///     type GenerationColumn = my_resource_generation;
+///     type MarkerIdColumn = my_resource_id;
 /// }
 /// ```
 ///
-/// All three constants here are hard-coded `&'static str`s, never user input,
-/// and safe to inject directly as text.
 pub trait SitrepGuardedResource {
     /// Column on `fm_sitrep` carrying this resource's generation counter.
-    const GENERATION_COLUMN: &'static str;
-    /// Creation table tracked alongside the resource.
-    const MARKER_TABLE: &'static str;
+    type GenerationColumn: Column;
     /// Resource-id column in the marker table.
-    const MARKER_ID_COLUMN: &'static str;
+    type MarkerIdColumn: Column;
 }
+
+/// The marker table for resource `R`: the table owning its
+/// [`SitrepGuardedResource::MarkerIdColumn`].
+type MarkerTable<R> =
+    <<R as SitrepGuardedResource>::MarkerIdColumn as Column>::Table;
 
 /// CTE-wrapped stale-execution-guarded INSERT.
 ///
@@ -75,7 +80,10 @@ pub trait SitrepGuardedResource {
 ///   `InsertStatement<...>`, inferred at the call site. It must include a
 ///   `RETURNING` clause projecting to `R`.
 #[must_use = "Queries must be executed"]
-pub struct SitrepGuardedInsert<R, ISR> {
+pub struct SitrepGuardedInsert<R, ISR>
+where
+    R: SitrepGuardedResource,
+{
     /// UUID of the resource being inserted. Used as the lookup key in the
     /// `prior_marker_guard` CTE and as the row value written by the
     /// `new_marker` CTE.
@@ -83,18 +91,25 @@ pub struct SitrepGuardedInsert<R, ISR> {
 
     /// Resource generation in the sitrep currently being executed by
     /// fm_rendezvous. The `stale_guard` CTE requires this to equal the latest
-    /// sitrep's value of [`SitrepGuardedResource::GENERATION_COLUMN`].
-    expected_generation: i64,
+    /// sitrep's value of [`SitrepGuardedResource::GenerationColumn`].
+    expected_generation: Generation,
 
     /// Caller-built INSERT for the resource row itself, nested into the
     /// `new_resource` CTE via [`QueryFragment::walk_ast`].
     resource_insert: ISR,
 
-    /// Phantom data field carrying the `R` type parameter to make rustc happy.
-    _phantom: PhantomData<R>,
+    /// The marker table's `FROM` clause, built once in [`Self::new`] from
+    /// [`MarkerTable<R>`]. Stored as a field here, rather than reconstructed
+    /// inside [`Self::walk_ast`] so it correctly shares `self`'s lifetime when
+    /// walked.
+    marker_from_clause: <MarkerTable<R> as QuerySource>::FromClause,
 }
 
-impl<R, ISR> SitrepGuardedInsert<R, ISR> {
+impl<R, ISR> SitrepGuardedInsert<R, ISR>
+where
+    R: SitrepGuardedResource,
+    MarkerTable<R>: HasTable<Table = MarkerTable<R>>,
+{
     /// Build a guarded insert for `resource_id` at `expected_generation`.
     ///
     /// The wrapped `resource_insert` statement should be built with
@@ -106,24 +121,24 @@ impl<R, ISR> SitrepGuardedInsert<R, ISR> {
     /// turn the "row already exists" outcome into a hard error.
     pub fn new(
         resource_id: Uuid,
-        expected_generation: i64,
+        expected_generation: Generation,
         resource_insert: ISR,
     ) -> Self {
+        let marker_from_clause =
+            <MarkerTable<R> as HasTable>::table().from_clause();
         Self {
             resource_id,
             expected_generation,
             resource_insert,
-            _phantom: PhantomData,
+            marker_from_clause,
         }
     }
 }
 
-/// Opt out of the prepared-statement cache. Because [`Self::walk_ast`] emits
-/// SQL with identifiers chosen from `R`'s `&'static str` consts, two distinct
-/// `R`s map to two different SQL strings even though they share a Rust type.
-/// Setting `HAS_STATIC_QUERY_ID = false` is what disables caching;
-/// [`Self::walk_ast`] does not need to call `out.unsafe_to_cache_prepared()`.
-impl<R, ISR> QueryId for SitrepGuardedInsert<R, ISR> {
+impl<R, ISR> QueryId for SitrepGuardedInsert<R, ISR>
+where
+    R: SitrepGuardedResource,
+{
     type QueryId = ();
     const HAS_STATIC_QUERY_ID: bool = false;
 }
@@ -132,6 +147,7 @@ impl<R, ISR> QueryId for SitrepGuardedInsert<R, ISR> {
 /// See [`Self::walk_ast`]'s outer `SELECT nr.* FROM new_resource nr`.
 impl<R, ISR> Query for SitrepGuardedInsert<R, ISR>
 where
+    R: SitrepGuardedResource,
     ISR: Query,
 {
     type SqlType = ISR::SqlType;
@@ -150,6 +166,7 @@ impl<R, ISR> QueryFragment<Pg> for SitrepGuardedInsert<R, ISR>
 where
     R: SitrepGuardedResource,
     ISR: QueryFragment<Pg>,
+    <MarkerTable<R> as QuerySource>::FromClause: QueryFragment<Pg>,
 {
     /// Executes a statement of the form:
     ///
@@ -175,9 +192,13 @@ where
     ///    error that maps to [`SitrepGuardedInsertOutcome::AlreadyExists`].
     /// 4. `new_resource`: the caller's resource INSERT.
     /// 5. `new_marker`: the marker INSERT, emitted inline by the
-    ///    combinator using R's `&'static str` consts. This only runs when
+    ///    combinator using R's schema types. This only runs when
     ///    `new_resource` actually produced a row.
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        // Column names injected into the CTEs below.
+        let marker_id_column = <R::MarkerIdColumn as Column>::NAME;
+        let generation_column = <R::GenerationColumn as Column>::NAME;
+
         // CTE 1: latest_history.
         out.push_sql(
             "WITH latest_history AS MATERIALIZED (\
@@ -212,7 +233,7 @@ where
             ", stale_guard AS MATERIALIZED (SELECT CAST(IF(\
                 ((SELECT s.",
         );
-        out.push_sql(R::GENERATION_COLUMN);
+        out.push_identifier(generation_column)?;
         out.push_sql(
             " FROM omicron.public.fm_sitrep s \
                   JOIN latest_history lh ON lh.sitrep_id = s.id) = ",
@@ -225,11 +246,11 @@ where
         // CTE 3: prior_marker_guard.
         out.push_sql(
             ", prior_marker_guard AS MATERIALIZED (SELECT CAST(IF(\
-                NOT EXISTS (SELECT 1 FROM omicron.public.",
+                NOT EXISTS (SELECT 1 FROM ",
         );
-        out.push_sql(R::MARKER_TABLE);
+        self.marker_from_clause.walk_ast(out.reborrow())?;
         out.push_sql(" WHERE ");
-        out.push_sql(R::MARKER_ID_COLUMN);
+        out.push_identifier(marker_id_column)?;
         out.push_sql(" = ");
         out.push_bind_param::<sql_types::Uuid, _>(&self.resource_id)?;
         out.push_sql("), 'TRUE', '");
@@ -248,20 +269,25 @@ where
         //
         // The `WHERE EXISTS (SELECT 1 FROM new_resource)` predicate gates the
         // marker INSERT on the inner resource INSERT having produced a row.
-        out.push_sql(", new_marker AS (INSERT INTO omicron.public.");
-        out.push_sql(R::MARKER_TABLE);
+        out.push_sql(", new_marker AS (INSERT INTO ");
+        self.marker_from_clause.walk_ast(out.reborrow())?;
         out.push_sql(" (");
-        out.push_sql(R::MARKER_ID_COLUMN);
-        out.push_sql(", created_at_generation) SELECT ");
+        out.push_identifier(marker_id_column)?;
+        out.push_sql(", ");
+        // The generation column name is hardcoded here rather than carried as a
+        // `SitrepGuardedResource` associated type. We expect all marker tables
+        // to use the same column name for consistency.
+        out.push_identifier("created_at_generation")?;
+        out.push_sql(") SELECT ");
         out.push_bind_param::<sql_types::Uuid, _>(&self.resource_id)?;
         out.push_sql(", ");
         out.push_bind_param::<sql_types::BigInt, _>(&self.expected_generation)?;
         out.push_sql(
             " WHERE EXISTS (SELECT 1 FROM new_resource) ON CONFLICT (",
         );
-        out.push_sql(R::MARKER_ID_COLUMN);
+        out.push_identifier(marker_id_column)?;
         out.push_sql(") DO NOTHING RETURNING ");
-        out.push_sql(R::MARKER_ID_COLUMN);
+        out.push_identifier(marker_id_column)?;
         out.push_sql(")");
 
         // Outer SELECT projects the inner INSERT's `RETURNING` columns through,
@@ -272,7 +298,10 @@ where
     }
 }
 
-impl<R, ISR> diesel::RunQueryDsl<DbConnection> for SitrepGuardedInsert<R, ISR> {}
+impl<R, ISR> diesel::RunQueryDsl<DbConnection> for SitrepGuardedInsert<R, ISR> where
+    R: SitrepGuardedResource
+{
+}
 
 /// Outcome of a [`SitrepGuardedInsert`] attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -293,8 +322,8 @@ pub enum SitrepGuardedInsertOutcome<R> {
 
 impl<R, ISR> SitrepGuardedInsert<R, ISR>
 where
-    R: Send + 'static,
-    ISR: Send + 'static,
+    R: SitrepGuardedResource + Send + 'static,
+    ISR: 'static,
     Self:
         Send + diesel::query_dsl::methods::LoadQuery<'static, DbConnection, R>,
 {
@@ -312,18 +341,81 @@ where
             Err(DieselError::NotFound) => {
                 Ok(SitrepGuardedInsertOutcome::AlreadyExists)
             }
-            Err(e) => {
-                if matches_sentinel(&e, &[STALE_GENERATION_SENTINEL]).is_some()
-                {
-                    Ok(SitrepGuardedInsertOutcome::StaleSitrep)
-                } else if matches_sentinel(&e, &[ALREADY_EXISTS_SENTINEL])
-                    .is_some()
-                {
-                    Ok(SitrepGuardedInsertOutcome::AlreadyExists)
-                } else {
-                    Err(e)
-                }
+            Err(e)
+                if matches_sentinel(&e, &[STALE_GENERATION_SENTINEL])
+                    .is_some() =>
+            {
+                Ok(SitrepGuardedInsertOutcome::StaleSitrep)
             }
+            Err(e)
+                if matches_sentinel(&e, &[ALREADY_EXISTS_SENTINEL])
+                    .is_some() =>
+            {
+                Ok(SitrepGuardedInsertOutcome::AlreadyExists)
+            }
+            Err(e) => Err(e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::raw_query_builder::expectorate_query_contents;
+    use diesel::prelude::*;
+
+    // Dummy schema standing in for a real resource. These tables exist only in
+    // this test module (not in the real schema) so we can exercise the typed
+    // `SitrepGuardedResource` path without a concrete resource, which lands in
+    // later PRs.
+    table! {
+        test_schema.dummy_sitrep (id) {
+            id -> Uuid,
+            dummy_generation -> Int8,
+        }
+    }
+    table! {
+        test_schema.dummy_marker (dummy_id) {
+            dummy_id -> Uuid,
+            created_at_generation -> Int8,
+        }
+    }
+    table! {
+        test_schema.dummy_resource (id) {
+            id -> Uuid,
+            name -> Text,
+        }
+    }
+
+    struct DummyResource;
+    impl SitrepGuardedResource for DummyResource {
+        type GenerationColumn = dummy_sitrep::dsl::dummy_generation;
+        type MarkerIdColumn = dummy_marker::dsl::dummy_id;
+    }
+
+    // Snapshots the SQL the combinator generates, so accidental changes to the
+    // hand-assembled query are caught in review.
+    #[tokio::test]
+    async fn expectorate_sitrep_guarded_insert() {
+        let resource_id =
+            "11111111-1111-1111-1111-111111111111".parse().unwrap();
+        let insert = diesel::insert_into(dummy_resource::table)
+            .values((
+                dummy_resource::dsl::id.eq(resource_id),
+                dummy_resource::dsl::name.eq("test"),
+            ))
+            .on_conflict(dummy_resource::dsl::id)
+            .do_nothing()
+            .returning(dummy_resource::dsl::id);
+        let query = SitrepGuardedInsert::<DummyResource, _>::new(
+            resource_id,
+            Generation::try_from(3).unwrap(),
+            insert,
+        );
+        expectorate_query_contents(
+            &query,
+            "tests/output/sitrep_guarded_insert.sql",
+        )
+        .await;
     }
 }

--- a/nexus/db-queries/tests/output/sitrep_guarded_insert.sql
+++ b/nexus/db-queries/tests/output/sitrep_guarded_insert.sql
@@ -49,7 +49,7 @@ WITH
       DO
         NOTHING
       RETURNING
-        test_schema.dummy_resource.id
+        test_schema.dummy_resource.id, test_schema.dummy_resource.name
     ),
   new_marker
     AS (

--- a/nexus/db-queries/tests/output/sitrep_guarded_insert.sql
+++ b/nexus/db-queries/tests/output/sitrep_guarded_insert.sql
@@ -1,0 +1,73 @@
+WITH
+  latest_history
+    AS MATERIALIZED (
+      SELECT sitrep_id FROM omicron.public.fm_sitrep_history ORDER BY version DESC LIMIT 1
+    ),
+  stale_guard
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          IF(
+            (
+              (
+                SELECT
+                  s.dummy_generation
+                FROM
+                  omicron.public.fm_sitrep AS s JOIN latest_history AS lh ON lh.sitrep_id = s.id
+              )
+              = $1
+            ),
+            'TRUE',
+            'stale generation'
+          )
+            AS BOOL
+        )
+          AS ok
+    ),
+  prior_marker_guard
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          IF(
+            NOT EXISTS(SELECT 1 FROM test_schema.dummy_marker WHERE dummy_id = $2),
+            'TRUE',
+            'marker already exists'
+          )
+            AS BOOL
+        )
+          AS ok
+    ),
+  new_resource
+    AS (
+      INSERT
+      INTO
+        test_schema.dummy_resource (id, name)
+      VALUES
+        ($3, $4)
+      ON CONFLICT
+        (id)
+      DO
+        NOTHING
+      RETURNING
+        test_schema.dummy_resource.id
+    ),
+  new_marker
+    AS (
+      INSERT
+      INTO
+        test_schema.dummy_marker (dummy_id, created_at_generation)
+      SELECT
+        $5, $6
+      WHERE
+        EXISTS(SELECT 1 FROM new_resource)
+      ON CONFLICT
+        (dummy_id)
+      DO
+        NOTHING
+      RETURNING
+        dummy_id
+    )
+SELECT
+  nr.*
+FROM
+  new_resource AS nr


### PR DESCRIPTION
Add the `SitrepGuardedInsert` Diesel combinator and the `SitrepGuardedResource` trait: a generic primitive for FM rendezvous to insert a resource row idempotently and guarded against stale-sitrep execution.

The combinator wraps a caller-supplied resource INSERT in a single CTE statement that:

  - aborts (StaleSitrep) unless the executor's expected generation still equals the latest sitrep's generation column;
  - short-circuits (AlreadyExists) if a creation marker already exists for the resource id;
  - on a successful insert, atomically writes a creation marker.

The result is surfaced as a `SitrepGuardedInsertOutcome` of `Created` / `AlreadyExists` / `StaleSitrep`.

Context: #10248. This is used in #10533 and #10535 which are split out in hopes of making the review somewhat less miserable.