### PR TITLE
Oximeter: add a metric to record samples dropped in the database batc…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9899,6 +9899,7 @@ dependencies = [
  "oximeter-api",
  "oximeter-client",
  "oximeter-db",
+ "oximeter-test-utils",
  "oximeter-types",
  "proptest",
  "qorb",

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -50,6 +50,7 @@ nexus-client.workspace = true
 expectorate.workspace = true
 httpmock.workspace = true
 omicron-test-utils.workspace = true
+oximeter-test-utils.workspace = true
 openapi-lint.workspace = true
 openapiv3.workspace = true
 proptest.workspace = true

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -15,6 +15,7 @@ use crate::collection_task::ForcedCollectionError;
 use crate::probes;
 use crate::results_sink;
 use crate::self_stats;
+use crate::self_stats::DatabaseSamplesDropped;
 use anyhow::anyhow;
 use chrono::DateTime;
 use chrono::Utc;
@@ -23,6 +24,9 @@ use nexus_client::Client as NexusClient;
 use nexus_client::types::IdSortMode;
 use omicron_common::backoff;
 use omicron_common::backoff::BackoffError;
+use oximeter::Sample;
+use oximeter::types::Cumulative;
+use oximeter::types::ProducerResultsItem;
 use oximeter_db::Client;
 use oximeter_db::DbWrite;
 use oximeter_types::producer::ProducerDetails;
@@ -45,8 +49,11 @@ use std::ops::Bound;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::sync::mpsc;
+use tokio::time::interval;
 use uuid::Uuid;
 
 /// The internal agent the oximeter server uses to collect metrics from producers.
@@ -95,7 +102,7 @@ impl OximeterAgent {
             "collector_ip" => address.ip().to_string(),
         ));
         let insertion_log = log.new(o!("component" => "results-sink"));
-        let instertion_log_cluster =
+        let insertion_log_cluster =
             log.new(o!("component" => "results-sink-cluster"));
 
         // Determine the version of the database.
@@ -141,17 +148,23 @@ impl OximeterAgent {
             collector_port: address.port(),
         };
 
+        let drop_counter = Arc::new(AtomicU64::new(0));
+
         // Spawn the task for aggregating and inserting all metrics to a
         // single node ClickHouse installation.
-        tokio::spawn(async move {
-            crate::results_sink::database_batcher(
-                insertion_log,
-                client,
-                db_config.batch_size,
-                Duration::from_secs(db_config.batch_interval),
-                collection_task_wrapper.single_rx,
-            )
-            .await
+        tokio::spawn({
+            let drop_counter = drop_counter.clone();
+            async move {
+                crate::results_sink::database_batcher(
+                    insertion_log,
+                    client,
+                    db_config.batch_size,
+                    Duration::from_secs(db_config.batch_interval),
+                    collection_task_wrapper.single_rx,
+                    drop_counter,
+                )
+                .await
+            }
         });
 
         // Our internal testing rack will be running a ClickHouse cluster
@@ -184,29 +197,114 @@ impl OximeterAgent {
             &log,
         );
 
+        let cluster_drop_counter = Arc::new(AtomicU64::new(0));
+
         // Spawn the task for aggregating and inserting all metrics to a
         // replicated cluster ClickHouse installation
-        tokio::spawn(async move {
-            results_sink::database_batcher(
-                instertion_log_cluster,
-                cluster_client,
-                db_config.batch_size,
-                Duration::from_secs(db_config.batch_interval),
-                collection_task_wrapper.cluster_rx,
-            )
-            .await
+        tokio::spawn({
+            let cluster_drop_counter = cluster_drop_counter.clone();
+            async move {
+                results_sink::database_batcher(
+                    insertion_log_cluster,
+                    cluster_client,
+                    db_config.batch_size,
+                    Duration::from_secs(db_config.batch_interval),
+                    collection_task_wrapper.cluster_rx,
+                    cluster_drop_counter,
+                )
+                .await
+            }
         });
 
         let self_ = Self {
             id,
-            log,
+            log: log.clone(),
             collection_target,
-            result_sender: collection_task_wrapper.wrapper_tx,
+            result_sender: collection_task_wrapper.wrapper_tx.clone(),
             collection_tasks: Arc::new(Mutex::new(BTreeMap::new())),
             refresh_interval,
             refresh_task: Arc::new(Mutex::new(None)),
             last_refresh_time: Arc::new(Mutex::new(None)),
         };
+
+        // Periodically emit self-stats about dropped samples.
+        //
+        // Note: If oximeter isn't able to write metrics to ClickHouse,
+        // self-stats about oximeter's inability to write metrics will
+        // also never reach ClickHouse. However, we may still be able to
+        // emit these metrics if the write path to ClickHouse is partially
+        // degraded. And because the relevant counters live in oximeter's
+        // memory, even if ClickHouse becomes fully unavailable and then
+        // recovers, the metrics will also eventually reach the database.
+        //
+        // TODO: Emit a metric about failed database writes as well.
+        tokio::spawn({
+            let mut drop_ticker = interval(self_stats::COLLECTION_INTERVAL);
+            let start_time = Utc::now();
+            async move {
+                loop {
+                    drop_ticker.tick().await;
+
+                    let single_metric = DatabaseSamplesDropped {
+                        datum: Cumulative::with_start_time(
+                            start_time,
+                            drop_counter.load(Ordering::Relaxed),
+                        ),
+                        collector_sink: "clickhouse-single".into(),
+                    };
+                    let single_sample = match Sample::new(
+                        &collection_target,
+                        &single_metric,
+                    ) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!(
+                                log,
+                                "failed to build single-node samples_dropped sample";
+                                InlineErrorChain::new(&e),
+                            );
+                            continue;
+                        }
+                    };
+
+                    let cluster_metric = DatabaseSamplesDropped {
+                        datum: Cumulative::with_start_time(
+                            start_time,
+                            cluster_drop_counter.load(Ordering::Relaxed),
+                        ),
+                        collector_sink: "clickhouse-cluster".into(),
+                    };
+                    let cluster_sample = match Sample::new(
+                        &collection_target,
+                        &cluster_metric,
+                    ) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!(
+                                log,
+                                "failed to build clustered samples_dropped sample";
+                                InlineErrorChain::new(&e),
+                            );
+                            continue;
+                        }
+                    };
+
+                    let _ = collection_task_wrapper
+                        .wrapper_tx
+                        .send(
+                            CollectionTaskOutput {
+                                results: vec![ProducerResultsItem::Ok(vec![
+                                    single_sample,
+                                    cluster_sample,
+                                ])],
+                                was_forced_collection: false,
+                            },
+                            &log,
+                        )
+                        .await;
+                }
+            }
+        });
 
         Ok(self_)
     }
@@ -271,6 +369,8 @@ impl OximeterAgent {
                 client.init_replicated_db().await?;
             }
 
+            let drop_counter = Arc::new(AtomicU64::new(0));
+
             // Spawn the task for aggregating and inserting all metrics
             tokio::spawn(async move {
                 results_sink::database_batcher(
@@ -279,6 +379,7 @@ impl OximeterAgent {
                     db_config.batch_size,
                     Duration::from_secs(db_config.batch_interval),
                     collection_task_wrapper.single_rx,
+                    drop_counter,
                 )
                 .await
             });

--- a/oximeter/collector/src/results_sink.rs
+++ b/oximeter/collector/src/results_sink.rs
@@ -26,6 +26,8 @@ use slog_error_chain::InlineErrorChain;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
@@ -43,6 +45,7 @@ pub async fn database_batcher(
     batch_size: usize,
     batch_interval: Duration,
     mut rx: mpsc::Receiver<CollectionTaskOutput>,
+    dropped_counter: Arc<AtomicU64>,
 ) {
     // Construct a handoff point between the batch task here, and the database
     // insertion task.
@@ -120,6 +123,7 @@ pub async fn database_batcher(
                                 "sample buffer full, dropped oldest samples";
                                 "n_dropped" => n_dropped,
                             );
+                            dropped_counter.fetch_add(n_dropped as u64, Ordering::Relaxed);
                         }
                     }
                     None => {
@@ -313,6 +317,7 @@ pub async fn logger(log: Logger, mut rx: mpsc::Receiver<CollectionTaskOutput>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use omicron_test_utils::dev::test_setup_log;
     use proptest::prelude::*;
     use tokio::time::timeout;
 
@@ -423,5 +428,43 @@ mod tests {
                 }).expect_err("Should not be notified");
             }
         }
+    }
+
+    #[tokio::test]
+    async fn batcher_increments_dropped_counter() {
+        let logctx = test_setup_log("batcher_increments_dropped_counter");
+        let log = &logctx.log;
+
+        // Construct a database batcher with a dummy ClickHouse client.
+        let client = Client::new("[::1]:0".parse().unwrap(), log);
+        let (tx, rx) = mpsc::channel(1);
+        let counter = Arc::new(AtomicU64::new(0));
+        let batcher = tokio::spawn(database_batcher(
+            log.clone(),
+            client,
+            BATCH_SIZE,
+            Duration::from_secs(3600),
+            rx,
+            counter.clone(),
+        ));
+
+        // Insert `want_dropped` too many samples into the batcher.
+        let want_dropped = 50;
+        let samples = (0..MAX_BUFFER_SIZE + want_dropped)
+            .map(|_| oximeter_test_utils::make_sample())
+            .collect();
+        tx.send(CollectionTaskOutput {
+            results: vec![ProducerResultsItem::Ok(samples)],
+            was_forced_collection: false,
+        })
+        .await
+        .unwrap();
+
+        // Drop the sender so that the batcher loop exits.
+        drop(tx);
+        batcher.await.unwrap();
+
+        assert_eq!(counter.load(Ordering::Relaxed), want_dropped as u64);
+        logctx.cleanup_successful();
     }
 }

--- a/oximeter/collector/src/self_stats.rs
+++ b/oximeter/collector/src/self_stats.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 oximeter::use_timeseries!("oximeter-collector.toml");
 pub use self::oximeter_collector::Collections;
+pub use self::oximeter_collector::DatabaseSamplesDropped;
 pub use self::oximeter_collector::FailedCollections;
 pub use self::oximeter_collector::OximeterCollector;
 

--- a/oximeter/oximeter/schema/oximeter-collector.toml
+++ b/oximeter/oximeter/schema/oximeter-collector.toml
@@ -26,6 +26,15 @@ versions = [
     { added_in = 1, fields = [ "base_route", "producer_id", "producer_ip", "producer_port", "reason" ] }
 ]
 
+[[metrics]]
+name = "database_samples_dropped"
+description = "Total number of samples dropped from the database queue"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [ "collector_sink" ] }
+]
+
 [fields.base_route]
 type = "string"
 description = "Base HTTP route used to request data from the producer"
@@ -41,6 +50,10 @@ description = "IP address of the oximeter collector instance"
 [fields.collector_port]
 type = "u16"
 description = "Port of the oximeter collector instance"
+
+[fields.collector_sink]
+type = "string"
+description = "Name of collector metrics destination"
 
 [fields.producer_id]
 type = "uuid"


### PR DESCRIPTION
…her.

Oximeter sends samples from all collection tasks to a shared database batcher, which then inserts samples into clickhouse. The database batcher uses a bounded queue that drops old samples when adding a new sample would overflow the queue. We currently log a warning when dropping an old sample, but operators would have to proactively check those logs in order to notice data loss via this queue. To make dropped samples more visible, this patches introduces a new oximeter metric that counts the number of dropped samples in the database batcher.

Note: if the batcher isn't able to push samples to the database at all, we won't be able to record the new metric! However, we write the new metric at the head of the queue, and dropped sample counts persist for the lifetime of the oximeter agent, so we'll be able to push metrics unless the queue is wildly oversaturated.

Part of #10552.