### PR TITLE
Add `omicron-git-version` and use it in Nexus/omdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7033,7 +7033,6 @@ dependencies = [
  "trust-quorum-protocol",
  "tufaceous-artifact",
  "uuid",
- "vergen-gitcl",
 ]
 
 [[package]]
@@ -9045,7 +9044,6 @@ dependencies = [
  "update-engine",
  "url",
  "uuid",
- "vergen-gitcl",
  "zip 4.6.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8637,6 +8637,7 @@ dependencies = [
 name = "omicron-git-version"
 version = "0.1.0"
 dependencies = [
+ "omicron-workspace-hack",
  "serde",
  "serde_with 3.17.0",
  "vergen-gitcl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7003,6 +7003,7 @@ dependencies = [
  "omicron-certificates",
  "omicron-cockroach-metrics",
  "omicron-common",
+ "omicron-git-version",
  "omicron-passwords",
  "omicron-rpaths",
  "omicron-uuid-kinds",
@@ -8633,6 +8634,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "omicron-git-version"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_with 3.17.0",
+ "vergen-gitcl",
+]
+
+[[package]]
 name = "omicron-ledger"
 version = "0.1.0"
 dependencies = [
@@ -8995,6 +9005,7 @@ dependencies = [
  "nexus-types",
  "ntp-admin-client",
  "omicron-common",
+ "omicron-git-version",
  "omicron-nexus",
  "omicron-rpaths",
  "omicron-test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "gateway-test-utils",
     "gateway-types",
     "gateway-types/versions",
+    "git-version",
     "illumos-utils",
     "installinator-api",
     "installinator-common",
@@ -664,6 +665,7 @@ omicron-common = { path = "common" }
 omicron-dev-lib = { path = "dev-tools/omicron-dev-lib" }
 omicron-ledger = { path = "ledger" }
 omicron-gateway = { path = "gateway" }
+omicron-git-version = { path = "git-version" }
 omicron-nexus = { path = "nexus" }
 omicron-ntp-admin = { path = "ntp-admin" }
 omicron-omdb = { path = "dev-tools/omdb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,7 @@ default-members = [
     "gateway-test-utils",
     "gateway-types",
     "gateway-types/versions",
+    "git-version",
     "illumos-utils",
     "installinator-api",
     "installinator-common",

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [build-dependencies]
 omicron-rpaths.workspace = true
-vergen-gitcl.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -62,6 +62,7 @@ nexus-saga-recovery.workspace = true
 nexus-types.workspace = true
 ntp-admin-client.workspace = true
 omicron-common.workspace = true
+omicron-git-version.workspace = true
 omicron-nexus.workspace = true
 omicron-uuid-kinds.workspace = true
 omicron-workspace-hack.workspace = true

--- a/dev-tools/omdb/build.rs
+++ b/dev-tools/omdb/build.rs
@@ -2,28 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use vergen_gitcl::Emitter;
-use vergen_gitcl::GitclBuilder;
-
 fn main() {
     // See omicron-rpaths for documentation. NOTE: This file MUST be kept in
     // sync with the other build.rs files in this repository.
     omicron_rpaths::configure_default_omicron_rpaths();
-
-    // Define the `VERGEN_GIT_SHA` and `VERGEN_GIT_DIRTY` environment variables
-    // (accessible via `env!()`) that note the current git commit and whether
-    // the working tree is dirty at the time of this build.
-    //
-    // We use this to check our own git SHA against the git SHA of the Nexus
-    // that generated blueprint planner debug logs.
-    let gitcl = GitclBuilder::default()
-        .sha(/* short= */ false)
-        .dirty(/* include_untracked= */ false)
-        .build()
-        .expect("valid GitclBuilder configuration");
-    Emitter::default()
-        .add_instructions(&gitcl)
-        .expect("valid instructions")
-        .emit()
-        .expect("emitted version information");
 }

--- a/dev-tools/omdb/src/bin/omdb/db/blueprints.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/blueprints.rs
@@ -160,6 +160,7 @@ async fn cmd_db_blueprint_planner_report_show(
     args: &ShowPlannerReportArgs,
 ) -> anyhow::Result<()> {
     use nexus_db_schema::schema::debug_log_blueprint_planning::dsl;
+    use omicron_git_version::GitVersion;
 
     let blueprint_id = args
         .blueprint_id
@@ -198,20 +199,30 @@ async fn cmd_db_blueprint_planner_report_show(
     // `debug_log`, because we don't want to expose such a thing in Nexus
     // proper. We'll peel out the git commit of the Nexus that produced this
     // report, compare it against our own, then try to parse the report.
-    let Some(log_git_commit) =
-        debug_log.get("git-commit").and_then(|v| v.as_str())
-    else {
+    let Some(log_git_commit) = debug_log.get("git-commit").and_then(|v| {
+        let s = v.as_str()?;
+        s.parse::<GitVersion>()
+            // `GitVersion::from_str` is infallible, so we _could_ expect()
+            // this, but I'd rather not have omdb crash if that ever changes...
+            .ok()
+    }) else {
         dump_raw_blob("missing `git-commit` key");
         return Ok(());
     };
 
-    let our_git_commit = env!("VERGEN_GIT_SHA");
+    let our_git_commit = GitVersion::current();
     if our_git_commit != log_git_commit {
         eprintln!(
             "WARNING: planner report debug log was produced by a Nexus \
              on git commit {log_git_commit}, but omdb was built from \
              {our_git_commit}. We will attempt to parse it anyway."
         );
+        if our_git_commit.is_dirty() || log_git_commit.is_dirty() {
+            eprintln!(
+                "note: dirty repositories (those with uncommitted changes) \
+                 will never be considered equal, even if the SHA is the same."
+            );
+        }
     }
 
     let Some(report_raw) = debug_log.get("report") else {

--- a/git-version/Cargo.toml
+++ b/git-version/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [dependencies]
 serde.workspace = true
 serde_with.workspace = true
+omicron-workspace-hack.workspace = true
 
 [build-dependencies]
 vergen-gitcl.workspace = true

--- a/git-version/Cargo.toml
+++ b/git-version/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "omicron-git-version"
+description = "A tiny crate for obtaining the current Git version"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_with.workspace = true
+
+[build-dependencies]
+vergen-gitcl.workspace = true
+
+[lints]
+workspace = true

--- a/git-version/build.rs
+++ b/git-version/build.rs
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use vergen_gitcl::Emitter;
+use vergen_gitcl::GitclBuilder;
+
+fn main() {
+    // Define the `VERGEN_GIT_SHA` and `VERGEN_GIT_DIRTY` environment variables
+    // (accessible via `env!()`) that note the current git commit and whether
+    // the working tree is dirty at the time of this build.
+    //
+    // We embed our git SHA in the JSON blobs for blueprint planner debug logs,
+    // so `omdb` can report if it's out of sync with the Nexus that created the
+    // debug log.
+    let gitcl = GitclBuilder::default()
+        .sha(/* short= */ false)
+        .dirty(/* include_untracked= */ false)
+        .build()
+        .expect("valid GitclBuilder configuration");
+    Emitter::default()
+        .add_instructions(&gitcl)
+        .expect("valid instructions")
+        .emit()
+        .expect("emitted version information");
+}

--- a/git-version/src/lib.rs
+++ b/git-version/src/lib.rs
@@ -13,7 +13,7 @@
 //! This lives in its own crate, rather than someplace like `omicron-common`,
 //! because the `vergen` stuff in the build script will invoke
 //! `cargo::rerun_if_changed` and so on any time the Git SHA changes. For
-//! incremental builds, like during development, don't want to invalidate the
+//! incremental builds, like during development, we don't want to invalidate the
 //! build cache for *every* crate in the workspace every time the developer
 //! makes a commit; we'd rather just invalidate the ones that actually need the
 //! Git version.

--- a/git-version/src/lib.rs
+++ b/git-version/src/lib.rs
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A very tiny crate for obtaining the current Git SHA of the `omicron`
+//! repository.
+//!
+//! This crate defines the [`GitVersion`] struct, which represents a Git version
+//! for the `omicron` repository, along with functions for [obtaining the
+//! version that the program was built from](GitVersion::current), serializing
+//! and deserializing it.
+//!
+//! This lives in its own crate, rather than someplace like `omicron-common`,
+//! because the `vergen` stuff in the build script will invoke
+//! `cargo::rerun_if_changed` and so on any time the Git SHA changes. For
+//! incremental builds, like during development, don't want to invalidate the
+//! build cache for *every* crate in the workspace every time the developer
+//! makes a commit; we'd rather just invalidate the ones that actually need the
+//! Git version.
+use std::borrow::Cow;
+use std::fmt;
+use std::str::FromStr;
+
+/// A Git version for the `omicron` repository, including the SHA of the HEAD
+/// commit and a flag indicating whether the repository is _dirty_ (has
+/// uncommitted changes).
+///
+/// Two Git versions are considered equal if their SHA is the same *and* neither
+/// has uncommitted changes. Two dirty versions with the same HEAD SHA will
+/// never be considered equal, because it is impossible to determine whether or
+/// not they have the same set of uncommitted changes.
+///
+/// Use [`GitVersion::current()`] to obtain the version of the repository when
+/// this code was compiled.
+///
+/// A `GitVersion` may also be deserialized from a string using
+/// [`GitVersion::from_str`], or its [`serde::Deserialize`] implementation. If
+/// the string ends with the suffix `-dirty`, the version is considered dirty;
+/// any other characters in the string are treated as the SHA.
+// TODO(eliza): we could probably validate that the SHA consists only of the
+// expected hex digits and is of the expected length, but that gets a bit
+// complex and is not necessary here.
+#[derive(Debug, serde_with::DeserializeFromStr)]
+pub struct GitVersion {
+    // We use a `Cow` here so that we need not allocate when constructing a
+    // `GitVersion` to represent the current state of the repository, as it can
+    // always be backed by a single build-time string constant. This may not
+    // *actually* matter that much, but it made me feel happier, especially
+    // since (at time of writing) Nexus only uses the `current()` path, and will
+    // never try to parse a git version from a string (the path that may
+    // allocate).
+    //
+    // So even if we aren't doing this in a particularly hot path, I felt
+    // pleased with being able to golf away the allocation in the path that
+    // Nexus uses in production.
+    sha: Cow<'static, str>,
+    dirty: bool,
+}
+
+impl GitVersion {
+    const DIRTY: &str = "-dirty";
+
+    /// Returns a `GitVersion` representing the state of the repository when
+    /// this code was compiled.
+    pub fn current() -> Self {
+        let dirty = env!("VERGEN_GIT_DIRTY") == "true";
+        const SHA: &str = env!("VERGEN_GIT_SHA");
+        Self { sha: Cow::Borrowed(SHA), dirty }
+    }
+
+    /// Returns `true` if this Git version has uncommitted changes.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+}
+
+impl FromStr for GitVersion {
+    type Err = core::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (sha, dirty) = match s.strip_suffix(Self::DIRTY) {
+            Some(sha) => (sha, true),
+            None => (s, false),
+        };
+        Ok(Self { sha: Cow::Owned(sha.to_owned()), dirty })
+    }
+}
+
+impl fmt::Display for GitVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let dirty = if self.is_dirty() { Self::DIRTY } else { "" };
+        write!(f, "{}{dirty}", self.sha)
+    }
+}
+
+impl PartialEq for GitVersion {
+    fn eq(&self, other: &Self) -> bool {
+        // If either version is dirty, then we cannot determine that they
+        // represent the same codebase, even if the SHA is the same.
+        if self.is_dirty() || other.is_dirty() {
+            return false;
+        }
+
+        self.sha == other.sha
+    }
+}
+
+impl serde::Serialize for GitVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if self.dirty {
+            // Using `collect_str` *may* avoid allocating a `String` if the
+            // serializer is smart enough
+            serializer.collect_str(self)
+        } else {
+            // If we don't need to add the dirty suffix, we can just use
+            // `serialize_str` and never make an intermediate `String`
+            // allocation.
+            serializer.serialize_str(&self.sha)
+        }
+    }
+}

--- a/git-version/src/lib.rs
+++ b/git-version/src/lib.rs
@@ -40,6 +40,46 @@ use std::str::FromStr;
 // TODO(eliza): we could probably validate that the SHA consists only of the
 // expected hex digits and is of the expected length, but that gets a bit
 // complex and is not necessary here.
+///
+/// ## Known Limitations
+///
+/// Currently, the determination of whether or not the repository is "dirty"
+/// (contains uncommitted changes) in [`GitVersion::current`] relies on a build
+/// script for this crate, which may not be re-run under some circumstances. In
+/// particular, the build script currently emits a `cargo::rerun-if-changed`
+/// directive that ensures it is re-run any time the `.git/HEAD` file changes.
+/// This ensures that the git version is re-generated whenever a commit is made
+/// or a branch is checked out. In order to detect transitions between clean (no
+/// uncommitted changes) and dirty (uncommitted changes) states reliably, the
+/// build script must issue `cargo::rerun-if-changed` directives for...every
+/// file in the workspace. If it does this unconditionally, this results in this
+/// crate, and any other crates that depend on it, being rebuilt every time any
+/// file in the workspace changes. This could substantially increase the amount
+/// of code which must be compiled for incremental builds while a developer is
+/// working in the repository, since any changes would invalidate the build
+/// cache for all crates that depend on this one.
+///
+/// In the future, we could potentially enhance the build script to emit
+/// rerun-if-changed directives only when it is in a clean state, so that any
+/// change causes the git version to become dirty, but to cease doing so once
+/// the repository has become dirty --- it is still dirty if additional files
+/// change. While the repository is dirty, the build script would only emit
+/// `cargo::rerun-if-changed` directives for `.git/HEAD`. This avoids
+/// invalidating the build cache on any change in the repository, while
+/// improving the accuracy of detecting dirty repos. However, it still has
+/// potential deficiencies, such as missing a transition back to the "clean"
+/// state due to _deleting_ uncommitted added files, rather than making a new
+/// commit.
+///
+/// For now, we accept that the dirty flag may not always be set accurately,
+/// since the primary purpose of including these versions is to compare the Git
+/// SHAs of TUF repos produced by CI. In that case, we are comparing between
+/// commits, and the repo should never be dirty. So...whatever. In the future,
+/// we may want to improve this.
+///
+/// See [here][1] for discussion of this limitation.
+///
+/// [1]: https://github.com/oxidecomputer/omicron/pull/10578#discussion_r3384362440
 #[derive(Debug, serde_with::DeserializeFromStr)]
 pub struct GitVersion {
     // We use a `Cow` here so that we need not allocate when constructing a

--- a/nexus/db-model/Cargo.toml
+++ b/nexus/db-model/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [build-dependencies]
 omicron-rpaths.workspace = true
-vergen-gitcl.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/nexus/db-model/Cargo.toml
+++ b/nexus/db-model/Cargo.toml
@@ -27,6 +27,7 @@ illumos-utils.workspace = true
 macaddr.workspace = true
 newtype_derive.workspace = true
 omicron-cockroach-metrics.workspace = true
+omicron-git-version.workspace = true
 omicron-uuid-kinds.workspace = true
 oxnet.workspace = true
 parse-display.workspace = true

--- a/nexus/db-model/build.rs
+++ b/nexus/db-model/build.rs
@@ -2,29 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use vergen_gitcl::Emitter;
-use vergen_gitcl::GitclBuilder;
-
 fn main() {
     // See omicron-rpaths for documentation. NOTE: This file MUST be kept in
     // sync with the other build.rs files in this repository.
     omicron_rpaths::configure_default_omicron_rpaths();
-
-    // Define the `VERGEN_GIT_SHA` and `VERGEN_GIT_DIRTY` environment variables
-    // (accessible via `env!()`) that note the current git commit and whether
-    // the working tree is dirty at the time of this build.
-    //
-    // We embed our git SHA in the JSON blobs for blueprint planner debug logs,
-    // so `omdb` can report if it's out of sync with the Nexus that created the
-    // debug log.
-    let gitcl = GitclBuilder::default()
-        .sha(/* short= */ false)
-        .dirty(/* include_untracked= */ false)
-        .build()
-        .expect("valid GitclBuilder configuration");
-    Emitter::default()
-        .add_instructions(&gitcl)
-        .expect("valid instructions")
-        .emit()
-        .expect("emitted version information");
 }

--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -1681,14 +1681,8 @@ impl DebugLogBlueprintPlanning {
         // `debug_blob`, because we don't want anyone to attempt to parse it. It
         // should only be useful to humans, potentially via omdb, and they (and
         // omdb) can duplicate these fields to understand it.
-        let git_commit = if env!("VERGEN_GIT_DIRTY") == "true" {
-            concat!(env!("VERGEN_GIT_SHA"), "-dirty")
-        } else {
-            env!("VERGEN_GIT_SHA")
-        };
-
         let debug_blob = serde_json::json!({
-            "git-commit": git_commit,
+            "git-commit": omicron_git_version::GitVersion::current(),
             "report": report,
         });
 


### PR DESCRIPTION
Currently, we have some code in Nexus which includes the current Git commit as part of Reconfigurator planning reports that are written to the database, so that `omdb`, which displays these reports, can determine whether or not the schema of the report JSON may be incompatible with the version from which `omdb` was built. I'm adding something similar for FM sitrep reports in #10556, which duplicated this code a bit. While talking to @smklein in [this comment][1], we realized that the semantics of how we compare these versions, and handle the fact that the repo may or may not have potentially uncommitted changes, are currently implemented correctly but are not super crisp. This change consolidates the logic for constructing the version string and for testing if two versions are equal in one place.

[1]:
https://github.com/oxidecomputer/omicron/pull/10556#discussion_r3382073279