### PR TITLE
[fm] add `rack_id` column to `ereporter_restart`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db/ereport.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/ereport.rs
@@ -38,6 +38,7 @@ use nexus_types::fm::ereport::Ena;
 use nexus_types::fm::ereport::Reporter;
 use omicron_uuid_kinds::EreporterRestartUuid;
 use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::RackUuid;
 use omicron_uuid_kinds::SledUuid;
 use std::collections::HashMap;
 use tabled::Tabled;
@@ -376,16 +377,20 @@ async fn cmd_db_ereport_info(
     const CLASS: &str = "class";
     const REPORTER: &str = "reported by";
     const RESTART_ID: &str = "restart ID";
+    const RACK_ID: &str = "rack ID";
     const SLED_ID: &str = "  sled ID";
     const PART_NUMBER: &str = "  part number";
     const SERIAL_NUMBER: &str = "  serial number";
     const MARKED_SEEN_IN: &str = "marked seen in sitrep";
     const WIDTH: usize = const_max_len(&[
+        ENA,
         CLASS,
         TIME_COLLECTED,
         TIME_DELETED,
         COLLECTOR_ID,
+        RESTART_ID,
         REPORTER,
+        RACK_ID,
         SLED_ID,
         PART_NUMBER,
         SERIAL_NUMBER,
@@ -467,6 +472,25 @@ async fn cmd_db_ereport_info(
             }
         }
         println!("    {RESTART_ID:>WIDTH$}: {restart_id}");
+
+        // Grab the reporter entry so that we can print the rack ID.
+        let reporter = restart_dsl::ereporter_restart
+            .filter(restart_dsl::id.eq(restart_id.into_untyped_uuid()))
+            .select(db::model::EreporterRestart::as_select())
+            .first_async(&*conn)
+            .await;
+        match reporter {
+            Ok(reporter) => {
+                println!("    {RACK_ID:>WIDTH$}: {}", reporter.rack_id());
+            }
+            Err(err) => {
+                eprintln!(
+                    "error: failed to fetch ereporter_restart entry for \
+                     {restart_id}: {err}"
+                );
+            }
+        }
+
         println!(
             "    {PART_NUMBER:>WIDTH$}: {}",
             part_number.as_deref().unwrap_or("<unknown>")
@@ -587,6 +611,7 @@ async fn cmd_db_ereporters(
         serial: Option<String>,
         #[tabled(display_with = "display_option_blank", rename = "P/N")]
         part_number: Option<String>,
+        rack_id: RackUuid,
         ereports: i64,
     }
 
@@ -628,6 +653,7 @@ async fn cmd_db_ereporters(
                 serial,
                 part_number,
                 ereports,
+                rack_id: *restart.rack_id(),
             })
         })
         .collect::<Vec<_>>();

--- a/nexus/db-model/src/ereporter_restart.rs
+++ b/nexus/db-model/src/ereporter_restart.rs
@@ -11,6 +11,8 @@ use chrono::Utc;
 use nexus_db_schema::schema::ereporter_restart;
 use omicron_uuid_kinds::EreporterRestartKind;
 use omicron_uuid_kinds::EreporterRestartUuid;
+use omicron_uuid_kinds::RackKind;
+use omicron_uuid_kinds::RackUuid;
 
 #[derive(Clone, Debug, Insertable, Queryable, Selectable)]
 #[diesel(table_name = ereporter_restart)]
@@ -20,6 +22,7 @@ pub struct EreporterRestart {
     pub reporter: EreporterType,
     pub slot_type: SpType,
     pub slot: Option<SpMgsSlot>,
+    pub rack_id: DbTypedUuid<RackKind>,
 }
 
 impl EreporterRestart {
@@ -29,6 +32,10 @@ impl EreporterRestart {
 
     pub fn id(&self) -> &EreporterRestartUuid {
         &self.id.0
+    }
+
+    pub fn rack_id(&self) -> &RackUuid {
+        &self.rack_id.0
     }
 }
 

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(273, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(274, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ pub static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(274, "ereporter-restart-rack-id"),
         KnownVersion::new(273, "fm-support-bundle-resource-deletion"),
         KnownVersion::new(272, "ereporter-restart-order-v2"),
         KnownVersion::new(271, "inv-fmd"),

--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -262,6 +262,7 @@ impl DataStore {
         restart_id: EreporterRestartUuid,
         time_collected: DateTime<Utc>,
         collector_id: OmicronZoneUuid,
+        rack_id: RackUuid,
         reporter: fm::Reporter,
         ereports: impl IntoIterator<Item = (fm::Ena, fm::EreportData)>,
     ) -> CreateResult<(usize, Option<EreportId>)> {
@@ -279,6 +280,7 @@ impl DataStore {
         let created = Self::ereports_insert_query(
             restart_id,
             time_collected,
+            rack_id,
             reporter,
             ereports,
         )
@@ -327,6 +329,7 @@ impl DataStore {
     fn ereports_insert_query(
         restart_id: EreporterRestartUuid,
         time_collected: chrono::DateTime<chrono::Utc>,
+        rack_id: RackUuid,
         reporter: fm::Reporter,
         ereports: Vec<Ereport>,
     ) -> impl RunnableQuery<i64> {
@@ -419,6 +422,7 @@ impl DataStore {
             reporter,
             slot_type,
             slot: slot.map(SpMgsSlot::from),
+            rack_id: rack_id.into(),
         });
         EreportInsertQuery { insert_ereports, insert_reporter, slot }
     }

--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -41,6 +41,7 @@ use omicron_common::api::external::LookupResult;
 use omicron_uuid_kinds::EreporterRestartUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::RackUuid;
 use omicron_uuid_kinds::SitrepUuid;
 use omicron_uuid_kinds::SledUuid;
 use uuid::Uuid;
@@ -605,6 +606,7 @@ mod tests {
     use ereport_types::Ena;
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::OmicronZoneUuid;
+    use omicron_uuid_kinds::RackUuid;
     use std::collections::BTreeMap;
     use std::num::NonZeroU32;
     use std::time::Duration;
@@ -925,11 +927,13 @@ mod tests {
     async fn expectorate_ereports_insert_sp() {
         let restart_id = EreporterRestartUuid::nil();
         let collector_id = OmicronZoneUuid::nil();
+        let rack_id = RackUuid::nil();
         let reporter =
             fm::Reporter::Sp { sp_type: SpType::Sled.into(), slot: 16 };
         let query = DataStore::ereports_insert_query(
             restart_id,
             DateTime::<Utc>::MIN_UTC,
+            rack_id,
             reporter,
             vec![
                 Ereport {
@@ -971,11 +975,13 @@ mod tests {
     async fn expectorate_ereports_insert_host() {
         let restart_id = EreporterRestartUuid::nil();
         let collector_id = OmicronZoneUuid::nil();
+        let rack_id = RackUuid::nil();
         let reporter =
             fm::Reporter::HostOs { slot: Some(16), sled: SledUuid::nil() };
         let query = DataStore::ereports_insert_query(
             restart_id,
             DateTime::<Utc>::MIN_UTC,
+            rack_id,
             reporter,
             vec![
                 Ereport {
@@ -1034,6 +1040,7 @@ mod tests {
         let id = fm::EreportId { restart_id, ena: ereport_types::Ena(2) };
         let time_collected = Utc::now();
         let collector_id = OmicronZoneUuid::new_v4();
+        let rack_id = RackUuid::new_v4();
         let ereport = fm::EreportData {
             part_number: Some("my cool CPN".to_string()),
             serial_number: Some("my cool serial".to_string()),
@@ -1046,6 +1053,7 @@ mod tests {
                 restart_id,
                 time_collected,
                 collector_id,
+                rack_id,
                 fm::Reporter::Sp {
                     sp_type: nexus_types::inventory::SpType::Sled,
                     slot: 19,
@@ -1138,6 +1146,7 @@ mod tests {
         // and NULL.
         let restart_id = EreporterRestartUuid::new_v4();
         let collector_id = OmicronZoneUuid::new_v4();
+        let rack_id = RackUuid::new_v4();
         let make = |ena: u64, class: Option<&str>| {
             (
                 ereport_types::Ena(ena),
@@ -1155,6 +1164,7 @@ mod tests {
                 restart_id,
                 Utc::now(),
                 collector_id,
+                rack_id,
                 fm::Reporter::Sp {
                     sp_type: nexus_types::inventory::SpType::Sled,
                     slot: 0,
@@ -1271,6 +1281,7 @@ mod tests {
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
         let collector_id = OmicronZoneUuid::new_v4();
+        let rack_id = RackUuid::new_v4();
         let t0 = Utc::now();
 
         let timestamp = move |secs: usize| -> DateTime<Utc> {
@@ -1300,6 +1311,7 @@ mod tests {
                 host0_restart_id,
                 host0_first_seen,
                 collector_id,
+                rack_id,
                 fm::Reporter::HostOs { sled, slot: None },
                 vec![mk_ereport(1)],
             )
@@ -1313,6 +1325,7 @@ mod tests {
                     host0_restart_id,
                     time_collected,
                     collector_id,
+                    rack_id,
                     fm::Reporter::HostOs { sled, slot: Some(host0_slot) },
                     vec![mk_ereport(2), mk_ereport(3)],
                 )
@@ -1335,6 +1348,7 @@ mod tests {
                 host1_restart_id,
                 host1_first_seen,
                 collector_id,
+                rack_id,
                 fm::Reporter::HostOs { sled, slot: Some(host1_slot) },
                 vec![mk_ereport(1), mk_ereport(2)],
             )
@@ -1346,6 +1360,7 @@ mod tests {
                 host1_restart_id,
                 timestamp(250),
                 collector_id,
+                rack_id,
                 fm::Reporter::HostOs { sled, slot: None },
                 vec![mk_ereport(3)],
             )
@@ -1363,6 +1378,7 @@ mod tests {
                 sp0_restart_id0,
                 sp0_first_seen,
                 collector_id,
+                rack_id,
                 fm::Reporter::Sp {
                     sp_type: SpType::Switch.into(),
                     slot: sp0_slot,
@@ -1379,6 +1395,7 @@ mod tests {
                     sp0_restart_id0,
                     time_collected,
                     collector_id,
+                    rack_id,
                     fm::Reporter::Sp {
                         sp_type: SpType::Switch.into(),
                         slot: sp0_slot,
@@ -1397,6 +1414,7 @@ mod tests {
                 sp0_restart_id1,
                 sp0_restart1_first_seen,
                 collector_id,
+                rack_id,
                 fm::Reporter::Sp {
                     sp_type: SpType::Switch.into(),
                     slot: sp0_slot,

--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -257,6 +257,13 @@ impl DataStore {
     ///   additional ereports were inserted concurrently
     /// - have a different restart ID than the one provided, if ereports from
     ///   a newer restart of that reporter were inserted concurrently
+    // Since all the arguments to this function are newtypes with pretty clear
+    // meanings (e.g. `rack_id`, `restart_id`, and `collector_id` are all
+    // different typed UUIDs), I'm not convinced that factoring stuff out into a
+    // struct like `EreportTrancheMetadata` or whatever would actually make this
+    // any clearer --- it feels like justadding noise to me. So ignore the
+    // warning.
+    #[allow(clippy::too_many_arguments)]
     pub async fn ereports_insert(
         &self,
         opctx: &OpContext,

--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -261,7 +261,7 @@ impl DataStore {
     // meanings (e.g. `rack_id`, `restart_id`, and `collector_id` are all
     // different typed UUIDs), I'm not convinced that factoring stuff out into a
     // struct like `EreportTrancheMetadata` or whatever would actually make this
-    // any clearer --- it feels like justadding noise to me. So ignore the
+    // any clearer --- it feels like just adding noise to me. So ignore the
     // warning.
     #[allow(clippy::too_many_arguments)]
     pub async fn ereports_insert(

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -1637,9 +1637,12 @@ mod tests {
     use nexus_types::fm::ereport::{EreportData, Reporter};
     use omicron_common::api::external::Generation;
     use omicron_test_utils::dev;
+    use omicron_uuid_kinds::CaseEreportUuid;
     use omicron_uuid_kinds::CollectionUuid;
+    use omicron_uuid_kinds::EreporterRestartUuid;
     use omicron_uuid_kinds::FactUuid;
     use omicron_uuid_kinds::OmicronZoneUuid;
+    use omicron_uuid_kinds::RackUuid;
     use omicron_uuid_kinds::SupportBundleUuid;
     use std::collections::BTreeMap;
     use std::collections::BTreeSet;
@@ -2232,8 +2235,9 @@ mod tests {
         // In order to read sitreps with case ereport assignments, the
         // corresponding entries in the `ereport` table must also exist, so
         // we'll make those here first.
-        let restart_id = omicron_uuid_kinds::EreporterRestartUuid::new_v4();
+        let restart_id = EreporterRestartUuid::new_v4();
         let collector_id = OmicronZoneUuid::new_v4();
+        let rack_id = RackUuid::new_v4();
         let time_collected = Utc::now();
 
         let ereport1_id =
@@ -2266,6 +2270,7 @@ mod tests {
                 restart_id,
                 time_collected,
                 collector_id,
+                rack_id,
                 reporter,
                 vec![
                     (ereport1_id.ena, ereport1.clone()),
@@ -2281,7 +2286,7 @@ mod tests {
             let mut ereports = iddqd::IdOrdMap::new();
             ereports
                 .insert_unique(fm::case::CaseEreport {
-                    id: omicron_uuid_kinds::CaseEreportUuid::new_v4(),
+                    id: CaseEreportUuid::new_v4(),
                     ereport: Arc::new(fm::Ereport::new(
                         ereport1_id,
                         time_collected,

--- a/nexus/db-queries/tests/output/ereports_insert_host.sql
+++ b/nexus/db-queries/tests/output/ereports_insert_host.sql
@@ -34,13 +34,13 @@ WITH
     AS (
       INSERT
       INTO
-        ereporter_restart (id, time_first_seen, reporter, slot_type, slot)
+        ereporter_restart (id, time_first_seen, reporter, slot_type, slot, rack_id)
       VALUES
-        ($25, $26, $27, $28, $29)
+        ($25, $26, $27, $28, $29, $30)
       ON CONFLICT
         (id)
       DO
-        UPDATE SET slot = $30
+        UPDATE SET slot = $31
       RETURNING
         id
     )

--- a/nexus/db-queries/tests/output/ereports_insert_sp.sql
+++ b/nexus/db-queries/tests/output/ereports_insert_sp.sql
@@ -34,13 +34,13 @@ WITH
     AS (
       INSERT
       INTO
-        ereporter_restart (id, time_first_seen, reporter, slot_type, slot)
+        ereporter_restart (id, time_first_seen, reporter, slot_type, slot, rack_id)
       VALUES
-        ($23, $24, $25, $26, $27)
+        ($23, $24, $25, $26, $27, $28)
       ON CONFLICT
         (id)
       DO
-        UPDATE SET slot = $28
+        UPDATE SET slot = $29
       RETURNING
         id
     )

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -3012,6 +3012,7 @@ table! {
         reporter -> crate::enums::EreporterTypeEnum,
         slot_type -> crate::enums::SpTypeEnum,
         slot -> Nullable<Int4>,
+        rack_id -> Uuid,
     }
 }
 

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -159,7 +159,9 @@ use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::PendingMgsUpdates;
 
 use nexus_types::inventory::Collection;
+use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::RackUuid;
 use oximeter::types::ProducerRegistry;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -1118,6 +1120,7 @@ impl BackgroundTasksInitializer {
                 datastore.clone(),
                 resolver.clone(),
                 nexus_id,
+                RackUuid::from_untyped_uuid(rack_id),
                 task_fm_analysis.clone(),
                 config.sp_ereport_ingester.disable,
             )),

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -92,6 +92,12 @@ impl SpEreportIngester {
         }
         // Find MGS clients.
         // TODO(eliza): reuse the same client across activations; qorb, etc.
+        //
+        // TODO-multirack: eventually, we'll need a way to discover the MGS
+        // clients for *all* the racks in the cluster, along with the rack ID of
+        // the rack those clients will talk to. How this works has yet to be
+        // determined. See also the 'TODO-multirack' comment in the
+        // `mgs_requests()` function for where the rack ID would be used.
         let mgs_clients = match GatewayClient::resolve_all_gateways(
             &opctx.log,
             &self.resolver,
@@ -305,7 +311,11 @@ impl Ingester {
                     // If this code changes to ingest ereports from the
                     // management gateways in multiple racks, we'll need to
                     // change this to pass the rack ID of the target rack, not
-                    // the one this Nexus lives in.
+                    // the one this Nexus lives in. Eventually, the rack ID will
+                    // become a property of the MGS clients that are passed into
+                    // this function: they'll have to become a type that says
+                    // "here are the clients for talking to the management
+                    // gateways in *that* rack, in particular".
                     self.rack_id,
                     reporter,
                     db_ereports,

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -24,6 +24,7 @@ use nexus_types::internal_api::background::SpEreportIngesterStatus;
 use nexus_types::internal_api::background::SpEreporterStatus;
 use omicron_uuid_kinds::EreporterRestartUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::RackUuid;
 use parallel_task_set::ParallelTaskSet;
 use slog_error_chain::InlineErrorChain;
 use std::collections::BTreeMap;
@@ -40,6 +41,7 @@ pub struct SpEreportIngester {
 struct Ingester {
     datastore: Arc<DataStore>,
     nexus_id: OmicronZoneUuid,
+    rack_id: RackUuid,
 }
 
 impl BackgroundTask for SpEreportIngester {
@@ -60,12 +62,13 @@ impl SpEreportIngester {
         datastore: Arc<DataStore>,
         resolver: internal_dns_resolver::Resolver,
         nexus_id: OmicronZoneUuid,
+        rack_id: RackUuid,
         fm_analysis: Activator,
         disabled: bool,
     ) -> Self {
         Self {
             resolver,
-            inner: Ingester { datastore, nexus_id },
+            inner: Ingester { datastore, nexus_id, rack_id },
             fm_analysis,
             disabled,
         }

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -293,6 +293,20 @@ impl Ingester {
                     restart_id,
                     time_collected,
                     self.nexus_id,
+                    // TODO-multirack: this argument to `ereports_insert` is
+                    // used to determine the rack ID of the SP that generated
+                    // this batch of ereports. Currently, using `self.rack_id`
+                    // (the rack ID of the Nexus instance ingesting the
+                    // ereports) is always correct, since this Nexus is only
+                    // ingesting ereports from SPs in its own rack. This will
+                    // not be the case if we begin ingesting ereports from SPs
+                    // in other racks.
+                    //
+                    // If this code changes to ingest ereports from the
+                    // management gateways in multiple racks, we'll need to
+                    // change this to pass the rack ID of the target rack, not
+                    // the one this Nexus lives in.
+                    self.rack_id,
                     reporter,
                     db_ereports,
                 )
@@ -443,6 +457,7 @@ mod tests {
             datastore.clone(),
             nexus.internal_resolver.clone(),
             nexus.id(),
+            RackUuid::from_untyped_uuid(nexus.rack_id()),
             fm_analysis_activator.clone(),
             false,
         );

--- a/nexus/src/app/background/tasks/fm_rendezvous.rs
+++ b/nexus/src/app/background/tasks/fm_rendezvous.rs
@@ -560,6 +560,7 @@ mod tests {
     use omicron_uuid_kinds::EreporterRestartUuid;
     use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::OmicronZoneUuid;
+    use omicron_uuid_kinds::RackUuid;
     use omicron_uuid_kinds::SitrepUuid;
     use omicron_uuid_kinds::SupportBundleUuid;
 
@@ -1294,6 +1295,7 @@ mod tests {
 
         let restart_id = EreporterRestartUuid::new_v4();
         let collector_id = OmicronZoneUuid::new_v4();
+        let rack_id = RackUuid::new_v4();
         let time_collected = Utc::now();
         let reporter = Reporter::Sp {
             sp_type: nexus_types::inventory::SpType::Sled,
@@ -1330,6 +1332,7 @@ mod tests {
                 restart_id,
                 time_collected,
                 collector_id,
+                rack_id,
                 reporter,
                 vec![
                     (ereport1_id.ena, ereport1_data.clone()),
@@ -1530,6 +1533,7 @@ mod tests {
 
         let restart_id = EreporterRestartUuid::new_v4();
         let collector_id = OmicronZoneUuid::new_v4();
+        let rack_id = RackUuid::new_v4();
         let reporter = Reporter::Sp {
             sp_type: nexus_types::inventory::SpType::Sled,
             slot: 1,
@@ -1565,6 +1569,7 @@ mod tests {
                 restart_id,
                 time_collected,
                 collector_id,
+                rack_id,
                 reporter,
                 vec![
                     (ereport1_id.ena, ereport1_data.clone()),

--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -735,7 +735,7 @@ mod test {
     use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::{
         BlueprintUuid, DatasetUuid, EreporterRestartUuid, OmicronZoneUuid,
-        PhysicalDiskUuid, SledUuid,
+        PhysicalDiskUuid, RackUuid, SledUuid,
     };
     use sled_agent_types::inventory::ZpoolHealth;
     use std::num::NonZeroU64;
@@ -862,7 +862,8 @@ mod test {
         let sp_restart_id = EreporterRestartUuid::new_v4();
         let time_collected = chrono::Utc::now();
         let collector_id = OmicronZoneUuid::new_v4();
-        datastore.ereports_insert(&opctx, sp_restart_id, time_collected, collector_id, Reporter::Sp { sp_type: SpType::Sled, slot: SLED_SLOT}, vec![
+        let rack_id = RackUuid::new_v4();
+        datastore.ereports_insert(&opctx, sp_restart_id, time_collected, collector_id, rack_id, Reporter::Sp { sp_type: SpType::Sled, slot: SLED_SLOT}, vec![
             (ereport_types::Ena(1), EreportData {
                 part_number: Some(GIMLET_PN.to_string()),
                 serial_number: Some(SP_SERIAL.to_string()),
@@ -887,6 +888,7 @@ mod test {
                 sp_restart_id2,
                 time_collected,
                 collector_id,
+                rack_id,
                 Reporter::Sp { sp_type: SpType::Sled, slot: SLED_SLOT },
                 vec![(
                     ereport_types::Ena(1),
@@ -912,6 +914,7 @@ mod test {
                 sp2_restart_id,
                 time_collected,
                 OmicronZoneUuid::new_v4(),
+                rack_id,
                 Reporter::Sp { sp_type: SpType::Switch, slot: 1 },
                 vec![(
                     ereport_types::Ena(1),
@@ -935,6 +938,7 @@ mod test {
                 sled1_restart_id,
                 time_collected,
                 collector_id,
+                rack_id,
                 Reporter::HostOs {
                     sled: SledUuid::new_v4(),
                     slot: Some(SLED_SLOT),
@@ -972,6 +976,7 @@ mod test {
                 sled2_restart_id,
                 time_collected,
                 OmicronZoneUuid::new_v4(),
+                rack_id,
                 Reporter::HostOs { sled: SledUuid::new_v4(), slot: Some(SLED_SLOT) },
                 vec![
                     (ereport_types::Ena(1), EreportData {

--- a/nexus/tests/integration_tests/data_migrations/ereporter_restart_rack_id.rs
+++ b/nexus/tests/integration_tests/data_migrations/ereporter_restart_rack_id.rs
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::super::schema::{DataMigrationFns, MigrationContext};
+use futures::future::BoxFuture;
+use pretty_assertions::assert_eq;
+use uuid::Uuid;
+
+// The single rack that all pre-existing ereporter restarts should be
+// backfilled to. The migration relies on there being exactly one rack present
+// when it runs.
+const RACK_ID: Uuid = Uuid::from_u128(0xeb030000_0000_0000_0000_000000000001);
+
+// An SP reporter restart and a host OS reporter restart that predate the
+// `rack_id` column.
+const SP_RESTART: Uuid =
+    Uuid::from_u128(0xeb030001_0000_0000_0000_000000000001);
+const HOST_RESTART: Uuid =
+    Uuid::from_u128(0xeb030001_0000_0000_0000_000000000002);
+
+// Hard-coded timestamps; their exact values are irrelevant to
+// this test.
+const T_00: &str = "2024-01-01T00:00:00Z";
+const T_10: &str = "2024-01-01T00:00:10Z";
+const T_20: &str = "2024-01-01T00:00:20Z";
+
+pub(crate) fn checks() -> DataMigrationFns {
+    DataMigrationFns::new().before(before).after(after)
+}
+
+fn before<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
+    Box::pin(async move {
+        // Insert exactly one rack. The migration's backfill selects the single
+        // rack ID via a scalar subquery, which would fail if more than one rack
+        // were present. Insert ereporter restarts that predate the `rack_id`
+        // column so that the migration must backfill them.
+        ctx.client
+            .batch_execute(&format!(
+                "
+                INSERT INTO omicron.public.rack (
+                    id, time_created, time_modified, initialized
+                ) VALUES
+                    ('{RACK_ID}', '{T_00}', '{T_00}', true);
+
+                INSERT INTO omicron.public.ereporter_restart (
+                    id, time_first_seen, reporter, slot_type, slot
+                ) VALUES
+                    ('{SP_RESTART}', '{T_10}', 'sp', 'switch', 1),
+                    ('{HOST_RESTART}', '{T_20}', 'host', 'sled', NULL);
+                "
+            ))
+            .await
+            .expect(
+                "failed to insert pre-migration rack and ereporter restarts",
+            );
+    })
+}
+
+fn after<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
+    Box::pin(async move {
+        let rows = ctx
+            .client
+            .query(
+                &format!(
+                    "SELECT id, rack_id
+                     FROM omicron.public.ereporter_restart
+                     WHERE id IN ('{SP_RESTART}', '{HOST_RESTART}')"
+                ),
+                &[],
+            )
+            .await
+            .expect("failed to query backfilled ereporter_restart rows");
+
+        assert_eq!(
+            rows.len(),
+            2,
+            "both pre-existing ereporter restarts should still be present"
+        );
+
+        for row in &rows {
+            let id: Uuid = row.get("id");
+            let rack_id: Uuid = row.get("rack_id");
+            assert_eq!(
+                rack_id, RACK_ID,
+                "ereporter restart {id} should be backfilled with the only \
+                 rack's ID"
+            );
+        }
+
+        // Clean up test data so it doesn't interfere with later checks.
+        ctx.client
+            .batch_execute(&format!(
+                "
+                DELETE FROM omicron.public.ereporter_restart
+                    WHERE id IN ('{SP_RESTART}', '{HOST_RESTART}');
+                DELETE FROM omicron.public.rack WHERE id = '{RACK_ID}';
+                "
+            ))
+            .await
+            .expect("failed to clean up ereporter-restart-rack-id test data");
+    })
+}

--- a/nexus/tests/integration_tests/data_migrations/mod.rs
+++ b/nexus/tests/integration_tests/data_migrations/mod.rs
@@ -37,6 +37,7 @@ mod drop_uninitialized_svc_enabled_not_online_state;
 mod ereport_everyone_gets_a_slot;
 mod ereport_trim_serial_trailing_nulls;
 mod ereporter_restart_order_v2;
+mod ereporter_restart_rack_id;
 mod fix_leaked_bp_oximeter_read_policy_rows;
 mod fix_session_token_column_order;
 mod inv_clear_mupdate_override;
@@ -96,6 +97,7 @@ pub(crate) fn get_migration_checks() -> BTreeMap<Version, DataMigrationFns> {
     register!(ereport_trim_serial_trailing_nulls);
     register!(sled_resource_vmm_state);
     register!(ereporter_restart_order_v2);
+    register!(ereporter_restart_rack_id);
 
     map
 }

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -7717,6 +7717,8 @@ CREATE TABLE IF NOT EXISTS omicron.public.ereporter_restart (
     -- location of the sled is determined later, subsequent attempts to insert
     -- ereports will update this field.
     slot INT4,
+    -- The ID of the rack that the reporter is located in.
+    rack_id UUID NOT NULL,
 
     CONSTRAINT reporter_validity CHECK (
         (

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -8965,7 +8965,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '273.0.0', NULL)
+    (TRUE, NOW(), NOW(), '274.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/ereporter-restart-rack-id/up01.sql
+++ b/schema/crdb/ereporter-restart-rack-id/up01.sql
@@ -1,0 +1,4 @@
+-- Add the `rack_id` column to `ereporter_restart`. This is currently nullable,
+-- as it will be backfilled in the next step of the migration.
+ALTER TABLE omicron.public.ereporter_restart
+    ADD COLUMN IF NOT EXISTS rack_id UUID;

--- a/schema/crdb/ereporter-restart-rack-id/up02.sql
+++ b/schema/crdb/ereporter-restart-rack-id/up02.sql
@@ -1,0 +1,23 @@
+-- Backfill `rack_id` for ereporter restarts that were recorded before this
+-- column existed.
+SET LOCAL disallow_full_table_scans = off;
+
+UPDATE
+    omicron.public.ereporter_restart
+SET
+    -- This relies on there being EXACTLY ONE record in the `rack` table.
+    -- Because the left-hand side of the SET is a scalar value, the UPDATE
+    -- statement will *fail* if the `rack` table contains multiple rows, as the
+    -- `SELECT id FROM omicron.public.rack` subquery will return multiple
+    -- values. This is on purpose! We could avoid this by using `LIMIT 1` in the
+    -- subquery, but this would result in arbitrary rows being returned if the
+    -- `rack` table contains multiple rows.
+    --
+    -- This migration will only run prior to any multi-rack support in the
+    -- Omicron database, so there will never be more than one row in the `rack`
+    -- table. And, because this migration will only run after rack init, it
+    -- should never encounter an empty `rack` table. Thus, we can safely rely on
+    -- the assumption that this query will return exactly one row.
+    rack_id = (SELECT id FROM omicron.public.rack)
+WHERE
+    rack_id IS NULL;

--- a/schema/crdb/ereporter-restart-rack-id/up03.sql
+++ b/schema/crdb/ereporter-restart-rack-id/up03.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.ereporter_restart
+    ALTER COLUMN rack_id SET NOT NULL;


### PR DESCRIPTION
Currently, we do not store the rack UUID of the rack from which an ereport is collected. While this is fine for now, it will become an issue when we become multirack. In the meantime, though, I want to be able to attach a rack ID to the payload of rectifier insertion and removal alerts. While we could do this by just threading through Nexus' rack ID into the diagnosis engine and assuming that we will never be operating on ereports collected from other racks, it seemed like it was worth taking a little extra time to do the more multirack-friendly thing now, rather than having to do it later once there might actually be multiple racks in the database. Therefore, this branch adds a `rack_id` column to the `omicron.public.ereporter_restart` table recording the rack ID that the ereports with that restart ID came from.

For new ereports, the rack ID _is_ assumed to be the collecting Nexus' rack ID, but this happens at collection-time rather than in diagnosis. This will have to be changed when the `sp_ereport_ingester` background task learns to talk to SPs that live in other racks, but since it currently lacks a way of doing this, we'll have to wait until it grows one in order to fix that. For preexisting restart IDs, I've added a migration that backfills the restart ID column by selecting the current rack ID from the `omicron.public.rack` table. This migration relies on the assumption that there will always be exactly one row in that table when the migration runs. I believe this is safe to do because the migration will always run *before* updating the control plane to a version with multi-rack support, and migrations will not run on an uninitialized rack, since an uninitialized rack doesn't *have* a control plane database at all.