### PR TITLE
[fm] Harden SitrepGuardedInsert dummy-resource test coverage.

### DIFF
--- a/nexus/db-queries/src/db/sitrep_guard.rs
+++ b/nexus/db-queries/src/db/sitrep_guard.rs
@@ -478,18 +478,20 @@ mod tests {
         .unwrap();
     }
 
-    // Inserts a current sitrep with a given `dummy_generation`.
+    // Inserts a current sitrep with a given `dummy_generation`, returning its
+    // ID so further sitreps can be chained onto it via `parent`.
     async fn insert_current_sitrep(
         datastore: &DataStore,
         opctx: &OpContext,
         conn: &async_bb8_diesel::Connection<DbConnection>,
+        parent: Option<SitrepUuid>,
         generation: i64,
-    ) {
+    ) -> SitrepUuid {
         let sitrep_id = SitrepUuid::new_v4();
         let sitrep = Sitrep {
             metadata: SitrepMetadata {
                 id: sitrep_id,
-                parent_sitrep_id: None,
+                parent_sitrep_id: parent,
                 inv_collection_id: CollectionUuid::new_v4(),
                 next_inv_min_time_started: Utc::now(),
                 creator_id: OmicronZoneUuid::new_v4(),
@@ -509,6 +511,8 @@ mod tests {
         ))
         .await
         .unwrap();
+
+        sitrep_id
     }
 
     // Builds and runs a guarded insert for `resource_id` at
@@ -565,6 +569,12 @@ mod tests {
 
     // Both guards pass: the resource row is inserted and a marker is written
     // with the executed generation.
+    //
+    // The history deliberately contains *two* sitreps at the same generation
+    // (the request set did not change between them), and the executor is
+    // working from the older one. Along a sitrep chain, an unchanged generation
+    // means an unchanged request set, so the executor here is creating exactly
+    // the resources a "fresh" one would, rather than a stale set.
     #[tokio::test]
     async fn sitrep_guarded_insert_created_writes_marker() {
         let logctx =
@@ -573,7 +583,9 @@ mod tests {
         let (opctx, datastore) = (db.opctx(), db.datastore());
         let conn = datastore.pool_connection_for_tests().await.unwrap();
         setup_dummy_schema(&conn).await;
-        insert_current_sitrep(datastore, opctx, &conn, 2).await;
+        let parent =
+            insert_current_sitrep(datastore, opctx, &conn, None, 2).await;
+        insert_current_sitrep(datastore, opctx, &conn, Some(parent), 2).await;
 
         let resource_id = uuid!("22222222-2222-2222-2222-222222222222");
         let outcome = run_guarded_insert(&conn, resource_id, 2).await;
@@ -601,14 +613,17 @@ mod tests {
         let (opctx, datastore) = (db.opctx(), db.datastore());
         let conn = datastore.pool_connection_for_tests().await.unwrap();
         setup_dummy_schema(&conn).await;
-        insert_current_sitrep(datastore, opctx, &conn, 2).await;
+        insert_current_sitrep(datastore, opctx, &conn, None, 2).await;
 
         let resource_id = uuid!("33333333-3333-3333-3333-333333333333");
-        // Seed a marker for this resource id.
+        // Seed a marker for this resource id, at a generation *different* from
+        // the one we will execute at, so the final assertion can distinguish
+        // "marker preserved" from "marker overwritten with the executed
+        // generation".
         diesel::insert_into(dummy_marker::table)
             .values((
                 dummy_marker::dsl::dummy_id.eq(resource_id),
-                dummy_marker::dsl::created_at_generation.eq(2i64),
+                dummy_marker::dsl::created_at_generation.eq(1i64),
             ))
             .execute_async(&*conn)
             .await
@@ -618,8 +633,12 @@ mod tests {
 
         assert_matches!(outcome, SitrepGuardedInsertOutcome::AlreadyExists);
         // The resource row was not inserted; the seeded marker is unchanged.
+        // If the marker INSERT were ever flipped to an UPSERT (or lost its
+        // `ON CONFLICT DO NOTHING`), this would read Some(2), breaking the
+        // invariant that markers record the generation at which the resource
+        // was originally created.
         assert!(!resource_exists(&conn, resource_id).await);
-        assert_eq!(marker_generation(&conn, resource_id).await, Some(2));
+        assert_eq!(marker_generation(&conn, resource_id).await, Some(1));
 
         db.terminate().await;
         logctx.cleanup_successful();
@@ -637,7 +656,7 @@ mod tests {
         let (opctx, datastore) = (db.opctx(), db.datastore());
         let conn = datastore.pool_connection_for_tests().await.unwrap();
         setup_dummy_schema(&conn).await;
-        insert_current_sitrep(datastore, opctx, &conn, 2).await;
+        insert_current_sitrep(datastore, opctx, &conn, None, 2).await;
 
         let resource_id = uuid!("44444444-4444-4444-4444-444444444444");
         // Seed the resource row, but no marker.
@@ -665,6 +684,12 @@ mod tests {
 
     // The executed generation does not match the latest sitrep's generation:
     // `stale_guard` aborts and nothing is written.
+    //
+    // The executed generation (1) deliberately matches an ancestor sitrep in
+    // the history: this is exactly the stale-executor case the guard exists
+    // for, and a `stale_guard` that matched any sitrep in `fm_sitrep_history`
+    // (rather than only the current one) would incorrectly let the insert
+    // through.
     #[tokio::test]
     async fn sitrep_guarded_insert_stale_sitrep() {
         let logctx = dev::test_setup_log("sitrep_guarded_insert_stale_sitrep");
@@ -672,14 +697,44 @@ mod tests {
         let (opctx, datastore) = (db.opctx(), db.datastore());
         let conn = datastore.pool_connection_for_tests().await.unwrap();
         setup_dummy_schema(&conn).await;
-        // Latest sitrep is at generation 2 ...
-        insert_current_sitrep(datastore, opctx, &conn, 2).await;
+        // History: ancestor at generation 1, current sitrep at generation 2...
+        let parent =
+            insert_current_sitrep(datastore, opctx, &conn, None, 1).await;
+        insert_current_sitrep(datastore, opctx, &conn, Some(parent), 2).await;
 
         let resource_id = uuid!("55555555-5555-5555-5555-555555555555");
-        // ... but we execute expecting generation 1.
+        // ... and we execute expecting generation 1.
         let outcome = run_guarded_insert(&conn, resource_id, 1).await;
 
         assert_matches!(outcome, SitrepGuardedInsertOutcome::StaleSitrep);
+        assert!(!resource_exists(&conn, resource_id).await);
+        assert_eq!(marker_generation(&conn, resource_id).await, None);
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // With no sitrep in history at all, there is no current generation to
+    // match, so the guarded insert must fail closed: no resource row and no
+    // marker row may be written. We deliberately do not assert *which*
+    // outcome is reported -- this situation is unreachable via fm_rendezvous,
+    // which only runs with a loaded sitrep, so the reported outcome is not a
+    // behavior we want to guarantee -- only that the guard does not fail
+    // open.
+    #[tokio::test]
+    async fn sitrep_guarded_insert_no_sitrep_writes_nothing() {
+        let logctx = dev::test_setup_log(
+            "sitrep_guarded_insert_no_sitrep_writes_nothing",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (_opctx, datastore) = (db.opctx(), db.datastore());
+        let conn = datastore.pool_connection_for_tests().await.unwrap();
+        setup_dummy_schema(&conn).await;
+        // Deliberately no sitrep inserted.
+
+        let resource_id = uuid!("88888888-8888-8888-8888-888888888888");
+        let _ = run_guarded_insert(&conn, resource_id, 1).await;
+
         assert!(!resource_exists(&conn, resource_id).await);
         assert_eq!(marker_generation(&conn, resource_id).await, None);
 

--- a/nexus/db-queries/src/db/sitrep_guard.rs
+++ b/nexus/db-queries/src/db/sitrep_guard.rs
@@ -633,10 +633,11 @@ mod tests {
 
         assert_matches!(outcome, SitrepGuardedInsertOutcome::AlreadyExists);
         // The resource row was not inserted; the seeded marker is unchanged.
-        // If the marker INSERT were ever flipped to an UPSERT (or lost its
-        // `ON CONFLICT DO NOTHING`), this would read Some(2), breaking the
+        // (The sentinel from `prior_marker_guard` aborts the whole statement
+        // atomically, so `new_marker` never runs here; the generation could
+        // only change if the guard itself regressed. Asserting it pins the
         // invariant that markers record the generation at which the resource
-        // was originally created.
+        // was originally created.)
         assert!(!resource_exists(&conn, resource_id).await);
         assert_eq!(marker_generation(&conn, resource_id).await, Some(1));
 


### PR DESCRIPTION
The existing tests for `SitrepGuardedInsert` (from #10564) all ran against a single-sitrep history, which can't distinguish "the guard compares against the current sitrep" from "the guard matches any sitrep in history". This change adds a new parent sitrep in a couple places to provide better coverage for the guard's behavior.

While we're at it, we also add a brand new test ensuring that we fail closed in the unexpected case where sitrep history is empty.