### PR TITLE
remove `access_repos = ["oxidecomputer/dendrite"]`

### DIFF
--- a/.github/buildomat/jobs/build-and-test-helios.sh
+++ b/.github/buildomat/jobs/build-and-test-helios.sh
@@ -14,9 +14,6 @@
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
 #:	"!/var/tmp/omicron_tmp/rustc*",
 #: ]
-#: access_repos = [
-#:	"oxidecomputer/dendrite"
-#: ]
 #:
 #: [[publish]]
 #: series = "junit-helios"

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -13,9 +13,6 @@
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
 #:	"!/var/tmp/omicron_tmp/rustc*",
 #: ]
-#: access_repos = [
-#:	"oxidecomputer/dendrite",
-#: ]
 #:
 #: [[publish]]
 #: series = "junit-linux"


### PR DESCRIPTION
Creating an access token that can clone a now-public repo is not required.