### PR TITLE
[3/n] [nexus] trigger dendrite NAT reconciliation in wait_for_n_nat_entries

### DIFF
--- a/docs/flake-patterns.adoc
+++ b/docs/flake-patterns.adoc
@@ -8,6 +8,7 @@ Omicron is a large distributed system, as a result of which it is somewhat susce
 
 == Glossary [[glossary]]
 
+Background task:: A task that runs periodically in the background on a timer. Most background tasks implement the _reliable persistent workflow_ or _RPW_ pattern; see https://rfd.shared.oxide.computer/rfd/0373[RFD 373 Reliable Persistent Workflows].
 Nexus test:: A test that uses the Nexus test framework, typically represented as an async function annotated with `#[nexus_test]`. (Some tests may manually set up Nexus.)
 System under test (SUT):: The production code (components or systems) being tested.
 
@@ -112,6 +113,8 @@ It is fine to call `activate_background_task` in a loop since it is synchronous:
 
 // FIXME: replace ZZZZ with the merged commit hash of the test_instance_migrate race-fix PR.
 * https://github.com/oxidecomputer/omicron/commit/ZZZZ[`ZZZZ`] activates the `abandoned_vmm_reaper` task on each poll instead of waiting out its periodic activation interval.
+// FIXME: replace WWWW with the merged commit hash of the dead-switch NAT race-fix PR.
+* https://github.com/oxidecomputer/omicron/commit/WWWW[`WWWW`] makes it so that when checking that a restarted switch zone has received its NAT entries, the test triggers dendrite's NAT reconciliation on each poll rather than waiting for dendrite's own periodic background task poll. Here, the background task lives inside `dpd` rather than Nexus, so it is triggered through the `dpd` client's `nat_trigger_update` rather than the Nexus lockstep API.
 
 === Teardown ordering races [[teardown-ordering-races]]
 

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1706,6 +1706,7 @@ mod test {
     use omicron_uuid_kinds::PropolisUuid;
     use sled_agent_types::early_networking::SwitchSlot;
     use sled_agent_types::instance::{MigrationRuntimeState, MigrationState};
+    use slog_error_chain::InlineErrorChain;
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::time::Duration;
@@ -2849,6 +2850,24 @@ mod test {
 
         poll::wait_for_condition(
             async || {
+                // Force dendrite's NAT to reconcile against Nexus now. (See
+                // "Relying on periodic background-task activation" in
+                // docs/flake-patterns.adoc.)
+                //
+                // (Triggering reconciliation is idempotent, so it is safe to do
+                // on every iteration.)
+                if let Err(error) = client.nat_trigger_update().await {
+                    slog::info!(
+                        log,
+                        "failed to trigger NAT reconciliation, will retry";
+                        "switch" => ?switch,
+                        InlineErrorChain::new(&error),
+                    );
+                    return Err(poll::CondCheckError::<&'static str>::NotYet {
+                        status: None,
+                    });
+                }
+
                 let result =
                     client.nat_ipv4_list(&NAT_SUBNET, None, None).await;
 


### PR DESCRIPTION
Should fix the flake seen in https://buildomat.eng.oxide.computer/wg/0/details/01KTVTGG7TGV1WN2CX0NC7H03W/jcCuCbR4iuO8KZ8Cl4elTpQ8aNdJLjVXMZEHWRwH4699extY/01KTVTHJDGMWFEW36PZ2TYEAN8.

(Re-do of #10608 that I accidentally landed on the wrong branch.)
