### PR TITLE
bump crucible and propolis; remove ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -416,7 +416,7 @@ name = "attest-data"
 version = "0.5.0"
 source = "git+https://github.com/oxidecomputer/dice-util?branch=main#ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der",
  "getrandom 0.3.4",
  "hex",
@@ -435,7 +435,7 @@ name = "attest-data"
 version = "0.5.0"
 source = "git+https://github.com/oxidecomputer/dice-util?rev=10952e8d9599b735b85d480af3560a11700e5b64#10952e8d9599b735b85d480af3560a11700e5b64"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der",
  "getrandom 0.3.4",
  "hex",
@@ -454,7 +454,7 @@ name = "attest-data"
 version = "0.5.0"
 source = "git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd#6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der",
  "getrandom 0.3.4",
  "hex",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -777,7 +777,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -814,6 +814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1385,7 +1394,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -1710,7 +1719,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1836,6 +1845,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
@@ -2134,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=bd9a0e2abe6b6b89aec8c85f4ee57474144ed150#bd9a0e2abe6b6b89aec8c85f4ee57474144ed150"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2150,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=bd9a0e2abe6b6b89aec8c85f4ee57474144ed150#bd9a0e2abe6b6b89aec8c85f4ee57474144ed150"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -2163,14 +2178,14 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=bd9a0e2abe6b6b89aec8c85f4ee57474144ed150#bd9a0e2abe6b6b89aec8c85f4ee57474144ed150"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
 dependencies = [
  "anyhow",
  "atty",
  "crucible-workspace-hack",
  "dropshot",
  "nix 0.31.2",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -2182,8 +2197,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls 0.24.1",
- "toml 1.0.6+spec-1.1.0",
+ "tokio-rustls",
+ "toml 1.1.2+spec-1.1.0",
  "twox-hash",
  "uuid",
  "vergen",
@@ -2193,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=bd9a0e2abe6b6b89aec8c85f4ee57474144ed150#bd9a0e2abe6b6b89aec8c85f4ee57474144ed150"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2210,7 +2225,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=bd9a0e2abe6b6b89aec8c85f4ee57474144ed150#bd9a0e2abe6b6b89aec8c85f4ee57474144ed150"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -2252,6 +2267,15 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2303,7 +2327,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rand_core 0.6.4",
  "rustc_version 0.4.1",
@@ -2631,7 +2655,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
  "pem-rfc7468",
@@ -2799,7 +2823,7 @@ name = "dice-mfg-msgs"
 version = "0.3.0"
 source = "git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd#6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "corncobs",
  "dice-util-barcode",
  "hubpack",
@@ -2824,7 +2848,7 @@ version = "0.3.0-pre0"
 source = "git+https://github.com/oxidecomputer/dice-util?branch=main#ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc"
 dependencies = [
  "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?branch=main)",
- "const-oid",
+ "const-oid 0.9.6",
  "ed25519-dalek",
  "env_logger",
  "hex",
@@ -2846,7 +2870,7 @@ version = "0.3.0-pre0"
 source = "git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd#6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd"
 dependencies = [
  "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd)",
- "const-oid",
+ "const-oid 0.9.6",
  "ed25519-dalek",
  "env_logger",
  "hex",
@@ -2933,10 +2957,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -3188,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409eb76c7ea1623d270393248ff55ec436841fcd724c2e1c9de294291edd35f5"
+checksum = "803c4a57fd2a611df2ddd7069a62a565253368ee96ad4e5ac2e74e625dcf8430"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -3213,8 +3248,8 @@ dependencies = [
  "openapiv3",
  "paste",
  "percent-encoding",
- "rustls 0.22.4",
- "rustls-pemfile 2.2.0",
+ "rustls",
+ "rustls-pemfile",
  "schemars 0.8.22",
  "scopeguard",
  "semver 1.0.28",
@@ -3222,7 +3257,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.11.0",
  "slog",
  "slog-async",
  "slog-bunyan",
@@ -3230,9 +3265,9 @@ dependencies = [
  "slog-term",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tokio-util",
- "toml 1.0.6+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "usdt 0.6.0",
  "uuid",
  "version_check",
@@ -3287,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot_endpoint"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906c3adfd4472030607130ed763e9af1b85f7e18832dd22998379d42ff81c28d"
+checksum = "5f176851eb52822c728ad7a1c5aea0e3c95e68d9876cfa06ae32d5018730acb4"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3355,7 +3390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -3402,7 +3437,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -3593,7 +3628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4253,7 +4288,7 @@ dependencies = [
 name = "gfss"
 version = "0.1.0"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "omicron-workspace-hack",
  "proptest",
  "rand 0.9.2",
@@ -4417,9 +4452,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4534,7 +4569,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -4769,7 +4804,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4805,9 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -4938,7 +4973,7 @@ name = "hubtools"
 version = "0.4.7"
 source = "git+https://github.com/oxidecomputer/hubtools.git?branch=main#2b1ef9b38d75563ea800baa3b17327eec17b1b7a"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hex",
  "lpc55_areas",
  "lpc55_sign",
@@ -4959,7 +4994,7 @@ name = "hubtools"
 version = "0.4.7"
 source = "git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a#2b1ef9b38d75563ea800baa3b17327eec17b1b7a"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hex",
  "lpc55_areas",
  "lpc55_sign",
@@ -4982,10 +5017,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "hybrid-array"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4998,7 +5042,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec 1.15.1",
  "tokio",
  "want",
@@ -5014,13 +5057,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -5075,7 +5117,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -5755,7 +5797,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5832,7 +5874,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6379,7 +6421,7 @@ version = "0.3.5"
 source = "git+https://github.com/oxidecomputer/lpc55_support#fc64732faf5511850b35f1734d572b9953d73374"
 dependencies = [
  "byteorder",
- "const-oid",
+ "const-oid 0.9.6",
  "crc-any",
  "der",
  "env_logger",
@@ -6471,7 +6513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7061,7 +7103,7 @@ dependencies = [
  "rcgen",
  "ref-cast",
  "regex",
- "rustls 0.22.4",
+ "rustls",
  "schemars 0.8.22",
  "scim2-rs",
  "semver 1.0.28",
@@ -8030,7 +8072,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8815,9 +8857,8 @@ dependencies = [
  "ref-cast",
  "regex",
  "reqwest 0.13.2",
- "ring",
- "rustls 0.22.4",
- "rustls-pemfile 2.2.0",
+ "rustls",
+ "rustls-pemfile",
  "samael",
  "schemars 0.8.22",
  "scim2-rs",
@@ -9028,9 +9069,9 @@ dependencies = [
  "petgraph 0.8.3",
  "rayon",
  "reqwest 0.13.2",
- "ring",
  "semver 1.0.28",
  "serde",
+ "sha2",
  "shell-words",
  "sled-hardware",
  "slog",
@@ -9352,8 +9393,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest 0.13.2",
- "ring",
- "rustls 0.22.4",
+ "rustls",
  "serde",
  "sha2",
  "slog",
@@ -9390,6 +9430,7 @@ dependencies = [
  "anstream 0.6.21",
  "anyhow",
  "aws-lc-rs",
+ "aws-lc-sys",
  "base16ct",
  "base64 0.22.1",
  "base64ct",
@@ -9399,22 +9440,21 @@ dependencies = [
  "buf-list",
  "bytes",
  "camino",
- "cc",
  "chrono",
  "cipher",
  "clap",
  "clap_builder",
- "const-oid",
+ "const-oid 0.9.6",
  "cookie",
  "crossbeam-epoch",
  "crossbeam-utils",
  "crossterm 0.28.1",
- "crypto-common",
+ "crypto-common 0.1.7",
  "curve25519-dalek",
  "daft",
  "data-encoding",
  "der",
- "digest",
+ "digest 0.10.7",
  "dof 0.3.0",
  "dof 0.4.0",
  "ecdsa",
@@ -9497,8 +9537,7 @@ dependencies = [
  "rsa",
  "rustix 0.38.44",
  "rustix 1.1.3",
- "rustls 0.23.37",
- "rustls-webpki 0.103.9",
+ "rustls",
  "schemars 0.8.22",
  "scopeguard",
  "semver 1.0.28",
@@ -9507,7 +9546,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.17.0",
  "serde_with_macros 3.17.0",
- "sha1",
+ "sha1 0.10.6",
  "sha2",
  "sha3",
  "simd-adler32",
@@ -9527,7 +9566,7 @@ dependencies = [
  "time-macros",
  "tokio",
  "tokio-postgres",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "toml 0.7.8",
@@ -9537,6 +9576,7 @@ dependencies = [
  "toml_parser",
  "tough",
  "tracing",
+ "typenum",
  "url",
  "usdt 0.6.0",
  "usdt-impl 0.5.0",
@@ -9544,7 +9584,6 @@ dependencies = [
  "uuid",
  "vergen",
  "vergen-lib 9.1.0",
- "winnow 0.7.14",
  "x509-cert",
  "zerocopy 0.8.40",
  "zeroize",
@@ -9554,9 +9593,9 @@ dependencies = [
 
 [[package]]
 name = "omicron-zone-package"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90857c497284b6cbd15e9d9531081a9abab15d7e4bc9eb6b0e4f176b9c024f7e"
+checksum = "2c8bd7aa2335195256a00e62ea85724df4582d7c4ddcc88f9d2349e2a0dd19cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9569,7 +9608,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "semver 1.0.28",
  "serde",
  "serde_derive",
@@ -10447,7 +10486,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
  "password-hash 0.4.2",
  "sha2",
@@ -10459,7 +10498,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -10590,7 +10629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "rand 0.8.6",
@@ -10669,12 +10708,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10725,9 +10758,9 @@ source = "git+https://github.com/oxidecomputer/pki-playground?rev=7600756029ce04
 dependencies = [
  "camino",
  "clap",
- "const-oid",
+ "const-oid 0.9.6",
  "der",
- "digest",
+ "digest 0.10.7",
  "ed25519-dalek",
  "flagset",
  "hex",
@@ -10739,7 +10772,7 @@ dependencies = [
  "pkcs8",
  "rand 0.8.6",
  "rsa",
- "sha1",
+ "sha1 0.10.6",
  "sha2",
  "sha3",
  "signature",
@@ -11230,7 +11263,7 @@ dependencies = [
 [[package]]
 name = "propolis-api-types-versions"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -11243,7 +11276,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -11267,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
 dependencies = [
  "anyhow",
  "atty",
@@ -11300,7 +11333,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
 dependencies = [
  "crucible-client-types",
  "propolis-api-types-versions",
@@ -11309,7 +11342,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -11420,8 +11453,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
- "socket2 0.5.10",
+ "rustls",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11441,7 +11474,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -11459,9 +11492,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11714,8 +11747,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48406db8ac1f3cbc7dcdb56ec355343817958a356ff430259bb07baf7607e1e1"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring",
  "time",
  "yasna",
 ]
@@ -12012,8 +12045,6 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -12021,7 +12052,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -12031,7 +12061,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -12061,7 +12090,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -12069,7 +12098,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -12140,8 +12169,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -12212,7 +12241,7 @@ dependencies = [
  "ctr",
  "curve25519-dalek",
  "des",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "flate2",
  "futures",
@@ -12230,7 +12259,7 @@ dependencies = [
  "rand_core 0.6.4",
  "russh-cryptovec",
  "russh-keys",
- "sha1",
+ "sha1 0.10.6",
  "sha2",
  "ssh-encoding",
  "ssh-key",
@@ -12264,7 +12293,7 @@ dependencies = [
  "ctr",
  "data-encoding",
  "der",
- "digest",
+ "digest 0.10.7",
  "ecdsa",
  "ed25519-dalek",
  "elliptic-curve",
@@ -12288,7 +12317,7 @@ dependencies = [
  "russh-cryptovec",
  "sec1",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2",
  "spki",
  "ssh-encoding",
@@ -12364,47 +12393,20 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -12419,15 +12421,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -12460,14 +12453,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12475,27 +12468,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -12815,16 +12787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13016,9 +12978,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -13079,9 +13041,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -13185,7 +13147,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -13196,7 +13169,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -13205,7 +13178,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -13270,7 +13243,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -14019,7 +13992,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14100,7 +14073,7 @@ dependencies = [
 [[package]]
 name = "sprockets-tls"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/sprockets.git?rev=d2b68e4f47e3c22bce0455aeb4cfb2e61ad229ba#d2b68e4f47e3c22bce0455aeb4cfb2e61ad229ba"
+source = "git+https://github.com/oxidecomputer/sprockets.git?rev=68a4b3bf819722f9f57a3f0c99e1393ed01ba392#68a4b3bf819722f9f57a3f0c99e1393ed01ba392"
 dependencies = [
  "anyhow",
  "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd)",
@@ -14113,7 +14086,7 @@ dependencies = [
  "hubpack",
  "libipcc 0.1.0 (git+https://github.com/oxidecomputer/ipcc-rs?rev=524eb8f125003dff50b9703900c6b323f00f9e1b)",
  "pem-rfc7468",
- "rustls 0.23.37",
+ "rustls",
  "secrecy 0.8.0",
  "serde",
  "sha2",
@@ -14124,7 +14097,7 @@ dependencies = [
  "slog-term",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "toml 0.8.23",
  "x509-cert",
  "zeroize",
@@ -14133,7 +14106,7 @@ dependencies = [
 [[package]]
 name = "sprockets-tls-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/sprockets.git?rev=d2b68e4f47e3c22bce0455aeb4cfb2e61ad229ba#d2b68e4f47e3c22bce0455aeb4cfb2e61ad229ba"
+source = "git+https://github.com/oxidecomputer/sprockets.git?rev=68a4b3bf819722f9f57a3f0c99e1393ed01ba392#68a4b3bf819722f9f57a3f0c99e1393ed01ba392"
 dependencies = [
  "camino",
  "pki-playground",
@@ -14702,7 +14675,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14722,7 +14695,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15119,32 +15092,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -15236,17 +15188,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -15269,9 +15221,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -15317,11 +15269,11 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -15332,9 +15284,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topological-sort"
@@ -15363,7 +15315,7 @@ dependencies = [
  "pem",
  "percent-encoding",
  "reqwest 0.12.28",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "serde_json",
  "serde_plain",
@@ -15763,7 +15715,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.0.6+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -15881,7 +15833,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "url",
  "utf-8",
@@ -15900,7 +15852,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
 ]
@@ -16095,7 +16047,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -16351,9 +16303,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
@@ -16716,15 +16668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17020,7 +16963,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17424,6 +17367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17542,7 +17491,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der",
  "spki",
  "tls_codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=979b72896bc39a876c98fb32fe706da37a4fc408#979b72896bc39a876c98fb32fe706da37a4fc408"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=979b72896bc39a876c98fb32fe706da37a4fc408#979b72896bc39a876c98fb32fe706da37a4fc408"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -2149,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2bfe090eb5318ec8c467157018db2429d4df535b#2bfe090eb5318ec8c467157018db2429d4df535b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2165,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2bfe090eb5318ec8c467157018db2429d4df535b#2bfe090eb5318ec8c467157018db2429d4df535b"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -2178,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2bfe090eb5318ec8c467157018db2429d4df535b#2bfe090eb5318ec8c467157018db2429d4df535b"
 dependencies = [
  "anyhow",
  "atty",
@@ -2208,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2bfe090eb5318ec8c467157018db2429d4df535b#2bfe090eb5318ec8c467157018db2429d4df535b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2225,7 +2225,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2a9e74d86987b46fa6ff155237b9f99a16e7fb80#2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2bfe090eb5318ec8c467157018db2429d4df535b#2bfe090eb5318ec8c467157018db2429d4df535b"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -11263,7 +11263,7 @@ dependencies = [
 [[package]]
 name = "propolis-api-types-versions"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=979b72896bc39a876c98fb32fe706da37a4fc408#979b72896bc39a876c98fb32fe706da37a4fc408"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -11276,7 +11276,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=979b72896bc39a876c98fb32fe706da37a4fc408#979b72896bc39a876c98fb32fe706da37a4fc408"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -11300,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=979b72896bc39a876c98fb32fe706da37a4fc408#979b72896bc39a876c98fb32fe706da37a4fc408"
 dependencies = [
  "anyhow",
  "atty",
@@ -11333,7 +11333,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=979b72896bc39a876c98fb32fe706da37a4fc408#979b72896bc39a876c98fb32fe706da37a4fc408"
 dependencies = [
  "crucible-client-types",
  "propolis-api-types-versions",
@@ -11342,7 +11342,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2fe83dba74296d9950f7b3fc898fed29ca0fe42d#2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=979b72896bc39a876c98fb32fe706da37a4fc408#979b72896bc39a876c98fb32fe706da37a4fc408"
 dependencies = [
  "schemars 0.8.22",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,11 +481,11 @@ crossterm = { version = "0.29.0", features = ["event-stream"] }
 # NOTE: if you change the pinned revision of the `crucible` dependencies, you
 # must also update the references in package-manifest.toml to match the new
 # revision.
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
-crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2bfe090eb5318ec8c467157018db2429d4df535b" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2bfe090eb5318ec8c467157018db2429d4df535b" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "2bfe090eb5318ec8c467157018db2429d4df535b" }
+crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "2bfe090eb5318ec8c467157018db2429d4df535b" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "2bfe090eb5318ec8c467157018db2429d4df535b" }
 # NOTE: See above!
 csv = "1.3.1"
 curve25519-dalek = "4"
@@ -734,11 +734,11 @@ progenitor-extras = "0.2.0"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
-propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "979b72896bc39a876c98fb32fe706da37a4fc408" }
+propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "979b72896bc39a876c98fb32fe706da37a4fc408" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "979b72896bc39a876c98fb32fe706da37a4fc408" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "979b72896bc39a876c98fb32fe706da37a4fc408" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "979b72896bc39a876c98fb32fe706da37a4fc408" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,11 +481,11 @@ crossterm = { version = "0.29.0", features = ["event-stream"] }
 # NOTE: if you change the pinned revision of the `crucible` dependencies, you
 # must also update the references in package-manifest.toml to match the new
 # revision.
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "bd9a0e2abe6b6b89aec8c85f4ee57474144ed150" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "bd9a0e2abe6b6b89aec8c85f4ee57474144ed150" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "bd9a0e2abe6b6b89aec8c85f4ee57474144ed150" }
-crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "bd9a0e2abe6b6b89aec8c85f4ee57474144ed150" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "bd9a0e2abe6b6b89aec8c85f4ee57474144ed150" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
+crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80" }
 # NOTE: See above!
 csv = "1.3.1"
 curve25519-dalek = "4"
@@ -507,7 +507,7 @@ dns-server = { path = "dns-server" }
 dns-server-api = { path = "dns-server-api" }
 dns-service-client = { path = "clients/dns-service-client" }
 dpd-client = { git = "https://github.com/oxidecomputer/dendrite", rev = "cc0c307c617f2988aafdca4e3bd35ea178b64801" }
-dropshot = { version = "0.17.0", features = [ "usdt-probes" ] }
+dropshot = { version = "0.17.1", features = [ "usdt-probes" ] }
 dropshot-api-manager = "0.7.2"
 dropshot-api-manager-types = "0.7.2"
 dyn-clone = "1.0.20"
@@ -678,7 +678,7 @@ omicron-rpaths = { path = "rpaths" }
 omicron-sled-agent = { path = "sled-agent" }
 omicron-test-utils = { path = "test-utils" }
 omicron-workspace-hack = "0.1.0"
-omicron-zone-package = "0.12.2"
+omicron-zone-package = "0.12.3"
 oxide-client = { path = "clients/oxide-client" }
 oxide-tokio-rt = "0.1.4"
 oxide-vpc = { git = "https://github.com/oxidecomputer/opte", rev = "8b44982bf0d3f8ea52c810b2b00425a1e350e2f8", features = [ "api", "std" ] }
@@ -734,11 +734,11 @@ progenitor-extras = "0.2.0"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
-propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
+propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.1"
@@ -754,7 +754,7 @@ ratatui = "0.29.0"
 rats-corim = { git = "https://github.com/oxidecomputer/rats-corim.git", rev = "f0d5d5168d3d31487a56df32c676b0c6240bcc6b" }
 raw-cpuid = { git = "https://github.com/oxidecomputer/rust-cpuid.git", rev = "a4cf01df76f35430ff5d39dc2fe470bcb953503b" }
 rayon = "1.10"
-rcgen = "0.12.1"
+rcgen = { version = "0.12.1", default-features = false, features = ["aws_lc_rs", "pem"] }
 mg-api-types = { git = "https://github.com/oxidecomputer/maghemite", rev = "dc84a6ce494a9d004568b67e22add2285a04d887" }
 reconfigurator-cli = { path = "dev-tools/reconfigurator-cli" }
 reedline = "0.40.0"
@@ -764,11 +764,10 @@ regress = "0.10.4"
 repo-depot-api = { path = "sled-agent/repo-depot-api" }
 repo-depot-client = { path = "clients/repo-depot-client" }
 reqwest = { version = "0.13", default-features = false }
-ring = "0.17.14"
 rpassword = "7.4.0"
 rstest = "0.25.0"
 rustfmt-wrapper = "0.2"
-rustls = "0.22.2"
+rustls = "0.23.40"
 rustls-pemfile = "2.2.0"
 rustyline = "14.0.0"
 rustix = "1.1.2"
@@ -823,8 +822,8 @@ slog-term = "2.9.1"
 smf = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
 sp-sim = { path = "sp-sim" }
-sprockets-tls = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "d2b68e4f47e3c22bce0455aeb4cfb2e61ad229ba" }
-sprockets-tls-test-utils = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "d2b68e4f47e3c22bce0455aeb4cfb2e61ad229ba" }
+sprockets-tls = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "68a4b3bf819722f9f57a3f0c99e1393ed01ba392" }
+sprockets-tls-test-utils = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "68a4b3bf819722f9f57a3f0c99e1393ed01ba392" }
 sqlformat = "0.3.5"
 sqlparser = { version = "0.61.0", features = [ "visitor" ] }
 static_assertions = "1.1.0"

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -99,7 +99,6 @@ range-requests.workspace = true
 ref-cast.workspace = true
 regex.workspace = true
 reqwest = { workspace = true, features = ["http2", "json"] }
-ring.workspace = true
 samael.workspace = true
 schemars = { workspace = true, features = ["chrono", "uuid1"] }
 semver.workspace = true

--- a/nexus/src/app/external_endpoints.rs
+++ b/nexus/src/app/external_endpoints.rs
@@ -436,7 +436,7 @@ impl TryFrom<Certificate> for TlsCertificate {
                 .expect("parsing private key PEM")
                 .expect("no private keys found");
             let rustls_signing_key =
-                rustls::crypto::ring::sign::any_supported_type(
+                rustls::crypto::aws_lc_rs::sign::any_supported_type(
                     &rustls_private_key,
                 )
                 .context("parsing DER private key")?;

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -624,10 +624,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "bd9a0e2abe6b6b89aec8c85f4ee57474144ed150"
+source.commit = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "918a3db80758e93b2f01c8bd78a358065f4636c4bda387e12948830d1028909a"
+source.sha256 = "d5b8cf7c2390a37614d6dc491a4a1025865fc4a5498b0c5198fb6ccc81bd7539"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -636,10 +636,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "bd9a0e2abe6b6b89aec8c85f4ee57474144ed150"
+source.commit = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "3567a37b4136b03fd08032ec88886223c8b33c227a7cb9e1ebdbe3e0198d6b98"
+source.sha256 = "5e43ced3ac12adb180a6414ff948f128e9a2949692b057079d8ef8edca4b4671"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -653,10 +653,10 @@ service_name = "crucible_utils"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "bd9a0e2abe6b6b89aec8c85f4ee57474144ed150"
+source.commit = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-utils.sha256.txt
-source.sha256 = "e1b87fa2a3b916ed67b31de02238691ddbf59def31336c1f73e182fd067a5c79"
+source.sha256 = "8ec1fef5ae73e68877be882f30147d7ceada0b56ac7391827b0e492618f146e6"
 output.type = "tarball"
 
 # Refer to
@@ -667,10 +667,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "6873add79b835f7932d9fe928340886df8e49676"
+source.commit = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "ccac586c3ed1e996d9554fb1db1b1096c0bcd0dd5712c14579924ea85dd16a34"
+source.sha256 = "7f6bd2eadba00e067c8d2635dfd20c84d8709023570e1670bcf45e7b0e643b37"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -624,10 +624,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
+source.commit = "2bfe090eb5318ec8c467157018db2429d4df535b"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "d5b8cf7c2390a37614d6dc491a4a1025865fc4a5498b0c5198fb6ccc81bd7539"
+source.sha256 = "86d155da32960b2d64bb0cceaccddfe10ae5bc8b44335e144436eeb0d5999b09"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -636,10 +636,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
+source.commit = "2bfe090eb5318ec8c467157018db2429d4df535b"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "5e43ced3ac12adb180a6414ff948f128e9a2949692b057079d8ef8edca4b4671"
+source.sha256 = "48d1e97bb1129666b5af5ca412eef3a1e99026c10222436bc04ad95dde8aaaf4"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -653,10 +653,10 @@ service_name = "crucible_utils"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "2a9e74d86987b46fa6ff155237b9f99a16e7fb80"
+source.commit = "2bfe090eb5318ec8c467157018db2429d4df535b"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-utils.sha256.txt
-source.sha256 = "8ec1fef5ae73e68877be882f30147d7ceada0b56ac7391827b0e492618f146e6"
+source.sha256 = "103aacff3cf1ffd29c0c66edaab1eeab85cf3123d149ebf4c6b1ee309d8d20ba"
 output.type = "tarball"
 
 # Refer to
@@ -667,10 +667,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "2fe83dba74296d9950f7b3fc898fed29ca0fe42d"
+source.commit = "979b72896bc39a876c98fb32fe706da37a4fc408"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "7f6bd2eadba00e067c8d2635dfd20c84d8709023570e1670bcf45e7b0e643b37"
+source.sha256 = "b950c8da9e2bb61eeb3b7087c27b2edab6c1b341ae8e7db6e88e7c172af58aff"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -25,9 +25,9 @@ oxide-tokio-rt.workspace = true
 petgraph.workspace = true
 rayon.workspace = true
 reqwest = { workspace = true, features = [ "rustls" ] }
-ring.workspace = true
 semver.workspace = true
 serde.workspace = true
+sha2.workspace = true
 shell-words.workspace = true
 sled-hardware.workspace = true
 slog.workspace = true

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -24,7 +24,7 @@ use omicron_zone_package::package::{Package, PackageOutput, PackageSource};
 use omicron_zone_package::progress::Progress;
 use omicron_zone_package::target::TargetMap;
 use rayon::prelude::*;
-use ring::digest::{Context as DigestContext, Digest, SHA256};
+use sha2::{Digest, Sha256};
 use sled_hardware::cleanup::cleanup_networking_resources;
 use slog::Drain;
 use slog::Logger;
@@ -243,14 +243,14 @@ async fn replace_active_link(
 }
 
 // Calculates the SHA256 digest for a file.
-async fn get_sha256_digest(path: &Utf8PathBuf) -> Result<Digest> {
+async fn get_sha256_digest(path: &Utf8PathBuf) -> Result<[u8; 32]> {
     let mut reader = BufReader::new(
         tokio::fs::File::open(&path)
             .await
             .with_context(|| format!("could not open {path:?}"))?,
     );
-    let mut context = DigestContext::new(&SHA256);
-    let mut buffer = [0; 1024];
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 8192];
 
     loop {
         let count = reader
@@ -260,10 +260,10 @@ async fn get_sha256_digest(path: &Utf8PathBuf) -> Result<Digest> {
         if count == 0 {
             break;
         } else {
-            context.update(&buffer[..count]);
+            hasher.update(&buffer[..count]);
         }
     }
-    Ok(context.finish())
+    Ok(hasher.finalize().into())
 }
 
 async fn download_prebuilt(
@@ -305,12 +305,12 @@ async fn download_prebuilt(
         .await
         .with_context(|| format!("failed to create {path:?}"))?;
     let mut stream = response.bytes_stream();
-    let mut context = DigestContext::new(&SHA256);
+    let mut hasher = Sha256::new();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk
             .with_context(|| format!("failed reading response from {url}"))?;
         // Update the running SHA digest
-        context.update(&chunk);
+        hasher.update(&chunk);
         // Update the downloaded file
         file.write_all(&chunk)
             .await
@@ -319,8 +319,8 @@ async fn download_prebuilt(
         progress.increment_completed(chunk.len().try_into().unwrap());
     }
 
-    let digest = context.finish();
-    if digest.as_ref() == expected_digest {
+    let digest: [u8; 32] = hasher.finalize().into();
+    if digest == **expected_digest {
         Ok(())
     } else {
         Err(anyhow!("Failed validating download of {url}").context(format!(

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -24,7 +24,6 @@ omicron-common.workspace = true
 oxide-tokio-rt.workspace = true
 pem.workspace = true
 regex.workspace = true
-ring.workspace = true
 rustls.workspace = true
 slog.workspace = true
 subprocess.workspace = true

--- a/test-utils/src/dev/seed.rs
+++ b/test-utils/src/dev/seed.rs
@@ -7,6 +7,7 @@ use std::io::{BufWriter, Write};
 use anyhow::{Context, Result, ensure};
 use camino::{Utf8Path, Utf8PathBuf};
 use filetime::FileTime;
+use sha2::{Digest, Sha256};
 use slog::Logger;
 
 use super::CRDB_SEED_TAR_ENV;
@@ -18,11 +19,10 @@ use super::CRDB_SEED_TAR_ENV;
 pub fn digest_unique_to_schema() -> String {
     let schema = include_str!("../../../schema/crdb/dbinit.sql");
     let crdb_version = include_str!("../../../tools/cockroachdb_version");
-    let mut ctx = ring::digest::Context::new(&ring::digest::SHA256);
-    ctx.update(&schema.as_bytes());
-    ctx.update(&crdb_version.as_bytes());
-    let digest = ctx.finish();
-    hex::encode(digest.as_ref())
+    let mut hasher = Sha256::new();
+    hasher.update(&schema.as_bytes());
+    hasher.update(&crdb_version.as_bytes());
+    hex::encode(&hasher.finalize())
 }
 
 /// Looks up the standard environment variable `CRDB_SEED_INVALIDATE` to check

--- a/tools/update_crucible.sh
+++ b/tools/update_crucible.sh
@@ -18,7 +18,7 @@ function usage {
 PACKAGES=(
   "crucible"
   "crucible-pantry"
-  "crucible-dtrace"
+  "crucible-utils"
 )
 
 CRATES=(

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -22,6 +22,8 @@ ahash = { version = "0.8.12" }
 aho-corasick = { version = "1.1.4" }
 anstream = { version = "0.6.21" }
 anyhow = { version = "1.0.102", features = ["backtrace"] }
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
+aws-lc-sys = { version = "0.40.0", default-features = false, features = ["prebuilt-nasm"] }
 base16ct = { version = "0.2.0", default-features = false, features = ["alloc"] }
 base64 = { version = "0.22.1" }
 base64ct = { version = "1.8.3", default-features = false, features = ["std"] }
@@ -70,7 +72,7 @@ hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16.1" }
 hex = { version = "0.4.3", features = ["serde"] }
 hickory-proto = { version = "0.25.2", features = ["serde", "text-parsing"] }
 hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
-hyper = { version = "1.8.1", features = ["full"] }
+hyper = { version = "1.10.1", features = ["full"] }
 iddqd = { version = "0.4.2", features = ["daft", "proptest", "schemars08"] }
 idna = { version = "1.1.0" }
 indexmap = { version = "2.14.0", features = ["serde"] }
@@ -113,16 +115,15 @@ regex = { version = "1.12.3" }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
 reqwest-594e8ee84c453af0 = { package = "reqwest", version = "0.13.2", features = ["blocking", "cookies", "json", "query", "stream"] }
-reqwest-5ef9efb8ec2df382 = { package = "reqwest", version = "0.12.28", features = ["blocking", "json", "rustls-tls", "stream"] }
+reqwest-5ef9efb8ec2df382 = { package = "reqwest", version = "0.12.28", features = ["blocking", "json", "stream"] }
 rsa = { version = "0.9.10", features = ["serde", "sha2"] }
-rustls = { version = "0.23.37", features = ["ring"] }
-rustls-webpki = { version = "0.103.9", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.41" }
 schemars = { version = "0.8.22", features = ["bytes", "chrono", "semver", "url", "uuid1"] }
 scopeguard = { version = "1.2.0" }
 semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
-serde_json = { version = "1.0.149", features = ["alloc", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.150", features = ["alloc", "raw_value", "unbounded_depth"] }
 serde_with = { version = "3.17.0", features = ["hex", "schemars_0_8"] }
 sha1 = { version = "0.10.6", features = ["oid"] }
 sha2 = { version = "0.10.9", features = ["oid"] }
@@ -142,20 +143,20 @@ syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.117", features = ["extr
 time = { version = "0.3.47", features = ["formatting", "local-offset", "macros", "parsing"] }
 tokio = { version = "1.52.1", features = ["full", "test-util"] }
 tokio-postgres = { version = "0.7.16", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
+tokio-rustls = { version = "0.26.4" }
 tokio-stream = { version = "0.1.18", features = ["net", "sync"] }
 tokio-util = { version = "0.7.18", features = ["codec", "io-util", "rt", "time"] }
 toml = { version = "0.7.8" }
 toml_edit-3c51e837cfc5589a = { package = "toml_edit", version = "0.22.27", features = ["serde"] }
-toml_parser = { version = "1.0.9" }
+toml_parser = { version = "1.1.2" }
 tough = { version = "0.22.0", default-features = false, features = ["http"] }
 tracing = { version = "0.1.44", features = ["log"] }
+typenum = { version = "1.19.0", default-features = false, features = ["const-generics"] }
 url = { version = "2.5.8", features = ["serde"] }
 usdt = { version = "0.6.0" }
 usdt-impl-3b31131e45eafb45 = { package = "usdt-impl", version = "0.6.0", default-features = false, features = ["des"] }
 usdt-impl-d8f496e17d97b5cb = { package = "usdt-impl", version = "0.5.0", default-features = false, features = ["asm", "des"] }
-uuid = { version = "1.23.0", features = ["serde", "v4"] }
-winnow = { version = "0.7.14" }
+uuid = { version = "1.23.4", features = ["serde", "v4"] }
 x509-cert = { version = "0.2.5" }
 zerocopy = { version = "0.8.40", default-features = false, features = ["derive", "simd"] }
 zeroize = { version = "1.8.2", features = ["std", "zeroize_derive"] }
@@ -167,6 +168,8 @@ ahash = { version = "0.8.12" }
 aho-corasick = { version = "1.1.4" }
 anstream = { version = "0.6.21" }
 anyhow = { version = "1.0.102", features = ["backtrace"] }
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
+aws-lc-sys = { version = "0.40.0", default-features = false, features = ["prebuilt-nasm"] }
 base16ct = { version = "0.2.0", default-features = false, features = ["alloc"] }
 base64 = { version = "0.22.1" }
 base64ct = { version = "1.8.3", default-features = false, features = ["std"] }
@@ -176,7 +179,6 @@ bstr = { version = "1.12.1" }
 buf-list = { version = "1.1.2", default-features = false, features = ["tokio1"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 camino = { version = "1.2.2", default-features = false, features = ["serde1"] }
-cc = { version = "1.2.56", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 cipher = { version = "0.4.4", default-features = false, features = ["block-padding", "zeroize"] }
 clap = { version = "4.6.1", features = ["cargo", "derive", "env", "wrap_help"] }
@@ -217,7 +219,7 @@ heck = { version = "0.4.1", features = ["unicode"] }
 hex = { version = "0.4.3", features = ["serde"] }
 hickory-proto = { version = "0.25.2", features = ["serde", "text-parsing"] }
 hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
-hyper = { version = "1.8.1", features = ["full"] }
+hyper = { version = "1.10.1", features = ["full"] }
 iddqd = { version = "0.4.2", features = ["daft", "proptest", "schemars08"] }
 idna = { version = "1.1.0" }
 indexmap = { version = "2.14.0", features = ["serde"] }
@@ -260,16 +262,15 @@ regex = { version = "1.12.3" }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
 reqwest-594e8ee84c453af0 = { package = "reqwest", version = "0.13.2", features = ["blocking", "cookies", "json", "query", "stream"] }
-reqwest-5ef9efb8ec2df382 = { package = "reqwest", version = "0.12.28", features = ["blocking", "json", "rustls-tls", "stream"] }
+reqwest-5ef9efb8ec2df382 = { package = "reqwest", version = "0.12.28", features = ["blocking", "json", "stream"] }
 rsa = { version = "0.9.10", features = ["serde", "sha2"] }
-rustls = { version = "0.23.37", features = ["ring"] }
-rustls-webpki = { version = "0.103.9", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+rustls = { version = "0.23.41" }
 schemars = { version = "0.8.22", features = ["bytes", "chrono", "semver", "url", "uuid1"] }
 scopeguard = { version = "1.2.0" }
 semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
-serde_json = { version = "1.0.149", features = ["alloc", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.150", features = ["alloc", "raw_value", "unbounded_depth"] }
 serde_with = { version = "3.17.0", features = ["hex", "schemars_0_8"] }
 serde_with_macros = { version = "3.17.0", default-features = false, features = ["schemars_0_8"] }
 sha1 = { version = "0.10.6", features = ["oid"] }
@@ -292,22 +293,22 @@ time = { version = "0.3.47", features = ["formatting", "local-offset", "macros",
 time-macros = { version = "0.2.27", default-features = false, features = ["formatting", "parsing"] }
 tokio = { version = "1.52.1", features = ["full", "test-util"] }
 tokio-postgres = { version = "0.7.16", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
+tokio-rustls = { version = "0.26.4" }
 tokio-stream = { version = "0.1.18", features = ["net", "sync"] }
 tokio-util = { version = "0.7.18", features = ["codec", "io-util", "rt", "time"] }
 toml = { version = "0.7.8" }
 toml_edit-3c51e837cfc5589a = { package = "toml_edit", version = "0.22.27", features = ["serde"] }
-toml_parser = { version = "1.0.9" }
+toml_parser = { version = "1.1.2" }
 tough = { version = "0.22.0", default-features = false, features = ["http"] }
 tracing = { version = "0.1.44", features = ["log"] }
+typenum = { version = "1.19.0", default-features = false, features = ["const-generics"] }
 url = { version = "2.5.8", features = ["serde"] }
 usdt = { version = "0.6.0" }
 usdt-impl-3b31131e45eafb45 = { package = "usdt-impl", version = "0.6.0", default-features = false, features = ["des"] }
 usdt-impl-d8f496e17d97b5cb = { package = "usdt-impl", version = "0.5.0", default-features = false, features = ["asm", "des"] }
-uuid = { version = "1.23.0", features = ["serde", "v4"] }
+uuid = { version = "1.23.4", features = ["serde", "v4"] }
 vergen = { version = "9.1.0", features = ["cargo", "rustc"] }
 vergen-lib = { version = "9.1.0", features = ["cargo", "git", "rustc"] }
-winnow = { version = "0.7.14" }
 x509-cert = { version = "0.2.5" }
 zerocopy = { version = "0.8.40", default-features = false, features = ["derive", "simd"] }
 zeroize = { version = "1.8.2", features = ["std", "zeroize_derive"] }
@@ -315,11 +316,10 @@ zip-164d15cefe24d7eb = { package = "zip", version = "4.6.1", default-features = 
 zip-3b31131e45eafb45 = { package = "zip", version = "0.6.6", default-features = false, features = ["bzip2", "deflate"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 dof-468e82937335b1c9 = { package = "dof", version = "0.3.0", default-features = false, features = ["des"] }
 dof-9fbad63c4bcf4a8f = { package = "dof", version = "0.4.0", default-features = false, features = ["des"] }
-hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
+hyper-rustls = { version = "0.27.7", features = ["http2"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 linux-raw-sys = { version = "0.4.15", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "system"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
@@ -329,11 +329,10 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 dof-468e82937335b1c9 = { package = "dof", version = "0.3.0", default-features = false, features = ["des"] }
 dof-9fbad63c4bcf4a8f = { package = "dof", version = "0.4.0", default-features = false, features = ["des"] }
-hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
+hyper-rustls = { version = "0.27.7", features = ["http2"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 linux-raw-sys = { version = "0.4.15", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "system"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
@@ -343,10 +342,9 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.x86_64-apple-darwin.dependencies]
-aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 errno = { version = "0.3.14" }
-hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
+hyper-rustls = { version = "0.27.7", features = ["http2"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 object = { version = "0.37.3", default-features = false, features = ["read", "std"] }
@@ -355,10 +353,9 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 errno = { version = "0.3.14" }
-hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
+hyper-rustls = { version = "0.27.7", features = ["http2"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 object = { version = "0.37.3", default-features = false, features = ["read", "std"] }
@@ -367,10 +364,9 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.aarch64-apple-darwin.dependencies]
-aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 errno = { version = "0.3.14" }
-hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
+hyper-rustls = { version = "0.27.7", features = ["http2"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 object = { version = "0.37.3", default-features = false, features = ["read", "std"] }
@@ -379,10 +375,9 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 errno = { version = "0.3.14" }
-hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
+hyper-rustls = { version = "0.27.7", features = ["http2"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 object = { version = "0.37.3", default-features = false, features = ["read", "std"] }
@@ -391,13 +386,12 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.x86_64-unknown-illumos.dependencies]
-aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 dof-468e82937335b1c9 = { package = "dof", version = "0.3.0", default-features = false, features = ["des"] }
 dof-9fbad63c4bcf4a8f = { package = "dof", version = "0.4.0", default-features = false, features = ["des"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.1", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
+hyper-rustls = { version = "0.27.7", features = ["http2"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 object = { version = "0.37.3", default-features = false, features = ["read", "std"] }
@@ -408,13 +402,12 @@ toml_datetime = { version = "0.6.11", default-features = false, features = ["ser
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }
 
 [target.x86_64-unknown-illumos.build-dependencies]
-aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 dof-468e82937335b1c9 = { package = "dof", version = "0.3.0", default-features = false, features = ["des"] }
 dof-9fbad63c4bcf4a8f = { package = "dof", version = "0.4.0", default-features = false, features = ["des"] }
 errno = { version = "0.3.14" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.1", default-features = false, features = ["std", "sys_rng"] }
-hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
+hyper-rustls = { version = "0.27.7", features = ["http2"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 mio = { version = "1.2.0", features = ["net", "os-ext"] }
 object = { version = "0.37.3", default-features = false, features = ["read", "std"] }


### PR DESCRIPTION
Bumps Crucible and Propolis:

https://github.com/oxidecomputer/crucible/compare/bd9a0e2abe6b6b89aec8c85f4ee57474144ed150...2bfe090eb5318ec8c467157018db2429d4df535b
https://github.com/oxidecomputer/propolis/compare/6873add79b835f7932d9fe928340886df8e49676...979b72896bc39a876c98fb32fe706da37a4fc408

This includes a change to swap ring for aws-lc-rs in Crucible as part of removing ring from Omicron. The goal is to avoid the painful rebuild times while running `cargo xtask releng` due to ring's extreme caution around environment variables impacting how it builds its non-Rust code. This has supposedly been fixed upstream but there hasn't been a new release in 15 months. In making this change in Crucible we also need to get rid of the ring feature in rustls, otherwise Nexus doesn't start.

Also pulls in:
- https://github.com/oxidecomputer/omicron-package/pull/78
- https://github.com/oxidecomputer/sprockets/pull/102