### PR TITLE
[omdb] fix wrong cooldown in `omdb db instance show`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -5056,13 +5056,27 @@ async fn cmd_db_instance_info(
         }
         Reincarnatability::CoolingDown { until } => {
             println!(
-                "/!\\ {KARMIC_STATUS:>WIDTH$}: cooling down \
+                "    {KARMIC_STATUS:>WIDTH$}: cooling down \
                  (until {until})"
             );
+
+            if let Some(last) = time_last_auto_restarted {
+                let icon = if needs_reincarnation { "/!\\" } else { "(i)" };
+                println!("{icon}  this instance last restarted at {last}.");
+                if needs_reincarnation {
+                    println!(
+                        "     it will not be permitted to restart until {until}"
+                    );
+                } else {
+                    println!(
+                        "     if it fails, it will not be permitted to \
+                        restart again until {until}"
+                    );
+                }
+            }
         }
     }
     println!("    {LAST_AUTO_RESTART:>WIDTH$}: {time_last_auto_restarted:?}");
-
     println!("    {ACTIVE_VMM:>WIDTH$}: {propolis_id:?}");
     println!("    {TARGET_VMM:>WIDTH$}: {dst_propolis_id:?}");
 

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -5054,10 +5054,10 @@ async fn cmd_db_instance_info(
                 "    {KARMIC_STATUS:>WIDTH$}: nirvāṇa (reincarnation disabled)"
             );
         }
-        Reincarnatability::CoolingDown(remaining) => {
+        Reincarnatability::CoolingDown { until } => {
             println!(
                 "/!\\ {KARMIC_STATUS:>WIDTH$}: cooling down \
-                 ({remaining:?} remaining)"
+                 (until {until})"
             );
         }
     }

--- a/nexus/db-model/src/instance.rs
+++ b/nexus/db-model/src/instance.rs
@@ -434,8 +434,13 @@ pub enum Reincarnatability {
     /// The instance remains bound to the cycle of saṃsāra and can return in the
     /// next life.
     WillReincarnate,
-    /// The instance cannot reincarnate again until the specified time.
-    CoolingDown(TimeDelta),
+    /// The instance cannot reincarnate again until the cooldown period elapses
+    /// at the specified time.
+    CoolingDown {
+        /// The wall-clock time at which the cooldown period will expire and the
+        /// instance will once again be eligible to reincarnate.
+        until: DateTime<Utc>,
+    },
     /// The instance's auto-restart policy indicates that it has attained
     /// nirvāṇa and will not reincarnate.
     Nirvana,
@@ -477,13 +482,14 @@ impl InstanceAutoRestart {
             // Eventually, we may also allow a project-level default, so we will
             // need to consider that as well.
             let cooldown = self.cooldown.unwrap_or(Self::DEFAULT_COOLDOWN);
-            let time_since_last = Utc::now().signed_duration_since(last);
-            if time_since_last >= cooldown {
+            // The instance is eligible to reincarnate if the current time is
+            // greater than or equal to the last restart time plus the cooldown
+            // duration.
+            let until = last + cooldown;
+            if Utc::now() >= until {
                 return Reincarnatability::WillReincarnate;
             } else {
-                return Reincarnatability::CoolingDown(
-                    cooldown - time_since_last,
-                );
+                return Reincarnatability::CoolingDown { until };
             }
         }
 


### PR DESCRIPTION
The `omdb db instance show` command currently displays the auto-restart cooldown duration as a time delta, calculated by the `InstanceAutoRestart::can_reincarnate` function. This function returns a `TimeDelta` with a _comment_ suggesting that this is an absolute expiry timestamp, but it is actually the duration until that timestamp, calculated by subtracting the current `Utc::now` from the expiry time. This means that if `Utc::now()` in the _omdb process_ ever returns a timestamp where `now.signed_duration_since(last)` is negative, the calculated cooldown duration will appear to be many years long. This branch fixes that by just making `can_reincarnate` return the absolute timestamp at which the cooldown will expire, which is what the doc comment on the enum says it is anyway. Since the timestamp value is only used by `omdb` anyway, this is a low-risk change.

I also added some additional help text to explain what these values mean.

Fixes #10660