### PR TITLE
[update-status] temporarily disable stuck saga reporting

### DIFF
--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -60,6 +60,8 @@ use uuid::Uuid;
 /// and 19m23s). Since sagas running longer than 15 minutes are so rare in
 /// practice, we use that as the threshold. Anything older is much more likely
 /// stuck than legitimately still in progress.
+// TODO-K: Remove in https://github.com/oxidecomputer/omicron/issues/10538
+#[allow(dead_code)]
 const STUCK_SAGA_THRESHOLD: TimeDelta = TimeDelta::minutes(15);
 
 /// Threshold at which we consider an inventory collection too old for the
@@ -627,17 +629,16 @@ impl super::Nexus {
             UpdateActivityState::Idle | UpdateActivityState::Stuck => {}
         };
 
-        let stuck_sagas = self
-            .datastore()
-            .saga_list_running_or_unwinding_older_than(
-                opctx,
-                Utc::now() - STUCK_SAGA_THRESHOLD,
-            )
-            .await;
-
         let checks = UpdateContactSupportChecksInput {
             inventory,
-            stuck_sagas,
+            // TODO-K: Temporarily disabling the retrieval of stuck sagas.
+            // In https://github.com/oxidecomputer/omicron/issues/10531 we found
+            // some old unwinding sagas that didn't really affect the update
+            // process in any way. The actual new retrieval method will be in
+            // https://github.com/oxidecomputer/omicron/issues/10538, but to
+            // make sure we don't block the upcoming release, we are disabling
+            // saga reporting for now.
+            stuck_sagas: Ok(vec![]),
             blueprint,
             current_target_version: current_target_version.cloned(),
             internal_update_status,
@@ -1312,10 +1313,10 @@ mod test {
         let version = fake_target_version();
         let blueprint =
             fake_blueprint(&cptestctx.logctx.log, &version, Utc::now(), false);
-        // There is a stuck active saga no update has ever been run, contact
-        // support should be true
+        // There is a stuck active saga no update has ever been run, but we
+        // disabled stuck staga retrieval contact support should be false
         assert!(
-            nexus
+            !nexus
                 .contact_support(
                     &opctx,
                     inventory,

--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -1314,7 +1314,7 @@ mod test {
         let blueprint =
             fake_blueprint(&cptestctx.logctx.log, &version, Utc::now(), false);
         // There is a stuck active saga no update has ever been run, but we
-        // disabled stuck staga retrieval contact support should be false
+        // disabled stuck staga retrieval. Contact support should be false
         assert!(
             !nexus
                 .contact_support(

--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -61,7 +61,7 @@ use uuid::Uuid;
 /// practice, we use that as the threshold. Anything older is much more likely
 /// stuck than legitimately still in progress.
 // TODO-K: Remove in https://github.com/oxidecomputer/omicron/issues/10538
-#[allow(dead_code)]
+#[cfg(test)]
 const STUCK_SAGA_THRESHOLD: TimeDelta = TimeDelta::minutes(15);
 
 /// Threshold at which we consider an inventory collection too old for the
@@ -1313,8 +1313,9 @@ mod test {
         let version = fake_target_version();
         let blueprint =
             fake_blueprint(&cptestctx.logctx.log, &version, Utc::now(), false);
-        // There is a stuck active saga no update has ever been run, but we
-        // disabled stuck staga retrieval. Contact support should be false
+        // There is a stuck active saga, but no update has ever been run. This
+        // should prompt the user to contact support, but we disabled stuck
+        // staga retrieval temporarily. Contact support should be false
         assert!(
             !nexus
                 .contact_support(


### PR DESCRIPTION
Follow up to https://github.com/oxidecomputer/omicron/issues/10531 . To make sure we don't report false positives in R20 we are temporarily disabling stuck saga retrieval. https://github.com/oxidecomputer/omicron/issues/10538 will be the proper implementation, which should be back on for R21