### PR TITLE
schema/crdb: correct README + comments on which DDL gets .verify.sql

### DIFF
--- a/nexus/db-queries/src/db/datastore/db_metadata.rs
+++ b/nexus/db-queries/src/db/datastore/db_metadata.rs
@@ -807,9 +807,11 @@ impl DataStore {
     /// Runs pre-computed verification SQL (from a `.verify.sql` file) in a
     /// **separate transaction** from the DDL that was just applied.
     /// The verification SQL is generated at test time by parsing each
-    /// migration and detecting operations that involve async backfill in
-    /// CockroachDB (CREATE INDEX, ALTER COLUMN SET NOT NULL, ADD CONSTRAINT,
-    /// ADD COLUMN with backfill).
+    /// migration and detecting operations whose async backfill or validation
+    /// can outlast the statement that issued it (CREATE INDEX and validating
+    /// ADD CONSTRAINT). Operations like ALTER COLUMN SET NOT NULL and ADD
+    /// COLUMN are excluded: their issuing statement blocks on the
+    /// schema-change job, so on success the change has already landed.
     ///
     /// If verification fails, the error propagates immediately — the outer
     /// startup retry loop will re-attempt the entire migration.

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -177,9 +177,8 @@ async fn apply_update(
 
         // After applying the step, run its verification SQL (if any) in a
         // separate transaction — just like the real Nexus startup path does.
-        // This confirms that async backfill operations (CREATE INDEX,
-        // ALTER COLUMN SET NOT NULL, ADD CONSTRAINT, ADD COLUMN with
-        // backfill) actually completed.
+        // This confirms that async backfill operations (CREATE INDEX and
+        // validating ADD CONSTRAINT) actually completed.
         if let Some(verify_sql) = step.verification_sql() {
             info!(
                 log,

--- a/schema/crdb/README.adoc
+++ b/schema/crdb/README.adoc
@@ -101,16 +101,23 @@ Process:
   updated `SCHEMA_VERSION` but not the database schema version).
 * Generate verification files by running
   `EXPECTORATE=overwrite cargo nextest run -p nexus-db-model 'test_migration_verification_files'`.
-  This auto-generates `.verify.sql` files for any migration steps that contain
-  DDL with async backfill operations (`CREATE INDEX`, `ADD CONSTRAINT`,
-  `ALTER COLUMN SET NOT NULL`, or `ADD COLUMN` with `NOT NULL` / non-null
-  `DEFAULT` / `STORED` computed columns).  Check these files in alongside the
-  migration.  If your migration doesn't contain backfill-prone DDL, no
-  `.verify.sql` file is generated and nothing changes.
+  This auto-generates `.verify.sql` files for migration steps containing DDL
+  whose backfill or validation can outlast the statement that issued it, namely
+  `CREATE INDEX` and validating `ADD CONSTRAINT` (anything other than
+  `NOT VALID`).  Check these files in alongside the migration.  If your
+  migration doesn't contain such DDL, no `.verify.sql` file is generated and
+  nothing changes.
 +
 At runtime, after applying each migration step, Nexus runs the verification
 queries from the corresponding `.verify.sql` file (if one exists) in a
 separate transaction to confirm the async backfill actually completed.
++
+DDL whose validation completes before its statement returns is intentionally
+excluded.  For example, `ALTER COLUMN ... SET NOT NULL` and `ADD COLUMN`
+(including the `NOT NULL`, non-null `DEFAULT`, and `STORED` variants) run their
+backfill or validation inside a schema-change job that the issuing statement
+blocks on, so on a successful return the change has already landed and there is
+nothing left to verify.
 
 There are automated tests to validate many of these steps:
 


### PR DESCRIPTION
The README and two code comments claimed `.verify.sql` files are auto-generated for `ALTER COLUMN SET NOT NULL` and `ADD COLUMN` with `NOT NULL` / non-null `DEFAULT` / `STORED`. They are not: `test_migration_verification_files` classifies those as `OtherDdl`, which produces no verification query.

Only `CREATE INDEX` and `ADD CONSTRAINT` actually generate a `.verify.sql` file. `SET NOT NULL` and `ADD COLUMN` run their validation inside a schema-change job that the issuing statement blocks on (this all happens internally in CRDB, via `JobRegistry.Run`), so on a successful return the change has already landed and there is nothing left to verify afterwards.

This corrects the README list, documents why those operations are excluded, and fixes the matching comments in `db_metadata.rs` and the schema integration test.

This PR is documentation/comment-only; no functional code changes.