### PR TITLE
bump Propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d59ac2dcf1a24f08f82ea803978d7a3351525c17#d59ac2dcf1a24f08f82ea803978d7a3351525c17"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d59ac2dcf1a24f08f82ea803978d7a3351525c17#d59ac2dcf1a24f08f82ea803978d7a3351525c17"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -2151,6 +2151,19 @@ dependencies = [
 name = "crucible-client-types"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/crucible?rev=bd9a0e2abe6b6b89aec8c85f4ee57474144ed150#bd9a0e2abe6b6b89aec8c85f4ee57474144ed150"
+dependencies = [
+ "base64 0.22.1",
+ "crucible-workspace-hack",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "crucible-client-types"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/crucible?rev=e7af674f27ed04ce27739edee96829f7d7d5e6c0#e7af674f27ed04ce27739edee96829f7d7d5e6c0"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -9211,7 +9224,7 @@ dependencies = [
  "clap",
  "clickhouse-admin-types",
  "crucible-agent-client",
- "crucible-client-types",
+ "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=bd9a0e2abe6b6b89aec8c85f4ee57474144ed150)",
  "derive_more 0.99.20",
  "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?branch=main)",
  "display-error-chain",
@@ -11230,9 +11243,9 @@ dependencies = [
 [[package]]
 name = "propolis-api-types-versions"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d59ac2dcf1a24f08f82ea803978d7a3351525c17#d59ac2dcf1a24f08f82ea803978d7a3351525c17"
 dependencies = [
- "crucible-client-types",
+ "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=e7af674f27ed04ce27739edee96829f7d7d5e6c0)",
  "propolis_types",
  "schemars 0.8.22",
  "serde",
@@ -11243,11 +11256,11 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d59ac2dcf1a24f08f82ea803978d7a3351525c17#d59ac2dcf1a24f08f82ea803978d7a3351525c17"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
- "crucible-client-types",
+ "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=e7af674f27ed04ce27739edee96829f7d7d5e6c0)",
  "futures",
  "progenitor 0.14.0",
  "progenitor-client 0.14.0",
@@ -11267,7 +11280,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d59ac2dcf1a24f08f82ea803978d7a3351525c17#d59ac2dcf1a24f08f82ea803978d7a3351525c17"
 dependencies = [
  "anyhow",
  "atty",
@@ -11300,16 +11313,16 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d59ac2dcf1a24f08f82ea803978d7a3351525c17#d59ac2dcf1a24f08f82ea803978d7a3351525c17"
 dependencies = [
- "crucible-client-types",
+ "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=e7af674f27ed04ce27739edee96829f7d7d5e6c0)",
  "propolis-api-types-versions",
 ]
 
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6873add79b835f7932d9fe928340886df8e49676#6873add79b835f7932d9fe928340886df8e49676"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d59ac2dcf1a24f08f82ea803978d7a3351525c17#d59ac2dcf1a24f08f82ea803978d7a3351525c17"
 dependencies = [
  "schemars 0.8.22",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -734,11 +734,11 @@ progenitor-extras = "0.2.0"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
-propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "6873add79b835f7932d9fe928340886df8e49676" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "d59ac2dcf1a24f08f82ea803978d7a3351525c17" }
+propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "d59ac2dcf1a24f08f82ea803978d7a3351525c17" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "d59ac2dcf1a24f08f82ea803978d7a3351525c17" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "d59ac2dcf1a24f08f82ea803978d7a3351525c17" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "d59ac2dcf1a24f08f82ea803978d7a3351525c17" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.1"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -667,10 +667,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "6873add79b835f7932d9fe928340886df8e49676"
+source.commit = "d59ac2dcf1a24f08f82ea803978d7a3351525c17"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "ccac586c3ed1e996d9554fb1db1b1096c0bcd0dd5712c14579924ea85dd16a34"
+source.sha256 = "c8a633e15b282e6e99cbd2f8497b181726b2376ac38552ace064c715b2fbb052"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -2090,7 +2090,7 @@ fn generate_new_volume_info(
                 blocks_per_extent: _,
                 extent_count: _,
                 opts:
-                    crucible_client_types::CrucibleOpts {
+                    propolis_client::CrucibleOpts {
                         id,
                         target,
                         lossy: _,


### PR DESCRIPTION
since last time:

* register Oximeter metrics for local disks (propolis#1144)
* add NVMe Discard Oximeter metrics (propolis#1143)
* fix nits on non-x86 (propolis#1150)
* Enable propolis to generate ACPI tables (propolis#999)
* viona: support (enough) `VIRTIO_NET_F_CTRL_RX` to leave all-multicast mode (propolis#1125)

the first two have Propolis offering up a bunch of additional Oximeter metrics (yay!). 1150 is unrelated to the product. 999 should not result in any changes either to guests or in the product at large.

1125 has Propolis actually support VIRTIO_NET_F_CTRL_RX where we were advertising and ignoring the related configuration before. it was not wrong to ignore that configuration, so this is not a correctness change, but it does have VMs behaving slightly different with viona. finally, it adjusts Propolis virtio NIC control queue handling a bit, fixing an issue that would have been an issue come VM migration.