### PR TITLE
[test-utils] bump up mgd and ddmd timeouts to 30s each

### DIFF
--- a/test-utils/src/dev/maghemite.rs
+++ b/test-utils/src/dev/maghemite.rs
@@ -20,7 +20,7 @@ use tokio::{
 /// Specifies the amount of time we will wait for `mgd` to launch,
 /// which is currently confirmed by watching `mgd`'s log output
 /// for a message specifying the address and port `mgd` is listening on.
-pub const MGD_TIMEOUT: Duration = Duration::new(5, 0);
+pub const MGD_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct MgdInstance {
     /// Port number the mgd instance is listening on. This can be provided
@@ -284,7 +284,7 @@ async fn find_mgd_port_in_log(logfile: String) -> Result<u16, anyhow::Error> {
 /// Specifies the amount of time we will wait for `ddmd` to bind its admin
 /// port, confirmed by asking the kernel which TCP port `ddmd`'s pid is
 /// listening on.
-const DDMD_TIMEOUT: Duration = Duration::from_secs(5);
+const DDMD_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Test fixture that spawns and supervises a legit `ddmd` subprocess.
 ///


### PR DESCRIPTION
Should fix the flakes seen in https://buildomat.eng.oxide.computer/wg/0/details/01KTT3D3T3MWW4JPNFG25XGBE6/FY3cC2D8bRGMZi1HA7E3oZMng70kfftq1AHo01A4m7qyUcTu/01KTT3DQ8GDWFT0SDW37WZB9W3 and https://buildomat.eng.oxide.computer/wg/0/details/01KTT25PAN9HQ0DW3FTT0WT8BF/oBe7I14rWSsZqUC5g0nwoqs7ZX6GBlWkvLEY8zSKbadsfhEm/01KTT26ABY8YWDTNSP7KWTJZZF.
