### PR TITLE
[nexus] fix test_update_status flake

### DIFF
--- a/nexus/test-utils/src/nexus_test.rs
+++ b/nexus/test-utils/src/nexus_test.rs
@@ -166,7 +166,7 @@ impl<N: NexusServer> ControlPlaneTestContext<N> {
     }
 
     /// Wait until at least one inventory collection has been inserted into the
-    /// datastore.
+    /// datastore, and the inventory watch channel is populated.
     ///
     /// # Panics
     ///

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -70,6 +70,15 @@ async fn test_unauthorized() {
             .start::<omicron_nexus::Server>()
             .await;
 
+    // Some endpoints, such as `/v1/system/update/status`, return errors until the
+    // inventory watch channel is populated, so wait for that here to avoid a
+    // flake under contention.
+    cptestctx
+        .wait_for_at_least_one_inventory_collection(
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+
     let mut disk_test = DiskTest::new(&cptestctx).await;
     let sled_id = cptestctx.first_sled_id();
     disk_test

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -39,8 +39,6 @@ use tufaceous_lib::assemble::{ArtifactManifest, OmicronRepoAssembler};
 use tufaceous_lib::assemble::{DeserializedManifest, ManifestTweak};
 
 use crate::integration_tests::target_release::set_target_release_for_mupdate_recovery;
-use omicron_test_utils::dev::poll::CondCheckError;
-use omicron_test_utils::dev::poll::wait_for_condition;
 
 const TRUST_ROOTS_URL: &str = "/v1/system/update/trust-roots";
 
@@ -173,25 +171,6 @@ impl TestRepo {
         self.0.close().unwrap();
         request
     }
-}
-
-async fn wait_for_inventory(cptestctx: &ControlPlaneTestContext) {
-    let log = cptestctx.logctx.log.new(o!());
-    let datastore = cptestctx.server.server_context().nexus.datastore();
-    let opctx = OpContext::for_tests(log, datastore.clone());
-    wait_for_condition(
-        || async {
-            datastore
-                .inventory_get_latest_collection(&opctx)
-                .await
-                .expect("failed to get inventory collection")
-                .ok_or(CondCheckError::<()>::NotYet)
-        },
-        &std::time::Duration::from_millis(100),
-        &std::time::Duration::from_secs(30),
-    )
-    .await
-    .expect("no inventory collection available");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -743,9 +722,14 @@ async fn test_update_status() -> Result<()> {
     let logctx = &cptestctx.logctx;
 
     // During high contention the inventory might not be ready yet, which will
-    // cause the call to /v1/system/update/status to 500. We thus query the
-    // database to make sure we have an inventory before proceeding.
-    wait_for_inventory(&cptestctx).await;
+    // cause the call to /v1/system/update/status to 500. Ensure the inventory
+    // watch channel is populated. (Do not query the database directly, since
+    // update status uses the watch channel.)
+    cptestctx
+        .wait_for_at_least_one_inventory_collection(
+            std::time::Duration::from_secs(60),
+        )
+        .await;
 
     // initial status
     let status: update::UpdateStatus =
@@ -1093,9 +1077,14 @@ async fn test_request_without_api_version(cptestctx: &ControlPlaneTestContext) {
         ClientTestContext::new(server_addr, cptestctx.logctx.log.clone());
 
     // During high contention the inventory might not be ready yet, which will
-    // cause the call to /v1/system/update/status to 500. We thus query the
-    // database to make sure we have an inventory before proceeding.
-    wait_for_inventory(cptestctx).await;
+    // cause the call to /v1/system/update/status to 500. Ensure the inventory
+    // watch channel is populated. (Do not query the database directly, since
+    // update status uses the watch channel.)
+    cptestctx
+        .wait_for_at_least_one_inventory_collection(
+            std::time::Duration::from_secs(60),
+        )
+        .await;
 
     let req_builder = RequestBuilder::new(
         &test_cx,


### PR DESCRIPTION
We were using the DB rather than the watch channel.

Also guard test_unauthorized against the same flake.

Fixes #10546.