### PR TITLE
[2/n][fm] factor `restart_id` and `time_created` out of `EreportData`

### DIFF
--- a/nexus/db-model/src/ereport.rs
+++ b/nexus/db-model/src/ereport.rs
@@ -172,13 +172,13 @@ impl Ereport {
     }
 
     pub fn new(
+        EreportId { ena, restart_id }: EreportId,
+        time_collected: DateTime<Utc>,
         data: types::EreportData,
         reporter: impl Into<Reporter>,
     ) -> Self {
         let types::EreportData {
-            id: EreportId { ena, restart_id },
             collector_id,
-            time_collected,
             serial_number,
             part_number,
             class,
@@ -203,11 +203,11 @@ impl Ereport {
 
 impl From<types::Ereport> for Ereport {
     fn from(
-        types::Ereport { data, reporter, marked_seen_in }: types::Ereport,
+        types::Ereport { id, time_collected, data, reporter, marked_seen_in }: types::Ereport,
     ) -> Self {
         Self {
             marked_seen_in: marked_seen_in.map(Into::into),
-            ..Self::new(data, reporter)
+            ..Self::new(id, time_collected, data, reporter)
         }
     }
 }
@@ -233,9 +233,9 @@ impl TryFrom<Ereport> for types::Ereport {
             ))
         })?;
         Ok(types::Ereport {
+            id,
+            time_collected,
             data: types::EreportData {
-                id,
-                time_collected,
                 collector_id: collector_id.into(),
                 serial_number,
                 part_number,

--- a/nexus/db-model/src/ereport.rs
+++ b/nexus/db-model/src/ereport.rs
@@ -174,16 +174,12 @@ impl Ereport {
     pub fn new(
         EreportId { ena, restart_id }: EreportId,
         time_collected: DateTime<Utc>,
+        collector_id: impl Into<DbTypedUuid<OmicronZoneKind>>,
         data: types::EreportData,
         reporter: impl Into<Reporter>,
     ) -> Self {
-        let types::EreportData {
-            collector_id,
-            serial_number,
-            part_number,
-            class,
-            report,
-        } = data;
+        let types::EreportData { serial_number, part_number, class, report } =
+            data;
 
         Self {
             ena: ena.into(),
@@ -203,11 +199,18 @@ impl Ereport {
 
 impl From<types::Ereport> for Ereport {
     fn from(
-        types::Ereport { id, time_collected, data, reporter, marked_seen_in }: types::Ereport,
+        types::Ereport {
+            id,
+            time_collected,
+            collector_id,
+            data,
+            reporter,
+            marked_seen_in,
+        }: types::Ereport,
     ) -> Self {
         Self {
             marked_seen_in: marked_seen_in.map(Into::into),
-            ..Self::new(id, time_collected, data, reporter)
+            ..Self::new(id, time_collected, collector_id, data, reporter)
         }
     }
 }
@@ -235,8 +238,8 @@ impl TryFrom<Ereport> for types::Ereport {
         Ok(types::Ereport {
             id,
             time_collected,
+            collector_id: collector_id.into(),
             data: types::EreportData {
-                collector_id: collector_id.into(),
                 serial_number,
                 part_number,
                 class,

--- a/nexus/db-model/src/fm/case.rs
+++ b/nexus/db-model/src/fm/case.rs
@@ -123,8 +123,8 @@ impl CaseEreport {
     ) -> Self {
         let fm::case::CaseEreport { id, ereport, assigned_sitrep_id, comment } =
             ereport;
-        let restart_id = ereport.id().restart_id.into();
-        let ena = ereport.id().ena.into();
+        let restart_id = ereport.id.restart_id.into();
+        let ena = ereport.id.ena.into();
         Self {
             id: id.into(),
             case_id: case_id.into(),

--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -261,14 +261,17 @@ impl DataStore {
         restart_id: EreporterRestartUuid,
         time_collected: DateTime<Utc>,
         reporter: fm::Reporter,
-        ereports: impl IntoIterator<Item = fm::EreportData>,
+        ereports: impl IntoIterator<Item = (fm::Ena, fm::EreportData)>,
     ) -> CreateResult<(usize, Option<EreportId>)> {
         opctx.authorize(authz::Action::CreateChild, &authz::FLEET).await?;
         let conn = self.pool_connection_authorized(opctx).await?;
 
         let ereports = ereports
             .into_iter()
-            .map(|data| Ereport::new(data, reporter))
+            .map(|(ena, data)| {
+                let id = EreportId { restart_id, ena };
+                Ereport::new(id, time_collected, data, reporter)
+            })
             .collect::<Vec<_>>();
         let n_ereports = ereports.len();
         let created = Self::ereports_insert_query(
@@ -1025,8 +1028,6 @@ mod tests {
         let id = fm::EreportId { restart_id, ena: ereport_types::Ena(2) };
         let time_collected = Utc::now();
         let ereport = fm::EreportData {
-            id,
-            time_collected,
             collector_id: OmicronZoneUuid::new_v4(),
             part_number: Some("my cool CPN".to_string()),
             serial_number: Some("my cool serial".to_string()),
@@ -1042,7 +1043,7 @@ mod tests {
                     sp_type: nexus_types::inventory::SpType::Sled,
                     slot: 19,
                 },
-                vec![ereport.clone()],
+                vec![(id.ena, ereport.clone())],
             )
             .await
             .expect("insert should succeed");
@@ -1084,9 +1085,7 @@ mod tests {
             .ereport_fetch_matching(
                 opctx,
                 &EreportFilters::new()
-                    .with_start_time(
-                        ereport.time_collected - Duration::from_secs(600),
-                    )
+                    .with_start_time(time_collected - Duration::from_secs(600))
                     .expect("no end time set"),
                 &pagparams,
             )
@@ -1134,14 +1133,17 @@ mod tests {
         // and NULL.
         let restart_id = EreporterRestartUuid::new_v4();
         let collector_id = OmicronZoneUuid::new_v4();
-        let make = |ena: u64, class: Option<&str>| fm::EreportData {
-            id: fm::EreportId { restart_id, ena: ereport_types::Ena(ena) },
-            time_collected: Utc::now(),
-            collector_id,
-            part_number: Some("CPN".to_string()),
-            serial_number: Some("SN".to_string()),
-            class: class.map(str::to_string),
-            report: serde_json::json!({}),
+        let make = |ena: u64, class: Option<&str>| {
+            (
+                ereport_types::Ena(ena),
+                fm::EreportData {
+                    collector_id,
+                    part_number: Some("CPN".to_string()),
+                    serial_number: Some("SN".to_string()),
+                    class: class.map(str::to_string),
+                    report: serde_json::json!({}),
+                },
+            )
         };
         datastore
             .ereports_insert(
@@ -1248,20 +1250,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_ereporter_restarts() {
-        fn ereport_data(
-            restart_id: EreporterRestartUuid,
-            ena: u64,
-            time_collected: DateTime<Utc>,
-        ) -> fm::EreportData {
-            fm::EreportData {
-                id: fm::EreportId { restart_id, ena: Ena(ena) },
-                time_collected,
-                collector_id: OmicronZoneUuid::new_v4(),
-                part_number: None,
-                serial_number: None,
-                class: None,
-                report: serde_json::json!({}),
-            }
+        fn mk_ereport(ena: u64) -> (fm::Ena, fm::EreportData) {
+            (
+                Ena(ena),
+                fm::EreportData {
+                    collector_id: OmicronZoneUuid::new_v4(),
+                    part_number: None,
+                    serial_number: None,
+                    class: None,
+                    report: serde_json::json!({}),
+                },
+            )
         }
 
         let logctx = dev::test_setup_log("test_ereporter_restarts");
@@ -1296,7 +1295,7 @@ mod tests {
                 host0_restart_id,
                 host0_first_seen,
                 fm::Reporter::HostOs { sled, slot: None },
-                vec![ereport_data(host0_restart_id, 1, host0_first_seen)],
+                vec![mk_ereport(1)],
             )
             .await
             .unwrap();
@@ -1308,10 +1307,7 @@ mod tests {
                     host0_restart_id,
                     time_collected,
                     fm::Reporter::HostOs { sled, slot: Some(host0_slot) },
-                    vec![
-                        ereport_data(host0_restart_id, 2, time_collected),
-                        ereport_data(host0_restart_id, 3, time_collected),
-                    ],
+                    vec![mk_ereport(2), mk_ereport(3)],
                 )
                 .await
                 .unwrap();
@@ -1332,10 +1328,7 @@ mod tests {
                 host1_restart_id,
                 host1_first_seen,
                 fm::Reporter::HostOs { sled, slot: Some(host1_slot) },
-                vec![
-                    ereport_data(host1_restart_id, 1, host1_first_seen),
-                    ereport_data(host1_restart_id, 2, host1_first_seen),
-                ],
+                vec![mk_ereport(1), mk_ereport(2)],
             )
             .await
             .unwrap();
@@ -1345,7 +1338,7 @@ mod tests {
                 host1_restart_id,
                 timestamp(250),
                 fm::Reporter::HostOs { sled, slot: None },
-                vec![ereport_data(host1_restart_id, 3, timestamp(250))],
+                vec![mk_ereport(3)],
             )
             .await
             .unwrap();
@@ -1364,10 +1357,7 @@ mod tests {
                     sp_type: SpType::Switch.into(),
                     slot: sp0_slot,
                 },
-                vec![
-                    ereport_data(sp0_restart_id0, 1, sp0_first_seen),
-                    ereport_data(sp0_restart_id0, 2, sp0_first_seen),
-                ],
+                vec![mk_ereport(1), mk_ereport(2)],
             )
             .await
             .unwrap();
@@ -1382,7 +1372,7 @@ mod tests {
                         sp_type: SpType::Switch.into(),
                         slot: sp0_slot,
                     },
-                    vec![ereport_data(sp0_restart_id0, 3, time_collected)],
+                    vec![mk_ereport(3)],
                 )
                 .await
                 .unwrap();
@@ -1399,10 +1389,7 @@ mod tests {
                     sp_type: SpType::Switch.into(),
                     slot: sp0_slot,
                 },
-                vec![
-                    ereport_data(sp0_restart_id1, 1, sp0_restart1_first_seen),
-                    ereport_data(sp0_restart_id1, 2, sp0_restart1_first_seen),
-                ],
+                vec![mk_ereport(1), mk_ereport(2)],
             )
             .await
             .unwrap();

--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -40,6 +40,7 @@ use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
 use omicron_uuid_kinds::EreporterRestartUuid;
 use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SitrepUuid;
 use omicron_uuid_kinds::SledUuid;
 use uuid::Uuid;
@@ -260,6 +261,7 @@ impl DataStore {
         opctx: &OpContext,
         restart_id: EreporterRestartUuid,
         time_collected: DateTime<Utc>,
+        collector_id: OmicronZoneUuid,
         reporter: fm::Reporter,
         ereports: impl IntoIterator<Item = (fm::Ena, fm::EreportData)>,
     ) -> CreateResult<(usize, Option<EreportId>)> {
@@ -270,7 +272,7 @@ impl DataStore {
             .into_iter()
             .map(|(ena, data)| {
                 let id = EreportId { restart_id, ena };
-                Ereport::new(id, time_collected, data, reporter)
+                Ereport::new(id, time_collected, collector_id, data, reporter)
             })
             .collect::<Vec<_>>();
         let n_ereports = ereports.len();
@@ -1027,8 +1029,8 @@ mod tests {
         let restart_id = EreporterRestartUuid::new_v4();
         let id = fm::EreportId { restart_id, ena: ereport_types::Ena(2) };
         let time_collected = Utc::now();
+        let collector_id = OmicronZoneUuid::new_v4();
         let ereport = fm::EreportData {
-            collector_id: OmicronZoneUuid::new_v4(),
             part_number: Some("my cool CPN".to_string()),
             serial_number: Some("my cool serial".to_string()),
             class: Some("my cool ereport".to_string()),
@@ -1039,6 +1041,7 @@ mod tests {
                 &opctx,
                 restart_id,
                 time_collected,
+                collector_id,
                 fm::Reporter::Sp {
                     sp_type: nexus_types::inventory::SpType::Sled,
                     slot: 19,
@@ -1052,14 +1055,12 @@ mod tests {
         fn check_results(
             found_ereports: Vec<Ereport>,
             expected_id: &fm::EreportId,
+            collector_id: OmicronZoneUuid,
             expected: &fm::EreportData,
         ) {
             assert_eq!(found_ereports.len(), 1);
             assert_eq!(&found_ereports[0].id(), expected_id);
-            assert_eq!(
-                found_ereports[0].collector_id,
-                expected.collector_id.into()
-            );
+            assert_eq!(found_ereports[0].collector_id, collector_id.into());
             assert_eq!(&found_ereports[0].part_number, &expected.part_number);
             assert_eq!(
                 &found_ereports[0].serial_number,
@@ -1079,7 +1080,7 @@ mod tests {
             .ereport_fetch_matching(opctx, &Default::default(), &pagparams)
             .await
             .expect("fetch matching with default filters should succeed");
-        check_results(dbg!(found_default), &id, &ereport);
+        check_results(dbg!(found_default), &id, collector_id, &ereport);
 
         let found_by_time_range = datastore
             .ereport_fetch_matching(
@@ -1091,7 +1092,7 @@ mod tests {
             )
             .await
             .expect("fetch matching with time range filters should succeed");
-        check_results(dbg!(found_by_time_range), &id, &ereport);
+        check_results(dbg!(found_by_time_range), &id, collector_id, &ereport);
 
         let found_by_serial = datastore
             .ereport_fetch_matching(
@@ -1101,7 +1102,7 @@ mod tests {
             )
             .await
             .expect("fetch matching with serial number filters should succeed");
-        check_results(dbg!(found_by_serial), &id, &ereport);
+        check_results(dbg!(found_by_serial), &id, collector_id, &ereport);
 
         let found_by_class = datastore
             .ereport_fetch_matching(
@@ -1111,7 +1112,7 @@ mod tests {
             )
             .await
             .expect("fetch matching with class filters should succeed");
-        check_results(dbg!(found_by_class), &id, &ereport);
+        check_results(dbg!(found_by_class), &id, collector_id, &ereport);
 
         db.terminate().await;
         logctx.cleanup_successful();
@@ -1137,7 +1138,6 @@ mod tests {
             (
                 ereport_types::Ena(ena),
                 fm::EreportData {
-                    collector_id,
                     part_number: Some("CPN".to_string()),
                     serial_number: Some("SN".to_string()),
                     class: class.map(str::to_string),
@@ -1150,6 +1150,7 @@ mod tests {
                 &opctx,
                 restart_id,
                 Utc::now(),
+                collector_id,
                 fm::Reporter::Sp {
                     sp_type: nexus_types::inventory::SpType::Sled,
                     slot: 0,
@@ -1254,7 +1255,6 @@ mod tests {
             (
                 Ena(ena),
                 fm::EreportData {
-                    collector_id: OmicronZoneUuid::new_v4(),
                     part_number: None,
                     serial_number: None,
                     class: None,
@@ -1266,6 +1266,7 @@ mod tests {
         let logctx = dev::test_setup_log("test_ereporter_restarts");
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
+        let collector_id = OmicronZoneUuid::new_v4();
         let t0 = Utc::now();
 
         let timestamp = move |secs: usize| -> DateTime<Utc> {
@@ -1294,6 +1295,7 @@ mod tests {
                 opctx,
                 host0_restart_id,
                 host0_first_seen,
+                collector_id,
                 fm::Reporter::HostOs { sled, slot: None },
                 vec![mk_ereport(1)],
             )
@@ -1306,6 +1308,7 @@ mod tests {
                     opctx,
                     host0_restart_id,
                     time_collected,
+                    collector_id,
                     fm::Reporter::HostOs { sled, slot: Some(host0_slot) },
                     vec![mk_ereport(2), mk_ereport(3)],
                 )
@@ -1327,6 +1330,7 @@ mod tests {
                 opctx,
                 host1_restart_id,
                 host1_first_seen,
+                collector_id,
                 fm::Reporter::HostOs { sled, slot: Some(host1_slot) },
                 vec![mk_ereport(1), mk_ereport(2)],
             )
@@ -1337,6 +1341,7 @@ mod tests {
                 opctx,
                 host1_restart_id,
                 timestamp(250),
+                collector_id,
                 fm::Reporter::HostOs { sled, slot: None },
                 vec![mk_ereport(3)],
             )
@@ -1353,6 +1358,7 @@ mod tests {
                 opctx,
                 sp0_restart_id0,
                 sp0_first_seen,
+                collector_id,
                 fm::Reporter::Sp {
                     sp_type: SpType::Switch.into(),
                     slot: sp0_slot,
@@ -1368,6 +1374,7 @@ mod tests {
                     opctx,
                     sp0_restart_id0,
                     time_collected,
+                    collector_id,
                     fm::Reporter::Sp {
                         sp_type: SpType::Switch.into(),
                         slot: sp0_slot,
@@ -1385,6 +1392,7 @@ mod tests {
                 opctx,
                 sp0_restart_id1,
                 sp0_restart1_first_seen,
+                collector_id,
                 fm::Reporter::Sp {
                     sp_type: SpType::Switch.into(),
                     slot: sp0_slot,

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -2229,9 +2229,9 @@ mod tests {
         let collector_id = OmicronZoneUuid::new_v4();
         let time_collected = Utc::now();
 
+        let ereport1_id =
+            fm::EreportId { restart_id, ena: ereport_types::Ena(2) };
         let ereport1 = EreportData {
-            id: fm::EreportId { restart_id, ena: ereport_types::Ena(2) },
-            time_collected,
             collector_id,
             part_number: Some("930-55555".to_string()),
             serial_number: Some("BRM6900420".to_string()),
@@ -2239,9 +2239,9 @@ mod tests {
             report: serde_json::json!({"severity": "critical"}),
         };
 
+        let ereport2_id =
+            fm::EreportId { restart_id, ena: ereport_types::Ena(3) };
         let ereport2 = EreportData {
-            id: fm::EreportId { restart_id, ena: ereport_types::Ena(3) },
-            time_collected,
             collector_id,
             part_number: Some("930-55555".to_string()),
             serial_number: Some("BRM6900420".to_string()),
@@ -2261,7 +2261,10 @@ mod tests {
                 restart_id,
                 time_collected,
                 reporter,
-                vec![ereport1.clone(), ereport2.clone()],
+                vec![
+                    (ereport1_id.ena, ereport1.clone()),
+                    (ereport2_id.ena, ereport2.clone()),
+                ],
             )
             .await
             .expect("failed to insert ereports");
@@ -2273,7 +2276,12 @@ mod tests {
             ereports
                 .insert_unique(fm::case::CaseEreport {
                     id: omicron_uuid_kinds::CaseEreportUuid::new_v4(),
-                    ereport: Arc::new(fm::Ereport::new(ereport1, reporter)),
+                    ereport: Arc::new(fm::Ereport::new(
+                        ereport1_id,
+                        time_collected,
+                        ereport1,
+                        reporter,
+                    )),
                     assigned_sitrep_id: sitrep_id,
                     comment: "this has something to do with case 1".to_string(),
                 })
@@ -2386,7 +2394,12 @@ mod tests {
             ereports
                 .insert_unique(fm::case::CaseEreport {
                     id: omicron_uuid_kinds::CaseEreportUuid::new_v4(),
-                    ereport: Arc::new(fm::Ereport::new(ereport2, reporter)),
+                    ereport: Arc::new(fm::Ereport::new(
+                        ereport2_id,
+                        time_collected,
+                        ereport2,
+                        reporter,
+                    )),
                     assigned_sitrep_id: sitrep_id,
                     comment: "this has something to do with case 2".to_string(),
                 })

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -2165,7 +2165,7 @@ mod tests {
             // Now, check that all the ereports are present in both cases.
             assert_eq!(ereports.len(), expected.ereports.len());
             for expected in &expected.ereports {
-                let ereport_id = expected.ereport.id();
+                let ereport_id = expected.ereport.id;
                 let Some(ereport) = ereports.get(&ereport_id) else {
                     panic!(
                         "assertion failed: left == right (while checking case {case_id})\n  \
@@ -2173,7 +2173,7 @@ mod tests {
                         it contains only these ereports: {:?}\n",
                         ereports
                             .iter()
-                            .map(|e| e.ereport.id().to_string())
+                            .map(|e| e.ereport.id.to_string())
                             .collect::<Vec<_>>(),
                     )
                 };
@@ -2191,8 +2191,7 @@ mod tests {
                 // This is where we go out of our way to avoid the timestamp,
                 // btw.
                 assert_eq!(
-                    expected.ereport.id(),
-                    ereport.id(),
+                    expected.ereport.id, ereport.id,
                     "while checking ereport {ereport_id} in case {case_id}",
                 );
                 assert_eq!(

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -2232,7 +2232,6 @@ mod tests {
         let ereport1_id =
             fm::EreportId { restart_id, ena: ereport_types::Ena(2) };
         let ereport1 = EreportData {
-            collector_id,
             part_number: Some("930-55555".to_string()),
             serial_number: Some("BRM6900420".to_string()),
             class: Some("ereport.my_cool_ereport.wow".to_string()),
@@ -2242,7 +2241,6 @@ mod tests {
         let ereport2_id =
             fm::EreportId { restart_id, ena: ereport_types::Ena(3) };
         let ereport2 = EreportData {
-            collector_id,
             part_number: Some("930-55555".to_string()),
             serial_number: Some("BRM6900420".to_string()),
             class: Some("ereport.gov.nasa.apollo".to_string()),
@@ -2260,6 +2258,7 @@ mod tests {
                 &opctx,
                 restart_id,
                 time_collected,
+                collector_id,
                 reporter,
                 vec![
                     (ereport1_id.ena, ereport1.clone()),
@@ -2279,6 +2278,7 @@ mod tests {
                     ereport: Arc::new(fm::Ereport::new(
                         ereport1_id,
                         time_collected,
+                        collector_id,
                         ereport1,
                         reporter,
                     )),
@@ -2397,6 +2397,7 @@ mod tests {
                     ereport: Arc::new(fm::Ereport::new(
                         ereport2_id,
                         time_collected,
+                        collector_id,
                         ereport2,
                         reporter,
                     )),

--- a/nexus/fm/src/analysis_input.rs
+++ b/nexus/fm/src/analysis_input.rs
@@ -189,9 +189,9 @@ impl Builder {
         let parent_sitrep = self.parent_sitrep.as_ref().map(|s| &s.1);
         self.new_ereports.extend(ereports.into_iter().filter_map(|ereport| {
             if let Some(sitrep) = parent_sitrep {
-                let id = ereport.id();
+                let id = ereport.id;
                 if sitrep.ereports_by_id.contains_key(&id) {
-                    self.unmarked_seen_ereports.insert(*id);
+                    self.unmarked_seen_ereports.insert(id);
                     return None;
                 }
             }
@@ -246,11 +246,7 @@ impl Builder {
             parent_sitrep_id,
             parent_inv_id,
             inv_id: self.inv.id,
-            new_ereport_ids: self
-                .new_ereports
-                .iter()
-                .map(|e| *e.id())
-                .collect(),
+            new_ereport_ids: self.new_ereports.iter().map(|e| e.id).collect(),
             num_ereporter_restarts: self.ereporter_restarts.len(),
             open_cases: BTreeMap::new(),
             closed_cases_copied_forward: BTreeMap::new(),
@@ -594,22 +590,22 @@ mod tests {
 
         // Check the "new ereports" in the constructed input.
         assert!(
-            input.new_ereports().contains_key(ereport_new.id()),
+            input.new_ereports().contains_key(&ereport_new.id),
             "ereport_new should be in new_ereports (it was not in the parent \
              sitrep)"
         );
         assert!(
-            !input.new_ereports().contains_key(ereport_in_open_case1.id()),
+            !input.new_ereports().contains_key(&ereport_in_open_case1.id),
             "ereport_in_open_case1 should NOT be in new_ereports (it is \
              already associated with an open case in the parent sitrep)"
         );
         assert!(
-            !input.new_ereports().contains_key(ereport_in_open_case2.id()),
+            !input.new_ereports().contains_key(&ereport_in_open_case2.id),
             "ereport_in_open_case2 should NOT be in new_ereports (it is \
              already associated with an open case in the parent sitrep)"
         );
         assert!(
-            !input.new_ereports().contains_key(ereport_in_closed_unmarked.id()),
+            !input.new_ereports().contains_key(&ereport_in_closed_unmarked.id),
             "ereport_in_closed_unmarked should NOT be in new_ereports (it is \
              already associated with a closed case in the parent sitrep)"
         );

--- a/nexus/fm/src/builder/case.rs
+++ b/nexus/fm/src/builder/case.rs
@@ -333,8 +333,8 @@ impl CaseBuilder {
             Ok(_) => {
                 slog::info!(
                     self.log,
-                    "assigned ereport {} to case", report.id();
-                    "ereport_id" => %report.id(),
+                    "assigned ereport {} to case", report.id;
+                    "ereport_id" => %report.id,
                     "ereport_class" => ?report.class,
                     "assignment_id" => %assignment_id,
                     "comment" => %comment,
@@ -343,7 +343,7 @@ impl CaseBuilder {
                 self.report_log
                     .entry("assigned ereport to case")
                     .comment(comment)
-                    .kv("ereport_id", &format_args!("{}", report.id()))
+                    .kv("ereport_id", &format_args!("{}", report.id))
                     .kv(
                         "ereport_class",
                         &report.class.as_deref().unwrap_or("<none>"),
@@ -353,8 +353,8 @@ impl CaseBuilder {
             Err(_) => {
                 slog::warn!(
                     self.log,
-                    "ereport {} already assigned to case", report.id();
-                    "ereport_id" => %report.id(),
+                    "ereport {} already assigned to case", report.id;
+                    "ereport_id" => %report.id,
                     "ereport_class" => ?report.class,
                 );
             }

--- a/nexus/fm/src/test_util.rs
+++ b/nexus/fm/src/test_util.rs
@@ -138,7 +138,7 @@ pub fn mk_ereport(
     let (_ena, data) = match reporter {
         Reporter::Sp { .. } => {
             let raw = ereport_types::Ereport { ena: id.ena, data: json };
-            EreportData::from_sp_ereport(log, id.restart_id, raw, collector_id)
+            EreportData::from_sp_ereport(log, id.restart_id, raw)
         }
         Reporter::HostOs { .. } => {
             todo!(
@@ -156,5 +156,5 @@ pub fn mk_ereport(
         "serial_number" => ?data.serial_number,
         "part_number" => ?data.part_number,
     );
-    Ereport::new(id, time_collected, data, reporter)
+    Ereport::new(id, time_collected, collector_id, data, reporter)
 }

--- a/nexus/fm/src/test_util.rs
+++ b/nexus/fm/src/test_util.rs
@@ -135,16 +135,10 @@ pub fn mk_ereport(
     time_collected: chrono::DateTime<Utc>,
     json: serde_json::Map<String, serde_json::Value>,
 ) -> Ereport {
-    let data = match reporter {
+    let (_ena, data) = match reporter {
         Reporter::Sp { .. } => {
             let raw = ereport_types::Ereport { ena: id.ena, data: json };
-            EreportData::from_sp_ereport(
-                log,
-                id.restart_id,
-                raw,
-                time_collected,
-                collector_id,
-            )
+            EreportData::from_sp_ereport(log, id.restart_id, raw, collector_id)
         }
         Reporter::HostOs { .. } => {
             todo!(
@@ -156,11 +150,11 @@ pub fn mk_ereport(
     };
     slog::info!(
         &log,
-        "simulating an ereport: {}", data.id;
-        "ereport_id" => %data.id,
+        "simulating an ereport: {}", id;
+        "ereport_id" => %id,
         "ereport_class" => ?data.class,
         "serial_number" => ?data.serial_number,
         "part_number" => ?data.part_number,
     );
-    Ereport::new(data, reporter)
+    Ereport::new(id, time_collected, data, reporter)
 }

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -281,12 +281,7 @@ impl Ingester {
             status.ereports_received += received;
 
             let db_ereports = reports.items.into_iter().map(|ereport| {
-                EreportData::from_sp_ereport(
-                    &opctx.log,
-                    restart_id,
-                    ereport,
-                    self.nexus_id,
-                )
+                EreportData::from_sp_ereport(&opctx.log, restart_id, ereport)
             });
             let created = match self
                 .datastore
@@ -294,6 +289,7 @@ impl Ingester {
                     &opctx,
                     restart_id,
                     time_collected,
+                    self.nexus_id,
                     reporter,
                     db_ereports,
                 )

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -285,7 +285,6 @@ impl Ingester {
                     &opctx.log,
                     restart_id,
                     ereport,
-                    time_collected,
                     self.nexus_id,
                 )
             });

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -389,7 +389,7 @@ impl FmAnalysis {
 
                 // Check if this is a reporter we know about, and issue a
                 // warning if it is not.
-                let id = ereport.id();
+                let id = ereport.id;
                 if !builder.ereporter_restarts().contains_key(&id.restart_id) {
                     let msg = format!(
                         "ereport {id} has a restart ID not contained in the \

--- a/nexus/src/app/background/tasks/fm_rendezvous.rs
+++ b/nexus/src/app/background/tasks/fm_rendezvous.rs
@@ -1052,36 +1052,27 @@ mod tests {
             slot: 0,
         };
 
+        let ereport1_id =
+            ereport_types::EreportId { restart_id, ena: ereport_types::Ena(2) };
         let ereport1_data = EreportData {
-            id: ereport_types::EreportId {
-                restart_id,
-                ena: ereport_types::Ena(2),
-            },
-            time_collected,
             collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.one".to_string()),
             report: serde_json::json!({"info": "first ereport"}),
         };
+        let ereport2_id =
+            ereport_types::EreportId { restart_id, ena: ereport_types::Ena(3) };
         let ereport2_data = EreportData {
-            id: ereport_types::EreportId {
-                restart_id,
-                ena: ereport_types::Ena(3),
-            },
-            time_collected,
             collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.two".to_string()),
             report: serde_json::json!({"info": "second ereport"}),
         };
+        let ereport3_id =
+            ereport_types::EreportId { restart_id, ena: ereport_types::Ena(4) };
         let ereport3_data = EreportData {
-            id: ereport_types::EreportId {
-                restart_id,
-                ena: ereport_types::Ena(4),
-            },
-            time_collected,
             collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
@@ -1095,9 +1086,9 @@ mod tests {
                 time_collected,
                 reporter,
                 vec![
-                    ereport1_data.clone(),
-                    ereport2_data.clone(),
-                    ereport3_data.clone(),
+                    (ereport1_id.ena, ereport1_data.clone()),
+                    (ereport2_id.ena, ereport2_data.clone()),
+                    (ereport3_id.ena, ereport3_data.clone()),
                 ],
             )
             .await
@@ -1107,7 +1098,7 @@ mod tests {
         assert_ereports_unseen(
             &datastore,
             opctx,
-            &[ereport1_data.id, ereport2_data.id, ereport3_data.id],
+            &[ereport1_id, ereport2_id, ereport3_id],
         )
         .await;
 
@@ -1121,6 +1112,8 @@ mod tests {
                 .insert_unique(fm::case::CaseEreport {
                     id: CaseEreportUuid::new_v4(),
                     ereport: Arc::new(fm::ereport::Ereport::new(
+                        ereport1_id,
+                        time_collected,
                         ereport1_data.clone(),
                         reporter,
                     )),
@@ -1132,6 +1125,8 @@ mod tests {
                 .insert_unique(fm::case::CaseEreport {
                     id: CaseEreportUuid::new_v4(),
                     ereport: Arc::new(fm::ereport::Ereport::new(
+                        ereport2_id,
+                        time_collected,
                         ereport2_data.clone(),
                         reporter,
                     )),
@@ -1213,11 +1208,11 @@ mod tests {
         assert_ereports_seen_in(
             &datastore,
             opctx,
-            &[ereport1_data.id, ereport2_data.id],
+            &[ereport1_id, ereport2_id],
             sitrep1_id,
         )
         .await;
-        assert_ereports_unseen(&datastore, opctx, &[ereport3_data.id]).await;
+        assert_ereports_unseen(&datastore, opctx, &[ereport3_id]).await;
 
         // Second activation: ereport1 and ereport2 are already marked
         // seen in the sitrep, so they should NOT be marked again
@@ -1246,11 +1241,11 @@ mod tests {
         assert_ereports_seen_in(
             &datastore,
             opctx,
-            &[ereport1_data.id, ereport2_data.id],
+            &[ereport1_id, ereport2_id],
             sitrep1_id,
         )
         .await;
-        assert_ereports_unseen(&datastore, opctx, &[ereport3_data.id]).await;
+        assert_ereports_unseen(&datastore, opctx, &[ereport3_id]).await;
 
         // Cleanup
         db.terminate().await;
@@ -1289,36 +1284,27 @@ mod tests {
             slot: 1,
         };
         let time_collected = Utc::now();
+        let ereport1_id =
+            ereport_types::EreportId { restart_id, ena: ereport_types::Ena(2) };
         let ereport1_data = EreportData {
-            id: ereport_types::EreportId {
-                restart_id,
-                ena: ereport_types::Ena(2),
-            },
-            time_collected,
             collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.one".to_string()),
             report: serde_json::json!({"info": "first ereport"}),
         };
+        let ereport2_id =
+            ereport_types::EreportId { restart_id, ena: ereport_types::Ena(3) };
         let ereport2_data = EreportData {
-            id: ereport_types::EreportId {
-                restart_id,
-                ena: ereport_types::Ena(3),
-            },
-            time_collected,
             collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.two".to_string()),
             report: serde_json::json!({"info": "second ereport"}),
         };
+        let ereport3_id =
+            ereport_types::EreportId { restart_id, ena: ereport_types::Ena(4) };
         let ereport3_data = EreportData {
-            id: ereport_types::EreportId {
-                restart_id,
-                ena: ereport_types::Ena(4),
-            },
-            time_collected,
             collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
@@ -1332,9 +1318,9 @@ mod tests {
                 time_collected,
                 reporter,
                 vec![
-                    ereport1_data.clone(),
-                    ereport2_data.clone(),
-                    ereport3_data.clone(),
+                    (ereport1_id.ena, ereport1_data.clone()),
+                    (ereport2_id.ena, ereport2_data.clone()),
+                    (ereport3_id.ena, ereport3_data.clone()),
                 ],
             )
             .await
@@ -1348,6 +1334,8 @@ mod tests {
                 .insert_unique(fm::case::CaseEreport {
                     id: CaseEreportUuid::new_v4(),
                     ereport: Arc::new(fm::ereport::Ereport::new(
+                        ereport1_id,
+                        time_collected,
                         ereport1_data.clone(),
                         reporter,
                     )),
@@ -1411,24 +1399,17 @@ mod tests {
         assert_eq!(ereport_marking.details.ereports_marked_seen, 1);
 
         // Verify DB state after sitrep 1.
-        assert_ereports_seen_in(
-            &datastore,
-            opctx,
-            &[ereport1_data.id],
-            sitrep1_id,
-        )
-        .await;
-        assert_ereports_unseen(
-            &datastore,
-            opctx,
-            &[ereport2_data.id, ereport3_data.id],
-        )
-        .await;
+        assert_ereports_seen_in(&datastore, opctx, &[ereport1_id], sitrep1_id)
+            .await;
+        assert_ereports_unseen(&datastore, opctx, &[ereport2_id, ereport3_id])
+            .await;
 
         // Sitrep 2: carries forward ereport1 AND adds ereport2 and
         // ereport3
         let sitrep2_id = SitrepUuid::new_v4();
         let ereport1_seen = fm::ereport::Ereport {
+            id: ereport1_id,
+            time_collected,
             data: ereport1_data.clone(),
             reporter,
             marked_seen_in: Some(sitrep1_id),
@@ -1448,6 +1429,8 @@ mod tests {
                 .insert_unique(fm::case::CaseEreport {
                     id: CaseEreportUuid::new_v4(),
                     ereport: Arc::new(fm::ereport::Ereport::new(
+                        ereport2_id,
+                        time_collected,
                         ereport2_data.clone(),
                         reporter,
                     )),
@@ -1459,6 +1442,8 @@ mod tests {
                 .insert_unique(fm::case::CaseEreport {
                     id: CaseEreportUuid::new_v4(),
                     ereport: Arc::new(fm::ereport::Ereport::new(
+                        ereport3_id,
+                        time_collected,
                         ereport3_data.clone(),
                         reporter,
                     )),
@@ -1530,17 +1515,12 @@ mod tests {
             "only ereport2 and ereport3 should be newly marked"
         );
         assert!(ereport_marking.details.errors.is_empty());
+        assert_ereports_seen_in(&datastore, opctx, &[ereport1_id], sitrep1_id)
+            .await;
         assert_ereports_seen_in(
             &datastore,
             opctx,
-            &[ereport1_data.id],
-            sitrep1_id,
-        )
-        .await;
-        assert_ereports_seen_in(
-            &datastore,
-            opctx,
-            &[ereport2_data.id, ereport3_data.id],
+            &[ereport2_id, ereport3_id],
             sitrep2_id,
         )
         .await;

--- a/nexus/src/app/background/tasks/fm_rendezvous.rs
+++ b/nexus/src/app/background/tasks/fm_rendezvous.rs
@@ -303,7 +303,7 @@ impl FmRendezvous {
             .cloned()
             .filter_map(|ereport| {
                 if ereport.marked_seen_in.is_none() {
-                    Some(*ereport.id())
+                    Some(ereport.id)
                 } else {
                     None
                 }

--- a/nexus/src/app/background/tasks/fm_rendezvous.rs
+++ b/nexus/src/app/background/tasks/fm_rendezvous.rs
@@ -1055,7 +1055,6 @@ mod tests {
         let ereport1_id =
             ereport_types::EreportId { restart_id, ena: ereport_types::Ena(2) };
         let ereport1_data = EreportData {
-            collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.one".to_string()),
@@ -1064,7 +1063,6 @@ mod tests {
         let ereport2_id =
             ereport_types::EreportId { restart_id, ena: ereport_types::Ena(3) };
         let ereport2_data = EreportData {
-            collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.two".to_string()),
@@ -1073,7 +1071,6 @@ mod tests {
         let ereport3_id =
             ereport_types::EreportId { restart_id, ena: ereport_types::Ena(4) };
         let ereport3_data = EreportData {
-            collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.three".to_string()),
@@ -1084,6 +1081,7 @@ mod tests {
                 &opctx,
                 restart_id,
                 time_collected,
+                collector_id,
                 reporter,
                 vec![
                     (ereport1_id.ena, ereport1_data.clone()),
@@ -1114,6 +1112,7 @@ mod tests {
                     ereport: Arc::new(fm::ereport::Ereport::new(
                         ereport1_id,
                         time_collected,
+                        collector_id,
                         ereport1_data.clone(),
                         reporter,
                     )),
@@ -1127,6 +1126,7 @@ mod tests {
                     ereport: Arc::new(fm::ereport::Ereport::new(
                         ereport2_id,
                         time_collected,
+                        collector_id,
                         ereport2_data.clone(),
                         reporter,
                     )),
@@ -1287,7 +1287,6 @@ mod tests {
         let ereport1_id =
             ereport_types::EreportId { restart_id, ena: ereport_types::Ena(2) };
         let ereport1_data = EreportData {
-            collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.one".to_string()),
@@ -1296,7 +1295,6 @@ mod tests {
         let ereport2_id =
             ereport_types::EreportId { restart_id, ena: ereport_types::Ena(3) };
         let ereport2_data = EreportData {
-            collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.two".to_string()),
@@ -1305,7 +1303,6 @@ mod tests {
         let ereport3_id =
             ereport_types::EreportId { restart_id, ena: ereport_types::Ena(4) };
         let ereport3_data = EreportData {
-            collector_id,
             part_number: Some("9130000019".to_string()),
             serial_number: Some("BRM420069".to_string()),
             class: Some("ereport.test.three".to_string()),
@@ -1316,6 +1313,7 @@ mod tests {
                 opctx,
                 restart_id,
                 time_collected,
+                collector_id,
                 reporter,
                 vec![
                     (ereport1_id.ena, ereport1_data.clone()),
@@ -1336,6 +1334,7 @@ mod tests {
                     ereport: Arc::new(fm::ereport::Ereport::new(
                         ereport1_id,
                         time_collected,
+                        collector_id,
                         ereport1_data.clone(),
                         reporter,
                     )),
@@ -1410,6 +1409,7 @@ mod tests {
         let ereport1_seen = fm::ereport::Ereport {
             id: ereport1_id,
             time_collected,
+            collector_id,
             data: ereport1_data.clone(),
             reporter,
             marked_seen_in: Some(sitrep1_id),
@@ -1431,6 +1431,7 @@ mod tests {
                     ereport: Arc::new(fm::ereport::Ereport::new(
                         ereport2_id,
                         time_collected,
+                        collector_id,
                         ereport2_data.clone(),
                         reporter,
                     )),
@@ -1444,6 +1445,7 @@ mod tests {
                     ereport: Arc::new(fm::ereport::Ereport::new(
                         ereport3_id,
                         time_collected,
+                        collector_id,
                         ereport3_data.clone(),
                         reporter,
                     )),

--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -863,16 +863,14 @@ mod test {
         let sp_restart_id = EreporterRestartUuid::new_v4();
         let time_collected = chrono::Utc::now();
         let collector_id = OmicronZoneUuid::new_v4();
-        datastore.ereports_insert(&opctx, sp_restart_id, time_collected, Reporter::Sp { sp_type: SpType::Sled, slot: SLED_SLOT}, vec![
+        datastore.ereports_insert(&opctx, sp_restart_id, time_collected, collector_id, Reporter::Sp { sp_type: SpType::Sled, slot: SLED_SLOT}, vec![
             (ereport_types::Ena(1), EreportData {
-                collector_id,
                 part_number: Some(GIMLET_PN.to_string()),
                 serial_number: Some(SP_SERIAL.to_string()),
                 class: Some("ereport.fake.whatever".to_string()),
                 report: serde_json::json!({"hello world": true})
             }),
             (ereport_types::Ena(2), EreportData {
-                collector_id,
                 part_number: Some(GIMLET_PN.to_string()),
                 serial_number: Some(SP_SERIAL.to_string()),
                 class: Some("ereport.something.blah".to_string()),
@@ -889,11 +887,11 @@ mod test {
                 &opctx,
                 sp_restart_id2,
                 time_collected,
+                collector_id,
                 Reporter::Sp { sp_type: SpType::Sled, slot: SLED_SLOT },
                 vec![(
                     ereport_types::Ena(1),
                     EreportData {
-                        collector_id,
                         part_number: None,
                         serial_number: None,
                         class: Some("ereport.fake.whatever".to_string()),
@@ -914,11 +912,11 @@ mod test {
                 &opctx,
                 sp2_restart_id,
                 time_collected,
+                OmicronZoneUuid::new_v4(),
                 Reporter::Sp { sp_type: SpType::Switch, slot: 1 },
                 vec![(
                     ereport_types::Ena(1),
                     EreportData {
-                        collector_id: OmicronZoneUuid::new_v4(),
                         part_number: Some("9130000006".to_string()),
                         serial_number: Some("BRM41000555".to_string()),
                         class: Some("ereport.fake.whatever".to_string()),
@@ -937,6 +935,7 @@ mod test {
                 &opctx,
                 sled1_restart_id,
                 time_collected,
+                collector_id,
                 Reporter::HostOs {
                     sled: SledUuid::new_v4(),
                     slot: Some(SLED_SLOT),
@@ -945,7 +944,6 @@ mod test {
                     (
                         ereport_types::Ena(1),
                         EreportData {
-                            collector_id,
                             serial_number: Some(HOST_SERIAL.to_string()),
                             part_number: Some(GIMLET_PN.to_string()),
                             class: Some("ereport.fake.whatever".to_string()),
@@ -955,7 +953,6 @@ mod test {
                     (
                         ereport_types::Ena(2),
                         EreportData {
-                            collector_id,
                             serial_number: Some(HOST_SERIAL.to_string()),
                             part_number: Some(GIMLET_PN.to_string()),
                             class: Some(
@@ -975,10 +972,10 @@ mod test {
                 &opctx,
                 sled2_restart_id,
                 time_collected,
+                OmicronZoneUuid::new_v4(),
                 Reporter::HostOs { sled: SledUuid::new_v4(), slot: Some(SLED_SLOT) },
                 vec![
                     (ereport_types::Ena(1), EreportData {
-                        collector_id: OmicronZoneUuid::new_v4(),
                         serial_number: Some(HOST_SERIAL.to_string()),
                         part_number: Some(GIMLET_PN.to_string()),
                         class: Some("ereport.something.hostos_related".to_string()),

--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -862,31 +862,48 @@ mod test {
         // Make some SP ereports...
         let sp_restart_id = EreporterRestartUuid::new_v4();
         let time_collected = chrono::Utc::now();
+        let collector_id = OmicronZoneUuid::new_v4();
         datastore.ereports_insert(&opctx, sp_restart_id, time_collected, Reporter::Sp { sp_type: SpType::Sled, slot: SLED_SLOT}, vec![
             (ereport_types::Ena(1), EreportData {
-                collector_id: OmicronZoneUuid::new_v4(),
+                collector_id,
                 part_number: Some(GIMLET_PN.to_string()),
                 serial_number: Some(SP_SERIAL.to_string()),
                 class: Some("ereport.fake.whatever".to_string()),
                 report: serde_json::json!({"hello world": true})
             }),
             (ereport_types::Ena(2), EreportData {
-                collector_id: OmicronZoneUuid::new_v4(),
+                collector_id,
                 part_number: Some(GIMLET_PN.to_string()),
                 serial_number: Some(SP_SERIAL.to_string()),
                 class: Some("ereport.something.blah".to_string()),
                 report: serde_json::json!({"system_working": "seems to be",})
             }),
-            (ereport_types::Ena(1), EreportData {
-                collector_id: OmicronZoneUuid::new_v4(),
-                // Let's do a silly one! No VPD, to make sure that's also
-                // handled correctly.
-                part_number: None,
-                serial_number: None,
-                class: Some("ereport.fake.whatever".to_string()),
-                report: serde_json::json!({"hello_world": true})
-            }),
         ]).await.expect("failed to insert fake SP ereports");
+
+        // Let's do a silly one! No VPD, to make sure that's also
+        // handled correctly.
+        let sp_restart_id2 = EreporterRestartUuid::new_v4();
+        let time_collected = chrono::Utc::now();
+        datastore
+            .ereports_insert(
+                &opctx,
+                sp_restart_id2,
+                time_collected,
+                Reporter::Sp { sp_type: SpType::Sled, slot: SLED_SLOT },
+                vec![(
+                    ereport_types::Ena(1),
+                    EreportData {
+                        collector_id,
+                        part_number: None,
+                        serial_number: None,
+                        class: Some("ereport.fake.whatever".to_string()),
+                        report: serde_json::json!({"hello_world": true}),
+                    },
+                )],
+            )
+            .await
+            .expect("failed to insert another fake SP ereport");
+
         // And one from a different serial. N.B. that I made sure the number of
         // host-OS and SP ereports are different for when we make assertions
         // about the bundle report.
@@ -914,6 +931,7 @@ mod test {
         // And some host OS ones...
         let sled1_restart_id = EreporterRestartUuid::new_v4();
         let time_collected = chrono::Utc::now();
+        let collector_id = OmicronZoneUuid::new_v4();
         datastore
             .ereports_insert(
                 &opctx,
@@ -927,7 +945,7 @@ mod test {
                     (
                         ereport_types::Ena(1),
                         EreportData {
-                            collector_id: OmicronZoneUuid::new_v4(),
+                            collector_id,
                             serial_number: Some(HOST_SERIAL.to_string()),
                             part_number: Some(GIMLET_PN.to_string()),
                             class: Some("ereport.fake.whatever".to_string()),
@@ -937,7 +955,7 @@ mod test {
                     (
                         ereport_types::Ena(2),
                         EreportData {
-                            collector_id: OmicronZoneUuid::new_v4(),
+                            collector_id,
                             serial_number: Some(HOST_SERIAL.to_string()),
                             part_number: Some(GIMLET_PN.to_string()),
                             class: Some(

--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -719,7 +719,7 @@ mod test {
     use nexus_db_queries::db::datastore::SupportBundleProvenance;
     use nexus_test_utils::SLED_AGENT_UUID;
     use nexus_test_utils_macros::nexus_test;
-    use nexus_types::fm::ereport::{EreportData, EreportId, Reporter};
+    use nexus_types::fm::ereport::{EreportData, Reporter};
     use nexus_types::identity::Asset;
     use nexus_types::internal_api::background::SupportBundleCollectionStep;
     use nexus_types::internal_api::background::SupportBundleCollectionStepStatus;
@@ -863,27 +863,21 @@ mod test {
         let sp_restart_id = EreporterRestartUuid::new_v4();
         let time_collected = chrono::Utc::now();
         datastore.ereports_insert(&opctx, sp_restart_id, time_collected, Reporter::Sp { sp_type: SpType::Sled, slot: SLED_SLOT}, vec![
-            EreportData {
-                id: EreportId { restart_id: sp_restart_id, ena: ereport_types::Ena(1) },
-                time_collected,
+            (ereport_types::Ena(1), EreportData {
                 collector_id: OmicronZoneUuid::new_v4(),
                 part_number: Some(GIMLET_PN.to_string()),
                 serial_number: Some(SP_SERIAL.to_string()),
                 class: Some("ereport.fake.whatever".to_string()),
                 report: serde_json::json!({"hello world": true})
-            },
-            EreportData {
-                id: EreportId { restart_id: sp_restart_id, ena: ereport_types::Ena(2) },
-                time_collected,
+            }),
+            (ereport_types::Ena(2), EreportData {
                 collector_id: OmicronZoneUuid::new_v4(),
                 part_number: Some(GIMLET_PN.to_string()),
                 serial_number: Some(SP_SERIAL.to_string()),
                 class: Some("ereport.something.blah".to_string()),
                 report: serde_json::json!({"system_working": "seems to be",})
-            },
-            EreportData {
-                id: EreportId { restart_id: EreporterRestartUuid::new_v4(), ena: ereport_types::Ena(1) },
-                time_collected,
+            }),
+            (ereport_types::Ena(1), EreportData {
                 collector_id: OmicronZoneUuid::new_v4(),
                 // Let's do a silly one! No VPD, to make sure that's also
                 // handled correctly.
@@ -891,7 +885,7 @@ mod test {
                 serial_number: None,
                 class: Some("ereport.fake.whatever".to_string()),
                 report: serde_json::json!({"hello_world": true})
-            },
+            }),
         ]).await.expect("failed to insert fake SP ereports");
         // And one from a different serial. N.B. that I made sure the number of
         // host-OS and SP ereports are different for when we make assertions
@@ -904,18 +898,16 @@ mod test {
                 sp2_restart_id,
                 time_collected,
                 Reporter::Sp { sp_type: SpType::Switch, slot: 1 },
-                vec![EreportData {
-                    id: EreportId {
-                        restart_id: sp2_restart_id,
-                        ena: ereport_types::Ena(1),
+                vec![(
+                    ereport_types::Ena(1),
+                    EreportData {
+                        collector_id: OmicronZoneUuid::new_v4(),
+                        part_number: Some("9130000006".to_string()),
+                        serial_number: Some("BRM41000555".to_string()),
+                        class: Some("ereport.fake.whatever".to_string()),
+                        report: serde_json::json!({"im_a_sidecar": true}),
                     },
-                    time_collected,
-                    collector_id: OmicronZoneUuid::new_v4(),
-                    part_number: Some("9130000006".to_string()),
-                    serial_number: Some("BRM41000555".to_string()),
-                    class: Some("ereport.fake.whatever".to_string()),
-                    report: serde_json::json!({"im_a_sidecar": true}),
-                }],
+                )],
             )
             .await
             .expect("failed to insert another fake SP ereport");
@@ -932,30 +924,28 @@ mod test {
                     slot: Some(SLED_SLOT),
                 },
                 vec![
-                    EreportData {
-                        id: EreportId {
-                            restart_id: sled1_restart_id,
-                            ena: ereport_types::Ena(1),
+                    (
+                        ereport_types::Ena(1),
+                        EreportData {
+                            collector_id: OmicronZoneUuid::new_v4(),
+                            serial_number: Some(HOST_SERIAL.to_string()),
+                            part_number: Some(GIMLET_PN.to_string()),
+                            class: Some("ereport.fake.whatever".to_string()),
+                            report: serde_json::json!({"hello_world": true}),
                         },
-                        time_collected,
-                        collector_id: OmicronZoneUuid::new_v4(),
-                        serial_number: Some(HOST_SERIAL.to_string()),
-                        part_number: Some(GIMLET_PN.to_string()),
-                        class: Some("ereport.fake.whatever".to_string()),
-                        report: serde_json::json!({"hello_world": true}),
-                    },
-                    EreportData {
-                        id: EreportId {
-                            restart_id: sled1_restart_id,
-                            ena: ereport_types::Ena(2),
+                    ),
+                    (
+                        ereport_types::Ena(2),
+                        EreportData {
+                            collector_id: OmicronZoneUuid::new_v4(),
+                            serial_number: Some(HOST_SERIAL.to_string()),
+                            part_number: Some(GIMLET_PN.to_string()),
+                            class: Some(
+                                "ereport.fake.whatever.thingy".to_string(),
+                            ),
+                            report: serde_json::json!({"goodbye_world": false}),
                         },
-                        time_collected,
-                        collector_id: OmicronZoneUuid::new_v4(),
-                        serial_number: Some(HOST_SERIAL.to_string()),
-                        part_number: Some(GIMLET_PN.to_string()),
-                        class: Some("ereport.fake.whatever.thingy".to_string()),
-                        report: serde_json::json!({"goodbye_world": false}),
-                    },
+                    ),
                 ],
             )
             .await
@@ -969,15 +959,13 @@ mod test {
                 time_collected,
                 Reporter::HostOs { sled: SledUuid::new_v4(), slot: Some(SLED_SLOT) },
                 vec![
-                    EreportData {
-                        id: EreportId { restart_id: sled2_restart_id, ena:  ereport_types::Ena(1) },
-                        time_collected,
+                    (ereport_types::Ena(1), EreportData {
                         collector_id: OmicronZoneUuid::new_v4(),
                         serial_number: Some(HOST_SERIAL.to_string()),
                         part_number: Some(GIMLET_PN.to_string()),
                         class: Some("ereport.something.hostos_related".to_string()),
                         report: serde_json::json!({"illumos": "very yes", "whatever": 42}),
-                    },
+                    }),
                 ],
             )
             .await

--- a/nexus/types/src/fm/case.rs
+++ b/nexus/types/src/fm/case.rs
@@ -537,9 +537,9 @@ mod tests {
             )
             .unwrap(),
             ereport: Arc::new(Ereport {
+                id: EreportId { restart_id, ena: Ena::from(2u64) },
+                time_collected,
                 data: crate::fm::ereport::EreportData {
-                    id: EreportId { restart_id, ena: Ena::from(2u64) },
-                    time_collected,
                     collector_id,
                     serial_number: Some("BRM6900420".to_string()),
                     part_number: Some("913-0000037".to_string()),
@@ -563,9 +563,9 @@ mod tests {
             )
             .unwrap(),
             ereport: Arc::new(Ereport {
+                id: EreportId { restart_id, ena: Ena::from(3u64) },
+                time_collected,
                 data: crate::fm::ereport::EreportData {
-                    id: EreportId { restart_id, ena: Ena::from(3u64) },
-                    time_collected,
                     collector_id,
                     serial_number: Some("BRM6900420".to_string()),
                     part_number: Some("913-0000037".to_string()),

--- a/nexus/types/src/fm/case.rs
+++ b/nexus/types/src/fm/case.rs
@@ -161,7 +161,7 @@ impl IdOrdItem for CaseEreport {
 
 impl CaseEreport {
     pub fn ereport_id(&self) -> &EreportId {
-        self.ereport.id()
+        &self.ereport.id
     }
 }
 
@@ -359,7 +359,7 @@ impl fmt::Display for DisplayCase<'_> {
                 let pn = ereport.part_number.as_deref().unwrap_or("<UNKNOWN>");
                 let sn =
                     ereport.serial_number.as_deref().unwrap_or("<UNKNOWN>");
-                writeln!(f, "{BULLET:>indent$}ereport {}", ereport.id())?;
+                writeln!(f, "{BULLET:>indent$}ereport {}", ereport.id)?;
                 writeln!(
                     f,
                     "{:>indent$}{CLASS:<WIDTH$} {}",

--- a/nexus/types/src/fm/case.rs
+++ b/nexus/types/src/fm/case.rs
@@ -539,8 +539,8 @@ mod tests {
             ereport: Arc::new(Ereport {
                 id: EreportId { restart_id, ena: Ena::from(2u64) },
                 time_collected,
+                collector_id,
                 data: crate::fm::ereport::EreportData {
-                    collector_id,
                     serial_number: Some("BRM6900420".to_string()),
                     part_number: Some("913-0000037".to_string()),
                     class: Some("hw.pwr.remove.psu".to_string()),
@@ -565,8 +565,8 @@ mod tests {
             ereport: Arc::new(Ereport {
                 id: EreportId { restart_id, ena: Ena::from(3u64) },
                 time_collected,
+                collector_id,
                 data: crate::fm::ereport::EreportData {
-                    collector_id,
                     serial_number: Some("BRM6900420".to_string()),
                     part_number: Some("913-0000037".to_string()),
                     class: Some("hw.pwr.insert.psu".to_string()),

--- a/nexus/types/src/fm/ereport.rs
+++ b/nexus/types/src/fm/ereport.rs
@@ -54,10 +54,6 @@ impl Ereport {
             marked_seen_in: None,
         }
     }
-
-    pub fn id(&self) -> &EreportId {
-        &self.id
-    }
 }
 
 impl core::ops::Deref for Ereport {
@@ -70,7 +66,7 @@ impl core::ops::Deref for Ereport {
 impl iddqd::IdOrdItem for Ereport {
     type Key<'a> = &'a EreportId;
     fn key(&self) -> Self::Key<'_> {
-        self.id()
+        &self.id
     }
 
     iddqd::id_upcast!();

--- a/nexus/types/src/fm/ereport.rs
+++ b/nexus/types/src/fm/ereport.rs
@@ -20,6 +20,9 @@ pub use ereport_types::{Ena, EreportId};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Ereport {
     #[serde(flatten)]
+    pub id: EreportId,
+    pub time_collected: DateTime<Utc>,
+    #[serde(flatten)]
     pub data: EreportData,
     #[serde(flatten)]
     pub reporter: Reporter,
@@ -28,12 +31,17 @@ pub struct Ereport {
 }
 
 impl Ereport {
-    pub fn new(data: EreportData, reporter: Reporter) -> Self {
-        Self { data, reporter, marked_seen_in: None }
+    pub fn new(
+        id: EreportId,
+        time_collected: DateTime<Utc>,
+        data: EreportData,
+        reporter: Reporter,
+    ) -> Self {
+        Self { id, time_collected, data, reporter, marked_seen_in: None }
     }
 
     pub fn id(&self) -> &EreportId {
-        &self.data.id
+        &self.id
     }
 }
 
@@ -55,9 +63,6 @@ impl iddqd::IdOrdItem for Ereport {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EreportData {
-    #[serde(flatten)]
-    pub id: EreportId,
-    pub time_collected: DateTime<Utc>,
     pub collector_id: OmicronZoneUuid,
     pub serial_number: Option<String>,
     pub part_number: Option<String>,
@@ -82,9 +87,8 @@ impl EreportData {
         log: &slog::Logger,
         restart_id: EreporterRestartUuid,
         ereport: ereport_types::Ereport,
-        time_collected: DateTime<Utc>,
         collector_id: OmicronZoneUuid,
-    ) -> Self {
+    ) -> (Ena, EreportData) {
         const MISSING_VPD: &str = " (perhaps the SP doesn't know its own VPD?)";
         let part_number = get_sp_metadata_string(
             "baseboard_part_number",
@@ -139,15 +143,16 @@ impl EreportData {
             }
         };
 
-        EreportData {
-            id: EreportId { restart_id, ena },
-            time_collected,
-            collector_id,
-            part_number,
-            serial_number,
-            class,
-            report: serde_json::Value::Object(ereport.data),
-        }
+        (
+            ena,
+            EreportData {
+                collector_id,
+                part_number,
+                serial_number,
+                class,
+                report: serde_json::Value::Object(ereport.data),
+            },
+        )
     }
 }
 

--- a/nexus/types/src/fm/ereport.rs
+++ b/nexus/types/src/fm/ereport.rs
@@ -80,8 +80,9 @@ pub struct EreportData {
 }
 
 impl EreportData {
-    /// Interpret a service processor ereport from a raw JSON blobule, plus the
-    /// restart ID and collection metadata.
+    /// Interpret a service processor ereport from a raw JSON blobule and
+    /// restart ID, returning a tuple of the [`Ena`] and [`EreportData`]
+    /// suitable for insertion into the database.
     ///
     /// This conversion is lossy; if some information is not present in the raw
     /// ereport JSON, such as the SP's VPD identity, we log a warning, rather

--- a/nexus/types/src/fm/ereport.rs
+++ b/nexus/types/src/fm/ereport.rs
@@ -22,6 +22,7 @@ pub struct Ereport {
     #[serde(flatten)]
     pub id: EreportId,
     pub time_collected: DateTime<Utc>,
+    pub collector_id: OmicronZoneUuid,
     #[serde(flatten)]
     pub data: EreportData,
     #[serde(flatten)]
@@ -34,10 +35,18 @@ impl Ereport {
     pub fn new(
         id: EreportId,
         time_collected: DateTime<Utc>,
+        collector_id: OmicronZoneUuid,
         data: EreportData,
         reporter: Reporter,
     ) -> Self {
-        Self { id, time_collected, data, reporter, marked_seen_in: None }
+        Self {
+            id,
+            time_collected,
+            collector_id,
+            data,
+            reporter,
+            marked_seen_in: None,
+        }
     }
 
     pub fn id(&self) -> &EreportId {
@@ -63,7 +72,6 @@ impl iddqd::IdOrdItem for Ereport {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EreportData {
-    pub collector_id: OmicronZoneUuid,
     pub serial_number: Option<String>,
     pub part_number: Option<String>,
     pub class: Option<String>,
@@ -87,7 +95,6 @@ impl EreportData {
         log: &slog::Logger,
         restart_id: EreporterRestartUuid,
         ereport: ereport_types::Ereport,
-        collector_id: OmicronZoneUuid,
     ) -> (Ena, EreportData) {
         const MISSING_VPD: &str = " (perhaps the SP doesn't know its own VPD?)";
         let part_number = get_sp_metadata_string(
@@ -146,7 +153,6 @@ impl EreportData {
         (
             ena,
             EreportData {
-                collector_id,
                 part_number,
                 serial_number,
                 class,

--- a/nexus/types/src/fm/ereport.rs
+++ b/nexus/types/src/fm/ereport.rs
@@ -17,6 +17,12 @@ use std::fmt;
 
 pub use ereport_types::{Ena, EreportId};
 
+/// A complete representation of an ereport that has been ingested by the
+/// control plane.
+///
+/// This type includes the [`data`](EreportData) payload of the ereport, its
+/// [ID](EreportId), the [`reporter`](Reporter) from which it was collected, and
+/// metadata describing its collection.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Ereport {
     #[serde(flatten)]
@@ -70,6 +76,8 @@ impl iddqd::IdOrdItem for Ereport {
     iddqd::id_upcast!();
 }
 
+/// Per-ereport data, including the VPD identity of the reporter, the ereport's
+/// class, and the actual JSON body of the ereport.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EreportData {
     pub serial_number: Option<String>,

--- a/support-bundle-collection/src/steps/ereports.rs
+++ b/support-bundle-collection/src/steps/ereports.rs
@@ -163,7 +163,7 @@ async fn write_ereport(ereport: Ereport, dir: &Utf8Path) -> anyhow::Result<()> {
         .as_deref()
         .filter(|&s| is_fs_safe_single_path_component(s))
         .unwrap_or("unknown_serial");
-    let id = &ereport.data.id;
+    let id = &ereport.id;
 
     let dir = dir
         .join(format!("{pn}-{sn}"))


### PR DESCRIPTION
Depends on #10618

This is a small refactor which I discussed in [this comment][1] on #10618. As part of that branch, I changed the `DataStore::ereports_insert` method to take the restart ID and `time_collected` timestamp as arguments to the method, since they are used for populating the restart entry. This results in the same values also being passed as part of the `EreportData` structs that represent the individual ereports to insert. This is unfortunate because it results in having to duplicate those values, but more importantly, because it allows them to differ when they should always be the same. This branch fixes that.

[1]: https://github.com/oxidecomputer/omicron/pull/10618#discussion_r3423482570