### PR TITLE
Distinguish 404 from 403 in authz-roles policy test snapshot

### DIFF
--- a/nexus/db-queries/src/policy_test/mod.rs
+++ b/nexus/db-queries/src/policy_test/mod.rs
@@ -448,6 +448,19 @@ async fn test_conferred_roles() {
         ResourceBuilder::new(&opctx, &datastore, &mut coverage, main_silo_id);
     builder.new_resource(authz::FLEET);
     builder.new_resource(authz::IP_POOL_LIST);
+    // A second Silo, distinct from the conferring users' own (main) Silo. A user
+    // whose main-Silo role confers a Fleet role is effectively a Fleet-level
+    // principal and must be able to reach OTHER Silos too; the Fleet-only
+    // resources above can't exercise that cross-Silo path. This also exercises
+    // the 404-vs-403 distinction: a user with no path to this Silo can't even
+    // see it, so it gets a 404 (∅) rather than a 403 (✘).
+    let other_silo_id: Uuid =
+        "22222222-2222-4222-8222-222222222222".parse().unwrap();
+    builder.new_resource(authz::Silo::new(
+        authz::FLEET,
+        other_silo_id,
+        LookupType::ByName("other-silo".to_string()),
+    ));
     let test_resources = builder.build();
 
     // We also create a Silo because the ResourceBuilder will create for us

--- a/nexus/db-queries/src/policy_test/mod.rs
+++ b/nexus/db-queries/src/policy_test/mod.rs
@@ -357,9 +357,10 @@ async fn authorize_one_resource(
                     "result" => ?result,
                 );
                 let summary = match result {
-                    Ok(_) => '\u{2714}', // ✔
-                    Err(Error::Forbidden)
-                    | Err(Error::ObjectNotFound { .. }) => '\u{2718}', // ✘
+                    Ok(_) => '\u{2714}',                 // ✔
+                    Err(Error::Forbidden) => '\u{2718}', // ✘ 403, visible
+                    // ∅ 404, hidden
+                    Err(Error::ObjectNotFound { .. }) => '\u{2205}',
                     Err(Error::Unauthenticated { .. }) => '!',
                     Err(_) => '\u{26a0}', // ⚠
                 };

--- a/nexus/db-queries/tests/output/authz-conferred-roles.out
+++ b/nexus/db-queries/tests/output/authz-conferred-roles.out
@@ -15,6 +15,14 @@ resource: authz::IpPoolList
   silo-limited-collaborator         ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   silo-viewer                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
 
+resource: Silo "other-silo"
+
+  USER                              Q  R LC RP  M MP CC  D
+  silo-admin                        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo-collaborator                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo-limited-collaborator         ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo-viewer                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+
 policy: {Admin: {Admin}}
 resource: Fleet id "001de000-1334-4000-8000-000000000000"
 
@@ -31,6 +39,14 @@ resource: authz::IpPoolList
   silo-collaborator                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   silo-limited-collaborator         ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   silo-viewer                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+
+resource: Silo "other-silo"
+
+  USER                              Q  R LC RP  M MP CC  D
+  silo-admin                        ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo-collaborator                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo-limited-collaborator         ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo-viewer                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 policy: {Viewer: {Viewer}}
 resource: Fleet id "001de000-1334-4000-8000-000000000000"
@@ -49,6 +65,14 @@ resource: authz::IpPoolList
   silo-limited-collaborator         ✘  ✘  ✔  ✘  ✘  ✘  ✘  ✘
   silo-viewer                       ✘  ✘  ✔  ✘  ✘  ✘  ✘  ✘
 
+resource: Silo "other-silo"
+
+  USER                              Q  R LC RP  M MP CC  D
+  silo-admin                        ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo-collaborator                 ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo-limited-collaborator         ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo-viewer                       ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+
 policy: {Admin: {Viewer}}
 resource: Fleet id "001de000-1334-4000-8000-000000000000"
 
@@ -65,6 +89,14 @@ resource: authz::IpPoolList
   silo-collaborator                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   silo-limited-collaborator         ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   silo-viewer                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+
+resource: Silo "other-silo"
+
+  USER                              Q  R LC RP  M MP CC  D
+  silo-admin                        ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo-collaborator                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo-limited-collaborator         ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo-viewer                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 policy: {Viewer: {Admin, Viewer}}
 resource: Fleet id "001de000-1334-4000-8000-000000000000"
@@ -83,6 +115,14 @@ resource: authz::IpPoolList
   silo-limited-collaborator         ✘  ✘  ✔  ✘  ✔  ✔  ✔  ✔
   silo-viewer                       ✘  ✘  ✔  ✘  ✔  ✔  ✔  ✔
 
+resource: Silo "other-silo"
+
+  USER                              Q  R LC RP  M MP CC  D
+  silo-admin                        ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo-collaborator                 ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo-limited-collaborator         ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo-viewer                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+
 policy: {Admin: {Admin}, Viewer: {Viewer}}
 resource: Fleet id "001de000-1334-4000-8000-000000000000"
 
@@ -99,4 +139,12 @@ resource: authz::IpPoolList
   silo-collaborator                 ✘  ✘  ✔  ✘  ✘  ✘  ✘  ✘
   silo-limited-collaborator         ✘  ✘  ✔  ✘  ✘  ✘  ✘  ✘
   silo-viewer                       ✘  ✘  ✔  ✘  ✘  ✘  ✘  ✘
+
+resource: Silo "other-silo"
+
+  USER                              Q  R LC RP  M MP CC  D
+  silo-admin                        ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo-collaborator                 ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo-limited-collaborator         ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo-viewer                       ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
 

--- a/nexus/db-queries/tests/output/authz-roles.out
+++ b/nexus/db-queries/tests/output/authz-roles.out
@@ -329,7 +329,7 @@ resource: Silo "silo1"
   silo1-proj1-limited-collaborator  ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
@@ -359,22 +359,22 @@ resource: Certificate "silo1-certificate"
 
   USER                              Q  R LC RP  M MP CC  D
   fleet-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   internal-api                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Silo "silo1": identity provider list
 
@@ -407,13 +407,13 @@ resource: IdentityProvider "silo1-identity-provider"
   silo1-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
@@ -428,13 +428,13 @@ resource: SamlIdentityProvider "silo1-saml-identity-provider"
   silo1-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
@@ -547,23 +547,23 @@ resource: SiloGroup "silo1-group"
 resource: SiloImage "silo1-silo-image"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: SiloUser "silo1-user": session list
 
@@ -610,65 +610,65 @@ resource: SiloUser "silo1-user": token list
 resource: Image "silo1-image"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Project "silo1-proj1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Disk "silo1-proj1-disk1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: MulticastGroup "silo1-proj1-multicast-group1"
 
@@ -686,94 +686,94 @@ resource: MulticastGroup "silo1-proj1-multicast-group1"
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  internal-api                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  internal-api                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: AffinityGroup "silo1-proj1-affinity-group1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: AntiAffinityGroup "silo1-proj1-anti-affinity-group1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Instance "silo1-proj1-instance1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InstanceNetworkInterface "silo1-proj1-instance1-nic1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Project "silo1-proj1": vpc list
 
@@ -799,86 +799,86 @@ resource: Project "silo1-proj1": vpc list
 resource: Vpc "silo1-proj1-vpc1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: VpcSubnet "silo1-proj1-vpc1-subnet1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: VpcRouter "silo1-proj1-vpc1-router1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: RouterRoute "silo1-proj1-vpc1-router1-route1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: VpcRouter "silo1-proj1-vpc1-router1"
 
@@ -917,191 +917,191 @@ resource: RouterRoute "silo1-proj1-vpc1-router1-route1"
 resource: Snapshot "silo1-proj1-disk1-snapshot1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: ProjectImage "silo1-proj1-image1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: FloatingIp "silo1-proj1-fip1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InternetGateway "silo1-proj1-igw1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InternetGatewayIpPool "silo1-proj1-igw1-pool1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InternetGatewayIpAddress "silo1-proj1-igw1-address1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: ExternalSubnet id "762e3d39-cd8a-4c59-ae6a-6efc9b2421df"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Project "silo1-proj2"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Disk "silo1-proj2-disk1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: MulticastGroup "silo1-proj2-multicast-group1"
 
@@ -1119,94 +1119,94 @@ resource: MulticastGroup "silo1-proj2-multicast-group1"
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  internal-api                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  internal-api                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: AffinityGroup "silo1-proj2-affinity-group1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: AntiAffinityGroup "silo1-proj2-anti-affinity-group1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Instance "silo1-proj2-instance1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InstanceNetworkInterface "silo1-proj2-instance1-nic1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Project "silo1-proj2": vpc list
 
@@ -1232,86 +1232,86 @@ resource: Project "silo1-proj2": vpc list
 resource: Vpc "silo1-proj2-vpc1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: VpcSubnet "silo1-proj2-vpc1-subnet1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: VpcRouter "silo1-proj2-vpc1-router1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: RouterRoute "silo1-proj2-vpc1-router1-route1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: VpcRouter "silo1-proj2-vpc1-router1"
 
@@ -1350,167 +1350,167 @@ resource: RouterRoute "silo1-proj2-vpc1-router1-route1"
 resource: Snapshot "silo1-proj2-disk1-snapshot1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: ProjectImage "silo1-proj2-image1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: FloatingIp "silo1-proj2-fip1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InternetGateway "silo1-proj2-igw1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InternetGatewayIpPool "silo1-proj2-igw1-pool1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InternetGatewayIpAddress "silo1-proj2-igw1-address1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: ExternalSubnet id "762e3d39-cd8a-4c59-ae6a-6efc9b2421df"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: ScimClientBearerToken id "7885144e-9c75-47f7-a97d-7dfc58e1186c"
 
   USER                              Q  R LC RP  M MP CC  D
   fleet-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   silo1-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   internal-api                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
@@ -1542,17 +1542,17 @@ resource: Silo "silo2"
   fleet-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   fleet-collaborator                ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   fleet-viewer                      ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
@@ -1582,22 +1582,22 @@ resource: Certificate "silo2-certificate"
 
   USER                              Q  R LC RP  M MP CC  D
   fleet-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   internal-api                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Silo "silo2": identity provider list
 
@@ -1626,17 +1626,17 @@ resource: IdentityProvider "silo2-identity-provider"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
@@ -1647,17 +1647,17 @@ resource: SamlIdentityProvider "silo2-saml-identity-provider"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
@@ -1710,17 +1710,17 @@ resource: SiloUser "silo2-user"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✔  ✔  ✔  ✔  ✘  ✔
@@ -1731,17 +1731,17 @@ resource: SshKey "silo2-user-ssh-key"
   fleet-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   fleet-collaborator                ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   internal-api                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
@@ -1752,17 +1752,17 @@ resource: SiloGroup "silo2-group"
   fleet-admin                       ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✔  ✔  ✔  ✔  ✘  ✔
@@ -1770,23 +1770,23 @@ resource: SiloGroup "silo2-group"
 resource: SiloImage "silo2-silo-image"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: SiloUser "silo2-user": session list
 
@@ -1833,65 +1833,65 @@ resource: SiloUser "silo2-user": token list
 resource: Image "silo2-image"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Project "silo2-proj1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Disk "silo2-proj1-disk1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: MulticastGroup "silo2-proj1-multicast-group1"
 
@@ -1909,94 +1909,94 @@ resource: MulticastGroup "silo2-proj1-multicast-group1"
   silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  internal-api                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  internal-api                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: AffinityGroup "silo2-proj1-affinity-group1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: AntiAffinityGroup "silo2-proj1-anti-affinity-group1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Instance "silo2-proj1-instance1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InstanceNetworkInterface "silo2-proj1-instance1-nic1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Project "silo2-proj1": vpc list
 
@@ -2022,86 +2022,86 @@ resource: Project "silo2-proj1": vpc list
 resource: Vpc "silo2-proj1-vpc1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: VpcSubnet "silo2-proj1-vpc1-subnet1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: VpcRouter "silo2-proj1-vpc1-router1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: RouterRoute "silo2-proj1-vpc1-router1-route1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: VpcRouter "silo2-proj1-vpc1-router1"
 
@@ -2140,167 +2140,167 @@ resource: RouterRoute "silo2-proj1-vpc1-router1-route1"
 resource: Snapshot "silo2-proj1-disk1-snapshot1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: ProjectImage "silo2-proj1-image1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: FloatingIp "silo2-proj1-fip1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InternetGateway "silo2-proj1-igw1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InternetGatewayIpPool "silo2-proj1-igw1-pool1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: InternetGatewayIpAddress "silo2-proj1-igw1-address1"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: ExternalSubnet id "762e3d39-cd8a-4c59-ae6a-6efc9b2421df"
 
   USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: ScimClientBearerToken id "7885144e-9c75-47f7-a97d-7dfc58e1186c"
 
   USER                              Q  R LC RP  M MP CC  D
   fleet-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  fleet-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   internal-api                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
@@ -2332,20 +2332,20 @@ resource: Rack id "c037e882-8b6d-c8b5-bef4-97e848eb0a50"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Rack id "c037e882-8b6d-c8b5-bef4-97e848eb0a50": trust quorum configuration
 
@@ -2353,20 +2353,20 @@ resource: Rack id "c037e882-8b6d-c8b5-bef4-97e848eb0a50": trust quorum configura
   fleet-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   fleet-collaborator                ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Sled id "8a785566-adaf-c8d8-e886-bee7f9b73ca7"
 
@@ -2374,20 +2374,20 @@ resource: Sled id "8a785566-adaf-c8d8-e886-bee7f9b73ca7"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Zpool id "aaaaaaaa-1233-af7d-9220-afe1d8090900"
 
@@ -2395,20 +2395,20 @@ resource: Zpool id "aaaaaaaa-1233-af7d-9220-afe1d8090900"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Service id "6b1f15ee-d6b3-424c-8436-94413a0b682d"
 
@@ -2416,20 +2416,20 @@ resource: Service id "6b1f15ee-d6b3-424c-8436-94413a0b682d"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Service id "7f7bb301-5dc9-41f1-ab29-d369f4835079"
 
@@ -2437,20 +2437,20 @@ resource: Service id "7f7bb301-5dc9-41f1-ab29-d369f4835079"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: PhysicalDisk id "c9f923f6-caf3-4c83-96f9-8ffe8c627dd2"
 
@@ -2458,20 +2458,20 @@ resource: PhysicalDisk id "c9f923f6-caf3-4c83-96f9-8ffe8c627dd2"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: SupportBundle id "d9f923f6-caf3-4c83-96f9-8ffe8c627dd2"
 
@@ -2479,20 +2479,20 @@ resource: SupportBundle id "d9f923f6-caf3-4c83-96f9-8ffe8c627dd2"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: DeviceAuthRequest "a-device-user-code"
 
@@ -2510,7 +2510,7 @@ resource: DeviceAuthRequest "a-device-user-code"
   silo1-proj1-limited-collaborator  ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   silo1-proj1-viewer                ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   db-init                           ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
@@ -2521,18 +2521,18 @@ resource: DeviceAccessToken id "3b80c7f9-bee0-4b42-8550-6cdfc74dafdb"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
 
@@ -2542,20 +2542,20 @@ resource: Blueprint id "b9e923f6-caf3-4c83-96f9-8ffe8c627dd2"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: TufRepo id "3c52d72f-cbf7-4951-a62f-a4154e74da87"
 
@@ -2563,20 +2563,20 @@ resource: TufRepo id "3c52d72f-cbf7-4951-a62f-a4154e74da87"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: TufArtifact id "6827813e-bfaa-4205-9b9f-9f7901e4aab1"
 
@@ -2584,20 +2584,20 @@ resource: TufArtifact id "6827813e-bfaa-4205-9b9f-9f7901e4aab1"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: TufTrustRoot id "b2c043c7-5eaa-40b5-a0a2-cdf97b2e66b3"
 
@@ -2605,20 +2605,20 @@ resource: TufTrustRoot id "b2c043c7-5eaa-40b5-a0a2-cdf97b2e66b3"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: AddressLot id "43259fdc-c5c0-4a21-8b1d-2f673ad00d93"
 
@@ -2626,20 +2626,20 @@ resource: AddressLot id "43259fdc-c5c0-4a21-8b1d-2f673ad00d93"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: LoopbackAddress id "9efbf1b1-16f9-45ab-864a-f7ebe501ae5b"
 
@@ -2647,20 +2647,20 @@ resource: LoopbackAddress id "9efbf1b1-16f9-45ab-864a-f7ebe501ae5b"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: Alert id "31cb17da-4164-4cbf-b9a3-b3e4a687c08b"
 
@@ -2668,20 +2668,20 @@ resource: Alert id "31cb17da-4164-4cbf-b9a3-b3e4a687c08b"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: AlertReceiver "webhooked-on-phonics"
 
@@ -2689,20 +2689,20 @@ resource: AlertReceiver "webhooked-on-phonics"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: WebhookSecret id "0c3e55cb-fcee-46e9-a2e3-0901dbd3b997"
 
@@ -2710,20 +2710,20 @@ resource: WebhookSecret id "0c3e55cb-fcee-46e9-a2e3-0901dbd3b997"
   fleet-admin                       ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   fleet-collaborator                ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: SubnetPool id "e3a6e04e-ad41-483c-8ee9-3958c3ffb4e5"
 
@@ -2731,20 +2731,20 @@ resource: SubnetPool id "e3a6e04e-ad41-483c-8ee9-3958c3ffb4e5"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: IpPool id "f9bf2e93-1f3f-4f4e-9c0f-3c8f6a8d6f2a"
 
@@ -2752,20 +2752,20 @@ resource: IpPool id "f9bf2e93-1f3f-4f4e-9c0f-3c8f6a8d6f2a"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ✔  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ✔  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ✔  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ✔  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ✔  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ✔  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ✔  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ✔  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ✔  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: ConsoleSession id "a1b2c3d4-0000-4000-8000-000000000001"
 
@@ -2773,18 +2773,18 @@ resource: ConsoleSession id "a1b2c3d4-0000-4000-8000-000000000001"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
 
@@ -2794,20 +2794,20 @@ resource: UserBuiltin id "a1b2c3d4-0000-4000-8000-000000000002"
   fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-user-self                   ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                       ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-collaborator                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-limited-collaborator        ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-viewer                      ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-user-self                   ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-admin                 ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-collaborator          ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-limited-collaborator  ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  silo1-proj1-viewer                ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  db-init                           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  scim                              ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
+  db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  external-authn                    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
 resource: IpPool id "f9bf2e93-1f3f-4f4e-9c0f-3c8f6a8d6f2a"
 

--- a/nexus/db-queries/tests/output/authz-roles.out
+++ b/nexus/db-queries/tests/output/authz-roles.out
@@ -880,40 +880,6 @@ resource: RouterRoute "silo1-proj1-vpc1-router1-route1"
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
-resource: VpcRouter "silo1-proj1-vpc1-router1"
-
-  USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-
-resource: RouterRoute "silo1-proj1-vpc1-router1-route1"
-
-  USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-proj1-collaborator          ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-proj1-limited-collaborator  ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-
 resource: Snapshot "silo1-proj1-disk1-snapshot1"
 
   USER                              Q  R LC RP  M MP CC  D
@@ -1312,40 +1278,6 @@ resource: RouterRoute "silo1-proj2-vpc1-router1-route1"
   db-init                           ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
-
-resource: VpcRouter "silo1-proj2-vpc1-router1"
-
-  USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-
-resource: RouterRoute "silo1-proj2-vpc1-router1-route1"
-
-  USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-collaborator                ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  silo1-limited-collaborator        ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
 
 resource: Snapshot "silo1-proj2-disk1-snapshot1"
 
@@ -2103,40 +2035,6 @@ resource: RouterRoute "silo2-proj1-vpc1-router1-route1"
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
 
-resource: VpcRouter "silo2-proj1-vpc1-router1"
-
-  USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-
-resource: RouterRoute "silo2-proj1-vpc1-router1-route1"
-
-  USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-
 resource: Snapshot "silo2-proj1-disk1-snapshot1"
 
   USER                              Q  R LC RP  M MP CC  D
@@ -2808,57 +2706,6 @@ resource: UserBuiltin id "a1b2c3d4-0000-4000-8000-000000000002"
   db-init                           ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
   internal-api                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
   external-authn                    ∅  ∅  ∅  ∅  ∅  ∅  ∅  ∅
-
-resource: IpPool id "f9bf2e93-1f3f-4f4e-9c0f-3c8f6a8d6f2a"
-
-  USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
-  fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✔  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✔  ✘
-  unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-
-resource: ConsoleSession id "a1b2c3d4-0000-4000-8000-000000000001"
-
-  USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-
-resource: UserBuiltin id "a1b2c3d4-0000-4000-8000-000000000002"
-
-  USER                              Q  R LC RP  M MP CC  D
-  fleet-admin                       ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
-  fleet-collaborator                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  fleet-viewer                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
-  silo1-admin                       ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-collaborator                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-limited-collaborator        ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-viewer                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-limited-collaborator  ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  silo1-proj1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
-  unauthenticated                   !  !  !  !  !  !  !  !
-  scim                              ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
 
 ACTIONS:
 


### PR DESCRIPTION
Built on top of #10550. Big diff but it's all in the snapshot. This snapshot was originally added in https://github.com/oxidecomputer/omicron/pull/1123 and I don't see a rationale given there for collapsing 404 and 403. I don't see a downside, it just gives you more info. Will take advantage of this in my Oso to Cedar port.