### PR TITLE
Check for cross-VPC firewall rules before DB write

### DIFF
--- a/nexus/networking/src/firewall_rules.rs
+++ b/nexus/networking/src/firewall_rules.rs
@@ -66,6 +66,39 @@ pub async fn vpc_list_firewall_rules(
     Ok(rules)
 }
 
+/// Ensure that none of the given rules reference a VPC other than the one they
+/// belong to.
+///
+/// Cross-VPC targets and host filters are unsupported. This check must run
+/// before any rules are persisted; otherwise an invalid update is rejected but
+/// the rules are modified anyway (see omicron#10561).
+pub fn ensure_no_cross_vpc_references(
+    vpc: &db::model::Vpc,
+    rules: &[db::model::VpcFirewallRule],
+) -> Result<(), Error> {
+    for rule in rules {
+        for target in &rule.targets {
+            if let external::VpcFirewallRuleTarget::Vpc(name) = &target.0 {
+                if name != vpc.name() {
+                    return Err(Error::invalid_request(
+                        "cross-VPC firewall target unsupported",
+                    ));
+                }
+            }
+        }
+        for host in rule.filter_hosts.iter().flatten() {
+            if let external::VpcFirewallRuleHostFilter::Vpc(name) = &host.0 {
+                if name != vpc.name() {
+                    return Err(Error::invalid_request(
+                        "cross-VPC firewall host filter unsupported",
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Resolve a set of VPC firewall rules into the form expected by sled-agents.
 ///
 /// NOTE: This function injects the Nexus-specific allowlist rules, if the VPC
@@ -95,6 +128,12 @@ pub async fn resolve_firewall_rules_for_sled_agent(
         Vec::new()
     };
 
+    // Reject any cross-VPC references up front. (When called from the firewall
+    // rule update path, the rules have already been validated before being
+    // persisted, but other callers pass rules straight from the database.)
+    ensure_no_cross_vpc_references(vpc, rules)
+        .map_err(FirewallRulesError::Lookup)?;
+
     // Collect the names of instances, subnets, and VPCs that are either
     // targets or host filters. We have to find the sleds for all the
     // targets, and we'll need information about the IP addresses or
@@ -112,13 +151,6 @@ pub async fn resolve_firewall_rules_for_sled_agent(
                     subnets.insert(name.clone().into());
                 }
                 external::VpcFirewallRuleTarget::Vpc(name) => {
-                    if name != vpc.name() {
-                        return Err(FirewallRulesError::Lookup(
-                            Error::invalid_request(
-                                "cross-VPC firewall target unsupported",
-                            ),
-                        ));
-                    }
                     vpcs.insert(name.clone().into());
                 }
                 external::VpcFirewallRuleTarget::Ip(_)
@@ -137,13 +169,6 @@ pub async fn resolve_firewall_rules_for_sled_agent(
                     subnets.insert(name.clone().into());
                 }
                 external::VpcFirewallRuleHostFilter::Vpc(name) => {
-                    if name != vpc.name() {
-                        return Err(FirewallRulesError::Lookup(
-                            Error::invalid_request(
-                                "cross-VPC firewall host filter unsupported",
-                            ),
-                        ));
-                    }
                     vpcs.insert(name.clone().into());
                 }
                 // We don't need to resolve anything for Ip(Net)s.

--- a/nexus/src/app/vpc.rs
+++ b/nexus/src/app/vpc.rs
@@ -192,6 +192,12 @@ impl super::Nexus {
             params.clone(),
         )?;
 
+        // Reject cross-VPC references before writing anything. The same check
+        // happens again when resolving rules for sled-agents, but that runs
+        // after the write, so without this the rules would be persisted even
+        // though the request fails (omicron#10561).
+        nexus_networking::ensure_no_cross_vpc_references(&db_vpc, &rules)?;
+
         let rules = self
             .db_datastore
             .vpc_update_firewall_rules(opctx, &authz_vpc, rules)

--- a/nexus/tests/integration_tests/vpc_firewall.rs
+++ b/nexus/tests/integration_tests/vpc_firewall.rs
@@ -334,6 +334,67 @@ async fn test_firewall_rules_same_name(cptestctx: &ControlPlaneTestContext) {
     );
 }
 
+// Regression test for https://github.com/oxidecomputer/omicron/issues/10561.
+//
+// A firewall rule update that references another VPC (here, via a host filter)
+// is rejected because cross-VPC references are unsupported. That rejection must
+// happen *before* the rules are written to the database; otherwise the update
+// fails but the rules are modified anyway.
+#[nexus_test]
+async fn test_firewall_rules_cross_vpc_rejected_before_write(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+
+    let project_name = "my-project";
+    create_project(&client, &project_name).await;
+
+    let firewall_url =
+        format!("/v1/vpc-firewall-rules?vpc=default&project={}", project_name);
+
+    // default VPC starts with the default rules.
+    let rules =
+        object_get::<VpcFirewallRules>(client, &firewall_url).await.rules;
+    assert!(is_default_firewall_rules("default", &rules));
+
+    // Attempt to replace the rules with a single rule whose host filter
+    // references a different VPC. This is unsupported and must be rejected.
+    let bad_rule = VpcFirewallRuleUpdate {
+        name: "cross-vpc".parse().unwrap(),
+        description: "references another VPC".to_string(),
+        status: VpcFirewallRuleStatus::Enabled,
+        direction: VpcFirewallRuleDirection::Inbound,
+        targets: vec![VpcFirewallRuleTarget::Vpc("default".parse().unwrap())],
+        filters: VpcFirewallRuleFilter {
+            hosts: Some(vec![VpcFirewallRuleHostFilter::Vpc(
+                "some-other-vpc".parse().unwrap(),
+            )]),
+            protocols: None,
+            ports: None,
+        },
+        action: VpcFirewallRuleAction::Allow,
+        priority: VpcFirewallRulePriority(100),
+    };
+
+    let error = object_put_error(
+        client,
+        &firewall_url,
+        &VpcFirewallRuleUpdateParams { rules: vec![bad_rule] },
+        StatusCode::BAD_REQUEST,
+    )
+    .await;
+    assert_eq!(error.error_code, Some("InvalidRequest".to_string()));
+    assert_eq!(error.message, "cross-VPC firewall host filter unsupported");
+
+    // The rejected update must not have modified the stored rules.
+    let rules =
+        object_get::<VpcFirewallRules>(client, &firewall_url).await.rules;
+    assert!(
+        is_default_firewall_rules("default", &rules),
+        "firewall rules were modified despite the update being rejected: {rules:#?}"
+    );
+}
+
 #[nexus_test]
 async fn test_firewall_rules_max_lengths(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;


### PR DESCRIPTION
Improves #10561 but does not fully fix it, which would require cascading VPC renames down through all existing firewall rules.

The real problem here is that after you rename a VPC, any future updates to the firewall rules will fail if they neglect to update the VPC name in all targets and filters it appears in. This is especially a problem in the console, where you can only update one rule at a time. So even if you update the VPC name in that rule correctly, any other rules with the old name can still blow up the request. **This PR does not fix this.**

On top of that, the check for VPC name mismatches happens _after_ we persist the rules to the DB. This is egregious, and it is what this PR fixes: we move the check for "cross-VPC rules" (mismatches between the VPC name and the VPC referenced in the rule) to before the DB write (technically we now do it both places to be safe).

A secondary accidental fix is that by erroring earlier, we avoid this `map_err` added in #10305 that turns the 400s into 500s. 500 is even worse than 400 here because it doesn't have the confusing message telling you that it's a cross-VPC issue.

https://github.com/oxidecomputer/omicron/blob/955bc66f068cc2847ebf23e5a17e5b949c410de4/nexus/src/app/vpc.rs#L258-L270