### PR TITLE
[nexus] fix flake in instance_start saga's test_action_failure_can_unwind test

### DIFF
--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -1177,7 +1177,6 @@ mod test {
         attach_disk_to_instance, create_default_ip_pools, create_project,
         object_create,
     };
-    use nexus_test_utils_macros::nexus_test;
     use nexus_types::external_api::instance::InstanceCpuCount;
     use nexus_types::external_api::{instance as instance_types, networking};
     use nexus_types::identity::Resource;
@@ -1190,9 +1189,6 @@ mod test {
     use uuid::Uuid;
 
     use super::*;
-
-    type ControlPlaneTestContext =
-        nexus_test_utils::ControlPlaneTestContext<crate::Server>;
 
     const PROJECT_NAME: &str = "test-project";
     const INSTANCE_NAME: &str = "test-instance";
@@ -1236,17 +1232,21 @@ mod test {
         .await
     }
 
-    #[nexus_test(server = crate::Server)]
-    async fn test_saga_basic_usage_succeeds(
-        cptestctx: &ControlPlaneTestContext,
-    ) {
+    #[tokio::test]
+    async fn test_saga_basic_usage_succeeds() {
+        let cptestctx = test_helpers::instance_saga_test_builder(
+            "test_saga_basic_usage_succeeds",
+        )
+        .start::<crate::Server>()
+        .await;
+
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let _project_id = setup_test_project(&client).await;
-        let opctx = test_helpers::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(&cptestctx);
         let instance = create_instance(client).await;
         let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
-        let db_instance = test_helpers::instance_fetch(cptestctx, instance_id)
+        let db_instance = test_helpers::instance_fetch(&cptestctx, instance_id)
             .await
             .instance()
             .clone();
@@ -1263,8 +1263,8 @@ mod test {
             .await
             .expect("Start saga should succeed");
 
-        test_helpers::instance_simulate(cptestctx, &instance_id).await;
-        let vmm_state = test_helpers::instance_fetch(cptestctx, instance_id)
+        test_helpers::instance_simulate(&cptestctx, &instance_id).await;
+        let vmm_state = test_helpers::instance_fetch(&cptestctx, instance_id)
             .await
             .vmm()
             .as_ref()
@@ -1272,11 +1272,13 @@ mod test {
             .state;
 
         assert_eq!(vmm_state, nexus_db_model::VmmState::Running);
+
+        cptestctx.teardown().await;
     }
 
     #[tokio::test]
     async fn should_start_with_dead_switch() {
-        let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
+        let cptestctx = test_helpers::instance_saga_test_builder(
             "should_start_with_dead_switch",
         )
         .with_extra_sled_agents(3)
@@ -1566,15 +1568,19 @@ mod test {
         cptestctx.teardown().await;
     }
 
-    #[nexus_test(server = crate::Server)]
-    async fn test_action_failure_can_unwind(
-        cptestctx: &ControlPlaneTestContext,
-    ) {
+    #[tokio::test]
+    async fn test_action_failure_can_unwind() {
+        let cptestctx = test_helpers::instance_saga_test_builder(
+            "test_action_failure_can_unwind",
+        )
+        .start::<crate::Server>()
+        .await;
+
         let log = &cptestctx.logctx.log;
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let _project_id = setup_test_project(&client).await;
-        let opctx = test_helpers::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(&cptestctx);
         let instance = create_instance(client).await;
         let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
 
@@ -1588,7 +1594,7 @@ mod test {
                 Box::pin({
                     async {
                         let db_instance = test_helpers::instance_fetch(
-                            cptestctx,
+                            &cptestctx,
                             instance_id,
                         )
                         .await.instance().clone();
@@ -1605,7 +1611,7 @@ mod test {
             || {
                 Box::pin(async {
                     let new_db_state = test_helpers::instance_wait_for_state(
-                        cptestctx,
+                        &cptestctx,
                         instance_id,
                         nexus_db_model::InstanceState::NoVmm,
                     ).await;
@@ -1618,25 +1624,31 @@ mod test {
 
                     assert!(new_db_instance.runtime().propolis_id.is_none());
 
-                    assert!(test_helpers::no_virtual_provisioning_resource_records_exist(cptestctx).await);
-                    assert!(test_helpers::no_virtual_provisioning_collection_records_using_instances(cptestctx).await);
+                    assert!(test_helpers::no_virtual_provisioning_resource_records_exist(&cptestctx).await);
+                    assert!(test_helpers::no_virtual_provisioning_collection_records_using_instances(&cptestctx).await);
                 })
             },
             log,
         ).await;
+
+        cptestctx.teardown().await;
     }
 
-    #[nexus_test(server = crate::Server)]
-    async fn test_actions_succeed_idempotently(
-        cptestctx: &ControlPlaneTestContext,
-    ) {
+    #[tokio::test]
+    async fn test_actions_succeed_idempotently() {
+        let cptestctx = test_helpers::instance_saga_test_builder(
+            "test_actions_succeed_idempotently",
+        )
+        .start::<crate::Server>()
+        .await;
+
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let _project_id = setup_test_project(&client).await;
-        let opctx = test_helpers::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(&cptestctx);
         let instance = create_instance(client).await;
         let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
-        let db_instance = test_helpers::instance_fetch(cptestctx, instance_id)
+        let db_instance = test_helpers::instance_fetch(&cptestctx, instance_id)
             .await
             .instance()
             .clone();
@@ -1649,8 +1661,8 @@ mod test {
 
         let dag = create_saga_dag::<SagaInstanceStart>(params).unwrap();
         test_helpers::actions_succeed_idempotently(nexus, dag).await;
-        test_helpers::instance_simulate(cptestctx, &instance_id).await;
-        let vmm_state = test_helpers::instance_fetch(cptestctx, instance_id)
+        test_helpers::instance_simulate(&cptestctx, &instance_id).await;
+        let vmm_state = test_helpers::instance_fetch(&cptestctx, instance_id)
             .await
             .vmm()
             .as_ref()
@@ -1658,6 +1670,8 @@ mod test {
             .state;
 
         assert_eq!(vmm_state, nexus_db_model::VmmState::Running);
+
+        cptestctx.teardown().await;
     }
 
     /// Tests that if a start saga unwinds because sled agent returned failure
@@ -1668,15 +1682,21 @@ mod test {
     /// test causes saga nodes to "fail" without actually executing anything,
     /// whereas this test injects a failure into the normal operation of the
     /// ensure-running node.
-    #[nexus_test(server = crate::Server)]
-    async fn test_ensure_running_unwind(cptestctx: &ControlPlaneTestContext) {
+    #[tokio::test]
+    async fn test_ensure_running_unwind() {
+        let cptestctx = test_helpers::instance_saga_test_builder(
+            "test_ensure_running_unwind",
+        )
+        .start::<crate::Server>()
+        .await;
+
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let _project_id = setup_test_project(&client).await;
-        let opctx = test_helpers::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(&cptestctx);
         let instance = create_instance(client).await;
         let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
-        let db_instance = test_helpers::instance_fetch(cptestctx, instance_id)
+        let db_instance = test_helpers::instance_fetch(&cptestctx, instance_id)
             .await
             .instance()
             .clone();
@@ -1722,7 +1742,7 @@ mod test {
         assert_eq!(saga_error.error_node_name, last_node_name);
 
         let db_instance =
-            test_helpers::instance_fetch(cptestctx, instance_id).await;
+            test_helpers::instance_fetch(&cptestctx, instance_id).await;
 
         assert_eq!(
             db_instance.instance().nexus_state,
@@ -1732,21 +1752,27 @@ mod test {
 
         assert!(
             test_helpers::no_virtual_provisioning_resource_records_exist(
-                cptestctx
+                &cptestctx
             )
             .await
         );
-        assert!(test_helpers::no_virtual_provisioning_collection_records_using_instances(cptestctx).await);
+        assert!(test_helpers::no_virtual_provisioning_collection_records_using_instances(&cptestctx).await);
+
+        cptestctx.teardown().await;
     }
 
-    #[nexus_test(server = crate::Server)]
-    async fn test_cannot_start_local_storage_disk_gone(
-        cptestctx: &ControlPlaneTestContext,
-    ) {
+    #[tokio::test]
+    async fn test_cannot_start_local_storage_disk_gone() {
+        let cptestctx = test_helpers::instance_saga_test_builder(
+            "test_cannot_start_local_storage_disk_gone",
+        )
+        .start::<crate::Server>()
+        .await;
+
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let _project_id = setup_test_project(&client).await;
-        let opctx = test_helpers::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(&cptestctx);
 
         let instance = create_instance(client).await;
 
@@ -1754,7 +1780,7 @@ mod test {
         // local storage on a pool, attach the disk to the instance, then
         // expunge the disk backing the pool.
 
-        let disk_test = DiskTest::new(cptestctx).await;
+        let disk_test = DiskTest::new(&cptestctx).await;
         let zpool = disk_test.zpools().next().unwrap();
         let disk = create_disk(&cptestctx, new_local_disk_create_params).await;
         let harness =
@@ -1773,7 +1799,7 @@ mod test {
         // Run the saga and make sure that the instance does not start
 
         let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
-        let db_instance = test_helpers::instance_fetch(cptestctx, instance_id)
+        let db_instance = test_helpers::instance_fetch(&cptestctx, instance_id)
             .await
             .instance()
             .clone();
@@ -1803,7 +1829,7 @@ mod test {
         );
 
         let db_instance =
-            test_helpers::instance_fetch(cptestctx, instance_id).await;
+            test_helpers::instance_fetch(&cptestctx, instance_id).await;
 
         assert_eq!(
             db_instance.instance().nexus_state,
@@ -1813,11 +1839,13 @@ mod test {
 
         assert!(
             test_helpers::no_virtual_provisioning_resource_records_exist(
-                cptestctx
+                &cptestctx
             )
             .await
         );
 
-        assert!(test_helpers::no_virtual_provisioning_collection_records_using_instances(cptestctx).await);
+        assert!(test_helpers::no_virtual_provisioning_collection_records_using_instances(&cptestctx).await);
+
+        cptestctx.teardown().await;
     }
 }

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -38,6 +38,20 @@ use uuid::Uuid;
 type ControlPlaneTestContext =
     nexus_test_utils::ControlPlaneTestContext<crate::Server>;
 
+/// Return a test context builder for instance start saga tests.
+///
+/// These tests effectively disable the instance_watcher background task to
+/// avoid colliding with it.
+pub(crate) fn instance_saga_test_builder(
+    test_name: &str,
+) -> nexus_test_utils::ControlPlaneBuilder<'_> {
+    nexus_test_utils::ControlPlaneBuilder::new(test_name)
+        .customize_nexus_config(&|config| {
+            config.pkg.background_tasks.instance_watcher.period_secs =
+                Duration::from_secs(86_400);
+        })
+}
+
 pub fn test_opctx(cptestctx: &ControlPlaneTestContext) -> OpContext {
     OpContext::for_tests(
         cptestctx.logctx.log.new(o!()),


### PR DESCRIPTION
Looks like the instance_watcher bg task was racing with the saga set up by the test. (This is the "background tasks mutating the SUT" pattern in flake-patterns.adoc.)

Also change the other instance start saga tests to disable the instance watcher task. I couldn't reproduce a similar race with any of them after setting the period to 1 second (lowering the period made test_action_failure_can_unwind very easy to repro), but I think from a test hygiene perspective it makes sense to turn the task off.

[Buildomat flake log](https://buildomat.eng.oxide.computer/wg/0/details/01KWA20DZM575ZVFAYEHZWYRHM/AoojbswG7hWSO6Xs0HcXmHfoJeoFoceqDtyS4rCp8kqpkFX2/01KWA215XCTNV5W8KC9K324M39#S6013)