### PR TITLE
[nexus-lockstep-client] use real early-networking types via replace

### DIFF
--- a/clients/nexus-lockstep-client/src/lib.rs
+++ b/clients/nexus-lockstep-client/src/lib.rs
@@ -33,6 +33,7 @@ progenitor::generate_api!(
     replace = {
         BaseboardId = sled_hardware_types::BaseboardId,
         BfdMode = sled_agent_types::early_networking::BfdMode,
+        BgpPeerConfig = sled_agent_types::early_networking::BgpPeerConfig,
         // It's kind of unfortunate to pull in such a complex and unstable type
         // as "blueprint" this way, but we have really useful functionality
         // (e.g., diff'ing) that's implemented on our local type.
@@ -54,6 +55,8 @@ progenitor::generate_api!(
         ImportExportPolicy = sled_agent_types::early_networking::ImportExportPolicy,
         LinkFec = sled_agent_types::early_networking::LinkFec,
         LinkSpeed = sled_agent_types::early_networking::LinkSpeed,
+        LldpAdminStatus = sled_agent_types::early_networking::LldpAdminStatus,
+        LldpPortConfig = sled_agent_types::early_networking::LldpPortConfig,
         MacAddr = omicron_common::api::external::MacAddr,
         MgsUpdateDriverStatus = nexus_types::internal_api::views::MgsUpdateDriverStatus,
         Name = omicron_common::api::external::Name,
@@ -64,14 +67,18 @@ progenitor::generate_api!(
         OximeterReadPolicy = nexus_types::deployment::OximeterReadPolicy,
         PendingMgsUpdate = nexus_types::deployment::PendingMgsUpdate,
         PlannerConfig = nexus_types::deployment::PlannerConfig,
+        PortConfig = sled_agent_types::early_networking::PortConfig,
         ReconfiguratorConfig = nexus_types::deployment::ReconfiguratorConfig,
         ReconfiguratorConfigParam = nexus_types::deployment::ReconfiguratorConfigParam,
         ReconfiguratorConfigView = nexus_types::deployment::ReconfiguratorConfigView,
         RecoverySiloConfig = bootstrap_agent_lockstep_types::RecoverySiloConfig,
+        RouteConfig = sled_agent_types::early_networking::RouteConfig,
+        RouterLifetimeConfig = sled_agent_types::early_networking::RouterLifetimeConfig,
         RouterPeerType = sled_agent_types::early_networking::RouterPeerType,
         SledAgentUpdateStatus = nexus_types::internal_api::views::SledAgentUpdateStatus,
         SwitchSlot = sled_agent_types::early_networking::SwitchSlot,
         TrustQuorumConfig = nexus_types::trust_quorum::TrustQuorumConfig,
+        TxEqConfig = sled_agent_types::early_networking::TxEqConfig,
         UpdateStatus = nexus_types::internal_api::views::UpdateStatus,
         UplinkAddressConfig = sled_agent_types::early_networking::UplinkAddressConfig,
         ZoneStatus = nexus_types::internal_api::views::ZoneStatus,

--- a/sled-agent/rack-setup/src/service.rs
+++ b/sled-agent/rack-setup/src/service.rs
@@ -109,9 +109,7 @@ use sled_agent_client::{
     Client as SledAgentClient, Error as SledAgentError, types as SledAgentTypes,
 };
 use sled_agent_config_reconciler::InternalDisksReceiver;
-use sled_agent_types::early_networking::{
-    EarlyNetworkConfigEnvelope, LldpAdminStatus,
-};
+use sled_agent_types::early_networking::EarlyNetworkConfigEnvelope;
 use sled_agent_types::inventory::{
     ConfigReconcilerInventoryResult, HostPhase2DesiredSlots, OmicronSledConfig,
     OmicronZoneConfig, OmicronZoneType, OmicronZonesConfig,
@@ -899,88 +897,7 @@ impl ServiceInner {
                 rack_subnet: config.rack_subnet,
                 infra_ip_first: config.infra_ip_first,
                 infra_ip_last: config.infra_ip_last,
-                ports: config
-                    .ports
-                    .iter()
-                    .map(|config| NexusTypes::PortConfig {
-                        port: config.port.clone(),
-                        routes: config
-                            .routes
-                            .iter()
-                            .map(|r| NexusTypes::RouteConfig {
-                                destination: r.destination,
-                                nexthop: r.nexthop,
-                                vlan_id: r.vlan_id,
-                                rib_priority: r.rib_priority,
-                            })
-                            .collect(),
-                        addresses: config.addresses.clone(),
-                        switch: config.switch,
-                        uplink_port_speed: config.uplink_port_speed,
-                        uplink_port_fec: config.uplink_port_fec,
-                        autoneg: config.autoneg,
-                        bgp_peers: config
-                            .bgp_peers
-                            .iter()
-                            .map(|b| NexusTypes::BgpPeerConfig {
-                                addr: b.addr,
-                                asn: b.asn,
-                                port: b.port.clone(),
-                                hold_time: b.hold_time,
-                                connect_retry: b.connect_retry,
-                                delay_open: b.delay_open,
-                                idle_hold_time: b.idle_hold_time,
-                                keepalive: b.keepalive,
-                                remote_asn: b.remote_asn,
-                                min_ttl: b.min_ttl,
-                                md5_auth_key: b.md5_auth_key.clone(),
-                                multi_exit_discriminator: b
-                                    .multi_exit_discriminator,
-                                local_pref: b.local_pref,
-                                enforce_first_as: b.enforce_first_as,
-                                communities: b.communities.clone(),
-                                allowed_export: b.allowed_export.clone(),
-                                allowed_import: b.allowed_import.clone(),
-                                vlan_id: b.vlan_id,
-                            })
-                            .collect(),
-                        lldp: config.lldp.as_ref().map(|lp| {
-                            NexusTypes::LldpPortConfig {
-                                status: match lp.status {
-                                    LldpAdminStatus::Enabled => {
-                                        NexusTypes::LldpAdminStatus::Enabled
-                                    }
-                                    LldpAdminStatus::Disabled => {
-                                        NexusTypes::LldpAdminStatus::Disabled
-                                    }
-                                    LldpAdminStatus::TxOnly => {
-                                        NexusTypes::LldpAdminStatus::TxOnly
-                                    }
-                                    LldpAdminStatus::RxOnly => {
-                                        NexusTypes::LldpAdminStatus::RxOnly
-                                    }
-                                },
-                                chassis_id: lp.chassis_id.clone(),
-                                port_id: lp.port_id.clone(),
-                                system_name: lp.system_name.clone(),
-                                system_description: lp
-                                    .system_description
-                                    .clone(),
-                                port_description: lp.port_description.clone(),
-                                management_addrs: lp.management_addrs.clone(),
-                            }
-                        }),
-                        tx_eq: config.tx_eq.as_ref().map(|tx_eq| {
-                            NexusTypes::TxEqConfig {
-                                pre1: tx_eq.pre1,
-                                pre2: tx_eq.pre2,
-                                main: tx_eq.main,
-                                post2: tx_eq.post2,
-                                post1: tx_eq.post1,
-                            }
-                        }),
-                    })
-                    .collect(),
+                ports: config.ports.clone(),
                 bgp: config
                     .bgp
                     .iter()


### PR DESCRIPTION
progenitor doesn't support `minItems`, so to prepare for an upcoming change (based on the investigation in #10640) to ensure that there's at least one port configured, use the real types with `replace`.

This brings `nexus-lockstep-client` to parity with `bootstrap-agent-lockstep-client`.
