### PR TITLE
Extract upstream network configuration from `PlanningInput`

### DIFF
--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -2606,12 +2606,16 @@ fn cmd_blueprint_edit(
             .context("failed to construct external networking allocator")?
             .for_new_nexus()
             .context("failed to pick an external IP for Nexus")?;
+            let nexus_config = planning_input
+                .external_service_networking_policy()
+                .operator_nexus_config();
             builder
                 .sled_add_zone_nexus(
                     sled_id,
                     image_source,
                     external_ip,
                     nexus_generation,
+                    &nexus_config,
                 )
                 .context("failed to add Nexus zone")?;
             format!("added Nexus zone to sled {}", sled_id)

--- a/live-tests/tests/test_nexus_add_remove.rs
+++ b/live-tests/tests/test_nexus_add_remove.rs
@@ -124,12 +124,16 @@ async fn test_nexus_add_remove(lc: &LiveTestContext) {
             .context("failed to construct external networking allocator")?
             .for_new_nexus()
             .context("failed to pick an external IP for Nexus")?;
+            let nexus_config = planning_input
+                .external_service_networking_policy()
+                .operator_nexus_config();
             builder
                 .sled_add_zone_nexus(
                     sled_id,
                     image_source,
                     external_ip,
                     *nexus_generation,
+                    &nexus_config,
                 )
                 .context("adding Nexus zone")?;
 

--- a/live-tests/tests/test_nexus_handoff.rs
+++ b/live-tests/tests/test_nexus_handoff.rs
@@ -188,6 +188,9 @@ async fn test_nexus_handoff(lc: &LiveTestContext) {
                     .context(
                         "failed to construct external networking allocator",
                     )?;
+                let nexus_config = planning_input
+                    .external_service_networking_policy()
+                    .operator_nexus_config();
                 for current_nexus in current_nexus_zones.values() {
                     let external_ip = external_networking_alloc
                         .for_new_nexus()
@@ -198,6 +201,7 @@ async fn test_nexus_handoff(lc: &LiveTestContext) {
                             current_nexus.image_source.clone(),
                             external_ip,
                             next_generation,
+                            &nexus_config,
                         )
                         .context("adding Nexus zone")?;
                 }

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -125,6 +125,8 @@ use uuid::Uuid;
 
 mod external_networking;
 
+pub use external_networking::ExternalServiceNetworkingConfig;
+
 impl DataStore {
     /// List blueprints
     pub async fn blueprints_list(

--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -15,8 +15,13 @@ use nexus_db_errors::TransactionError;
 use nexus_db_lookup::DbConnection;
 use nexus_db_model::IncompleteNetworkInterface;
 use nexus_db_model::IpPool;
+use nexus_types::deployment::Blueprint;
+use nexus_types::deployment::BlueprintExpungedZoneAccessReason;
 use nexus_types::deployment::BlueprintZoneConfig;
+use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::OmicronZoneExternalIp;
+use nexus_types::deployment::OperatorNexusConfig;
+use nexus_types::deployment::UpstreamNtpConfig;
 use nexus_types::external_api::instance::PrivateIpStackCreate;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::IdentityMetadataCreateParams;
@@ -36,42 +41,157 @@ use slog_error_chain::InlineErrorChain;
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 
-impl DataStore {
-    /// Return the set of external IPs configured for our external DNS servers
-    /// when the rack was set up.
-    ///
-    /// We should have explicit storage for the external IPs on which we run
-    /// external DNS that an operator can update. Today, we do not: whatever
-    /// external DNS IPs are provided at rack setup time are the IPs we use
-    /// forever. (Fixing this is tracked by
-    /// <https://github.com/oxidecomputer/omicron/issues/8255>.)
-    pub async fn external_dns_external_ips_specified_by_rack_setup(
-        &self,
-        opctx: &OpContext,
-    ) -> Result<BTreeSet<IpAddr>, Error> {
-        // We can _implicitly_ determine the set of external DNS IPs provided
-        // during rack setup by examining the current target blueprint and
-        // looking at the IPs of all of its external DNS zones. We _must_
-        // include expunged zones as well as in-service zones: during an update,
-        // we'll create a blueprint that expunges an external DNS zone, waits
-        // for it to go away, then wants to reassign that zone's external IP to
-        // a new external DNS zone. But because we are scanning expunged zones,
-        // we also have to allow for duplicates - this isn't an error and is
-        // expected if we've performed more than one update, at least until we
-        // start pruning old expunged zones out of the blueprint (tracked by
-        // https://github.com/oxidecomputer/omicron/issues/5552).
-        //
-        // Because we can't (yet) change external DNS IPs, we don't have to
-        // worry about the current blueprint changing between when we read it
-        // and when we calculate the set of external DNS IPs: the set will be
-        // identical for all blueprints back to the original one created by RSS.
-        //
-        // We don't really need to load the entire blueprint here, but it's easy
-        // and ideally this code will be deleted in relatively short order.
-        let (_target, blueprint) =
-            self.blueprint_target_get_current_full(opctx).await?;
+/// External networking configuration for Oxide-managed services, extracted from
+/// the a blueprint at `PlanningInput` construction time.
+///
+/// These values are fleet-scoped today and lifted from the parent blueprint
+/// because we don't yet have operator-updatable storage for them. Tracked by
+///
+/// - <https://github.com/oxidecomputer/omicron/issues/8255> (external DNS
+///   configurability)
+/// - <https://github.com/oxidecomputer/omicron/issues/10574> (per-service IP
+///   pool assignment)
+/// - <https://github.com/oxidecomputer/omicron/issues/3732> (upstream NTP /
+///   DNS server lists).
+#[derive(Debug, Clone, Default)]
+pub struct ExternalServiceNetworkingConfig {
+    /// External IPs that external DNS zones listen on.
+    pub external_dns_external_ips: BTreeSet<IpAddr>,
+    /// Upstream NTP servers used by boundary NTP zones.
+    pub upstream_ntp_servers: Vec<String>,
+    /// Resolver search-suffix for boundary NTP zones.
+    //
+    // NOTE: This is always None today. See
+    // https://github.com/oxidecomputer/omicron/issues/10588.
+    pub upstream_ntp_domain: Option<String>,
+    /// Upstream DNS servers used by boundary NTP zones to resolve upstream
+    /// NTP server names, and provided to Nexus as its external DNS servers.
+    pub upstream_dns_servers: Vec<IpAddr>,
+    /// Whether Nexus serves its external API over TLS.
+    pub nexus_external_tls: bool,
+}
 
-        Ok(blueprint.all_external_dns_external_ips())
+impl DataStore {
+    /// Extract the external networking configuration for services from a
+    /// blueprint.
+    ///
+    /// This is a transitional facility: today the only persisted home for
+    /// these values is the current target blueprint (we copy them forward
+    /// from RSS into every blueprint). The values here are read out by
+    /// `PlanningInputFromDb` so the planner doesn't have to reach back into
+    /// the parent blueprint via `Blueprint::upstream_ntp_config()` /
+    /// `operator_nexus_config()` on every planning run.
+    ///
+    /// This method should be deleted once operators can update these
+    /// settings directly via the API; see the issues referenced on
+    /// [`ExternalServiceNetworkingConfig`].
+    pub fn blueprint_external_service_networking_config(
+        blueprint: &Blueprint,
+    ) -> Result<ExternalServiceNetworkingConfig, Error> {
+        let (upstream_ntp_servers, upstream_ntp_domain, upstream_dns_servers) =
+            match Self::blueprint_upstream_ntp_config(&blueprint) {
+                Some(cfg) => (
+                    cfg.ntp_servers.to_vec(),
+                    cfg.domain.map(String::from),
+                    cfg.dns_servers.to_vec(),
+                ),
+                None => {
+                    return Err(Error::internal_error(
+                        "Rack setup appears not to have provided an upstream \
+                    NTP configuration, which should be impossible",
+                    ));
+                }
+            };
+
+        let nexus_external_tls =
+            Self::blueprint_operator_nexus_config(&blueprint)
+                .map(|cfg| cfg.external_tls)
+                .unwrap_or(false);
+
+        Ok(ExternalServiceNetworkingConfig {
+            external_dns_external_ips: blueprint
+                .all_external_dns_external_ips(),
+            upstream_ntp_servers,
+            upstream_ntp_domain,
+            upstream_dns_servers,
+            nexus_external_tls,
+        })
+    }
+
+    /// Extract the operator-specified configuration of Nexus from the provided
+    /// blueprint.
+    ///
+    /// This information should be operator-configurable, but currently is not:
+    /// we carry it forward from rack setup time onward from blueprint to
+    /// blueprint. Fixing this is
+    /// <https://github.com/oxidecomputer/omicron/issues/3732> for the upstream
+    /// DNS servers. There's no issue specifically to track modifying whether
+    /// Nexus serves the API over TLS.
+    ///
+    /// Returns `None` if this blueprint contains no Nexus zones from which we
+    /// can infer the configuration. (This should only be the case for test
+    /// blueprints - real systems always deploy at least one Nexus zone).
+    ///
+    /// NOTE: This method is public only for tests outside this crate.
+    pub fn blueprint_operator_nexus_config(
+        blueprint: &Blueprint,
+    ) -> Option<OperatorNexusConfig<'_>> {
+        // The Nexus config can't be changed, so it's fine to use
+        // `find()` here and include searching both in-service and expunged
+        // zones. (Real racks will always have at least one in-service Nexus
+        // zone - the one calling this code - but some tests create blueprints
+        // without any.)
+        blueprint
+            .all_in_service_and_expunged_zones(
+                BlueprintExpungedZoneAccessReason::NexusExternalConfig,
+            )
+            .find_map(|(_sled_id, zone)| match &zone.zone_type {
+                BlueprintZoneType::Nexus(nexus_config) => {
+                    Some(OperatorNexusConfig {
+                        external_tls: nexus_config.external_tls,
+                        external_dns_servers: nexus_config
+                            .external_dns_servers
+                            .as_slice(),
+                    })
+                }
+                _ => None,
+            })
+    }
+
+    /// Extract the configuration of upstream NTP settings (needed to configure
+    /// boundary NTP zones) from the provided blueprint.
+    ///
+    /// This information should be operator-configurable, but currently is not:
+    /// we carry it forward from rack setup time onward from blueprint to
+    /// blueprint. Fixing this is
+    /// <https://github.com/oxidecomputer/omicron/issues/3732>.
+    ///
+    /// Returns `None` if this blueprint contains no boundary NTP zones from
+    /// which we can infer the upstream configuration. (This should only be the
+    /// case for test blueprints - real systems always deploy at least one
+    /// boundary NTP zone).
+    fn blueprint_upstream_ntp_config(
+        blueprint: &Blueprint,
+    ) -> Option<UpstreamNtpConfig<'_>> {
+        // The upstream NTP config can't be changed, so it's fine to use
+        // `find()` here and include searching both in-service and expunged
+        // zones. (Real racks will always have at least one in-service boundary
+        // NTP zone, but some test or test systems may have 0 if they have only
+        // a single sled and that sled's boundary NTP zone is being upgraded.)
+        blueprint
+            .all_in_service_and_expunged_zones(
+                BlueprintExpungedZoneAccessReason::BoundaryNtpUpstreamConfig,
+            )
+            .find_map(|(_sled_id, zone)| match &zone.zone_type {
+                BlueprintZoneType::BoundaryNtp(ntp_config) => {
+                    Some(UpstreamNtpConfig {
+                        ntp_servers: ntp_config.ntp_servers.as_slice(),
+                        dns_servers: ntp_config.dns_servers.as_slice(),
+                        domain: ntp_config.domain.as_deref(),
+                    })
+                }
+                _ => None,
+            })
     }
 
     pub(super) async fn ensure_zone_external_networking_allocated_on_connection(
@@ -1428,6 +1548,7 @@ mod tests {
             ExampleSystemBuilder::new(&opctx.log, TEST_NAME)
                 .external_dns_count(0)
                 .expect("external DNS count can be 0")
+                .boundary_ntp_count(1)
                 .build();
 
         // Insert the example system's initial empty blueprint and the one we
@@ -1449,10 +1570,10 @@ mod tests {
                 .external_dns_ips()
                 .is_empty()
         );
-        let external_dns_ips = datastore
-            .external_dns_external_ips_specified_by_rack_setup(opctx)
-            .await
-            .expect("got external DNS IPs");
+        let external_dns_ips =
+            DataStore::blueprint_external_service_networking_config(&bp1)
+                .expect("got service networking config")
+                .external_dns_external_ips;
         assert_eq!(external_dns_ips, BTreeSet::new());
 
         // Extend the external IP policy to allow for external DNS.
@@ -1474,7 +1595,10 @@ mod tests {
             }
 
             let mut input_builder = example_system.input.into_builder();
-            input_builder.policy_mut().external_ips = policy_builder.build();
+            input_builder
+                .policy_mut()
+                .external_service_networking
+                .external_ips = policy_builder.build();
             input_builder.build()
         };
 
@@ -1516,10 +1640,10 @@ mod tests {
             .blueprint_target_set_current(opctx, make_bp_target(bp2.id))
             .await
             .expect("made bp2 the target");
-        let external_dns_ips = datastore
-            .external_dns_external_ips_specified_by_rack_setup(opctx)
-            .await
-            .expect("got external DNS IPs");
+        let external_dns_ips =
+            DataStore::blueprint_external_service_networking_config(&bp2)
+                .expect("got service networking config")
+                .external_dns_external_ips;
         assert_eq!(external_dns_ips, expected_ips);
 
         // Create a new blueprint that expunges two of those zones.
@@ -1557,13 +1681,123 @@ mod tests {
             .blueprint_target_set_current(opctx, make_bp_target(bp3.id))
             .await
             .expect("made bp3 the target");
-        let external_dns_ips = datastore
-            .external_dns_external_ips_specified_by_rack_setup(opctx)
-            .await
-            .expect("got external DNS IPs");
+        let external_dns_ips =
+            DataStore::blueprint_external_service_networking_config(&bp3)
+                .expect("got service networking config")
+                .external_dns_external_ips;
         assert_eq!(external_dns_ips, expected_ips);
 
         // Clean up.
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // Verify that upstream NTP and operator Nexus configuration are pulled
+    // through every blueprint from rack setup onwards. The `BlueprintBuilder`
+    // carries existing boundary NTP and Nexus zones forward unchanged, so a
+    // new blueprint based on a populated parent should expose the same
+    // upstream values when read back through the datastore.
+    #[tokio::test]
+    async fn test_upstream_config_propagates_across_blueprints() {
+        const TEST_NAME: &str =
+            "test_upstream_config_propagates_across_blueprints";
+
+        let make_bp_target = |blueprint_id| BlueprintTarget {
+            target_id: blueprint_id,
+            enabled: false,
+            time_made_target: Utc::now(),
+        };
+
+        let logctx = dev::test_setup_log(TEST_NAME);
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        // The example system, when configured to create boundary NTP zones,
+        // populates them with non-empty upstream NTP servers, an upstream
+        // DNS server, and a domain; and creates Nexus zones with
+        // `external_tls: false`. So the values we read back through the
+        // datastore should match what the example system stamped into the
+        // blueprint.
+        let (example_system, bp1) =
+            ExampleSystemBuilder::new(&opctx.log, TEST_NAME)
+                .boundary_ntp_count(2)
+                .build();
+
+        let bp0 = &example_system.initial_blueprint;
+        for bp in [bp0, &bp1] {
+            datastore.blueprint_insert(opctx, bp).await.expect("inserted bp");
+            datastore
+                .blueprint_target_set_current(opctx, make_bp_target(bp.id))
+                .await
+                .expect("made bp the target");
+        }
+
+        // Capture the upstream config from the initial target blueprint.
+        let initial =
+            DataStore::blueprint_external_service_networking_config(&bp1)
+                .expect("got config from initial blueprint");
+
+        // Sanity check: confirm the example system actually populated the
+        // upstream values, otherwise the propagation test below would pass
+        // trivially.
+        assert!(
+            !initial.upstream_ntp_servers.is_empty(),
+            "example system should populate upstream NTP servers"
+        );
+        assert!(
+            !initial.upstream_dns_servers.is_empty(),
+            "example system should populate upstream DNS servers"
+        );
+        assert!(
+            initial.upstream_ntp_domain.is_some(),
+            "example system should populate upstream NTP domain"
+        );
+
+        // Build a new blueprint based on the current target, with no edits.
+        // The existing boundary NTP and Nexus zones carry forward unchanged.
+        let bp2 = BlueprintBuilder::new_based_on(
+            &opctx.log,
+            &bp1,
+            TEST_NAME,
+            PlannerRng::from_entropy(),
+        )
+        .expect("created builder")
+        .build(BlueprintSource::Test);
+
+        datastore.blueprint_insert(opctx, &bp2).await.expect("inserted bp2");
+        datastore
+            .blueprint_target_set_current(opctx, make_bp_target(bp2.id))
+            .await
+            .expect("made bp2 the target");
+
+        // Re-read the config from the new target blueprint and verify it
+        // matches the initial values.
+        let propagated =
+            DataStore::blueprint_external_service_networking_config(&bp2)
+                .expect("got config from second blueprint");
+
+        assert_eq!(
+            initial.upstream_ntp_servers, propagated.upstream_ntp_servers,
+            "upstream NTP servers should propagate"
+        );
+        assert_eq!(
+            initial.upstream_ntp_domain, propagated.upstream_ntp_domain,
+            "upstream NTP domain should propagate"
+        );
+        assert_eq!(
+            initial.upstream_dns_servers, propagated.upstream_dns_servers,
+            "upstream DNS servers should propagate"
+        );
+        assert_eq!(
+            initial.nexus_external_tls, propagated.nexus_external_tls,
+            "Nexus external_tls should propagate"
+        );
+        assert_eq!(
+            initial.external_dns_external_ips,
+            propagated.external_dns_external_ips,
+            "external DNS IPs should propagate"
+        );
+
         db.terminate().await;
         logctx.cleanup_successful();
     }

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -159,6 +159,7 @@ pub use alert::FmRendezvousAlertCreateError;
 pub use db_metadata::DatastoreSetupAction;
 pub use db_metadata::ValidatedDatastoreSetupAction;
 pub use deployment::BlueprintLimitReachedOutput;
+pub use deployment::ExternalServiceNetworkingConfig;
 pub use disk::CrucibleDisk;
 pub use disk::Disk;
 pub use disk::LocalStorageAllocation;

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1085,8 +1085,10 @@ mod test {
     use nexus_types::deployment::BlueprintSource;
     use nexus_types::deployment::CockroachDbPreserveDowngrade;
     use nexus_types::deployment::ExternalIpPolicy;
+    use nexus_types::deployment::OperatorNexusConfig;
     use nexus_types::deployment::PendingMgsUpdates;
     use nexus_types::deployment::SledFilter;
+    use nexus_types::deployment::UpstreamNtpConfig;
     use nexus_types::deployment::{BlueprintZoneImageSource, OximeterReadMode};
     use nexus_types::external_api::silo::SiloIdentityMode;
     use nexus_types::identity::Asset;
@@ -1480,13 +1482,15 @@ mod test {
             )
             .expect("added zone");
         builder
-            .sled_add_zone_nexus_with_config(
+            .sled_add_zone_nexus(
                 sled2.id(),
-                false,
-                Vec::new(),
                 BlueprintZoneImageSource::InstallDataset,
                 nexus_networking,
                 *Generation::new(),
+                &OperatorNexusConfig {
+                    external_tls: false,
+                    external_dns_servers: &[],
+                },
             )
             .expect("added zone");
 
@@ -1494,13 +1498,15 @@ mod test {
             [(sled1.id(), ntp1_networking), (sled2.id(), ntp2_networking)]
         {
             builder
-                .sled_add_zone_boundary_ntp_with_config(
+                .sled_add_zone_boundary_ntp(
                     sled_id,
-                    Vec::new(),
-                    Vec::new(),
-                    None,
                     BlueprintZoneImageSource::InstallDataset,
                     external_ip,
+                    &UpstreamNtpConfig {
+                        ntp_servers: &[],
+                        dns_servers: &[],
+                        domain: None,
+                    },
                 )
                 .expect("added boundary NTP");
         }
@@ -1705,15 +1711,17 @@ mod test {
             .expect("constructed allocator");
         for _ in 0..2 {
             builder
-                .sled_add_zone_nexus_with_config(
+                .sled_add_zone_nexus(
                     sled.id(),
-                    false,
-                    Vec::new(),
                     BlueprintZoneImageSource::InstallDataset,
                     external_networking_alloc
                         .for_new_nexus()
                         .expect("got Nexus IP"),
                     *Generation::new(),
+                    &OperatorNexusConfig {
+                        external_tls: false,
+                        external_dns_servers: &[],
+                    },
                 )
                 .expect("added Nexus");
         }
@@ -1898,15 +1906,17 @@ mod test {
             )
             .expect("constructed allocator");
         builder
-            .sled_add_zone_nexus_with_config(
+            .sled_add_zone_nexus(
                 sled.id(),
-                false,
-                Vec::new(),
                 BlueprintZoneImageSource::InstallDataset,
                 external_networking_alloc
                     .for_new_nexus()
                     .expect("got Nexus IP"),
                 *Generation::new(),
+                &OperatorNexusConfig {
+                    external_tls: false,
+                    external_dns_servers: &[],
+                },
             )
             .expect("added Nexus");
         let mut blueprint = builder.build(BlueprintSource::Test);
@@ -2074,10 +2084,8 @@ mod test {
                 .unwrap();
         let mut macs = MacAddr::iter_system();
         builder
-            .sled_add_zone_nexus_with_config(
+            .sled_add_zone_nexus(
                 sled.id(),
-                false,
-                Vec::new(),
                 BlueprintZoneImageSource::InstallDataset,
                 ExternalNetworkingChoice {
                     external_ip: nexus_ip,
@@ -2085,6 +2093,10 @@ mod test {
                     nic_mac: macs.next().unwrap(),
                 },
                 *Generation::new(),
+                &OperatorNexusConfig {
+                    external_tls: false,
+                    external_dns_servers: &[],
+                },
             )
             .expect("added Nexus");
 
@@ -2148,13 +2160,15 @@ mod test {
             external_networking_alloc.for_new_nexus().expect("got Nexus IP");
         for _ in 0..2 {
             builder
-                .sled_add_zone_nexus_with_config(
+                .sled_add_zone_nexus(
                     sled.id(),
-                    false,
-                    Vec::new(),
                     BlueprintZoneImageSource::InstallDataset,
                     nexus_external_ip.clone(),
                     *Generation::new(),
+                    &OperatorNexusConfig {
+                        external_tls: false,
+                        external_dns_servers: &[],
+                    },
                 )
                 .expect("added Nexus");
         }

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -2979,6 +2979,7 @@ mod tests {
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
     use nexus_types::deployment::BlueprintZoneImageSource;
+    use nexus_types::deployment::OperatorNexusConfig;
     use nexus_types::external_api::instance as instance_types;
     use nexus_types::external_api::instance::PrivateIpStackCreate;
     use nexus_types::external_api::project;
@@ -3352,13 +3353,15 @@ mod tests {
             .for_new_nexus()
             .expect("found external IP for Nexus");
             builder
-                .sled_add_zone_nexus_with_config(
+                .sled_add_zone_nexus(
                     sled_ids[2],
-                    false,
-                    Vec::new(),
                     BlueprintZoneImageSource::InstallDataset,
                     external_ip,
                     bp0.nexus_generation,
+                    &OperatorNexusConfig {
+                        external_tls: false,
+                        external_dns_servers: &[],
+                    },
                 )
                 .expect("added nexus to third sled");
             builder.build(BlueprintSource::Test)
@@ -3442,13 +3445,15 @@ mod tests {
                     .for_new_nexus()
                     .expect("found external IP for Nexus");
                 builder
-                    .sled_add_zone_nexus_with_config(
+                    .sled_add_zone_nexus(
                         sled_id,
-                        false,
-                        Vec::new(),
                         BlueprintZoneImageSource::InstallDataset,
                         external_ip,
                         bp2.nexus_generation,
+                        &OperatorNexusConfig {
+                            external_tls: false,
+                            external_dns_servers: &[],
+                        },
                     )
                     .expect("added nexus to third sled");
             }

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -1530,12 +1530,16 @@ mod test {
             .expect("constructed ExternalNetworkingAllocator")
             .for_new_nexus()
             .expect("found external IP for Nexus");
+        let nexus_config =
+            DataStore::blueprint_operator_nexus_config(&blueprint)
+                .expect("blueprint has at least one Nexus zone");
         builder
             .sled_add_zone_nexus(
                 sled_id,
                 BlueprintZoneImageSource::InstallDataset,
                 new_nexus_external_ip,
                 blueprint.nexus_generation,
+                &nexus_config,
             )
             .unwrap();
         // The silo creation above advanced external DNS past B1's recorded

--- a/nexus/reconfigurator/execution/src/sagas.rs
+++ b/nexus/reconfigurator/execution/src/sagas.rs
@@ -167,6 +167,10 @@ mod test {
                 example.input.external_ip_policy(),
             )
             .expect("constructed ExternalNetworkingAllocator");
+        let nexus_config = example
+            .input
+            .external_service_networking_policy()
+            .operator_nexus_config();
         for (sled_id, _zone_id, image_source) in &g1_nexus_ids {
             let external_ip = external_networking_alloc
                 .for_new_nexus()
@@ -177,6 +181,7 @@ mod test {
                     image_source.clone(),
                     external_ip,
                     g2,
+                    &nexus_config,
                 )
                 .expect("add Nexus zone");
         }

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -89,7 +89,6 @@ use std::collections::BTreeSet;
 use std::collections::btree_map::Entry;
 use std::fmt;
 use std::iter;
-use std::net::IpAddr;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
 use std::net::SocketAddrV6;
@@ -111,8 +110,6 @@ pub enum Error {
     NoActiveNexusZonesInBlueprint,
     #[error("conflicting values for active Nexus zones in parent blueprint")]
     ActiveNexusZoneGenerationConflictInParentBlueprint,
-    #[error("no Boundary NTP zones exist in parent blueprint")]
-    NoBoundaryNtpZonesInParentBlueprint,
     #[error(
         "invariant violation: commissioned sled missing from planning input's \
          list of sleds: {sled_id}"
@@ -1704,33 +1701,7 @@ impl<'a> BlueprintBuilder<'a> {
         image_source: BlueprintZoneImageSource,
         external_ip: ExternalNetworkingChoice,
         nexus_generation: Generation,
-    ) -> Result<(), Error> {
-        // Whether Nexus should use TLS and what the external DNS servers it
-        // should use are currently provided at rack-setup time, and should be
-        // consistent across all Nexus instances.
-        let OperatorNexusConfig { external_tls, external_dns_servers } = self
-            .parent_blueprint
-            .operator_nexus_config()
-            .ok_or(Error::NoNexusZonesInParentBlueprint)?;
-
-        self.sled_add_zone_nexus_with_config(
-            sled_id,
-            external_tls,
-            external_dns_servers.to_vec(),
-            image_source,
-            external_ip,
-            nexus_generation,
-        )
-    }
-
-    pub fn sled_add_zone_nexus_with_config(
-        &mut self,
-        sled_id: SledUuid,
-        external_tls: bool,
-        external_dns_servers: Vec<IpAddr>,
-        image_source: BlueprintZoneImageSource,
-        external_ip: ExternalNetworkingChoice,
-        nexus_generation: Generation,
+        config: &OperatorNexusConfig<'_>,
     ) -> Result<(), Error> {
         let nexus_id = self.rng.sled_rng(sled_id).next_zone();
         let ExternalNetworkingChoice { external_ip, nic_ip_config, nic_mac } =
@@ -1761,8 +1732,8 @@ impl<'a> BlueprintBuilder<'a> {
             lockstep_port: omicron_common::address::NEXUS_LOCKSTEP_PORT,
             external_ip,
             nic,
-            external_tls,
-            external_dns_servers: external_dns_servers.clone(),
+            external_tls: config.external_tls,
+            external_dns_servers: config.external_dns_servers.to_vec(),
             nexus_generation,
         });
         let filesystem_pool =
@@ -1962,37 +1933,7 @@ impl<'a> BlueprintBuilder<'a> {
         sled_id: SledUuid,
         image_source: BlueprintZoneImageSource,
         external_ip: ExternalSnatNetworkingChoice,
-    ) -> Result<(), Error> {
-        let UpstreamNtpConfig { ntp_servers, dns_servers, domain } = self
-            .parent_blueprint
-            .upstream_ntp_config()
-            .ok_or(Error::NoBoundaryNtpZonesInParentBlueprint)?;
-        self.sled_add_zone_boundary_ntp_with_config(
-            sled_id,
-            ntp_servers.to_vec(),
-            dns_servers.to_vec(),
-            domain.map(str::to_string),
-            image_source,
-            external_ip,
-        )
-    }
-
-    /// Add a new boundary NTP server to a sled.
-    ///
-    /// This is unusual: typically during planning we promote internal NTP
-    /// servers to boundary NTP servers via
-    /// `sled_promote_internal_ntp_to_boundary_ntp()`, because adding a new
-    /// boundary NTP zone to a sled is only valid if the sled doesn't currently
-    /// have any NTP zone at all. Only tests and possibly RSS can really make
-    /// use of this.
-    pub fn sled_add_zone_boundary_ntp_with_config(
-        &mut self,
-        sled_id: SledUuid,
-        ntp_servers: Vec<String>,
-        dns_servers: Vec<IpAddr>,
-        domain: Option<String>,
-        image_source: BlueprintZoneImageSource,
-        external_ip: ExternalSnatNetworkingChoice,
+        config: &UpstreamNtpConfig<'_>,
     ) -> Result<(), Error> {
         let editor = self.sled_editors.get_mut(&sled_id).ok_or_else(|| {
             Error::Planner(anyhow!(
@@ -2036,9 +1977,9 @@ impl<'a> BlueprintBuilder<'a> {
         let zone_type =
             BlueprintZoneType::BoundaryNtp(blueprint_zone_type::BoundaryNtp {
                 address: SocketAddrV6::new(underlay_ip, port, 0, 0),
-                ntp_servers,
-                dns_servers,
-                domain,
+                ntp_servers: config.ntp_servers.to_vec(),
+                dns_servers: config.dns_servers.to_vec(),
+                domain: config.domain.map(String::from),
                 nic,
                 external_ip,
             });
@@ -2062,29 +2003,7 @@ impl<'a> BlueprintBuilder<'a> {
         sled_id: SledUuid,
         image_source: BlueprintZoneImageSource,
         external_ip: ExternalSnatNetworkingChoice,
-    ) -> Result<(), Error> {
-        let UpstreamNtpConfig { ntp_servers, dns_servers, domain } = self
-            .parent_blueprint
-            .upstream_ntp_config()
-            .ok_or(Error::NoBoundaryNtpZonesInParentBlueprint)?;
-        self.sled_promote_internal_ntp_to_boundary_ntp_with_config(
-            sled_id,
-            ntp_servers.to_vec(),
-            dns_servers.to_vec(),
-            domain.map(str::to_string),
-            image_source,
-            external_ip,
-        )
-    }
-
-    pub fn sled_promote_internal_ntp_to_boundary_ntp_with_config(
-        &mut self,
-        sled_id: SledUuid,
-        ntp_servers: Vec<String>,
-        dns_servers: Vec<IpAddr>,
-        domain: Option<String>,
-        image_source: BlueprintZoneImageSource,
-        external_ip: ExternalSnatNetworkingChoice,
+        config: &UpstreamNtpConfig<'_>,
     ) -> Result<(), Error> {
         let editor = self.sled_editors.get_mut(&sled_id).ok_or_else(|| {
             Error::Planner(anyhow!(
@@ -2125,13 +2044,11 @@ impl<'a> BlueprintBuilder<'a> {
         })?;
 
         // Add the new boundary NTP zone.
-        self.sled_add_zone_boundary_ntp_with_config(
+        self.sled_add_zone_boundary_ntp(
             sled_id,
-            ntp_servers,
-            dns_servers,
-            domain,
             image_source,
             external_ip,
+            config,
         )
     }
 
@@ -3379,13 +3296,14 @@ pub mod test {
     }
 
     #[test]
-    fn test_add_nexus_with_no_existing_nexus_zones() {
-        static TEST_NAME: &str =
-            "blueprint_builder_test_add_nexus_with_no_existing_nexus_zones";
+    fn test_add_nexus_without_existing_nexus_zones() {
+        static TEST_NAME: &str = "test_add_nexus_without_existing_nexus_zones";
         let logctx = test_setup_log(TEST_NAME);
         let mut rng = SimRngState::from_seed(TEST_NAME);
 
-        // Start with an empty system (sleds with no zones).
+        // Start with an empty system (sleds with no zones), so there are
+        // no existing Nexus zones in the parent blueprint. The Nexus config
+        // we supply comes from `PlanningInput`, not from a parent zone.
         let (example, parent) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME)
                 .create_zones(false)
@@ -3393,9 +3311,6 @@ pub mod test {
         let collection = example.collection;
         let input = example.input;
 
-        // Adding a new Nexus zone currently requires copying settings from an
-        // existing Nexus zone. `parent` has no zones, so we should fail if we
-        // try to add a Nexus zone.
         let mut builder = BlueprintBuilder::new_based_on(
             &logctx.log,
             &parent,
@@ -3404,6 +3319,9 @@ pub mod test {
         )
         .expect("failed to create builder");
 
+        let nexus_config =
+            input.external_service_networking_policy().operator_nexus_config();
+
         let mut external_networking_alloc =
             ExternalNetworkingAllocator::from_current_zones(
                 &builder,
@@ -3411,7 +3329,7 @@ pub mod test {
             )
             .expect("created external networking allocator");
 
-        let err = builder
+        builder
             .sled_add_zone_nexus(
                 collection
                     .sled_agents
@@ -3424,13 +3342,9 @@ pub mod test {
                     .for_new_nexus()
                     .expect("have IP for Nexus"),
                 parent.nexus_generation,
+                &nexus_config,
             )
-            .unwrap_err();
-
-        assert!(
-            matches!(err, Error::NoNexusZonesInParentBlueprint),
-            "unexpected error {err}"
-        );
+            .expect("added Nexus zone with operator config from PlanningInput");
 
         logctx.cleanup_successful();
     }
@@ -3520,6 +3434,9 @@ pub mod test {
                 rng.next_planner_rng(),
             )
             .expect("failed to create builder");
+            let nexus_config = input
+                .external_service_networking_policy()
+                .operator_nexus_config();
             let mut external_networking_alloc =
                 ExternalNetworkingAllocator::from_current_zones(
                     &builder,
@@ -3534,6 +3451,7 @@ pub mod test {
                         .for_new_nexus()
                         .expect("have IP for Nexus"),
                     parent.nexus_generation,
+                    &nexus_config,
                 )
                 .expect("added nexus zone");
         }
@@ -3549,6 +3467,9 @@ pub mod test {
                 rng.next_planner_rng(),
             )
             .expect("failed to create builder");
+            let nexus_config = input
+                .external_service_networking_policy()
+                .operator_nexus_config();
             let mut external_networking_alloc =
                 ExternalNetworkingAllocator::from_current_zones(
                     &builder,
@@ -3564,6 +3485,7 @@ pub mod test {
                             .for_new_nexus()
                             .expect("have IP for Nexus"),
                         parent.nexus_generation,
+                        &nexus_config,
                     )
                     .expect("added nexus zone");
             }
@@ -3584,7 +3506,7 @@ pub mod test {
             assert!(!used_ip_ranges.is_empty());
             let input = {
                 let mut builder = input.into_builder();
-                builder.policy_mut().external_ips = {
+                builder.policy_mut().external_service_networking.external_ips = {
                     let mut ip_policy = ExternalIpPolicy::builder();
                     for r in used_ip_ranges {
                         ip_policy.push_service_pool_range(r).unwrap();

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -38,9 +38,11 @@ use nexus_types::deployment::ClickhouseMode;
 use nexus_types::deployment::ClickhousePolicy;
 use nexus_types::deployment::ExpectedVersion;
 use nexus_types::deployment::OmicronZoneNic;
+use nexus_types::deployment::OperatorNexusConfig;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
 use nexus_types::deployment::TargetReleaseDescription;
+use nexus_types::deployment::UpstreamNtpConfig;
 use nexus_types::external_api::sled::SledPolicy;
 use nexus_types::inventory::Collection;
 use omicron_common::address::Ipv4Range;
@@ -736,15 +738,17 @@ impl ExampleSystemBuilder {
                             .for_new_nexus()
                             .expect("should have an external IP for Nexus");
                         builder
-                            .sled_add_zone_nexus_with_config(
+                            .sled_add_zone_nexus(
                                 sled_id,
-                                false,
-                                vec![],
                                 self.target_release
                                     .zone_image_source(ZoneKind::Nexus)
                                     .expect("obtained Nexus image source"),
                                 external_ip,
                                 initial_blueprint.nexus_generation,
+                                &OperatorNexusConfig {
+                                    external_tls: false,
+                                    external_dns_servers: &[],
+                                },
                             )
                             .unwrap();
                     }
@@ -898,26 +902,35 @@ impl ExampleSystemBuilder {
                     }
                     // Add BoundaryNtp zones on the first N discretionary sleds.
                     if will_get_boundary_ntp {
-                        let ntp_servers = vec!["ntp.example.com".to_string()];
-                        let dns_servers = vec!["8.8.8.8".parse().unwrap()];
-                        let domain = Some("example.com".to_string());
+                        // Use the upstream NTP / DNS values from the
+                        // `PlanningInput`'s policy so this stays in sync with
+                        // the `SystemDescription` defaults.
+                        let networking =
+                            base_input.external_service_networking_policy();
+                        let ntp_servers =
+                            networking.upstream_ntp_servers.clone();
+                        let dns_servers =
+                            networking.upstream_dns_servers.clone();
+                        let domain = networking.upstream_ntp_domain.clone();
                         let external_ip = external_networking_alloc
                             .for_new_boundary_ntp()
                             .expect(
                                 "should have an external IP for BoundaryNtp",
                             );
                         builder
-                            .sled_add_zone_boundary_ntp_with_config(
+                            .sled_add_zone_boundary_ntp(
                                 sled_id,
-                                ntp_servers,
-                                dns_servers,
-                                domain,
                                 self.target_release
                                     .zone_image_source(ZoneKind::BoundaryNtp)
                                     .expect(
                                         "obtained BoundaryNtp image source",
                                     ),
                                 external_ip,
+                                &UpstreamNtpConfig {
+                                    ntp_servers: &ntp_servers,
+                                    dns_servers: &dns_servers,
+                                    domain: domain.as_deref(),
+                                },
                             )
                             .unwrap();
                     }

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1366,16 +1366,10 @@ impl<'a> Planner<'a> {
                 self.input.target_internal_dns_zone_count()
             }
             DiscretionaryOmicronZone::ExternalDns => {
-                // TODO-cleanup: When external DNS addresses are
-                // in the policy, this can use the input, too.
-                //
                 // The target number of external DNS zones is exactly equal to
                 // the number of distinct external DNS IPs we're supposed to
                 // service.
-                self.input
-                    .parent_blueprint()
-                    .all_external_dns_external_ips()
-                    .len()
+                self.input.external_ip_policy().external_dns_ips().len()
             }
             DiscretionaryOmicronZone::Nexus => {
                 self.input.target_nexus_zone_count()
@@ -1452,6 +1446,10 @@ impl<'a> Planner<'a> {
                         sled_id,
                         image,
                         external_ip,
+                        &self
+                            .input
+                            .external_service_networking_policy()
+                            .upstream_ntp_config(),
                     )?
                 }
                 DiscretionaryOmicronZone::Clickhouse => {
@@ -1496,6 +1494,10 @@ impl<'a> Planner<'a> {
                         image,
                         external_ip,
                         nexus_generation,
+                        &self
+                            .input
+                            .external_service_networking_policy()
+                            .operator_nexus_config(),
                     )?
                 }
                 DiscretionaryOmicronZone::Oximeter => {

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -22,6 +22,7 @@ use nexus_types::deployment::CockroachDbClusterVersion;
 use nexus_types::deployment::CockroachDbSettings;
 use nexus_types::deployment::ExpectedVersion;
 use nexus_types::deployment::ExternalIpPolicy;
+use nexus_types::deployment::ExternalServiceNetworkingPolicy;
 use nexus_types::deployment::OximeterReadPolicy;
 use nexus_types::deployment::PlannerConfig;
 use nexus_types::deployment::PlanningInputBuilder;
@@ -124,7 +125,7 @@ pub struct SystemDescription {
     target_cockroachdb_zone_count: usize,
     target_cockroachdb_cluster_version: CockroachDbClusterVersion,
     target_crucible_pantry_zone_count: usize,
-    external_ip_policy: ExternalIpPolicy,
+    external_service_networking: ExternalServiceNetworkingPolicy,
     internal_dns_version: Generation,
     external_dns_version: Generation,
     clickhouse_policy: Option<ClickhousePolicy>,
@@ -193,7 +194,7 @@ impl SystemDescription {
         // Nexus / Boundary NTPs IPs from TEST-NET-1 (RFC 5737).
         //
         // This policy doesn't configure any external DNS IPs.
-        let external_ip_policy = {
+        let external_ips = {
             let mut builder = ExternalIpPolicy::builder();
             builder
                 .push_service_pool_ipv4_range(
@@ -205,6 +206,18 @@ impl SystemDescription {
                 )
                 .unwrap();
             builder.build()
+        };
+
+        // Upstream networking policy for an example system. This mirrors the
+        // values used in `ExampleSystemBuilder`, so that a new
+        // `SystemDescription` produces a `PlanningInput` whose policy matches
+        // the zones that it would build.
+        let external_service_networking = ExternalServiceNetworkingPolicy {
+            external_ips,
+            upstream_ntp_servers: vec!["ntp.example.com".to_string()],
+            upstream_ntp_domain: Some("example.com".to_string()),
+            upstream_dns_servers: vec!["8.8.8.8".parse().unwrap()],
+            nexus_external_tls: false,
         };
 
         SystemDescription {
@@ -220,7 +233,7 @@ impl SystemDescription {
             target_cockroachdb_zone_count,
             target_cockroachdb_cluster_version,
             target_crucible_pantry_zone_count,
-            external_ip_policy,
+            external_service_networking,
             internal_dns_version: Generation::new(),
             external_dns_version: Generation::new(),
             clickhouse_policy: None,
@@ -334,15 +347,29 @@ impl SystemDescription {
         self.target_oximeter_zone_count
     }
 
+    pub fn external_service_networking_policy(
+        &self,
+    ) -> &ExternalServiceNetworkingPolicy {
+        &self.external_service_networking
+    }
+
+    pub fn set_external_service_networking_policy(
+        &mut self,
+        policy: ExternalServiceNetworkingPolicy,
+    ) -> &mut Self {
+        self.external_service_networking = policy;
+        self
+    }
+
     pub fn external_ip_policy(&self) -> &ExternalIpPolicy {
-        &self.external_ip_policy
+        &self.external_service_networking.external_ips
     }
 
     pub fn set_external_ip_policy(
         &mut self,
         policy: ExternalIpPolicy,
     ) -> &mut Self {
-        self.external_ip_policy = policy;
+        self.external_service_networking.external_ips = policy;
         self
     }
 
@@ -1172,7 +1199,9 @@ impl SystemDescription {
         parent_blueprint: Arc<Blueprint>,
     ) -> anyhow::Result<PlanningInputBuilder> {
         let policy = Policy {
-            external_ips: self.external_ip_policy.clone(),
+            external_service_networking: self
+                .external_service_networking
+                .clone(),
             target_boundary_ntp_zone_count: self.target_boundary_ntp_zone_count,
             target_nexus_zone_count: self.target_nexus_zone_count,
             target_internal_dns_zone_count: self.target_internal_dns_zone_count,

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -13,6 +13,7 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_db_queries::db::datastore::DataStoreDnsTest;
 use nexus_db_queries::db::datastore::Discoverability;
+use nexus_db_queries::db::datastore::ExternalServiceNetworkingConfig;
 use nexus_db_queries::db::datastore::SQL_BATCH_SIZE;
 use nexus_db_queries::db::pagination::Paginator;
 use nexus_types::deployment::Blueprint;
@@ -21,6 +22,7 @@ use nexus_types::deployment::ClickhousePolicy;
 use nexus_types::deployment::CockroachDbClusterVersion;
 use nexus_types::deployment::CockroachDbSettings;
 use nexus_types::deployment::ExternalIpPolicy;
+use nexus_types::deployment::ExternalServiceNetworkingPolicy;
 use nexus_types::deployment::OmicronZoneExternalIp;
 use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::OximeterReadPolicy;
@@ -60,7 +62,6 @@ use slog_error_chain::InlineErrorChain;
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::net::IpAddr;
 use std::sync::Arc;
 
 /// Given various pieces of database state that go into the blueprint planning
@@ -72,7 +73,7 @@ pub struct PlanningInputFromDb<'a> {
     pub zpool_rows:
         &'a [(nexus_db_model::Zpool, nexus_db_model::PhysicalDisk)],
     pub ip_pool_range_rows: &'a [nexus_db_model::IpPoolRange],
-    pub external_dns_external_ips: BTreeSet<IpAddr>,
+    pub external_service_networking: ExternalServiceNetworkingConfig,
     pub external_ip_rows: &'a [nexus_db_model::ExternalIp],
     pub service_nic_rows: &'a [nexus_db_model::ServiceNetworkInterface],
     pub target_boundary_ntp_zone_count: usize,
@@ -158,14 +159,16 @@ impl PlanningInputFromDb<'_> {
             .internal_context("fetching all external zpool rows")?;
         let ip_pool_range_rows =
             fetch_all_service_ip_pool_ranges(opctx, datastore).await?;
-        // TODO-correctness We ought to allow the IPs on which we run external
-        // DNS servers to change, but we don't: instead, we always reuse the IPs
-        // that were specified when the rack was set up.
+        // TODO-correctness We ought to allow operators to update the upstream
+        // NTP and DNS servers, the external DNS listener IPs, and Nexus's TLS
+        // flag, but today they're frozen at rack-setup time. Until that
+        // changes, we lift them out of the current target blueprint here.
         //
-        // https://github.com/oxidecomputer/omicron/issues/8255
-        let external_dns_external_ips = datastore
-            .external_dns_external_ips_specified_by_rack_setup(opctx)
-            .await?;
+        // See #8255, #10574, #3732.
+        let external_service_networking =
+            DataStore::blueprint_external_service_networking_config(
+                &parent_blueprint,
+            )?;
         let external_ip_rows = datastore
             .external_ip_list_service_all_batched(opctx)
             .await
@@ -275,7 +278,7 @@ impl PlanningInputFromDb<'_> {
             sled_rows: &sled_rows,
             zpool_rows: &zpool_rows,
             ip_pool_range_rows: &ip_pool_range_rows,
-            external_dns_external_ips,
+            external_service_networking,
             target_boundary_ntp_zone_count: BOUNDARY_NTP_REDUNDANCY,
             target_nexus_zone_count: NEXUS_REDUNDANCY,
             target_internal_dns_zone_count: INTERNAL_DNS_REDUNDANCY,
@@ -304,8 +307,10 @@ impl PlanningInputFromDb<'_> {
         Ok(planning_input)
     }
 
-    fn build_external_ip_policy(&self) -> Result<ExternalIpPolicy, Error> {
-        let mut builder = ExternalIpPolicy::builder();
+    fn build_external_service_networking_policy(
+        &self,
+    ) -> Result<ExternalServiceNetworkingPolicy, Error> {
+        let mut ip_builder = ExternalIpPolicy::builder();
         for range in self.ip_pool_range_rows {
             let range = IpRange::try_from(range).map_err(|e| {
                 Error::internal_error(&format!(
@@ -313,27 +318,45 @@ impl PlanningInputFromDb<'_> {
                     InlineErrorChain::new(&e),
                 ))
             })?;
-            builder.push_service_pool_range(range).map_err(|e| {
+            ip_builder.push_service_pool_range(range).map_err(|e| {
                 Error::internal_error(&format!(
                     "cannot construct external IP policy: {}",
                     InlineErrorChain::new(&e),
                 ))
             })?;
         }
-        for &ip in &self.external_dns_external_ips {
-            builder.add_external_dns_ip(ip).map_err(|e| {
+        for &ip in &self.external_service_networking.external_dns_external_ips {
+            ip_builder.add_external_dns_ip(ip).map_err(|e| {
                 Error::internal_error(&format!(
                     "cannot construct external IP policy: {}",
                     InlineErrorChain::new(&e),
                 ))
             })?;
         }
-        Ok(builder.build())
+        Ok(ExternalServiceNetworkingPolicy {
+            external_ips: ip_builder.build(),
+            upstream_ntp_servers: self
+                .external_service_networking
+                .upstream_ntp_servers
+                .clone(),
+            upstream_ntp_domain: self
+                .external_service_networking
+                .upstream_ntp_domain
+                .clone(),
+            upstream_dns_servers: self
+                .external_service_networking
+                .upstream_dns_servers
+                .clone(),
+            nexus_external_tls: self
+                .external_service_networking
+                .nexus_external_tls,
+        })
     }
 
     pub fn build(&self) -> Result<PlanningInput, Error> {
         let policy = Policy {
-            external_ips: self.build_external_ip_policy()?,
+            external_service_networking: self
+                .build_external_service_networking_policy()?,
             target_boundary_ntp_zone_count: self.target_boundary_ntp_zone_count,
             target_nexus_zone_count: self.target_nexus_zone_count,
             target_internal_dns_zone_count: self.target_internal_dns_zone_count,

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -115,6 +115,7 @@ pub use planning_input::DiskFilter;
 pub use planning_input::ExternalIpPolicy;
 pub use planning_input::ExternalIpPolicyBuilder;
 pub use planning_input::ExternalIpPolicyError;
+pub use planning_input::ExternalServiceNetworkingPolicy;
 pub use planning_input::OximeterReadMode;
 pub use planning_input::OximeterReadPolicy;
 pub use planning_input::PlanningInput;
@@ -681,69 +682,6 @@ impl Blueprint {
         )))
     }
 
-    /// Return the configuration of upstream NTP settings (needed to configure
-    /// boundary NTP zones).
-    ///
-    /// This information should be operator-configurable, but currently is not:
-    /// we carry it forward from rack setup time onward from blueprint to
-    /// blueprint. Fixing this is
-    /// <https://github.com/oxidecomputer/omicron/issues/9040>.
-    ///
-    /// Returns `None` if this blueprint contains no boundary NTP zones from
-    /// which we can infer the upstream configuration. (This should only be the
-    /// case for test blueprints - real systems always deploy at least one
-    /// boundary NTP zone).
-    pub fn upstream_ntp_config(&self) -> Option<UpstreamNtpConfig<'_>> {
-        // The upstream NTP config can't be changed, so it's fine to use
-        // `find()` here and include searching both in-service and expunged
-        // zones. (Real racks will always have at least one in-service boundary
-        // NTP zone, but some test or test systems may have 0 if they have only
-        // a single sled and that sled's boundary NTP zone is being upgraded.)
-        self.all_in_service_and_expunged_zones(
-            BlueprintExpungedZoneAccessReason::BoundaryNtpUpstreamConfig,
-        )
-        .find_map(|(_sled_id, zone)| match &zone.zone_type {
-            BlueprintZoneType::BoundaryNtp(ntp_config) => {
-                Some(UpstreamNtpConfig {
-                    ntp_servers: &ntp_config.ntp_servers,
-                    dns_servers: &ntp_config.dns_servers,
-                    domain: ntp_config.domain.as_deref(),
-                })
-            }
-            _ => None,
-        })
-    }
-
-    /// Return the operator-specified configuration of Nexus.
-    ///
-    /// This information should be operator-configurable, but currently is not:
-    /// we carry it forward from rack setup time onward from blueprint to
-    /// blueprint. Fixing this is
-    /// <https://github.com/oxidecomputer/omicron/issues/9040>.
-    ///
-    /// Returns `None` if this blueprint contains no Nexus zones from which we
-    /// can infer the configuration. (This should only be the case for test
-    /// blueprints - real systems always deploy at least one Nexus zone).
-    pub fn operator_nexus_config(&self) -> Option<OperatorNexusConfig<'_>> {
-        // The Nexus config can't be changed, so it's fine to use
-        // `find()` here and include searching both in-service and expunged
-        // zones. (Real racks will always have at least one in-service Nexus
-        // zone - the one calling this code - but some tests create blueprints
-        // without any.)
-        self.all_in_service_and_expunged_zones(
-            BlueprintExpungedZoneAccessReason::NexusExternalConfig,
-        )
-        .find_map(|(_sled_id, zone)| match &zone.zone_type {
-            BlueprintZoneType::Nexus(nexus_config) => {
-                Some(OperatorNexusConfig {
-                    external_tls: nexus_config.external_tls,
-                    external_dns_servers: &nexus_config.external_dns_servers,
-                })
-            }
-            _ => None,
-        })
-    }
-
     /// Returns the complete set of external IP addresses assigned to external
     /// DNS servers described by this blueprint, including both in-service and
     /// expunged external DNS zones.
@@ -751,7 +689,7 @@ impl Blueprint {
     /// This information should be operator-configurable, but currently is not:
     /// we carry it forward from rack setup time onward from blueprint to
     /// blueprint. Fixing this is
-    /// <https://github.com/oxidecomputer/omicron/issues/9040>.
+    /// <https://github.com/oxidecomputer/omicron/issues/3732>.
     ///
     /// Returns an empty set if this blueprint contains no external DNS zones.
     /// (This should only be the case for test blueprints - real systems always
@@ -794,14 +732,17 @@ impl Blueprint {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Operator-supplied upstream NTP configuration plumbed into boundary NTP
+/// zones.
+#[derive(Debug, Clone)]
 pub struct UpstreamNtpConfig<'a> {
     pub ntp_servers: &'a [String],
     pub dns_servers: &'a [IpAddr],
     pub domain: Option<&'a str>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Operator-supplied configuration for Nexus's external API endpoint.
+#[derive(Debug, Clone)]
 pub struct OperatorNexusConfig<'a> {
     pub external_tls: bool,
     pub external_dns_servers: &'a [IpAddr],
@@ -861,7 +802,7 @@ pub enum BlueprintExpungedZoneAccessReason {
     // conditions the planner must consider during pruning.
     // --------------------------------------------------------------------
     /// Carrying forward the upstream NTP configuration provided by the operator
-    /// during rack setup; see [`Blueprint::upstream_ntp_config()`].
+    /// during rack setup.
     ///
     /// The planner must not prune a boundary NTP zone if it's the last zone
     /// remaining with the set of configuration.
@@ -906,7 +847,7 @@ pub enum BlueprintExpungedZoneAccessReason {
     NexusDeleteMetadataRecord,
 
     /// Carrying forward the external Nexus configuration provided by the
-    /// operator during rack setup; see [`Blueprint::operator_nexus_config()`].
+    /// operator during rack setup.
     ///
     /// The planner must not prune a Nexus zone if it's the last zone
     /// remaining with the set of configuration.

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -11,6 +11,8 @@ use super::BlueprintZoneImageSource;
 use super::OmicronZoneExternalIp;
 use super::OmicronZoneNetworkResources;
 use super::OmicronZoneNic;
+use super::OperatorNexusConfig;
+use super::UpstreamNtpConfig;
 use super::blueprint_display::BpDiffState;
 use super::blueprint_display::KvList;
 use super::blueprint_display::KvPair;
@@ -241,8 +243,14 @@ impl PlanningInput {
         &self.policy.planner_config
     }
 
+    pub fn external_service_networking_policy(
+        &self,
+    ) -> &ExternalServiceNetworkingPolicy {
+        &self.policy.external_service_networking
+    }
+
     pub fn external_ip_policy(&self) -> &ExternalIpPolicy {
-        &self.policy.external_ips
+        &self.policy.external_service_networking.external_ips
     }
 
     pub fn clickhouse_cluster_enabled(&self) -> bool {
@@ -1102,9 +1110,12 @@ impl SledFilter {
 /// sled additionally has non-policy [`SledResources`] needed for planning.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Policy {
-    /// description of IP addresses for externally-visible control plane
-    /// services (e.g., external DNS, Nexus, boundary NTP)
-    pub external_ips: ExternalIpPolicy,
+    /// configuration for externally-visible control plane services (IP
+    /// pools, upstream NTP / DNS servers, Nexus TLS).
+    ///
+    /// Fleet-scoped today; tracked at #8255, #10574, #3732 for future
+    /// operator-updatable storage.
+    pub external_service_networking: ExternalServiceNetworkingPolicy,
 
     /// desired total number of deployed Boundary NTP zones
     pub target_boundary_ntp_zone_count: usize,
@@ -1461,6 +1472,85 @@ pub enum ExternalIpPolicyError {
     OverlappingRanges { new_range: IpRange, existing_range: IpRange },
     #[error("external DNS IP {0} is not a member of any service IP pool")]
     ExternalDnsOutsideServiceIpPools(IpAddr),
+}
+
+/// Operator-supplied configuration for the rack's externally-facing service
+/// networking.
+///
+/// This includes the [`ExternalIpPolicy`], upstream NTP / DNS servers, and
+/// whether Nexus serves its API over TLS.
+///
+/// This is fleet-scoped today. It's lifted from the parent blueprint's
+/// boundary NTP and Nexus zones at `PlanningInput` construction time, since
+/// those values are still effectively set once at rack setup and never
+/// changed. Operator-updatable storage is tracked at
+/// <https://github.com/oxidecomputer/omicron/issues/8255> (external DNS
+/// configurability), <https://github.com/oxidecomputer/omicron/issues/10574>
+/// (per-service IP pool assignment), and
+/// <https://github.com/oxidecomputer/omicron/issues/3732> (upstream NTP /
+/// DNS server lists).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalServiceNetworkingPolicy {
+    /// IP pools available for Oxide-managed services, plus the addresses that
+    /// external DNS zones listen on.
+    pub external_ips: ExternalIpPolicy,
+
+    /// Upstream NTP servers used by boundary NTP zones as time sources.
+    pub upstream_ntp_servers: Vec<String>,
+
+    /// Optional resolver search-suffix for the boundary NTP zone, used when
+    /// `upstream_ntp_servers` contains bare (unqualified) hostnames.
+    //
+    // NOTE: This is always `None` in production today. There is no way to
+    // specify it at RSS-time, and the sled-agent hard-codes it to `None` when
+    // implementing the service plan.
+    //
+    // The fate of this is tracked by:
+    // https://github.com/oxidecomputer/omicron/issues/10588.
+    pub upstream_ntp_domain: Option<String>,
+
+    /// Operator-supplied upstream DNS servers. Used by boundary NTP zones to
+    /// resolve upstream NTP server names, and surfaced to Nexus zones as
+    /// their `external_dns_servers`.
+    pub upstream_dns_servers: Vec<IpAddr>,
+
+    /// Whether Nexus serves its external API over TLS.
+    pub nexus_external_tls: bool,
+}
+
+impl ExternalServiceNetworkingPolicy {
+    /// Construct an empty policy with no IP pools, no upstream servers, and
+    /// TLS disabled. Primarily for tests.
+    pub fn empty() -> Self {
+        Self {
+            external_ips: ExternalIpPolicy::empty(),
+            upstream_ntp_servers: Vec::new(),
+            upstream_ntp_domain: None,
+            upstream_dns_servers: Vec::new(),
+            nexus_external_tls: false,
+        }
+    }
+
+    /// Configuration values for constructing a new boundary NTP zone.
+    ///
+    /// Always returns a value. In real systems the underlying data is
+    /// populated at rack setup. In tests, the lists it contains may be empty,
+    /// but we still return a value so the callers have the same shape.
+    pub fn upstream_ntp_config(&self) -> UpstreamNtpConfig<'_> {
+        UpstreamNtpConfig {
+            ntp_servers: self.upstream_ntp_servers.as_slice(),
+            dns_servers: self.upstream_dns_servers.as_slice(),
+            domain: self.upstream_ntp_domain.as_deref(),
+        }
+    }
+
+    /// Configuration values for constructing a new Nexus zone.
+    pub fn operator_nexus_config(&self) -> OperatorNexusConfig<'_> {
+        OperatorNexusConfig {
+            external_tls: self.nexus_external_tls,
+            external_dns_servers: self.upstream_dns_servers.as_slice(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
- Move construction of the upstream network configuration out of the `BlueprintBuilder` and into the `PlanningInput`. The builder no longer scans all its zones to determine the upstream NTP servers, DNS servers, etc. Instead, read this from a combination of the DB and the parent blueprint at planning construction time. This will eventually come from the database entirely, when we persist operator decisions around this data to it.
- Fixes #9040