### PR TITLE
[api] `icmp`/`icmp6` → `icmp_v4`/`icmp_v6`

### DIFF
--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -197,8 +197,8 @@ impl From<omicron_common::api::external::VpcFirewallRuleProtocol>
         match s {
             Tcp => Self::Tcp,
             Udp => Self::Udp,
-            Icmp(v) => Self::Icmp(v),
-            Icmp6(v) => Self::Icmp6(v),
+            IcmpV4(v) => Self::IcmpV4(v),
+            IcmpV6(v) => Self::IcmpV6(v),
         }
     }
 }

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1855,27 +1855,33 @@ pub struct VpcFirewallRuleFilter {
 pub enum VpcFirewallRuleProtocol {
     Tcp,
     Udp,
-    Icmp(Option<VpcFirewallIcmpFilter>),
-    Icmp6(Option<VpcFirewallIcmpFilter>),
+    IcmpV4(Option<VpcFirewallIcmpFilter>),
+    IcmpV6(Option<VpcFirewallIcmpFilter>),
     // TODO: OPTE does not yet permit further L4 protocols. (opte#609)
     // Other(u16),
 }
 
 impl VpcFirewallRuleProtocol {
-    /// Returns a string representation of this protocol filter suitable for
-    /// use as an API string or in the database.
+    /// Returns the string representation of this protocol filter used for
+    /// database storage.
+    ///
+    /// This deliberately keeps the legacy `icmp`/`icmp6` spellings rather than
+    /// the API wire spellings (`icmp_v4`/`icmp_v6`), so that existing stored
+    /// rows remain valid without a data migration. The wire representation is
+    /// produced by serde (see the `serde(rename_all = "snake_case")` attribute
+    /// on the enum).
     ///
     /// This is the inverse of `from_api_string`.
     pub fn to_api_string(&self) -> String {
         match self {
             VpcFirewallRuleProtocol::Tcp => "tcp".to_string(),
             VpcFirewallRuleProtocol::Udp => "udp".to_string(),
-            VpcFirewallRuleProtocol::Icmp(None) => "icmp".to_string(),
-            VpcFirewallRuleProtocol::Icmp(Some(v)) => {
+            VpcFirewallRuleProtocol::IcmpV4(None) => "icmp".to_string(),
+            VpcFirewallRuleProtocol::IcmpV4(Some(v)) => {
                 format!("icmp:{}", v.to_api_string())
             }
-            VpcFirewallRuleProtocol::Icmp6(None) => "icmp6".to_string(),
-            VpcFirewallRuleProtocol::Icmp6(Some(v)) => {
+            VpcFirewallRuleProtocol::IcmpV6(None) => "icmp6".to_string(),
+            VpcFirewallRuleProtocol::IcmpV6(Some(v)) => {
                 format!("icmp6:{}", v.to_api_string())
             }
         }
@@ -1894,17 +1900,21 @@ impl VpcFirewallRuleProtocol {
             (lhs, None) if lhs.eq_ignore_ascii_case("tcp") => Ok(Self::Tcp),
             (lhs, None) if lhs.eq_ignore_ascii_case("udp") => Ok(Self::Udp),
             (lhs, None) if lhs.eq_ignore_ascii_case("icmp") => {
-                Ok(Self::Icmp(None))
+                Ok(Self::IcmpV4(None))
             }
-            (lhs, Some(rhs)) if lhs.eq_ignore_ascii_case("icmp") => Ok(
-                Self::Icmp(Some(VpcFirewallIcmpFilter::from_api_string(rhs)?)),
-            ),
+            (lhs, Some(rhs)) if lhs.eq_ignore_ascii_case("icmp") => {
+                Ok(Self::IcmpV4(Some(VpcFirewallIcmpFilter::from_api_string(
+                    rhs,
+                )?)))
+            }
             (lhs, None) if lhs.eq_ignore_ascii_case("icmp6") => {
-                Ok(Self::Icmp6(None))
+                Ok(Self::IcmpV6(None))
             }
-            (lhs, Some(rhs)) if lhs.eq_ignore_ascii_case("icmp6") => Ok(
-                Self::Icmp6(Some(VpcFirewallIcmpFilter::from_api_string(rhs)?)),
-            ),
+            (lhs, Some(rhs)) if lhs.eq_ignore_ascii_case("icmp6") => {
+                Ok(Self::IcmpV6(Some(VpcFirewallIcmpFilter::from_api_string(
+                    rhs,
+                )?)))
+            }
             (lhs, None) => Err(Error::invalid_value(
                 "vpc_firewall_rule_protocol",
                 format!("unrecognized protocol: {lhs}"),
@@ -3714,25 +3724,25 @@ mod test {
         );
 
         assert_eq!(
-            VpcFirewallRuleProtocol::Icmp(None),
+            VpcFirewallRuleProtocol::IcmpV4(None),
             VpcFirewallRuleProtocol::from_api_string("icmp").unwrap()
         );
         assert_eq!(
-            VpcFirewallRuleProtocol::Icmp(Some(VpcFirewallIcmpFilter {
+            VpcFirewallRuleProtocol::IcmpV4(Some(VpcFirewallIcmpFilter {
                 icmp_type: 4,
                 code: None
             })),
             VpcFirewallRuleProtocol::from_api_string("icmp:4").unwrap()
         );
         assert_eq!(
-            VpcFirewallRuleProtocol::Icmp(Some(VpcFirewallIcmpFilter {
+            VpcFirewallRuleProtocol::IcmpV4(Some(VpcFirewallIcmpFilter {
                 icmp_type: 60,
                 code: Some(0.into())
             })),
             VpcFirewallRuleProtocol::from_api_string("icmp:60,0").unwrap()
         );
         assert_eq!(
-            VpcFirewallRuleProtocol::Icmp(Some(VpcFirewallIcmpFilter {
+            VpcFirewallRuleProtocol::IcmpV4(Some(VpcFirewallIcmpFilter {
                 icmp_type: 60,
                 code: Some((0..=10).try_into().unwrap())
             })),

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -3790,6 +3790,40 @@ mod test {
     }
 
     #[test]
+    fn test_firewall_rule_protocol_wire_format() {
+        assert_eq!(
+            serde_json::to_value(VpcFirewallRuleProtocol::IcmpV4(None))
+                .unwrap(),
+            serde_json::json!({
+                "type": "icmp_v4",
+                "value": null,
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(VpcFirewallRuleProtocol::IcmpV6(Some(
+                VpcFirewallIcmpFilter { icmp_type: 128, code: None }
+            )))
+            .unwrap(),
+            serde_json::json!({
+                "type": "icmp_v6",
+                "value": {
+                    "icmp_type": 128,
+                    "code": null,
+                },
+            })
+        );
+
+        assert_eq!(
+            VpcFirewallRuleProtocol::IcmpV4(None).to_api_string(),
+            "icmp"
+        );
+        assert_eq!(
+            VpcFirewallRuleProtocol::IcmpV6(None).to_api_string(),
+            "icmp6"
+        );
+    }
+
+    #[test]
     fn test_digest() {
         // No prefix
         assert!(

--- a/illumos-utils/src/opte/firewall_rules.rs
+++ b/illumos-utils/src/opte/firewall_rules.rs
@@ -102,7 +102,7 @@ impl FromVpcFirewallRule for ResolvedVpcFirewallRule {
                 .map(|proto| match proto {
                     VpcFirewallRuleProtocol::Tcp => ProtoFilter::Tcp,
                     VpcFirewallRuleProtocol::Udp => ProtoFilter::Udp,
-                    VpcFirewallRuleProtocol::Icmp(v) => {
+                    VpcFirewallRuleProtocol::IcmpV4(v) => {
                         ProtoFilter::Icmp(v.map(|v| {
                             oxide_vpc::api::IcmpFilter {
                                 ty: v.icmp_type,
@@ -110,7 +110,7 @@ impl FromVpcFirewallRule for ResolvedVpcFirewallRule {
                             }
                         }))
                     }
-                    VpcFirewallRuleProtocol::Icmp6(v) => {
+                    VpcFirewallRuleProtocol::IcmpV6(v) => {
                         ProtoFilter::Icmpv6(v.map(|v| {
                             oxide_vpc::api::IcmpFilter {
                                 ty: v.icmp_type,

--- a/nexus/db-fixed-data/src/vpc_firewall_rule.rs
+++ b/nexus/db-fixed-data/src/vpc_firewall_rule.rs
@@ -65,18 +65,18 @@ pub static NEXUS_ICMP_FW_RULE: LazyLock<VpcFirewallRuleUpdate> =
         filters: VpcFirewallRuleFilter {
             hosts: None,
             protocols: Some(vec![
-                VpcFirewallRuleProtocol::Icmp(Some(VpcFirewallIcmpFilter {
+                VpcFirewallRuleProtocol::IcmpV4(Some(VpcFirewallIcmpFilter {
                     // Type 3 -- Destination Unreachable
                     icmp_type: 3,
                     // Codes 3,4 -- Port Unreachable, Fragmentation needed
                     code: Some((3..=4).try_into().expect("3 <= 4")),
                 })),
-                VpcFirewallRuleProtocol::Icmp(Some(VpcFirewallIcmpFilter {
+                VpcFirewallRuleProtocol::IcmpV4(Some(VpcFirewallIcmpFilter {
                     // Type 5 -- Redirect
                     icmp_type: 5,
                     code: None,
                 })),
-                VpcFirewallRuleProtocol::Icmp(Some(VpcFirewallIcmpFilter {
+                VpcFirewallRuleProtocol::IcmpV4(Some(VpcFirewallIcmpFilter {
                     // Type 11 -- Time Exceeded
                     icmp_type: 11,
                     code: None,

--- a/nexus/db-model/src/vpc_firewall_rule.rs
+++ b/nexus/db-model/src/vpc_firewall_rule.rs
@@ -226,7 +226,7 @@ fn validate_protocols(
     items: &[external::VpcFirewallRuleProtocol],
 ) -> Result<(), external::Error> {
     for proto in items {
-        if let external::VpcFirewallRuleProtocol::Icmp(Some(
+        if let external::VpcFirewallRuleProtocol::IcmpV4(Some(
             external::VpcFirewallIcmpFilter {
                 code: Some(external::IcmpParamRange { first, last }),
                 ..

--- a/nexus/defaults/src/lib.rs
+++ b/nexus/defaults/src/lib.rs
@@ -82,7 +82,7 @@ pub static DEFAULT_FIREWALL_RULES: LazyLock<VpcFirewallRuleUpdateParams> =
                     targets,
                     filters: VpcFirewallRuleFilter {
                         hosts: None,
-                        protocols: Some(vec![VpcFirewallRuleProtocol::Icmp(None)]),
+                        protocols: Some(vec![VpcFirewallRuleProtocol::IcmpV4(None)]),
                         ports: None,
                     },
                     action: VpcFirewallRuleAction::Allow,

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -56,6 +56,7 @@ mod v2026_01_01_00_local;
 mod v2026_01_30_00_local;
 mod v2026_03_24_00_local;
 mod v2026_05_20_00_local;
+mod v2026_06_16_00_local;
 
 api_versions!([
     // API versions are in the format YYYY_MM_DD_NN.0.0, defined below as
@@ -86,6 +87,7 @@ api_versions!([
     // |  date-based version should be at the top of the list.
     // v
     // (next_yyyy_mm_dd_nn, IDENT),
+    (2026_06_16_00, RENAME_FIREWALL_ICMP_PROTOCOLS),
     (2026_06_08_00, INSTANCE_CPU_TYPE_TURIN_V2),
     (2026_06_05_00, EXTERNAL_JUMBO_FRAMES),
     (2026_06_04_00, IMAGE_BLOCK_SIZE_TYPE),
@@ -6914,12 +6916,30 @@ pub trait NexusExternalApi {
         method = GET,
         path = "/v1/vpc-firewall-rules",
         tags = ["vpcs"],
-        versions = VERSION_ADD_ICMPV6_FIREWALL_SUPPORT..,
+        versions = VERSION_RENAME_FIREWALL_ICMP_PROTOCOLS..,
     }]
     async fn vpc_firewall_rules_view(
         rqctx: RequestContext<Self::Context>,
         query_params: Query<latest::vpc::VpcSelector>,
     ) -> Result<HttpResponseOk<VpcFirewallRules>, HttpError>;
+
+    /// List firewall rules
+    #[endpoint {
+        operation_id = "vpc_firewall_rules_view",
+        method = GET,
+        path = "/v1/vpc-firewall-rules",
+        tags = ["vpcs"],
+        versions = VERSION_ADD_ICMPV6_FIREWALL_SUPPORT..VERSION_RENAME_FIREWALL_ICMP_PROTOCOLS,
+    }]
+    async fn vpc_firewall_rules_view_v2026_06_16_00(
+        rqctx: RequestContext<Self::Context>,
+        query_params: Query<latest::vpc::VpcSelector>,
+    ) -> Result<HttpResponseOk<v2026_06_16_00_local::VpcFirewallRules>, HttpError>
+    {
+        Self::vpc_firewall_rules_view(rqctx, query_params)
+            .await
+            .map(|resp| resp.map(Into::into))
+    }
 
     /// List firewall rules
     #[endpoint {
@@ -6960,13 +6980,33 @@ pub trait NexusExternalApi {
         method = PUT,
         path = "/v1/vpc-firewall-rules",
         tags = ["vpcs"],
-        versions = VERSION_ADD_ICMPV6_FIREWALL_SUPPORT..,
+        versions = VERSION_RENAME_FIREWALL_ICMP_PROTOCOLS..,
     }]
     async fn vpc_firewall_rules_update(
         rqctx: RequestContext<Self::Context>,
         query_params: Query<latest::vpc::VpcSelector>,
         update: TypedBody<VpcFirewallRuleUpdateParams>,
     ) -> Result<HttpResponseOk<VpcFirewallRules>, HttpError>;
+
+    /// Replace firewall rules
+    #[endpoint {
+        operation_id = "vpc_firewall_rules_update",
+        method = PUT,
+        path = "/v1/vpc-firewall-rules",
+        tags = ["vpcs"],
+        versions = VERSION_ADD_ICMPV6_FIREWALL_SUPPORT..VERSION_RENAME_FIREWALL_ICMP_PROTOCOLS,
+    }]
+    async fn vpc_firewall_rules_update_v2026_06_16_00(
+        rqctx: RequestContext<Self::Context>,
+        query_params: Query<latest::vpc::VpcSelector>,
+        update: TypedBody<v2026_06_16_00_local::VpcFirewallRuleUpdateParams>,
+    ) -> Result<HttpResponseOk<v2026_06_16_00_local::VpcFirewallRules>, HttpError>
+    {
+        let body = update.map(Into::into);
+        Self::vpc_firewall_rules_update(rqctx, query_params, body)
+            .await
+            .map(|resp| resp.map(Into::into))
+    }
 
     /// Replace firewall rules
     #[endpoint {

--- a/nexus/external-api/src/v2026_06_16_00_local.rs
+++ b/nexus/external-api/src/v2026_06_16_00_local.rs
@@ -224,3 +224,55 @@ impl From<VpcFirewallRuleUpdateParams>
         Self { rules: p.rules.into_iter().map(Into::into).collect() }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn firewall_protocol_uses_legacy_wire_spelling() {
+        let icmp = VpcFirewallRuleProtocol::Icmp(None);
+        assert_eq!(
+            serde_json::to_value(icmp).unwrap(),
+            serde_json::json!({
+                "type": "icmp",
+                "value": null,
+            })
+        );
+
+        let icmp6 =
+            VpcFirewallRuleProtocol::Icmp6(Some(VpcFirewallIcmpFilter {
+                icmp_type: 128,
+                code: None,
+            }));
+        assert_eq!(
+            serde_json::to_value(icmp6).unwrap(),
+            serde_json::json!({
+                "type": "icmp6",
+                "value": {
+                    "icmp_type": 128,
+                    "code": null,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn firewall_protocol_converts_to_latest_variants() {
+        let icmp: external::VpcFirewallRuleProtocol =
+            VpcFirewallRuleProtocol::Icmp(None).into();
+        assert_eq!(icmp, external::VpcFirewallRuleProtocol::IcmpV4(None));
+
+        let icmp6: external::VpcFirewallRuleProtocol =
+            VpcFirewallRuleProtocol::Icmp6(None).into();
+        assert_eq!(icmp6, external::VpcFirewallRuleProtocol::IcmpV6(None));
+
+        let old: VpcFirewallRuleProtocol =
+            external::VpcFirewallRuleProtocol::IcmpV4(None).into();
+        assert_eq!(old, VpcFirewallRuleProtocol::Icmp(None));
+
+        let old6: VpcFirewallRuleProtocol =
+            external::VpcFirewallRuleProtocol::IcmpV6(None).into();
+        assert_eq!(old6, VpcFirewallRuleProtocol::Icmp6(None));
+    }
+}

--- a/nexus/external-api/src/v2026_06_16_00_local.rs
+++ b/nexus/external-api/src/v2026_06_16_00_local.rs
@@ -2,12 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Types from API version 2026_03_14_00 that cannot live in `nexus-types-versions`
+//! Types from API version 2026_06_16_00 that cannot live in `nexus-types-versions`
 //! because they convert to/from `omicron-common` types (orphan rule).
 
 use api_identity::ObjectIdentity;
 use omicron_common::api::external;
-use omicron_common::api::external::Error;
 use omicron_common::api::external::IdentityMetadata;
 use omicron_common::api::external::L4PortRange;
 use omicron_common::api::external::Name;
@@ -26,8 +25,10 @@ use uuid::Uuid;
 
 /// The protocols that may be specified in a firewall rule's filter.
 //
-// This is the version of the enum without `Icmp6`, for API versions up
-// through `MULTICAST_DROP_MVLAN`.
+// This is the version of the enum that serializes ICMP protocols as `icmp` and
+// `icmp6`, for API versions from `ADD_ICMPV6_FIREWALL_SUPPORT` up through
+// `INSTANCE_CPU_TYPE_TURIN_V2`. The current version renames these to
+// `icmp_v4` and `icmp_v6`.
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type", content = "value")]
@@ -35,6 +36,7 @@ pub enum VpcFirewallRuleProtocol {
     Tcp,
     Udp,
     Icmp(Option<VpcFirewallIcmpFilter>),
+    Icmp6(Option<VpcFirewallIcmpFilter>),
 }
 
 impl From<VpcFirewallRuleProtocol> for external::VpcFirewallRuleProtocol {
@@ -43,14 +45,27 @@ impl From<VpcFirewallRuleProtocol> for external::VpcFirewallRuleProtocol {
             VpcFirewallRuleProtocol::Tcp => Self::Tcp,
             VpcFirewallRuleProtocol::Udp => Self::Udp,
             VpcFirewallRuleProtocol::Icmp(v) => Self::IcmpV4(v),
+            VpcFirewallRuleProtocol::Icmp6(v) => Self::IcmpV6(v),
+        }
+    }
+}
+
+impl From<external::VpcFirewallRuleProtocol> for VpcFirewallRuleProtocol {
+    fn from(p: external::VpcFirewallRuleProtocol) -> Self {
+        match p {
+            external::VpcFirewallRuleProtocol::Tcp => Self::Tcp,
+            external::VpcFirewallRuleProtocol::Udp => Self::Udp,
+            external::VpcFirewallRuleProtocol::IcmpV4(v) => Self::Icmp(v),
+            external::VpcFirewallRuleProtocol::IcmpV6(v) => Self::Icmp6(v),
         }
     }
 }
 
 /// Filters reduce the scope of a firewall rule.
 //
-// This is the version of the filter without `Icmp6` protocol support, for API
-// versions up through `MULTICAST_DROP_MVLAN`.
+// This is the version of the filter that serializes ICMP protocols as `icmp`
+// and `icmp6`, for API versions from `ADD_ICMPV6_FIREWALL_SUPPORT` up through
+// `INSTANCE_CPU_TYPE_TURIN_V2`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct VpcFirewallRuleFilter {
     /// If present, host filters match the "other end" of traffic from the
@@ -68,38 +83,15 @@ pub struct VpcFirewallRuleFilter {
     pub ports: Option<Vec<L4PortRange>>,
 }
 
-impl TryFrom<external::VpcFirewallRuleFilter> for VpcFirewallRuleFilter {
-    type Error = Error;
-
-    fn try_from(f: external::VpcFirewallRuleFilter) -> Result<Self, Error> {
-        let protocols = f
-            .protocols
-            .map(|ps| {
-                ps.into_iter()
-                    .map(|p| match p {
-                        external::VpcFirewallRuleProtocol::Tcp => {
-                            Ok(VpcFirewallRuleProtocol::Tcp)
-                        }
-                        external::VpcFirewallRuleProtocol::Udp => {
-                            Ok(VpcFirewallRuleProtocol::Udp)
-                        }
-                        external::VpcFirewallRuleProtocol::IcmpV4(v) => {
-                            Ok(VpcFirewallRuleProtocol::Icmp(v))
-                        }
-                        external::VpcFirewallRuleProtocol::IcmpV6(_) => {
-                            Err(Error::invalid_value(
-                                "vpc_firewall_rule_protocol",
-                                format!(
-                                    "unrecognized protocol: {}",
-                                    p.to_api_string()
-                                ),
-                            ))
-                        }
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .transpose()?;
-        Ok(Self { hosts: f.hosts, protocols, ports: f.ports })
+impl From<external::VpcFirewallRuleFilter> for VpcFirewallRuleFilter {
+    fn from(f: external::VpcFirewallRuleFilter) -> Self {
+        Self {
+            hosts: f.hosts,
+            protocols: f
+                .protocols
+                .map(|ps| ps.into_iter().map(Into::into).collect()),
+            ports: f.ports,
+        }
     }
 }
 
@@ -117,8 +109,9 @@ impl From<VpcFirewallRuleFilter> for external::VpcFirewallRuleFilter {
 
 /// A single rule in a VPC firewall.
 //
-// This is the version of the rule without `Icmp6` protocol support, for API
-// versions up through `MULTICAST_DROP_MVLAN`.
+// This is the version of the rule that serializes ICMP protocols as `icmp` and
+// `icmp6`, for API versions from `ADD_ICMPV6_FIREWALL_SUPPORT` up through
+// `INSTANCE_CPU_TYPE_TURIN_V2`.
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct VpcFirewallRule {
     /// Common identifying metadata
@@ -140,49 +133,42 @@ pub struct VpcFirewallRule {
     pub vpc_id: Uuid,
 }
 
-impl TryFrom<external::VpcFirewallRule> for VpcFirewallRule {
-    type Error = Error;
-
-    fn try_from(r: external::VpcFirewallRule) -> Result<Self, Error> {
-        Ok(Self {
+impl From<external::VpcFirewallRule> for VpcFirewallRule {
+    fn from(r: external::VpcFirewallRule) -> Self {
+        Self {
             identity: r.identity,
             status: r.status,
             direction: r.direction,
             targets: r.targets,
-            filters: r.filters.try_into()?,
+            filters: r.filters.into(),
             action: r.action,
             priority: r.priority,
             vpc_id: r.vpc_id,
-        })
+        }
     }
 }
 
 /// Collection of a VPC's firewall rules.
 //
-// This is the version of the collection without `Icmp6` protocol support, for
-// API versions up through `MULTICAST_DROP_MVLAN`.
+// This is the version of the collection that serializes ICMP protocols as
+// `icmp` and `icmp6`, for API versions from `ADD_ICMPV6_FIREWALL_SUPPORT` up
+// through `INSTANCE_CPU_TYPE_TURIN_V2`.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct VpcFirewallRules {
     pub rules: Vec<VpcFirewallRule>,
 }
 
-impl TryFrom<external::VpcFirewallRules> for VpcFirewallRules {
-    type Error = Error;
-
-    fn try_from(r: external::VpcFirewallRules) -> Result<Self, Error> {
-        let rules = r
-            .rules
-            .into_iter()
-            .map(VpcFirewallRule::try_from)
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Self { rules })
+impl From<external::VpcFirewallRules> for VpcFirewallRules {
+    fn from(r: external::VpcFirewallRules) -> Self {
+        Self { rules: r.rules.into_iter().map(VpcFirewallRule::from).collect() }
     }
 }
 
 /// A single rule in a VPC firewall update request.
 //
-// This is the version of the update without `Icmp6` protocol support, for API
-// versions up through `MULTICAST_DROP_MVLAN`.
+// This is the version of the update that serializes ICMP protocols as `icmp`
+// and `icmp6`, for API versions from `ADD_ICMPV6_FIREWALL_SUPPORT` up through
+// `INSTANCE_CPU_TYPE_TURIN_V2`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct VpcFirewallRuleUpdate {
     /// Name of the rule, unique to this VPC
@@ -221,8 +207,9 @@ impl From<VpcFirewallRuleUpdate> for external::VpcFirewallRuleUpdate {
 
 /// Updated list of firewall rules. Will replace all existing rules.
 //
-// This is the version of the params without `Icmp6` protocol support, for API
-// versions up through `MULTICAST_DROP_MVLAN`.
+// This is the version of the params that serializes ICMP protocols as `icmp`
+// and `icmp6`, for API versions from `ADD_ICMPV6_FIREWALL_SUPPORT` up through
+// `INSTANCE_CPU_TYPE_TURIN_V2`.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct VpcFirewallRuleUpdateParams {
     #[schemars(length(max = 1024))]

--- a/nexus/tests/integration_tests/vpc_firewall.rs
+++ b/nexus/tests/integration_tests/vpc_firewall.rs
@@ -99,7 +99,7 @@ async fn test_vpc_firewall(cptestctx: &ControlPlaneTestContext) {
             filters: VpcFirewallRuleFilter {
                 hosts: None,
                 ports: None,
-                protocols: Some(vec![VpcFirewallRuleProtocol::Icmp(None)]),
+                protocols: Some(vec![VpcFirewallRuleProtocol::IcmpV4(None)]),
             },
             direction: VpcFirewallRuleDirection::Inbound,
             priority: VpcFirewallRulePriority(10),
@@ -200,7 +200,7 @@ fn is_default_firewall_rules(
             )],
             filters: VpcFirewallRuleFilter {
                 hosts: None,
-                protocols: Some(vec![VpcFirewallRuleProtocol::Icmp(None)]),
+                protocols: Some(vec![VpcFirewallRuleProtocol::IcmpV4(None)]),
                 ports: None,
             },
             action: VpcFirewallRuleAction::Allow,
@@ -670,7 +670,7 @@ async fn test_firewall_rules_illegal_range(
         targets: vec![],
         filters: VpcFirewallRuleFilter {
             hosts: None,
-            protocols: Some(vec![VpcFirewallRuleProtocol::Icmp(Some(
+            protocols: Some(vec![VpcFirewallRuleProtocol::IcmpV4(Some(
                 VpcFirewallIcmpFilter {
                     icmp_type: 0,
                     code: Some(IcmpParamRange { first: 21, last: 20 }),

--- a/openapi/nexus/nexus-2026060800.0.0-f1db6e.json.gitstub
+++ b/openapi/nexus/nexus-2026060800.0.0-f1db6e.json.gitstub
@@ -1,0 +1,1 @@
+456b293ebc28e8419ce4829e90318a7ab500754e:openapi/nexus/nexus-2026060800.0.0-f1db6e.json

--- a/openapi/nexus/nexus-2026061600.0.0-c310b8.json
+++ b/openapi/nexus/nexus-2026061600.0.0-c310b8.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "2026060800.0.0"
+    "version": "2026061600.0.0"
   },
   "paths": {
     "/device/auth": {
@@ -31012,7 +31012,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "icmp"
+                  "icmp_v4"
                 ]
               },
               "value": {
@@ -31035,7 +31035,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "icmp6"
+                  "icmp_v6"
                 ]
               },
               "value": {

--- a/openapi/nexus/nexus-latest.json
+++ b/openapi/nexus/nexus-latest.json
@@ -1,1 +1,1 @@
-nexus-2026060800.0.0-f1db6e.json
+nexus-2026061600.0.0-c310b8.json

--- a/openapi/sled-agent/sled-agent-41.0.0-d909db.json.gitstub
+++ b/openapi/sled-agent/sled-agent-41.0.0-d909db.json.gitstub
@@ -1,0 +1,1 @@
+c007af2f407ddbee44a9c37a690e3208a0f848cc:openapi/sled-agent/sled-agent-41.0.0-d909db.json

--- a/openapi/sled-agent/sled-agent-42.0.0-afe251.json
+++ b/openapi/sled-agent/sled-agent-42.0.0-afe251.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "41.0.0"
+    "version": "42.0.0"
   },
   "paths": {
     "/artifacts": {
@@ -10676,7 +10676,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "icmp"
+                  "icmp_v4"
                 ]
               },
               "value": {
@@ -10699,7 +10699,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "icmp6"
+                  "icmp_v6"
                 ]
               },
               "value": {

--- a/openapi/sled-agent/sled-agent-latest.json
+++ b/openapi/sled-agent/sled-agent-latest.json
@@ -1,1 +1,1 @@
-sled-agent-41.0.0-d909db.json
+sled-agent-42.0.0-afe251.json

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -21,7 +21,7 @@ use omicron_common::api::internal::{
 };
 use sled_agent_types_versions::{
     latest, v1, v4, v6, v7, v9, v10, v11, v12, v14, v16, v17, v18, v20, v22,
-    v24, v25, v26, v28, v29, v30, v31, v32, v33, v34, v37, v39,
+    v24, v25, v26, v28, v29, v30, v31, v32, v33, v34, v37, v39, v41, v42,
 };
 use sled_diagnostics::SledDiagnosticsQueryOutput;
 use slog_error_chain::InlineErrorChain;
@@ -38,6 +38,7 @@ api_versions!([
     // |  example for the next person.
     // v
     // (next_int, IDENT),
+    (42, RENAME_FIREWALL_ICMP_PROTOCOLS),
     (41, ADD_INSTANCE_PRIMARY_NIC_MTU),
     (40, ADD_FMD_TO_INVENTORY),
     (39, BOOTSTORE_SERVICE_NAT_GENERATION),
@@ -445,13 +446,27 @@ pub trait SledAgentApi {
         operation_id = "vmm_register",
         method = PUT,
         path = "/vmms/{propolis_id}",
-        versions = VERSION_ADD_INSTANCE_PRIMARY_NIC_MTU..
+        versions = VERSION_RENAME_FIREWALL_ICMP_PROTOCOLS..
     }]
     async fn vmm_register(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<latest::instance::VmmPathParam>,
         body: TypedBody<latest::instance::InstanceEnsureBody>,
     ) -> Result<HttpResponseOk<latest::instance::SledVmmState>, HttpError>;
+
+    #[endpoint {
+        operation_id = "vmm_register",
+        method = PUT,
+        path = "/vmms/{propolis_id}",
+        versions = VERSION_ADD_INSTANCE_PRIMARY_NIC_MTU..VERSION_RENAME_FIREWALL_ICMP_PROTOCOLS
+    }]
+    async fn vmm_register_v41(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<latest::instance::VmmPathParam>,
+        body: TypedBody<v41::instance::InstanceEnsureBody>,
+    ) -> Result<HttpResponseOk<latest::instance::SledVmmState>, HttpError> {
+        Self::vmm_register(rqctx, path_params, body.map(Into::into)).await
+    }
 
     #[endpoint {
         operation_id = "vmm_register",
@@ -464,7 +479,7 @@ pub trait SledAgentApi {
         path_params: Path<latest::instance::VmmPathParam>,
         body: TypedBody<v32::instance::InstanceEnsureBody>,
     ) -> Result<HttpResponseOk<latest::instance::SledVmmState>, HttpError> {
-        Self::vmm_register(rqctx, path_params, body.map(Into::into)).await
+        Self::vmm_register_v41(rqctx, path_params, body.map(Into::into)).await
     }
 
     #[endpoint {
@@ -753,13 +768,29 @@ pub trait SledAgentApi {
     #[endpoint {
         method = PUT,
         path = "/vpc/{vpc_id}/firewall/rules",
-        versions = VERSION_ADD_ICMPV6_FIREWALL_SUPPORT..,
+        versions = VERSION_RENAME_FIREWALL_ICMP_PROTOCOLS..,
     }]
     async fn vpc_firewall_rules_put(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<latest::instance::VpcPathParam>,
         body: TypedBody<latest::firewall_rules::VpcFirewallRulesEnsureBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
+
+    #[endpoint {
+        operation_id = "vpc_firewall_rules_put",
+        method = PUT,
+        path = "/vpc/{vpc_id}/firewall/rules",
+        versions = VERSION_ADD_ICMPV6_FIREWALL_SUPPORT..VERSION_RENAME_FIREWALL_ICMP_PROTOCOLS,
+    }]
+    async fn vpc_firewall_rules_put_v31(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<latest::instance::VpcPathParam>,
+        body: TypedBody<v31::firewall_rules::VpcFirewallRulesEnsureBody>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let body =
+            body.map(v42::firewall_rules::VpcFirewallRulesEnsureBody::from);
+        Self::vpc_firewall_rules_put(rqctx, path_params, body).await
+    }
 
     #[endpoint {
         operation_id = "vpc_firewall_rules_put",
@@ -774,7 +805,7 @@ pub trait SledAgentApi {
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let body =
             body.map(v31::firewall_rules::VpcFirewallRulesEnsureBody::from);
-        Self::vpc_firewall_rules_put(rqctx, path_params, body).await
+        Self::vpc_firewall_rules_put_v31(rqctx, path_params, body).await
     }
 
     #[endpoint {

--- a/sled-agent/types/versions/src/add_icmpv6_firewall_support/instance.rs
+++ b/sled-agent/types/versions/src/add_icmpv6_firewall_support/instance.rs
@@ -166,3 +166,32 @@ impl From<v18::instance::InstanceSledLocalConfig> for InstanceSledLocalConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn firewall_protocol_uses_legacy_wire_spelling() {
+        assert_eq!(
+            serde_json::to_value(VpcFirewallRuleProtocol::Icmp(None)).unwrap(),
+            serde_json::json!({
+                "type": "icmp",
+                "value": null,
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(VpcFirewallRuleProtocol::Icmp6(Some(
+                external::VpcFirewallIcmpFilter { icmp_type: 128, code: None }
+            )))
+            .unwrap(),
+            serde_json::json!({
+                "type": "icmp6",
+                "value": {
+                    "icmp_type": 128,
+                    "code": null,
+                },
+            })
+        );
+    }
+}

--- a/sled-agent/types/versions/src/latest.rs
+++ b/sled-agent/types/versions/src/latest.rs
@@ -86,7 +86,7 @@ pub mod early_networking {
 }
 
 pub mod firewall_rules {
-    pub use crate::v31::firewall_rules::VpcFirewallRulesEnsureBody;
+    pub use crate::v42::firewall_rules::VpcFirewallRulesEnsureBody;
 }
 
 pub mod instance {
@@ -113,13 +113,14 @@ pub mod instance {
 
     pub use crate::v29::instance::VmmSpec;
 
-    pub use crate::v31::instance::ResolvedVpcFirewallRule;
     pub use crate::v32::instance::ExternalIpConfig;
     pub use crate::v32::instance::ExternalIps;
     pub use crate::v32::instance::ExternalIpv4Config;
     pub use crate::v32::instance::ExternalIpv6Config;
-    pub use crate::v41::instance::InstanceEnsureBody;
-    pub use crate::v41::instance::InstanceSledLocalConfig;
+
+    pub use crate::v42::instance::InstanceEnsureBody;
+    pub use crate::v42::instance::InstanceSledLocalConfig;
+    pub use crate::v42::instance::ResolvedVpcFirewallRule;
 }
 
 pub mod inventory {

--- a/sled-agent/types/versions/src/lib.rs
+++ b/sled-agent/types/versions/src/lib.rs
@@ -89,6 +89,8 @@ pub mod v4;
 pub mod v40;
 #[path = "add_instance_primary_nic_mtu/mod.rs"]
 pub mod v41;
+#[path = "rename_firewall_icmp_protocols/mod.rs"]
+pub mod v42;
 #[path = "add_probe_put_endpoint/mod.rs"]
 pub mod v6;
 #[path = "multicast_support/mod.rs"]

--- a/sled-agent/types/versions/src/rename_firewall_icmp_protocols/firewall_rules.rs
+++ b/sled-agent/types/versions/src/rename_firewall_icmp_protocols/firewall_rules.rs
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Firewall rule types for version `RENAME_FIREWALL_ICMP_PROTOCOLS`.
+
+use crate::v31;
+use crate::v42::instance::ResolvedVpcFirewallRule;
+use omicron_common::api::external;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Update firewall rules for a VPC
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct VpcFirewallRulesEnsureBody {
+    pub vni: external::Vni,
+    pub rules: Vec<ResolvedVpcFirewallRule>,
+}
+
+impl From<v31::firewall_rules::VpcFirewallRulesEnsureBody>
+    for VpcFirewallRulesEnsureBody
+{
+    fn from(old: v31::firewall_rules::VpcFirewallRulesEnsureBody) -> Self {
+        Self {
+            vni: old.vni,
+            rules: old
+                .rules
+                .into_iter()
+                .map(ResolvedVpcFirewallRule::from)
+                .collect(),
+        }
+    }
+}

--- a/sled-agent/types/versions/src/rename_firewall_icmp_protocols/instance.rs
+++ b/sled-agent/types/versions/src/rename_firewall_icmp_protocols/instance.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Instance types for version `ADD_ICMPV6_FIREWALL_SUPPORT`.
+//! Instance types for version `RENAME_FIREWALL_ICMP_PROTOCOLS`.
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -21,34 +21,18 @@ use uuid::Uuid;
 use crate::v1::instance::InstanceMetadata;
 use crate::v1::instance::VmmRuntimeState;
 use crate::v7::instance::InstanceMulticastMembership;
-use crate::v10;
 use crate::v10::inventory::NetworkInterface;
-use crate::v11::instance::ExternalIpConfig;
-use crate::v18;
 use crate::v18::attached_subnet::AttachedSubnet;
-use crate::v29;
 use crate::v29::instance::VmmSpec;
-
-/// The protocols that may be specified in a firewall rule's filter.
-//
-// This is frozen at the `ADD_ICMPV6_FIREWALL_SUPPORT` representation, which
-// serializes ICMP protocols as `icmp` and `icmp6`. It is a local copy rather
-// than `external::VpcFirewallRuleProtocol` so that later renames of that type
-// (to `icmp_v4`/`icmp_v6`) do not change this version's wire format.
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-#[serde(tag = "type", content = "value")]
-pub enum VpcFirewallRuleProtocol {
-    Tcp,
-    Udp,
-    Icmp(Option<external::VpcFirewallIcmpFilter>),
-    Icmp6(Option<external::VpcFirewallIcmpFilter>),
-}
+use crate::v31;
+use crate::v32::instance::ExternalIpConfig;
+use crate::v41;
 
 /// VPC firewall rule after object name resolution has been performed by Nexus.
 //
-// This version supports `Icmp6` in the protocol filter, added in
-// `ADD_ICMPV6_FIREWALL_SUPPORT`.
+// This version uses `external::VpcFirewallRuleProtocol`, which serializes ICMP
+// protocols as `icmp_v4` and `icmp_v6`. The prior version (`v31`) froze its own
+// copy that serializes them as `icmp`/`icmp6`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct ResolvedVpcFirewallRule {
     pub status: external::VpcFirewallRuleStatus,
@@ -56,13 +40,13 @@ pub struct ResolvedVpcFirewallRule {
     pub targets: Vec<NetworkInterface>,
     pub filter_hosts: Option<HashSet<HostIdentifier>>,
     pub filter_ports: Option<Vec<external::L4PortRange>>,
-    pub filter_protocols: Option<Vec<VpcFirewallRuleProtocol>>,
+    pub filter_protocols: Option<Vec<external::VpcFirewallRuleProtocol>>,
     pub action: external::VpcFirewallRuleAction,
     pub priority: external::VpcFirewallRulePriority,
 }
 
-impl From<v10::instance::ResolvedVpcFirewallRule> for ResolvedVpcFirewallRule {
-    fn from(old: v10::instance::ResolvedVpcFirewallRule) -> Self {
+impl From<v31::instance::ResolvedVpcFirewallRule> for ResolvedVpcFirewallRule {
+    fn from(old: v31::instance::ResolvedVpcFirewallRule) -> Self {
         Self {
             status: old.status,
             direction: old.direction,
@@ -72,14 +56,17 @@ impl From<v10::instance::ResolvedVpcFirewallRule> for ResolvedVpcFirewallRule {
             filter_protocols: old.filter_protocols.map(|ps| {
                 ps.into_iter()
                     .map(|p| match p {
-                        v10::instance::VpcFirewallRuleProtocol::Tcp => {
-                            VpcFirewallRuleProtocol::Tcp
+                        v31::instance::VpcFirewallRuleProtocol::Tcp => {
+                            external::VpcFirewallRuleProtocol::Tcp
                         }
-                        v10::instance::VpcFirewallRuleProtocol::Udp => {
-                            VpcFirewallRuleProtocol::Udp
+                        v31::instance::VpcFirewallRuleProtocol::Udp => {
+                            external::VpcFirewallRuleProtocol::Udp
                         }
-                        v10::instance::VpcFirewallRuleProtocol::Icmp(f) => {
-                            VpcFirewallRuleProtocol::Icmp(f)
+                        v31::instance::VpcFirewallRuleProtocol::Icmp(f) => {
+                            external::VpcFirewallRuleProtocol::IcmpV4(f)
+                        }
+                        v31::instance::VpcFirewallRuleProtocol::Icmp6(f) => {
+                            external::VpcFirewallRuleProtocol::IcmpV6(f)
                         }
                     })
                     .collect()
@@ -126,16 +113,20 @@ pub struct InstanceEnsureBody {
 pub struct InstanceSledLocalConfig {
     pub hostname: Hostname,
     pub nics: Vec<NetworkInterface>,
-    pub external_ips: Option<ExternalIpConfig>,
+    pub external_ips: ExternalIpConfig,
     pub attached_subnets: Vec<AttachedSubnet>,
     pub multicast_groups: Vec<InstanceMulticastMembership>,
     pub firewall_rules: Vec<ResolvedVpcFirewallRule>,
     pub dhcp_config: DhcpConfig,
     pub delegated_zvols: Vec<DelegatedZvol>,
+    /// The MTU to apply to the instance's primary OPTE port, in bytes. If
+    /// `None`, the OPTE default is used (1500). Set when the fleet has
+    /// enabled external jumbo frames and the instance has opted in.
+    pub primary_nic_mtu: Option<u32>,
 }
 
-impl From<v29::instance::InstanceEnsureBody> for InstanceEnsureBody {
-    fn from(old: v29::instance::InstanceEnsureBody) -> Self {
+impl From<v41::instance::InstanceEnsureBody> for InstanceEnsureBody {
+    fn from(old: v41::instance::InstanceEnsureBody) -> Self {
         Self {
             vmm_spec: old.vmm_spec,
             local_config: old.local_config.into(),
@@ -148,21 +139,22 @@ impl From<v29::instance::InstanceEnsureBody> for InstanceEnsureBody {
     }
 }
 
-impl From<v18::instance::InstanceSledLocalConfig> for InstanceSledLocalConfig {
-    fn from(v18: v18::instance::InstanceSledLocalConfig) -> Self {
+impl From<v41::instance::InstanceSledLocalConfig> for InstanceSledLocalConfig {
+    fn from(old: v41::instance::InstanceSledLocalConfig) -> Self {
         Self {
-            hostname: v18.hostname,
-            nics: v18.nics,
-            external_ips: v18.external_ips,
-            attached_subnets: v18.attached_subnets,
-            multicast_groups: v18.multicast_groups,
-            firewall_rules: v18
+            hostname: old.hostname,
+            nics: old.nics,
+            external_ips: old.external_ips,
+            attached_subnets: old.attached_subnets,
+            multicast_groups: old.multicast_groups,
+            firewall_rules: old
                 .firewall_rules
                 .into_iter()
                 .map(ResolvedVpcFirewallRule::from)
                 .collect(),
-            dhcp_config: v18.dhcp_config,
-            delegated_zvols: v18.delegated_zvols,
+            dhcp_config: old.dhcp_config,
+            delegated_zvols: old.delegated_zvols,
+            primary_nic_mtu: old.primary_nic_mtu,
         }
     }
 }

--- a/sled-agent/types/versions/src/rename_firewall_icmp_protocols/instance.rs
+++ b/sled-agent/types/versions/src/rename_firewall_icmp_protocols/instance.rs
@@ -158,3 +158,34 @@ impl From<v41::instance::InstanceSledLocalConfig> for InstanceSledLocalConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolved_firewall_rule_converts_legacy_protocol_variants() {
+        let old = v31::instance::ResolvedVpcFirewallRule {
+            status: external::VpcFirewallRuleStatus::Enabled,
+            direction: external::VpcFirewallRuleDirection::Inbound,
+            targets: Vec::new(),
+            filter_hosts: None,
+            filter_ports: None,
+            filter_protocols: Some(vec![
+                v31::instance::VpcFirewallRuleProtocol::Icmp(None),
+                v31::instance::VpcFirewallRuleProtocol::Icmp6(None),
+            ]),
+            action: external::VpcFirewallRuleAction::Allow,
+            priority: external::VpcFirewallRulePriority(100),
+        };
+
+        let new = ResolvedVpcFirewallRule::from(old);
+        assert_eq!(
+            new.filter_protocols,
+            Some(vec![
+                external::VpcFirewallRuleProtocol::IcmpV4(None),
+                external::VpcFirewallRuleProtocol::IcmpV6(None),
+            ])
+        );
+    }
+}

--- a/sled-agent/types/versions/src/rename_firewall_icmp_protocols/mod.rs
+++ b/sled-agent/types/versions/src/rename_firewall_icmp_protocols/mod.rs
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Version `RENAME_FIREWALL_ICMP_PROTOCOLS` of the Sled Agent API.
+//!
+//! Renames the firewall rule ICMP protocols from `icmp`/`icmp6` to
+//! `icmp_v4`/`icmp_v6`, matching the external API. This re-versions the chain
+//! of types that embed `ResolvedVpcFirewallRule`.
+
+pub mod firewall_rules;
+pub mod instance;


### PR DESCRIPTION
We're already calling them `ICMPv4` and `ICMPv6` in the console as of https://github.com/oxidecomputer/console/pull/3212. @taspelund [agreed](https://github.com/oxidecomputer/console/issues/3207#issuecomment-4594825225) with me that it would be ideal if the API matched that.

This is a fully robot-authored attempt at the rename. Leaving draft because I will need to review it. I went with `IcmpV4` and `IcmpV6` in Rust, which by default becomes `icmp_v4` and `icmp_v6` in the JSON. That seems like the least bad option, but it would be easy to change. It's a lot of line additions, but it's all versioning boilerplate and tests. It looks pretty good at a glance.

Note that because this is just a rename of existing enum values, there is a straightforward 1-1 mapping, so old clients will Just Work as long as they're passing the `api-version` header.