### PR TITLE
Implement Default for Generation and derive it for sitrep/config types

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -777,6 +777,13 @@ impl Generation {
     }
 }
 
+impl Default for Generation {
+    /// Returns the initial generation, [`Generation::new`] (i.e. 1).
+    fn default() -> Self {
+        Generation::new()
+    }
+}
+
 impl<'de> Deserialize<'de> for Generation {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/common/src/disk.rs
+++ b/common/src/disk.rs
@@ -56,7 +56,15 @@ impl IdOrdItem for OmicronPhysicalDiskConfig {
 }
 
 #[derive(
-    Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    PartialEq,
+    Eq,
+    Hash,
 )]
 pub struct OmicronPhysicalDisksConfig {
     /// generation number of this configuration
@@ -70,12 +78,6 @@ pub struct OmicronPhysicalDisksConfig {
     pub generation: Generation,
 
     pub disks: Vec<OmicronPhysicalDiskConfig>,
-}
-
-impl Default for OmicronPhysicalDisksConfig {
-    fn default() -> Self {
-        Self { generation: Generation::new(), disks: vec![] }
-    }
 }
 
 impl Ledgerable for OmicronPhysicalDisksConfig {
@@ -424,7 +426,15 @@ impl IdOrdItem for DatasetConfig {
 }
 
 #[derive(
-    Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    PartialEq,
+    Eq,
+    Hash,
 )]
 pub struct DatasetsConfig {
     /// generation number of this configuration
@@ -442,12 +452,6 @@ pub struct DatasetsConfig {
     pub generation: Generation,
 
     pub datasets: BTreeMap<DatasetUuid, DatasetConfig>,
-}
-
-impl Default for DatasetsConfig {
-    fn default() -> Self {
-        Self { generation: Generation::new(), datasets: BTreeMap::new() }
-    }
 }
 
 impl Ledgerable for DatasetsConfig {

--- a/nexus/types/src/fm.rs
+++ b/nexus/types/src/fm.rs
@@ -114,7 +114,7 @@ impl Sitrep {
 /// Metadata describing a sitrep.
 ///
 /// This corresponds to the records stored in the `fm_sitrep` database table.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct SitrepMetadata {
     /// The ID of this sitrep.
     pub id: SitrepUuid,


### PR DESCRIPTION
Add an `impl Default for Generation` equivalent to `new()` so any struct containing a `Generation` can derive it. Notably, `SitrepMetadata`, which we'd like to be able to construct default instances of in tests without detailed knowledge about all its fields.