### PR TITLE
ci/build-and-test: revert #7659

### DIFF
--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -110,16 +110,6 @@ export CARGO_INCREMENTAL=0
 export RUSTC_BOOTSTRAP=1
 
 # Build all the packages and tests, and keep track of how long each took to build.
-#
-# The build graph ends up building several bin/test targets that depend on
-# omicron-nexus at the same time, which uses significant memory to compile on
-# illumos. To mitigate this we build everything except omicron-nexus's bin/test
-# targets first, then finish the build after.
-#
-# Both invocations use the same flags to avoid cache invalidation.
-# We collect timing data only from the second (full workspace) build.
-ptime -m cargo --config 'build.analysis.enabled=true' build -Zbuild-analysis \
-    --workspace --exclude=omicron-nexus --tests --locked --verbose
 ptime -m cargo --config 'build.analysis.enabled=true' build -Zbuild-analysis \
     --workspace --tests --locked --verbose
 cp "$(ls -t "${CARGO_HOME:-$HOME/.cargo}/log/"*.jsonl | head -1)" \


### PR DESCRIPTION
In #7659 I added a stupid hack to improve Helios build-and-test times in CI: first build everything with `--exclude=omicron-nexus`, then perform a normal build. This was to mitigate the effect of simultaneously linking all Nexus-containing binaries (bin and test targets for both Nexus and OMDB), which severely pushed the memory limits of Buildomat instances at the time.

Since #10018 this job now uses an instance with 256 GB of memory. This is enough RAM.

This change appears to shave about four minutes off of this job. This may also have the side effect of making the build timing data useful again. #10058 had to deal with a change to rustc's build analysis output and given my read of the script the uploaded build timing file would have basically only contained information about how long it took to build Nexus. (But I could be wrong, I have not actually looked at the file.)