### PR TITLE
update pinned dpd-client to version from R20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,28 +1766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "common"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dendrite?rev=cc8e02a0800034c431c8cf96b889ea638da3d194#cc8e02a0800034c431c8cf96b889ea638da3d194"
-dependencies = [
- "anyhow",
- "chrono",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oxnet",
- "rand 0.9.2",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "slog",
- "slog-async",
- "slog-bunyan",
- "slog-term",
- "smf 0.10.0",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,30 +3163,6 @@ dependencies = [
  "progenitor 0.13.0",
  "regress 0.10.5",
  "reqwest 0.13.2",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "slog",
- "tokio",
- "transceiver-controller 0.1.1 (git+https://github.com/oxidecomputer/transceiver-control?branch=main)",
- "uuid",
-]
-
-[[package]]
-name = "dpd-client"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dendrite?rev=cc8e02a0800034c431c8cf96b889ea638da3d194#cc8e02a0800034c431c8cf96b889ea638da3d194"
-dependencies = [
- "async-trait",
- "chrono",
- "common 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=cc8e02a0800034c431c8cf96b889ea638da3d194)",
- "crc8",
- "futures",
- "http",
- "oxnet",
- "progenitor 0.11.2",
- "regress 0.10.5",
- "reqwest 0.12.28",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -7094,7 +7048,7 @@ dependencies = [
  "once_cell",
  "openapiv3",
  "oso",
- "oximeter 0.1.0",
+ "oximeter",
  "oxnet",
  "paste",
  "pem",
@@ -7185,7 +7139,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "openapiv3",
- "oximeter-types-versions 0.1.0",
+ "oximeter-types-versions",
  "oxnet",
  "oxql-types",
  "schemars 0.8.22",
@@ -7780,7 +7734,7 @@ dependencies = [
  "omicron-test-utils",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-collector",
  "oximeter-producer",
  "oxnet",
@@ -8336,7 +8290,7 @@ dependencies = [
  "openapi-lint",
  "openapiv3",
  "oxide-tokio-rt",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-db",
  "oximeter-test-utils",
  "schemars 0.8.22",
@@ -8609,7 +8563,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxide-tokio-rt",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-instruments",
  "oximeter-producer",
  "schemars 0.8.22",
@@ -8830,7 +8784,7 @@ dependencies = [
  "openssl",
  "oxide-client",
  "oxide-tokio-rt",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-client",
  "oximeter-collector",
  "oximeter-db",
@@ -9255,7 +9209,7 @@ dependencies = [
  "derive_more 0.99.20",
  "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?branch=main)",
  "display-error-chain",
- "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=cc8e02a0800034c431c8cf96b889ea638da3d194)",
+ "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=cc0c307c617f2988aafdca4e3bd35ea178b64801)",
  "dropshot",
  "expectorate",
  "flate2",
@@ -9296,7 +9250,7 @@ dependencies = [
  "omicron-workspace-hack",
  "opte-ioctl",
  "oxide-tokio-rt",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-instruments",
  "oximeter-producer",
  "oxnet",
@@ -9875,29 +9829,10 @@ dependencies = [
  "chrono",
  "clap",
  "omicron-workspace-hack",
- "oximeter-macro-impl 0.1.0",
- "oximeter-schema 0.1.0",
- "oximeter-timeseries-macro 0.1.0",
- "oximeter-types 0.1.0",
- "prettyplease",
- "syn 2.0.117",
- "toml 0.8.23",
- "uuid",
-]
-
-[[package]]
-name = "oximeter"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#ccede3cb5287e447b0f30916000c7943b1596689"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "omicron-workspace-hack",
- "oximeter-macro-impl 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-schema 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-timeseries-macro 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter-macro-impl",
+ "oximeter-schema",
+ "oximeter-timeseries-macro",
+ "oximeter-types",
  "prettyplease",
  "syn 2.0.117",
  "toml 0.8.23",
@@ -9912,7 +9847,7 @@ dependencies = [
  "dropshot-api-manager-types",
  "omicron-common",
  "omicron-workspace-hack",
- "oximeter-types-versions 0.1.0",
+ "oximeter-types-versions",
  "semver 1.0.28",
 ]
 
@@ -9954,11 +9889,11 @@ dependencies = [
  "openapi-lint",
  "openapiv3",
  "oxide-tokio-rt",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-api",
  "oximeter-client",
  "oximeter-db",
- "oximeter-types 0.1.0",
+ "oximeter-types",
  "proptest",
  "qorb",
  "rand 0.9.2",
@@ -10019,7 +9954,7 @@ dependencies = [
  "omicron-test-utils",
  "omicron-workspace-hack",
  "oxide-tokio-rt",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-test-utils",
  "oxql-types",
  "parse-display",
@@ -10069,7 +10004,7 @@ dependencies = [
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
+ "oximeter",
  "rand 0.9.2",
  "schemars 0.8.22",
  "serde",
@@ -10093,17 +10028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oximeter-macro-impl"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#ccede3cb5287e447b0f30916000c7943b1596689"
-dependencies = [
- "omicron-workspace-hack",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "oximeter-producer"
 version = "0.1.0"
 dependencies = [
@@ -10118,7 +10042,7 @@ dependencies = [
  "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-producer-api",
  "schemars 0.8.22",
  "serde",
@@ -10138,7 +10062,7 @@ version = "0.1.0"
 dependencies = [
  "dropshot",
  "omicron-workspace-hack",
- "oximeter-types-versions 0.1.0",
+ "oximeter-types-versions",
 ]
 
 [[package]]
@@ -10150,28 +10074,7 @@ dependencies = [
  "clap",
  "heck 0.5.0",
  "omicron-workspace-hack",
- "oximeter-types 0.1.0",
- "prettyplease",
- "proc-macro2",
- "quote",
- "schemars 0.8.22",
- "serde",
- "slog-error-chain",
- "syn 2.0.117",
- "toml 0.8.23",
-]
-
-[[package]]
-name = "oximeter-schema"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#ccede3cb5287e447b0f30916000c7943b1596689"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "heck 0.5.0",
- "omicron-workspace-hack",
- "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter-types",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -10192,8 +10095,8 @@ dependencies = [
  "omicron-test-utils",
  "omicron-workspace-hack",
  "oximeter-db",
- "oximeter-macro-impl 0.1.0",
- "oximeter-types 0.1.0",
+ "oximeter-macro-impl",
+ "oximeter-types",
  "slog",
  "uuid",
 ]
@@ -10203,21 +10106,8 @@ name = "oximeter-timeseries-macro"
 version = "0.1.0"
 dependencies = [
  "omicron-workspace-hack",
- "oximeter-schema 0.1.0",
- "oximeter-types 0.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "oximeter-timeseries-macro"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#ccede3cb5287e447b0f30916000c7943b1596689"
-dependencies = [
- "omicron-workspace-hack",
- "oximeter-schema 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter-schema",
+ "oximeter-types",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10231,32 +10121,11 @@ dependencies = [
  "chrono",
  "criterion",
  "omicron-workspace-hack",
- "oximeter-macro-impl 0.1.0",
- "oximeter-types-versions 0.1.0",
+ "oximeter-macro-impl",
+ "oximeter-types-versions",
  "rand 0.9.2",
  "rand_distr",
  "trybuild",
- "uuid",
-]
-
-[[package]]
-name = "oximeter-types"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#ccede3cb5287e447b0f30916000c7943b1596689"
-dependencies = [
- "bytes",
- "chrono",
- "float-ord",
- "num",
- "omicron-common",
- "omicron-workspace-hack",
- "oximeter-types-versions 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "parse-display",
- "regex",
- "schemars 0.8.22",
- "serde",
- "strum 0.27.2",
- "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -10279,19 +10148,6 @@ dependencies = [
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.18",
- "uuid",
-]
-
-[[package]]
-name = "oximeter-types-versions"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#ccede3cb5287e447b0f30916000c7943b1596689"
-dependencies = [
- "chrono",
- "omicron-common",
- "omicron-workspace-hack",
- "schemars 0.8.22",
- "serde",
  "uuid",
 ]
 
@@ -10332,7 +10188,7 @@ dependencies = [
  "highway",
  "num",
  "omicron-workspace-hack",
- "oximeter-types 0.1.0",
+ "oximeter-types",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -11223,17 +11079,6 @@ dependencies = [
 
 [[package]]
 name = "progenitor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2326f73d5326257514712436680ef8da4543ee47c0e9e0d501545c8909ee12e4"
-dependencies = [
- "progenitor-client 0.11.2",
- "progenitor-impl 0.11.2",
- "progenitor-macro 0.11.2",
-]
-
-[[package]]
-name = "progenitor"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36315275b213c64c68dff684477ea7118a0f630832f737b550796a368f9962c"
@@ -11252,21 +11097,6 @@ dependencies = [
  "progenitor-client 0.14.0",
  "progenitor-impl 0.14.0",
  "progenitor-macro 0.14.0",
-]
-
-[[package]]
-name = "progenitor-client"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a0beb939758f229cbae70a4889c7c76a4ac0e90f0b1e7ae9b4636a927d1018"
-dependencies = [
- "bytes",
- "futures-core",
- "percent-encoding",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_urlencoded",
 ]
 
 [[package]]
@@ -11313,28 +11143,6 @@ dependencies = [
 
 [[package]]
 name = "progenitor-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f6d9109b04e005bbdec84cacec7e81cc15533f2b5dc505f0defc212d270c15"
-dependencies = [
- "heck 0.5.0",
- "http",
- "indexmap 2.14.0",
- "openapiv3",
- "proc-macro2",
- "quote",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "syn 2.0.117",
- "thiserror 2.0.18",
- "typify 0.4.3",
- "unicode-ident",
-]
-
-[[package]]
-name = "progenitor-impl"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de362a0477182f45accdbad4d43cd89a95a1db0a518a7c1ddf3e525e6896f0f0"
@@ -11351,7 +11159,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "thiserror 2.0.18",
- "typify 0.6.2",
+ "typify",
  "unicode-ident",
 ]
 
@@ -11373,26 +11181,8 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
  "thiserror 2.0.18",
- "typify 0.6.2",
+ "typify",
  "unicode-ident",
-]
-
-[[package]]
-name = "progenitor-macro"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46596c574831739c661f22923fe587399c61f5e3e79b73cc9a93644c72248d84"
-dependencies = [
- "openapiv3",
- "proc-macro2",
- "progenitor-impl 0.11.2",
- "quote",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "serde_yaml",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -13657,7 +13447,7 @@ name = "sled-agent-early-networking"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=cc8e02a0800034c431c8cf96b889ea638da3d194)",
+ "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=cc0c307c617f2988aafdca4e3bd35ea178b64801)",
  "futures",
  "gateway-client",
  "http",
@@ -16149,42 +15939,12 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typify"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7144144e97e987c94758a3017c920a027feac0799df325d6df4fc8f08d02068e"
-dependencies = [
- "typify-impl 0.4.3",
- "typify-macro 0.4.3",
-]
-
-[[package]]
-name = "typify"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
 dependencies = [
- "typify-impl 0.6.2",
- "typify-macro 0.6.2",
-]
-
-[[package]]
-name = "typify-impl"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062879d46aa4c9dfe0d33b035bbaf512da192131645d05deacb7033ec8581a09"
-dependencies = [
- "heck 0.5.0",
- "log",
- "proc-macro2",
- "quote",
- "regress 0.10.5",
- "schemars 0.8.22",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "syn 2.0.117",
- "thiserror 2.0.18",
- "unicode-ident",
+ "typify-impl",
+ "typify-macro",
 ]
 
 [[package]]
@@ -16209,23 +15969,6 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9708a3ceb6660ba3f8d2b8f0567e7d4b8b198e2b94d093b8a6077a751425de9e"
-dependencies = [
- "proc-macro2",
- "quote",
- "schemars 0.8.22",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "syn 2.0.117",
- "typify-impl 0.4.3",
-]
-
-[[package]]
-name = "typify-macro"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
@@ -16238,7 +15981,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "syn 2.0.117",
- "typify-impl 0.6.2",
+ "typify-impl",
 ]
 
 [[package]]

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -34,9 +34,9 @@ derive_more.workspace = true
 dice-verifier = { workspace = true, features = ["ipcc", "mock"] }
 display-error-chain.workspace = true
 # XXX NOTE this is due to https://github.com/oxidecomputer/omicron/issues/9704
-# This is the R17 dpd client
+# This is the R20 dpd client
 # dpd-client.workspace = true
-dpd-client = { git = "https://github.com/oxidecomputer/dendrite", rev = "cc8e02a0800034c431c8cf96b889ea638da3d194" }
+dpd-client = { git = "https://github.com/oxidecomputer/dendrite", rev = "cc0c307c617f2988aafdca4e3bd35ea178b64801" }
 dropshot.workspace = true
 flate2.workspace = true
 flume.workspace = true

--- a/sled-agent/early-networking/Cargo.toml
+++ b/sled-agent/early-networking/Cargo.toml
@@ -10,9 +10,9 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 # XXX NOTE this is due to https://github.com/oxidecomputer/omicron/issues/9704
-# This is the R17 dpd client
+# This is the R20 dpd client
 # dpd-client.workspace = true
-dpd-client = { git = "https://github.com/oxidecomputer/dendrite", rev = "cc8e02a0800034c431c8cf96b889ea638da3d194" }
+dpd-client = { git = "https://github.com/oxidecomputer/dendrite", rev = "cc0c307c617f2988aafdca4e3bd35ea178b64801" }
 futures.workspace = true
 gateway-client.workspace = true
 http.workspace = true


### PR DESCRIPTION
This is part of what is required to remove `ring` from Omicron; all I need from this is to shake some very old stuff out of the dependency graph.

This is currently the same version that's used elsewhere in the workspace, but we want to leave the pins in place until #9727 is fixed.