### PR TITLE
Reduce uses of is_oxide_sled in sled-agent

### DIFF
--- a/installinator/src/bootstrap.rs
+++ b/installinator/src/bootstrap.rs
@@ -18,6 +18,7 @@ use omicron_common::address::SLED_PREFIX;
 use omicron_common::backoff::retry_notify;
 use omicron_common::backoff::retry_policy_internal_service_aggressive;
 use omicron_ddm_admin_client::Client as DdmAdminClient;
+use sled_hardware::DataLinks;
 use sled_hardware::underlay;
 use sled_hardware::underlay::BootstrapInterface;
 use slog::Logger;
@@ -31,11 +32,11 @@ const MG_DDM_MANIFEST_PATH: &str = "/opt/oxide/mg-ddm/pkg/ddm/manifest.xml";
 // `sled_agent::bootstrap::server::Server::start()`; consider whether we could
 // find a way for them to share it.
 pub(crate) async fn bootstrap_sled(
-    data_links: &[String; 2],
+    links: &DataLinks,
     log: Logger,
 ) -> Result<()> {
     // Find address objects to pass to maghemite.
-    let links = underlay::find_chelsio_links(data_links)
+    let links = underlay::find_chelsio_links(links)
         .await
         .context("failed to find chelsio links")?;
     ensure!(

--- a/installinator/src/dispatch.rs
+++ b/installinator/src/dispatch.rs
@@ -30,6 +30,7 @@ use crate::{
     peers::{DiscoveryMechanism, LastKnownPeer},
     reporter::{HttpProgressBackend, ProgressReporter, ReportProgressBackend},
 };
+use sled_hardware::{DataLinks, is_oxide_sled};
 
 /// Installinator app.
 #[derive(Debug, Parser)]
@@ -190,7 +191,16 @@ struct InstallOpts {
 impl InstallOpts {
     async fn exec(self, log: &slog::Logger) -> Result<()> {
         if self.bootstrap_sled {
-            let data_links = [self.data_link0.clone(), self.data_link1.clone()];
+            let data_links = if is_oxide_sled()? {
+                DataLinks::Physical
+            } else {
+                DataLinks::Virtual {
+                    devices: vec![
+                        self.data_link0.clone(),
+                        self.data_link1.clone(),
+                    ],
+                }
+            };
             crate::bootstrap::bootstrap_sled(&data_links, log.clone()).await?;
         }
 

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -14,8 +14,8 @@ use illumos_utils::dladm::FindPhysicalLinkError;
 use illumos_utils::dladm::PhysicalLink;
 use omicron_common::vlan::VlanID;
 use serde::Deserialize;
+use sled_hardware::DataLinks;
 use sled_hardware::UnparsedDisk;
-use sled_hardware::is_oxide_sled;
 use sprockets_tls::keys::SprocketsConfig;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -99,9 +99,8 @@ pub struct Config {
     /// systems.
     pub data_link: Option<PhysicalLink>,
 
-    /// The data links that sled-agent will treat as a real gimlet cxgbe0/cxgbe1
-    /// links.
-    pub data_links: [String; 2],
+    /// The data links sled-agent will use.
+    pub data_links: DataLinks,
 
     #[serde(default)]
     pub updates: ConfigUpdates,
@@ -159,8 +158,11 @@ impl Config {
         if let Some(link) = self.data_link.as_ref() {
             Ok(link.clone())
         } else {
-            if is_oxide_sled().map_err(ConfigError::SystemDetection)? {
-                Dladm::list_physical()
+            match self.data_links {
+                DataLinks::Virtual { .. } => {
+                    Dladm::find_physical().await.map_err(ConfigError::FindLinks)
+                }
+                DataLinks::Physical => Dladm::list_physical()
                     .await
                     .map_err(ConfigError::FindLinks)?
                     .into_iter()
@@ -169,9 +171,7 @@ impl Config {
                         ConfigError::FindLinks(
                             FindPhysicalLinkError::NoPhysicalLinkFound,
                         )
-                    })
-            } else {
-                Dladm::find_physical().await.map_err(ConfigError::FindLinks)
+                    }),
             }
         }
     }

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -35,6 +35,15 @@ pub enum SidecarRevision {
     SoftPropolis(SoftPortConfig),
 }
 
+impl SidecarRevision {
+    pub fn is_physical(&self) -> bool {
+        match self {
+            Self::Physical(_) => true,
+            Self::SoftZone(_) | Self::SoftPropolis(_) => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct SoftPortConfig {
     /// Number of front ports

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -102,7 +102,6 @@ use sled_agent_types::system_networking::SystemNetworkingConfig;
 use sled_agent_types::uplink::HostPortConfig;
 use sled_hardware::DendriteAsic;
 use sled_hardware::SledMode;
-use sled_hardware::is_oxide_sled;
 use sled_hardware::underlay;
 use sled_hardware_types::Baseboard;
 use slog::Logger;
@@ -972,10 +971,6 @@ impl ServiceManager {
     ) -> Result<Vec<(Link, bool)>, Error> {
         let mut links: Vec<(Link, bool)> = Vec::new();
 
-        let is_oxide_sled = is_oxide_sled().map_err(|e| {
-            Error::Underlay(underlay::Error::SystemDetection(e))
-        })?;
-
         for svc_details in zone_args.switch_zone_services() {
             match &svc_details {
                 SwitchService::Tfport { pkt_source, asic: _ } => {
@@ -995,7 +990,7 @@ impl ServiceManager {
                             links.push((link, false));
                         }
                         Err(_) => {
-                            if is_oxide_sled {
+                            if self.inner.sidecar_revision.is_physical() {
                                 return Err(Error::MissingDevice {
                                     device: pkt_source.to_string(),
                                 });
@@ -2559,6 +2554,8 @@ impl ServiceManager {
             ),
         };
 
+        let real_sidecar = self.inner.sidecar_revision.is_physical();
+
         // Define all services in the switch zone
         let mut mgs_service = ServiceBuilder::new("oxide/mgs");
         let mut wicketd_service = ServiceBuilder::new("oxide/wicketd");
@@ -2879,11 +2876,7 @@ impl ServiceManager {
                         );
                     }
 
-                    let is_oxide_sled = is_oxide_sled().map_err(|e| {
-                        Error::Underlay(underlay::Error::SystemDetection(e))
-                    })?;
-
-                    if is_oxide_sled {
+                    if real_sidecar {
                         // Collect the prefixes for each techport.
                         let nameaddr = bootstrap_name_and_address.as_ref();
                         let techport_prefixes = match nameaddr {
@@ -2912,7 +2905,7 @@ impl ServiceManager {
                         }
                     };
 
-                    if is_oxide_sled
+                    if real_sidecar
                         || asic == &DendriteAsic::SoftNpuPropolisDevice
                         || asic == &DendriteAsic::TofinoAsic
                     {
@@ -3080,12 +3073,7 @@ impl ServiceManager {
                         }
                     }
 
-                    let is_oxide_sled = is_oxide_sled().map_err(|e| {
-                        Error::Underlay(underlay::Error::SystemDetection(e))
-                    })?;
-
-                    let maghemite_interfaces: Vec<AddrObject> = if is_oxide_sled
-                    {
+                    let maghemite_interfaces: Vec<_> = if real_sidecar {
                         (0..32)
                             .map(|i| {
                                 // See the `tfport_name` function
@@ -3129,7 +3117,7 @@ impl ServiceManager {
                         );
                     }
 
-                    if is_oxide_sled {
+                    if real_sidecar {
                         mg_ddm_config = mg_ddm_config
                             .add_property("dpd_host", "astring", "[::1]")
                             .add_property(

--- a/sled-hardware/src/lib.rs
+++ b/sled-hardware/src/lib.rs
@@ -53,6 +53,18 @@ impl std::fmt::Display for DendriteAsic {
     }
 }
 
+/// Whether physical or virtual NICs are present in the system.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum DataLinks {
+    /// Virtual NICs are present. This is the case for development environments,
+    /// or any Oxide sled running outside of a rack.
+    Virtual { devices: Vec<String> },
+    /// Physical NICs are present, with device names like `cxgbeN`. This is the
+    /// case for Oxide compute sleds running inside of a rack.
+    Physical,
+}
+
 /// Configuration for forcing a sled to run as a Scrimlet or compute Sled
 #[derive(Copy, Clone, Debug)]
 pub enum SledMode {

--- a/sled-hardware/src/underlay.rs
+++ b/sled-hardware/src/underlay.rs
@@ -7,7 +7,6 @@
 
 use std::net::Ipv6Addr;
 
-use crate::is_oxide_sled;
 use illumos_utils::addrobj;
 use illumos_utils::addrobj::AddrObject;
 use illumos_utils::dladm;
@@ -19,6 +18,8 @@ use illumos_utils::dladm::PhysicalLink;
 use illumos_utils::dladm::SetLinkpropError;
 use illumos_utils::zone::Zones;
 use omicron_common::api::external::MacAddr;
+
+use crate::DataLinks;
 
 #[doc(inline)]
 pub use sled_hardware_types::underlay::BOOTSTRAP_MASK;
@@ -51,10 +52,8 @@ pub enum Error {
 /// Convenience function that calls
 /// `ensure_links_have_global_zone_link_local_v6_addresses()` with the links
 /// returned by `find_chelsio_links()`.
-pub async fn find_nics(
-    config_data_links: &[String; 2],
-) -> Result<Vec<AddrObject>, Error> {
-    let underlay_nics = find_chelsio_links(config_data_links).await?;
+pub async fn find_nics(links: &DataLinks) -> Result<Vec<AddrObject>, Error> {
+    let underlay_nics = find_chelsio_links(links).await?;
 
     // Before these links have any consumers (eg. IP interfaces), set the MTU.
     // If we have previously set the MTU, do not attempt to re-set.
@@ -72,25 +71,23 @@ pub async fn find_nics(
 }
 
 /// Return the Chelsio links on the system.
-///
-/// For a real Oxide sled, this should return the devices like `cxgbeN`. For a
-/// developer machine, or generally a non-sled, this will return the
-/// VNICs we use to emulate those Chelsio links.
 pub async fn find_chelsio_links(
-    config_data_links: &[String; 2],
+    links: &DataLinks,
 ) -> Result<Vec<PhysicalLink>, Error> {
-    if is_oxide_sled().map_err(Error::SystemDetection)? {
-        Dladm::list_physical().await.map_err(Error::FindLinks).map(|links| {
-            links
-                .into_iter()
-                .filter(|link| link.0.starts_with(CHELSIO_LINK_PREFIX))
-                .collect()
-        })
-    } else {
-        Ok(config_data_links
-            .into_iter()
+    match links {
+        DataLinks::Virtual { devices } => Ok(devices
+            .iter()
             .map(|name| PhysicalLink(name.to_string()))
-            .collect())
+            .collect()),
+        DataLinks::Physical => Dladm::list_physical()
+            .await
+            .map_err(Error::FindLinks)
+            .map(|links| {
+                links
+                    .into_iter()
+                    .filter(|link| link.0.starts_with(CHELSIO_LINK_PREFIX))
+                    .collect()
+            }),
     }
 }
 

--- a/smf/sled-agent/gimlet-standalone/config.toml
+++ b/smf/sled-agent/gimlet-standalone/config.toml
@@ -63,7 +63,9 @@ swap_device_size_gb = 256
 # $ dladm show-phys -p -o LINK
 # data_link = "igb0"
 
-data_links = ["net0", "net1"]
+[data_links]
+kind = "virtual"
+devices = ["net0", "net1"]
 
 [dropshot]
 default_request_body_max_bytes = 1048576

--- a/smf/sled-agent/gimlet/config.toml
+++ b/smf/sled-agent/gimlet/config.toml
@@ -59,7 +59,8 @@ vmm_reservoir_percentage = 86.3
 # allocated.
 swap_device_size_gb = 256
 
-data_links = ["cxgbe0", "cxgbe1"]
+[data_links]
+kind = "physical"
 
 [dropshot]
 default_request_body_max_bytes = 1048576

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -105,7 +105,9 @@ swap_device_size_gb = 64
 # as-is.
 switch_zone_maghemite_links = ["tfportrear0_0"]
 
-data_links = ["net0", "net1"]
+[data_links]
+kind = "virtual"
+devices = ["net0", "net1"]
 
 [dropshot]
 default_request_body_max_bytes = 1048576


### PR DESCRIPTION
`sled-hardware::is_oxide_sled` is meant to detect whether sled-agent is running on an actual sled, but that's not how `sled-agent` uses it. In some places, it treats that function as "is it running on an actual sled inside of a functioning rack", which fails in fun and interesting ways when running it on a bench gimlet.

This PR moves two uses of it into dedicated fields of sled-agent's `config.toml`:

* For finding physical Chelsio links, there is now a new `data_links` config.
* For deciding whether to expect a Tofino to be connected, we piggyback on the existing `sidecar_revision` config.

With both of these in, it's possible to run the deploy job on lab gimlets!