### PR TITLE
scrimlet-reconcilers: add lldpd SMF reconciler

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -34,10 +34,21 @@ workspace-members = [
     # Exclude dev-tools-common and xtask because they need to be built quickly.
     "dev-tools-common",
     "xtask",
-    
+
     # Exclude omicron-uuid-kinds because it is a no-std crate. Depending on the
     # workspace-hack isn't too problematic because other projects pulling in
     # omicron as a git dependency will only see an empty workspace-hack. But
     # let's make this explicit.
     "omicron-uuid-kinds",
+]
+
+[final-excludes]
+third-party = [
+    # `scuffle` has a `testing` features that's pulled in when it's used as a
+    # dev-dependency. This feature enables some gnarly stuff (poking at
+    # undocumented and unstable features in illumos's libscf), and should not
+    # be enabled to the workspace-hack. If/when hakari adds a way to exclude
+    # a feature only we can use that; until then, it's fine to just exclude
+    # this crate entirely: it's not very big and isn't used by many things.
+    { name = "scuffle" },
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9542,7 +9542,6 @@ dependencies = [
  "rustls",
  "schemars 0.8.22",
  "scopeguard",
- "scuffle",
  "semver 1.0.28",
  "serde",
  "serde_core",

--- a/sled-agent/scrimlet-reconcilers/src/handle.rs
+++ b/sled-agent/scrimlet-reconcilers/src/handle.rs
@@ -8,6 +8,7 @@
 
 use crate::DetermineSwitchSlotStatus;
 use crate::dpd_reconciler::DpdReconciler;
+use crate::lldpd_reconciler::LldpdReconciler;
 use crate::mgd_reconciler::MgdReconciler;
 use crate::reconciler_task::ReconcilerTaskHandle;
 use crate::status::ScrimletReconcilersStatus;
@@ -223,11 +224,13 @@ impl ScrimletReconcilers {
         if let Some(running) = self.running_reconcilers.get() {
             let RunningReconcilers {
                 dpd_reconciler,
+                lldpd_reconciler,
                 mgd_reconciler,
                 uplinkd_reconciler,
             } = running;
             ScrimletReconcilersStatus::Running {
                 dpd_reconciler: dpd_reconciler.status(),
+                lldpd_reconciler: lldpd_reconciler.status(),
                 mgd_reconciler: mgd_reconciler.status(),
                 uplinkd_reconciler: uplinkd_reconciler.status(),
             }
@@ -359,6 +362,7 @@ async fn determine_switch_slot(
 #[derive(Debug)]
 struct RunningReconcilers {
     dpd_reconciler: ReconcilerTaskHandle<DpdReconciler>,
+    lldpd_reconciler: ReconcilerTaskHandle<LldpdReconciler>,
     mgd_reconciler: ReconcilerTaskHandle<MgdReconciler>,
     uplinkd_reconciler: ReconcilerTaskHandle<UplinkdReconciler>,
 }
@@ -371,6 +375,13 @@ impl RunningReconcilers {
         parent_log: &Logger,
     ) -> Self {
         let dpd_reconciler = ReconcilerTaskHandle::<DpdReconciler>::spawn(
+            scrimlet_status_rx.clone(),
+            networking_info.system_networking_config_rx.clone(),
+            networking_info.mode,
+            this_sled_switch_slot,
+            parent_log,
+        );
+        let lldpd_reconciler = ReconcilerTaskHandle::<LldpdReconciler>::spawn(
             scrimlet_status_rx.clone(),
             networking_info.system_networking_config_rx.clone(),
             networking_info.mode,
@@ -392,7 +403,12 @@ impl RunningReconcilers {
                 this_sled_switch_slot,
                 parent_log,
             );
-        Self { dpd_reconciler, mgd_reconciler, uplinkd_reconciler }
+        Self {
+            dpd_reconciler,
+            lldpd_reconciler,
+            mgd_reconciler,
+            uplinkd_reconciler,
+        }
     }
 }
 

--- a/sled-agent/scrimlet-reconcilers/src/lib.rs
+++ b/sled-agent/scrimlet-reconcilers/src/lib.rs
@@ -44,6 +44,7 @@
 
 mod dpd_reconciler;
 mod handle;
+mod lldpd_reconciler;
 mod mgd_reconciler;
 mod reconciler_task;
 mod status;
@@ -58,6 +59,7 @@ pub use dpd_reconciler::DpdReconcilerStatus;
 pub use handle::ScrimletReconcilers;
 pub use handle::ScrimletReconcilersMode;
 pub use handle::SledAgentNetworkingInfo;
+pub use lldpd_reconciler::LldpdReconcilerStatus;
 pub use mgd_reconciler::MgdBgpReconcilerStatus;
 pub use mgd_reconciler::MgdBgpReconcilerStatusOpCount;
 pub use mgd_reconciler::MgdReconcilerStatus;

--- a/sled-agent/scrimlet-reconcilers/src/lldpd_reconciler.rs
+++ b/sled-agent/scrimlet-reconcilers/src/lldpd_reconciler.rs
@@ -1,0 +1,428 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Reconciler for configuration of `lldpd` within a scrimlet's switch zone.
+//!
+//! Unlike most reconcilers in this crate, `lldpd`'s configuration is managed
+//! via SMF, not a dropshot server.
+
+use crate::SWITCH_ZONE_NAME;
+use crate::ScrimletReconcilersMode;
+use crate::reconciler_task::Reconciler;
+use crate::switch_zone_slot::ThisSledSwitchSlot;
+use anyhow::anyhow;
+use anyhow::bail;
+use scuffle::AddPropertyGroupFlags;
+use scuffle::EditPropertyGroups;
+use scuffle::HasComposedPropertyGroups;
+use scuffle::HasDirectPropertyGroups;
+use scuffle::Instance;
+use scuffle::PropertyGroupType;
+use scuffle::Scf;
+use scuffle::Value;
+use scuffle::ValueKind;
+use scuffle::ValueRef;
+use scuffle::error::SingleValueError;
+use sled_agent_types::early_networking::LldpAdminStatus;
+use sled_agent_types::early_networking::RackNetworkConfig;
+use sled_agent_types::system_networking::SystemNetworkingConfig;
+use slog::Logger;
+use slog::info;
+use slog::warn;
+use slog_error_chain::InlineErrorChain;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+// SMF service/instance names
+const LLDPD_SERVICE_NAME: &str = "oxide/lldpd";
+const LLDPD_INSTANCE_NAME: &str = "default";
+
+// All the properties we set live underneath property groups named
+// `port_{port_name}`.
+const LLDPD_PORT_PG_PREFIX: &str = "port_";
+
+mod property_name {
+    pub(super) const STATUS: &str = "status";
+    pub(super) const CHASSIS_ID: &str = "chassis_id";
+    pub(super) const PORT_ID: &str = "port_id";
+    pub(super) const PORT_DESCRIPTION: &str = "port_description";
+    pub(super) const SYSTEM_NAME: &str = "system_name";
+    pub(super) const SYSTEM_DESCRIPTION: &str = "system_description";
+    pub(super) const MANAGEMENT_ADDRS: &str = "management_addrs";
+}
+
+#[derive(Debug, Clone)]
+pub enum LldpdReconcilerStatus {
+    Failed(String),
+    SkippedConfigUpToDate,
+    Reconciled { ports: BTreeMap<String, LldpAdminStatus> },
+}
+
+impl slog::KV for LldpdReconcilerStatus {
+    fn serialize(
+        &self,
+        _record: &slog::Record<'_>,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        match self {
+            LldpdReconcilerStatus::Failed(reason) => {
+                serializer.emit_str("lldpd".into(), reason)
+            }
+            LldpdReconcilerStatus::SkippedConfigUpToDate => serializer
+                .emit_str("lldpd".into(), "skipped: config up-to-date"),
+            LldpdReconcilerStatus::Reconciled { ports } => serializer
+                .emit_usize("lldpd-reconciled-ports".into(), ports.len()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct LldpdReconciler {
+    switch_slot: ThisSledSwitchSlot,
+    is_running_in_test_mode: bool,
+}
+
+impl Reconciler for LldpdReconciler {
+    type Status = LldpdReconcilerStatus;
+
+    const LOGGER_COMPONENT_NAME: &'static str = "LldpdReconciler";
+    const RE_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
+
+    fn new(
+        mode: ScrimletReconcilersMode,
+        switch_slot: ThisSledSwitchSlot,
+        _parent_log: &slog::Logger,
+    ) -> Self {
+        let is_running_in_test_mode = match mode {
+            ScrimletReconcilersMode::SwitchZone(_) => false,
+            #[cfg(any(test, feature = "testing"))]
+            ScrimletReconcilersMode::Test { .. } => true,
+        };
+        Self { switch_slot, is_running_in_test_mode }
+    }
+
+    async fn do_reconciliation(
+        &mut self,
+        system_networking_config: &SystemNetworkingConfig,
+        log: &slog::Logger,
+    ) -> Self::Status {
+        if self.is_running_in_test_mode {
+            // We can't run SMF-based reconcilers in test mode. We could thread
+            // through a separate status variant just for this, but that'd be a
+            // little painful for upstream callers; it's probably okay to report
+            // any status, so we pick `Failed` to give a description of why we
+            // didn't run.
+            return LldpdReconcilerStatus::Failed(
+                "reconcilation disabled \
+                 (SMF within the switch zone not available in test mode)"
+                    .to_string(),
+            );
+        }
+
+        let result = {
+            let config = system_networking_config.rack_network_config.clone();
+            let log = log.clone();
+            let switch_slot = self.switch_slot;
+            tokio::task::spawn_blocking(move || {
+                do_reconciliation_blocking(&config, switch_slot, &log)
+            })
+            .await
+        };
+
+        match result {
+            Ok(Ok(status)) => status,
+            Ok(Err(err)) => LldpdReconcilerStatus::Failed(format!(
+                "reconciliation failed: {}",
+                InlineErrorChain::new(&*err)
+            )),
+            Err(err) => {
+                // We don't expect any of these cases, except possibly during
+                // tokio runtime shutdown in unit tests, but it's easy to map
+                // them to errors instead of panicking ourselves.
+                if err.is_cancelled() {
+                    LldpdReconcilerStatus::Failed(
+                        "do_reconciliation_blocking() \
+                         was cancelled unexpectedly"
+                            .to_string(),
+                    )
+                } else if err.is_panic() {
+                    LldpdReconcilerStatus::Failed(
+                        "do_reconciliation_blocking() panicked".to_string(),
+                    )
+                } else {
+                    LldpdReconcilerStatus::Failed(
+                        "tokio::task::spawn_blocking() failed without \
+                         being cancelled or panicking ?!"
+                            .to_string(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+fn do_reconciliation_blocking(
+    config: &RackNetworkConfig,
+    our_switch_slot: ThisSledSwitchSlot,
+    log: &Logger,
+) -> anyhow::Result<LldpdReconcilerStatus> {
+    // Connect to SMF inside the zone.
+    let scf = Scf::connect_zone(SWITCH_ZONE_NAME)?;
+
+    // Forward to the real function; it's separate so unit tests can connect to
+    // an isolated `svc.configd` instead of requiring a real switch zone.
+    do_reconciliation_blocking_impl(&scf, config, our_switch_slot, log)
+}
+
+fn do_reconciliation_blocking_impl(
+    scf: &Scf<'_>,
+    config: &RackNetworkConfig,
+    our_switch_slot: ThisSledSwitchSlot,
+    log: &Logger,
+) -> anyhow::Result<LldpdReconcilerStatus> {
+    let scope = scf.scope_local()?;
+    let Some(service) = scope.service(LLDPD_SERVICE_NAME)? else {
+        bail!("no `{LLDPD_SERVICE_NAME}` service present in switch zone");
+    };
+    let Some(mut instance) = service.instance(LLDPD_INSTANCE_NAME)? else {
+        bail!("no `{LLDPD_INSTANCE_NAME}` instance within {}", service.fmri());
+    };
+
+    info!(log, "reading properties from running snapshot");
+    let current_properties = current_port_configs(&instance, log)?;
+    let (desired_properties, ports_by_status) =
+        desired_port_configs(config, our_switch_slot);
+
+    // We could compute exact diffs to know exactly what properties need to be
+    // removed / added / changed, but we'd need to compute _two_ diffs:
+    //
+    // 1. Does the running snapshot match the desired config? If so, nothing to
+    //    do.
+    // 2. If not, we have to compute a diff against the current instance
+    //    properties, not the running snapshot - it's possible a previous
+    //    reconciliation attempt changed the instance properties but failed to
+    //    refresh, so this could be in any previous state.
+    //
+    // Instead, we do something simpler: if the running snapshot matches the
+    // desired config, we do nothing; otherwise, we apply the new config
+    // wholesale without computing a precise diff. `apply_config()` deletes all
+    // port property groups entirely, then creates only the ones described by
+    // `desired_properties`.
+    if current_properties == desired_properties {
+        Ok(LldpdReconcilerStatus::SkippedConfigUpToDate)
+    } else {
+        info!(log, "applying new configuration");
+        apply_config(&mut instance, &desired_properties)?;
+        Ok(LldpdReconcilerStatus::Reconciled { ports: ports_by_status })
+    }
+}
+
+fn apply_config(
+    instance: &mut Instance<'_>,
+    ports: &BTreeMap<String, DiffablePortConfig>,
+) -> anyhow::Result<()> {
+    // Delete all preexisting `port_*` property groups.
+    let mut pgs_to_delete = Vec::new();
+    for pg in instance.property_groups_direct()? {
+        let pg = pg?;
+        if pg.name().starts_with(LLDPD_PORT_PG_PREFIX) {
+            pgs_to_delete.push(pg.name().to_owned());
+        }
+    }
+    for pg_name in pgs_to_delete {
+        instance.delete_property_group(&pg_name)?;
+    }
+
+    // Add new property groups for all desired ports.
+    for (pg_name, config) in ports {
+        let mut pg = instance.add_property_group(
+            pg_name,
+            PropertyGroupType::Application,
+            AddPropertyGroupFlags::Persistent,
+        )?;
+
+        let mut tx = pg.transaction()?.start()?;
+        for (field_name, field_value) in config.string_fields() {
+            if let Some(field_value) = field_value {
+                tx.property_new(field_name, ValueRef::AString(field_value))?;
+            }
+        }
+        if !config.management_addrs.is_empty() {
+            tx.property_new_multiple(
+                property_name::MANAGEMENT_ADDRS,
+                ValueKind::AString,
+                config.management_addrs.iter().map(|ip| ValueRef::AString(ip)),
+            )?;
+        }
+        tx.commit()?;
+    }
+
+    instance.smf_refresh()?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct DiffablePortConfig {
+    status: Option<String>,
+    chassis_id: Option<String>,
+    port_id: Option<String>,
+    port_description: Option<String>,
+    system_name: Option<String>,
+    system_description: Option<String>,
+    management_addrs: BTreeSet<String>,
+}
+
+impl DiffablePortConfig {
+    fn string_fields(
+        &self,
+    ) -> impl Iterator<Item = (&'static str, Option<&str>)> {
+        [
+            (property_name::STATUS, self.status.as_deref()),
+            (property_name::CHASSIS_ID, self.chassis_id.as_deref()),
+            (property_name::PORT_ID, self.port_id.as_deref()),
+            (property_name::PORT_DESCRIPTION, self.port_description.as_deref()),
+            (property_name::SYSTEM_NAME, self.system_name.as_deref()),
+            (
+                property_name::SYSTEM_DESCRIPTION,
+                self.system_description.as_deref(),
+            ),
+        ]
+        .into_iter()
+    }
+
+    fn string_fields_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&'static str, &mut Option<String>)> {
+        [
+            (property_name::STATUS, &mut self.status),
+            (property_name::CHASSIS_ID, &mut self.chassis_id),
+            (property_name::PORT_ID, &mut self.port_id),
+            (property_name::PORT_DESCRIPTION, &mut self.port_description),
+            (property_name::SYSTEM_NAME, &mut self.system_name),
+            (property_name::SYSTEM_DESCRIPTION, &mut self.system_description),
+        ]
+        .into_iter()
+    }
+}
+
+fn current_port_configs(
+    instance: &Instance<'_>,
+    log: &Logger,
+) -> anyhow::Result<BTreeMap<String, DiffablePortConfig>> {
+    let snapshot = instance
+        .snapshot("running")?
+        .ok_or_else(|| anyhow!("no running snapshot for lldpd"))?;
+
+    let mut port_configs = BTreeMap::new();
+
+    for pg in snapshot.property_groups_composed()? {
+        let pg = pg?;
+
+        // skip property groups that we're not responsible for reconciling
+        if !pg.name().starts_with(LLDPD_PORT_PG_PREFIX) {
+            continue;
+        }
+
+        let mut config = DiffablePortConfig::default();
+        for (prop_name, destination) in config.string_fields_mut() {
+            let Some(prop) = pg.property(prop_name)? else {
+                continue;
+            };
+            match prop.single_value() {
+                Ok(Value::AString(value)) => {
+                    *destination = Some(value);
+                }
+                Ok(value) => {
+                    warn!(
+                        log,
+                        "ignoring unexpected SMF property value type";
+                        "property" => prop.fmri(),
+                        "type" => %value.kind(),
+                        "value" => %value.display_smf(),
+                    );
+                }
+                Err(SingleValueError::NoValues { .. }) => {
+                    warn!(
+                        log, "SMF property exists but has no values";
+                        "property" => prop.fmri(),
+                    );
+                }
+                Err(SingleValueError::MultipleValues { .. }) => {
+                    warn!(
+                        log,
+                        "ignoring SMF property with multiple values";
+                        "property" => prop.fmri(),
+                    );
+                }
+                Err(err @ SingleValueError::IterError(_)) => bail!(err),
+            }
+        }
+
+        if let Some(prop) = pg.property(property_name::MANAGEMENT_ADDRS)? {
+            for value in prop.values()? {
+                match value? {
+                    Value::AString(value) => {
+                        config.management_addrs.insert(value);
+                    }
+                    other => {
+                        warn!(
+                            log,
+                            "ignoring unexpected SMF property value type";
+                            "property" => prop.fmri(),
+                            "type" => %other.kind(),
+                            "value" => %other.display_smf(),
+                        );
+                    }
+                }
+            }
+        }
+
+        port_configs.insert(pg.name().to_string(), config);
+    }
+
+    Ok(port_configs)
+}
+
+fn desired_port_configs(
+    rack_config: &RackNetworkConfig,
+    our_switch_slot: ThisSledSwitchSlot,
+) -> (BTreeMap<String, DiffablePortConfig>, BTreeMap<String, LldpAdminStatus>) {
+    let mut desired_ports = BTreeMap::new();
+    let mut ports_by_status = BTreeMap::new();
+
+    for port_config in
+        rack_config.ports.iter().filter(|port| port.switch == our_switch_slot)
+    {
+        let Some(config) = port_config.lldp.as_ref() else {
+            continue;
+        };
+
+        ports_by_status.insert(port_config.port.clone(), config.status);
+
+        let name = format!("{LLDPD_PORT_PG_PREFIX}{}", port_config.port);
+        let value = DiffablePortConfig {
+            status: Some(config.status.to_lldpd_smf_property().to_owned()),
+            chassis_id: config.chassis_id.clone(),
+            port_id: config.port_id.clone(),
+            port_description: config.port_description.clone(),
+            system_name: config.system_name.clone(),
+            system_description: config.system_description.clone(),
+            management_addrs: config
+                .management_addrs
+                .iter()
+                .flatten()
+                .map(|ip| ip.to_string())
+                .collect(),
+        };
+        desired_ports.insert(name, value);
+    }
+
+    (desired_ports, ports_by_status)
+}
+
+// Our tests require smf, which is only available on illumos.
+#[cfg(all(test, target_os = "illumos"))]
+mod tests;

--- a/sled-agent/scrimlet-reconcilers/src/lldpd_reconciler.rs
+++ b/sled-agent/scrimlet-reconcilers/src/lldpd_reconciler.rs
@@ -115,7 +115,7 @@ impl Reconciler for LldpdReconciler {
             // any status, so we pick `Failed` to give a description of why we
             // didn't run.
             return LldpdReconcilerStatus::Failed(
-                "reconcilation disabled \
+                "reconciliation disabled \
                  (SMF within the switch zone not available in test mode)"
                     .to_string(),
             );

--- a/sled-agent/scrimlet-reconcilers/src/lldpd_reconciler/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/lldpd_reconciler/tests.rs
@@ -1,0 +1,333 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::*;
+use proptest::collection::btree_map;
+use proptest::prelude::*;
+use scuffle::AddPropertyGroupFlags;
+use scuffle::EditPropertyGroups;
+use scuffle::HasComposedPropertyGroups;
+use scuffle::PropertyGroupType;
+use scuffle::Scf;
+use scuffle::Scope;
+use scuffle::Value;
+use scuffle::ValueKind;
+use scuffle::isolated::IsolatedConfigd;
+use sled_agent_types::early_networking::LinkSpeed;
+use sled_agent_types::early_networking::LldpPortConfig;
+use sled_agent_types::early_networking::PortConfig;
+use sled_agent_types::early_networking::RackNetworkConfig;
+use sled_agent_types::early_networking::SwitchSlot;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use test_strategy::Arbitrary;
+
+// arbitrary port name
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+struct PortName(#[strategy(r"[a-z]{1,5}")] String);
+
+#[derive(Debug, Clone, Arbitrary)]
+enum PortSetup {
+    // Port should exist before reconciliation then be removed
+    Remove(LldpPortConfig),
+    // Port should not exist before reconciliation and should be added
+    Add(LldpPortConfig),
+    // Port should exist and remain unchanged after reconciliation
+    Unchanged(LldpPortConfig),
+    // Port should exist both before and after but have different config
+    // after reconciliation (except when proptest gives us the same values for
+    // both, in which case this goes to "unchanged" instead).
+    Change { before: LldpPortConfig, after: LldpPortConfig },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct LldpSmfProperties {
+    single_valued: BTreeMap<String, String>,
+    management_addrs: BTreeSet<String>,
+}
+
+impl From<&'_ LldpPortConfig> for LldpSmfProperties {
+    fn from(value: &'_ LldpPortConfig) -> Self {
+        let LldpPortConfig {
+            status,
+            chassis_id,
+            port_id,
+            port_description,
+            system_name,
+            system_description,
+            management_addrs,
+        } = value;
+
+        let mut single_valued = BTreeMap::new();
+        single_valued.insert(
+            property_name::STATUS.to_owned(),
+            status.to_lldpd_smf_property().to_owned(),
+        );
+        for (name, val) in [
+            (property_name::CHASSIS_ID, chassis_id),
+            (property_name::PORT_ID, port_id),
+            (property_name::PORT_DESCRIPTION, port_description),
+            (property_name::SYSTEM_NAME, system_name),
+            (property_name::SYSTEM_DESCRIPTION, system_description),
+        ] {
+            if let Some(val) = val {
+                single_valued.insert(name.to_owned(), val.clone());
+            }
+        }
+
+        let management_addrs = management_addrs
+            .iter()
+            .flatten()
+            .map(|ip| ip.to_string())
+            .collect();
+
+        Self { single_valued, management_addrs }
+    }
+}
+
+#[derive(Debug, Clone, Arbitrary)]
+struct TestSetup {
+    #[strategy(btree_map(any::<PortName>(), any::<PortSetup>(), 1..=8))]
+    ports: BTreeMap<PortName, PortSetup>,
+}
+
+impl TestSetup {
+    // Ports that should exist before reconciliation.
+    fn before_ports(&self) -> impl Iterator<Item = (&str, &LldpPortConfig)> {
+        self.ports.iter().filter_map(|(port, port_setup)| match port_setup {
+            PortSetup::Add(_) => None,
+            PortSetup::Remove(config)
+            | PortSetup::Unchanged(config)
+            | PortSetup::Change { before: config, after: _ } => {
+                Some((port.0.as_str(), config))
+            }
+        })
+    }
+
+    // Ports that should exist after reconciliation.
+    fn after_ports(&self) -> impl Iterator<Item = (&str, &LldpPortConfig)> {
+        self.ports.iter().filter_map(|(port, port_setup)| match port_setup {
+            PortSetup::Remove(_) => None,
+            PortSetup::Add(config)
+            | PortSetup::Unchanged(config)
+            | PortSetup::Change { before: _, after: config } => {
+                Some((port.0.as_str(), config))
+            }
+        })
+    }
+
+    fn expected_before(&self) -> BTreeMap<String, LldpSmfProperties> {
+        Self::expected_common(self.before_ports())
+    }
+
+    fn expected_after(&self) -> BTreeMap<String, LldpSmfProperties> {
+        Self::expected_common(self.after_ports())
+    }
+
+    fn expected_common<'a>(
+        ports: impl Iterator<Item = (&'a str, &'a LldpPortConfig)>,
+    ) -> BTreeMap<String, LldpSmfProperties> {
+        ports
+            .map(|(port, config)| {
+                (
+                    format!("{LLDPD_PORT_PG_PREFIX}{port}"),
+                    LldpSmfProperties::from(config),
+                )
+            })
+            .collect()
+    }
+
+    fn rack_network_config(&self) -> RackNetworkConfig {
+        let mut ports = Vec::new();
+
+        for (port, config) in self.after_ports() {
+            ports.push(PortConfig {
+                routes: Vec::new(),
+                addresses: Vec::new(),
+                switch: SwitchSlot::Switch0,
+                port: port.to_owned(),
+                uplink_port_speed: LinkSpeed::Speed100G,
+                uplink_port_fec: None,
+                bgp_peers: Vec::new(),
+                autoneg: false,
+                lldp: Some(config.clone()),
+                tx_eq: None,
+            });
+        }
+
+        RackNetworkConfig {
+            rack_subnet: "fd00::/48".parse().unwrap(),
+            infra_ip_first: "10.0.0.1".parse().unwrap(),
+            infra_ip_last: "10.0.0.100".parse().unwrap(),
+            ports,
+            bgp: Vec::new(),
+            bfd: Vec::new(),
+        }
+    }
+}
+
+fn erase_port_configs(scope: &Scope<'_>) {
+    let service = scope.service("oxide/lldpd").unwrap().unwrap();
+    let mut instance = service.instance("default").unwrap().unwrap();
+
+    let mut pgs_to_delete = Vec::new();
+    for pg in instance.property_groups_direct().unwrap() {
+        let pg = pg.unwrap();
+        if pg.name().starts_with(LLDPD_PORT_PG_PREFIX) {
+            pgs_to_delete.push(pg.name().to_owned());
+        }
+    }
+    for pg_name in pgs_to_delete {
+        instance.delete_property_group(&pg_name).unwrap();
+    }
+}
+
+fn apply_port_configs(
+    scope: &Scope<'_>,
+    configs: BTreeMap<String, LldpSmfProperties>,
+    refresh_instance: bool,
+) {
+    let service = scope.service("oxide/lldpd").unwrap().unwrap();
+    let mut instance = service.instance("default").unwrap().unwrap();
+
+    for (pg_name, config) in configs {
+        let mut pg = instance
+            .add_property_group(
+                &pg_name,
+                PropertyGroupType::Application,
+                AddPropertyGroupFlags::Persistent,
+            )
+            .unwrap();
+
+        let mut tx = pg.transaction().unwrap().start().unwrap();
+
+        for (name, val) in config.single_valued {
+            tx.property_new(&name, ValueRef::AString(&val)).unwrap();
+        }
+        if !config.management_addrs.is_empty() {
+            tx.property_new_multiple(
+                property_name::MANAGEMENT_ADDRS,
+                ValueKind::AString,
+                config.management_addrs.iter().map(|ip| ValueRef::AString(ip)),
+            )
+            .unwrap();
+        }
+
+        tx.commit().unwrap();
+    }
+
+    if refresh_instance {
+        instance.smf_refresh().unwrap();
+    }
+}
+
+fn config_of_running_snapshot(
+    scope: &Scope<'_>,
+) -> BTreeMap<String, LldpSmfProperties> {
+    let service = scope.service("oxide/lldpd").unwrap().unwrap();
+    let instance = service.instance("default").unwrap().unwrap();
+    let snapshot = instance.snapshot("running").unwrap().unwrap();
+
+    let mut config_pgs = BTreeMap::new();
+    for pg in snapshot.property_groups_composed().unwrap() {
+        let pg = pg.unwrap();
+        if !pg.name().starts_with(LLDPD_PORT_PG_PREFIX) {
+            continue;
+        }
+        let mut props = LldpSmfProperties::default();
+        for property in pg.properties().unwrap() {
+            let property = property.unwrap();
+            if property.name() == property_name::MANAGEMENT_ADDRS {
+                for value in property.values().unwrap() {
+                    match value.unwrap() {
+                        Value::AString(value) => {
+                            props.management_addrs.insert(value);
+                        }
+                        other => panic!("unexpected property value: {other:?}"),
+                    }
+                }
+            } else {
+                let value = property.single_value().unwrap();
+                match value {
+                    Value::AString(value) => {
+                        props
+                            .single_valued
+                            .insert(property.name().to_owned(), value);
+                    }
+                    other => panic!("unexpected property value: {other:?}"),
+                }
+            }
+        }
+        config_pgs.insert(pg.name().to_owned(), props);
+    }
+
+    config_pgs
+}
+
+// Normal reconciliation.
+#[test]
+fn proptest_lldpd_reconciliation() {
+    let logctx = omicron_test_utils::dev::test_setup_log(
+        "proptest_lldpd_reconciliation",
+    );
+    let log = &logctx.log;
+    let isolated =
+        IsolatedConfigd::builder("oxide/lldpd").unwrap().build().unwrap();
+    let scf = Scf::connect_isolated(&isolated).unwrap();
+    let scope = scf.scope_local().unwrap();
+
+    proptest!(|(test_setup: TestSetup)| {
+        erase_port_configs(&scope);
+        apply_port_configs(&scope, test_setup.expected_before(), true);
+
+        super::do_reconciliation_blocking_impl(
+            &scf,
+            &test_setup.rack_network_config(),
+            ThisSledSwitchSlot::TEST_FAKE,
+            log,
+        ).unwrap();
+
+        let reconciled_config = config_of_running_snapshot(&scope);
+        let expected_config = test_setup.expected_after();
+
+        assert_eq!(reconciled_config, expected_config);
+    });
+
+    logctx.cleanup_successful();
+}
+
+// Abnormal reconciliation: Apply the expected _reconciled_ config to the
+// instance, but do not refresh. This emulates reconciliation succeeding in
+// committing changes but failing to refresh the instance; the next
+// reconciliation attempt should still work to refresh the instance.
+#[test]
+fn proptest_lldpd_reconciliation_refresh() {
+    let logctx = omicron_test_utils::dev::test_setup_log(
+        "proptest_lldpd_reconciliation_refresh",
+    );
+    let log = &logctx.log;
+    let isolated =
+        IsolatedConfigd::builder("oxide/lldpd").unwrap().build().unwrap();
+    let scf = Scf::connect_isolated(&isolated).unwrap();
+    let scope = scf.scope_local().unwrap();
+
+    proptest!(|(test_setup: TestSetup)| {
+        erase_port_configs(&scope);
+        apply_port_configs(&scope, test_setup.expected_before(), false);
+
+        super::do_reconciliation_blocking_impl(
+            &scf,
+            &test_setup.rack_network_config(),
+            ThisSledSwitchSlot::TEST_FAKE,
+            log,
+        ).unwrap();
+
+        let reconciled_config = config_of_running_snapshot(&scope);
+        let expected_config = test_setup.expected_after();
+
+        assert_eq!(reconciled_config, expected_config);
+    });
+
+    logctx.cleanup_successful();
+}

--- a/sled-agent/scrimlet-reconcilers/src/lldpd_reconciler/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/lldpd_reconciler/tests.rs
@@ -168,8 +168,8 @@ impl TestSetup {
 }
 
 fn erase_port_configs(scope: &Scope<'_>) {
-    let service = scope.service("oxide/lldpd").unwrap().unwrap();
-    let mut instance = service.instance("default").unwrap().unwrap();
+    let service = scope.service(LLDPD_SERVICE_NAME).unwrap().unwrap();
+    let mut instance = service.instance(LLDPD_INSTANCE_NAME).unwrap().unwrap();
 
     let mut pgs_to_delete = Vec::new();
     for pg in instance.property_groups_direct().unwrap() {
@@ -188,8 +188,8 @@ fn apply_port_configs(
     configs: BTreeMap<String, LldpSmfProperties>,
     refresh_instance: bool,
 ) {
-    let service = scope.service("oxide/lldpd").unwrap().unwrap();
-    let mut instance = service.instance("default").unwrap().unwrap();
+    let service = scope.service(LLDPD_SERVICE_NAME).unwrap().unwrap();
+    let mut instance = service.instance(LLDPD_INSTANCE_NAME).unwrap().unwrap();
 
     for (pg_name, config) in configs {
         let mut pg = instance
@@ -225,8 +225,8 @@ fn apply_port_configs(
 fn config_of_running_snapshot(
     scope: &Scope<'_>,
 ) -> BTreeMap<String, LldpSmfProperties> {
-    let service = scope.service("oxide/lldpd").unwrap().unwrap();
-    let instance = service.instance("default").unwrap().unwrap();
+    let service = scope.service(LLDPD_SERVICE_NAME).unwrap().unwrap();
+    let instance = service.instance(LLDPD_INSTANCE_NAME).unwrap().unwrap();
     let snapshot = instance.snapshot("running").unwrap().unwrap();
 
     let mut config_pgs = BTreeMap::new();
@@ -273,7 +273,7 @@ fn proptest_lldpd_reconciliation() {
     );
     let log = &logctx.log;
     let isolated =
-        IsolatedConfigd::builder("oxide/lldpd").unwrap().build().unwrap();
+        IsolatedConfigd::builder(LLDPD_SERVICE_NAME).unwrap().build().unwrap();
     let scf = Scf::connect_isolated(&isolated).unwrap();
     let scope = scf.scope_local().unwrap();
 
@@ -308,7 +308,7 @@ fn proptest_lldpd_reconciliation_refresh() {
     );
     let log = &logctx.log;
     let isolated =
-        IsolatedConfigd::builder("oxide/lldpd").unwrap().build().unwrap();
+        IsolatedConfigd::builder(LLDPD_SERVICE_NAME).unwrap().build().unwrap();
     let scf = Scf::connect_isolated(&isolated).unwrap();
     let scope = scf.scope_local().unwrap();
 

--- a/sled-agent/scrimlet-reconcilers/src/status.rs
+++ b/sled-agent/scrimlet-reconcilers/src/status.rs
@@ -5,6 +5,7 @@
 //! Types for the status and results of the reconcilers in this crate.
 
 use crate::DpdReconcilerStatus;
+use crate::LldpdReconcilerStatus;
 use crate::MgdReconcilerStatus;
 use crate::UplinkdReconcilerStatus;
 use chrono::DateTime;
@@ -135,6 +136,7 @@ pub enum ScrimletReconcilersStatus {
     /// We are a scrimlet and the individual reconcilers are running.
     Running {
         dpd_reconciler: ReconcilerStatus<DpdReconcilerStatus>,
+        lldpd_reconciler: ReconcilerStatus<LldpdReconcilerStatus>,
         mgd_reconciler: ReconcilerStatus<MgdReconcilerStatus>,
         uplinkd_reconciler: ReconcilerStatus<UplinkdReconcilerStatus>,
     },

--- a/sled-agent/scrimlet-reconcilers/src/uplinkd_reconciler.rs
+++ b/sled-agent/scrimlet-reconcilers/src/uplinkd_reconciler.rs
@@ -280,7 +280,6 @@ fn current_uplink_addresses(
         .properties()?
         .map(|prop| {
             let prop = prop?;
-            let name = prop.name();
 
             let mut addrs = Vec::new();
             for value in prop.values()? {
@@ -291,15 +290,15 @@ fn current_uplink_addresses(
                     other => {
                         warn!(
                             log, "ignoring address value with unexpected type";
-                            "property" => name,
-                            "value-type" => %other.kind(),
+                            "property" => prop.fmri(),
+                            "type" => %other.kind(),
                             "value" => %other.display_smf(),
                         );
                     }
                 }
             }
 
-            Ok((name.to_owned(), addrs))
+            Ok((prop.name().to_owned(), addrs))
         })
         .collect::<anyhow::Result<BTreeMap<_, _>>>()?;
 

--- a/sled-agent/types/versions/src/initial/early_networking.rs
+++ b/sled-agent/types/versions/src/initial/early_networking.rs
@@ -190,6 +190,7 @@ pub struct UplinkAddressConfig {
 
 #[derive(
     Clone,
+    Copy,
     Debug,
     Default,
     Deserialize,
@@ -200,6 +201,7 @@ pub struct UplinkAddressConfig {
     JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(any(test, feature = "testing"), derive(test_strategy::Arbitrary))]
 /// To what extent should this port participate in LLDP
 pub enum LldpAdminStatus {
     #[default]
@@ -215,6 +217,7 @@ pub enum LldpAdminStatus {
 #[derive(
     Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, JsonSchema,
 )]
+#[cfg_attr(any(test, feature = "testing"), derive(test_strategy::Arbitrary))]
 pub struct LldpPortConfig {
     /// To what extent should this port participate in LLDP
     pub status: LldpAdminStatus,

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -119,7 +119,6 @@ rsa = { version = "0.9.10", features = ["serde", "sha2"] }
 rustls = { version = "0.23.41" }
 schemars = { version = "0.8.22", features = ["bytes", "chrono", "semver", "url", "uuid1"] }
 scopeguard = { version = "1.2.0" }
-scuffle = { version = "0.1.0", default-features = false, features = ["daft", "smf-by-instance", "testing"] }
 semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
@@ -266,7 +265,6 @@ rsa = { version = "0.9.10", features = ["serde", "sha2"] }
 rustls = { version = "0.23.41" }
 schemars = { version = "0.8.22", features = ["bytes", "chrono", "semver", "url", "uuid1"] }
 scopeguard = { version = "1.2.0" }
-scuffle = { version = "0.1.0", default-features = false, features = ["daft", "smf-by-instance", "testing"] }
 semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }


### PR DESCRIPTION
This is a continuation of #10686 and adds an SMF reconciler for `lldpd`, the other part of `uplink_ensure`. As with 10686, this should be consistent with [the existing sled-agent implementation](https://github.com/oxidecomputer/omicron/blob/23404772ccb0c2a8c8dc501b34bb15940d1e1cc7/sled-agent/src/services.rs#L3501-L3547), but using `scuffle` instead of spinning up child processes.