### PR TITLE
releng: better dynamic library verification

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -81,4 +81,4 @@ esac
 pfexec zfs create -p "rpool/images/$USER/host"
 pfexec zfs create -p "rpool/images/$USER/recovery"
 
-cargo xtask releng --output-dir /work --mkincorp
+cargo xtask releng --output-dir /work --mkincorp --verify-debug-libraries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,10 @@ dependencies = [
 [[package]]
 name = "dev-tools-common"
 version = "0.1.0"
+dependencies = [
+ "camino",
+ "serde",
+]
 
 [[package]]
 name = "dhcproto"
@@ -9190,6 +9194,7 @@ dependencies = [
  "cargo_metadata 0.21.0",
  "chrono",
  "clap",
+ "dev-tools-common",
  "fs-err 3.3.0",
  "futures",
  "hex",

--- a/dev-tools/common/Cargo.toml
+++ b/dev-tools/common/Cargo.toml
@@ -7,6 +7,8 @@ license = "MPL-2.0"
 [lints]
 workspace = true
 
-[dependencies]
 # Please read the note in `dev-tools/xtask/Cargo.toml` before adding a new
 # dependency!
+[dependencies]
+camino.workspace = true
+serde.workspace = true

--- a/dev-tools/common/src/lib.rs
+++ b/dev-tools/common/src/lib.rs
@@ -3,5 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod cargo_command;
+mod verify_libraries;
+mod xtask_config;
 
 pub use cargo_command::{CargoLocation, cargo_command};
+pub use verify_libraries::{LibraryError, verify_executable_libraries};
+pub use xtask_config::{LibraryConfig, XtaskConfig};

--- a/dev-tools/common/src/verify_libraries.rs
+++ b/dev-tools/common/src/verify_libraries.rs
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeMap;
+use std::io::ErrorKind;
+use std::process::Command;
+
+use camino::Utf8Path;
+
+use crate::XtaskConfig;
+
+/// Verify that the binary at the provided path complies with the rules laid out
+/// in the xtask.toml config file. Errors are pushed to a hashmap so that we can
+/// display to a user the entire list of issues in one go.
+pub fn verify_executable_libraries(
+    config: &XtaskConfig,
+    path: &Utf8Path,
+    errors: &mut BTreeMap<String, Vec<LibraryError>>,
+) -> std::io::Result<()> {
+    if !cfg!(target_os = "illumos") {
+        return Err(std::io::Error::other(
+            "cannot verify libraries on non-illumos system",
+        ));
+    }
+
+    let binary = path.file_name().ok_or_else(|| {
+        std::io::Error::new(ErrorKind::InvalidInput, "path has no file name")
+    })?;
+    let command = Command::new("elfedit")
+        .args(["-o", "simple", "-r", "-e", "dyn:tag NEEDED"])
+        .arg(path)
+        .output()?;
+    if !command.status.success() {
+        return Err(std::io::Error::other(format!(
+            "elfedit exited unsuccessfully: {}",
+            command.status
+        )));
+    }
+    let stdout = String::from_utf8(command.stdout).map_err(|_| {
+        std::io::Error::new(
+            ErrorKind::InvalidData,
+            "elfedit output was not valid UTF-8",
+        )
+    })?;
+    // `elfedit -o simple -r -e "dyn:tag NEEDED" /file/path` will return
+    // a new line seperated list of required libraries so we walk over
+    // them looking for a match in our configuration file. If we find
+    // the library we make sure the binary is allowed to pull it in via
+    // the whitelist.
+    for library in stdout.lines() {
+        let library_config = match config.libraries.get(library.trim()) {
+            Some(config) => config,
+            None => {
+                errors
+                    .entry(binary.to_string())
+                    .or_default()
+                    .push(LibraryError::Unexpected(library.to_string()));
+
+                continue;
+            }
+        };
+
+        if let Some(allowed) = &library_config.binary_allow_list {
+            if !allowed.contains(binary) {
+                errors
+                    .entry(binary.to_string())
+                    .or_default()
+                    .push(LibraryError::NotAllowed(library.to_string()));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum LibraryError {
+    Unexpected(String),
+    NotAllowed(String),
+}
+
+impl std::fmt::Display for LibraryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LibraryError::Unexpected(lib) => {
+                write!(f, "UNEXPECTED dependency on {lib}")
+            }
+            LibraryError::NotAllowed(lib) => {
+                write!(f, "NEEDS {lib} but is not allowed")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LibraryError {}

--- a/dev-tools/common/src/xtask_config.rs
+++ b/dev-tools/common/src/xtask_config.rs
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Deserialize;
+
+/// The format for `.config/xtask.toml`.
+#[derive(Deserialize, Debug)]
+pub struct XtaskConfig {
+    pub libraries: BTreeMap<String, LibraryConfig>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LibraryConfig {
+    /// If `Some`, this library is only allowed in the given list of binaries.
+    /// If `None`, this library is allowed in any binary.
+    pub binary_allow_list: Option<BTreeSet<String>>,
+}

--- a/dev-tools/releng/Cargo.toml
+++ b/dev-tools/releng/Cargo.toml
@@ -12,6 +12,7 @@ camino-tempfile.workspace = true
 cargo_metadata.workspace = true
 chrono.workspace = true
 clap.workspace = true
+dev-tools-common.workspace = true
 fs-err = { workspace = true, features = ["tokio"] }
 futures.workspace = true
 hex.workspace = true

--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -764,8 +764,8 @@ async fn main() -> Result<()> {
         .after("recovery-stamp");
 
     if args.verify_debug_libraries {
-        // Run `nice cargo xtask verify-libraries`. This builds *all* binaries
-        // in the workspace in debug mode and verifies them against the rules in
+        // Run `cargo xtask verify-libraries`. This builds *all* binaries in
+        // the workspace in debug mode and verifies them against the rules in
         // .cargo/xtask.toml.
         //
         // This does not directly contribute to building or verifying the TUF
@@ -777,11 +777,7 @@ async fn main() -> Result<()> {
         // save this job any time.)
         jobs.push_command(
             "verify-libraries",
-            Command::new("nice").args([
-                cargo.as_str(),
-                "xtask",
-                "verify-libraries",
-            ]),
+            Command::new(&cargo).args(["xtask", "verify-libraries"]),
         )
         .after("host-libraries")
         .after("recovery-libraries");

--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -18,13 +18,17 @@ use std::time::Instant;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
+use anyhow::ensure;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use chrono::Utc;
 use clap::Parser;
+use dev_tools_common::XtaskConfig;
+use dev_tools_common::verify_executable_libraries;
 use fs_err::tokio as fs;
 use omicron_zone_package::config::Config;
 use omicron_zone_package::config::PackageName;
+use omicron_zone_package::package::PackageSource;
 use semver::Version;
 use slog::Drain;
 use slog::Logger;
@@ -170,6 +174,13 @@ struct Args {
     /// tools/pins.toml.
     #[clap(long, conflicts_with("helios_local"))]
     mkincorp: bool,
+
+    /// Verify binaries against the dynamic library linking rules in
+    /// .cargo/xtask.toml.
+    ///
+    /// This is run in CI.
+    #[clap(long)]
+    verify_debug_libraries: bool,
 }
 
 impl Args {
@@ -263,6 +274,13 @@ async fn main() -> Result<()> {
     let version_str = version.to_string();
     info!(logger, "version: {}", version_str);
 
+    let xtask_config: Arc<XtaskConfig> = Arc::new(
+        toml::from_str(
+            &fs::read_to_string(WORKSPACE_DIR.join(".cargo/xtask.toml"))
+                .await?,
+        )
+        .context("failed to parse .cargo/xtask.toml")?,
+    );
     let manifest = Arc::new(omicron_zone_package::config::parse_manifest(
         &fs::read_to_string(WORKSPACE_DIR.join("package-manifest.toml"))
             .await?,
@@ -593,6 +611,17 @@ async fn main() -> Result<()> {
         )
         .after(format!("{}-target", target));
 
+        // verify libraries built by omicron-package
+        jobs.push(
+            format!("{}-libraries", target),
+            target.verify_libraries(
+                xtask_config.clone(),
+                manifest.clone(),
+                target_dir.clone(),
+            ),
+        )
+        .after(format!("{}-package", target));
+
         // omicron-package stamp
         stamp_packages!(
             format!("{}-stamp", target),
@@ -711,11 +740,12 @@ async fn main() -> Result<()> {
             image_job.after(format!("{target}-opte-p5p"));
         }
     }
-    // Build the recovery target after we build the host target. Only one
-    // of these will build at a time since Cargo locks its target directory;
-    // since host-package and host-image both take longer than their recovery
-    // counterparts, this should be the fastest option to go first.
-    jobs.select("recovery-package").after("host-package");
+    // Build the recovery target after we build the host target (and have
+    // finished verifying its binaries). Only one of these will build at a time
+    // since Cargo locks its target directory; since host-package and host-image
+    // both take longer than their recovery counterparts, this should be the
+    // fastest option to go first.
+    jobs.select("recovery-package").after("host-libraries");
     if args.host_dataset == args.recovery_dataset {
         // If the datasets are the same, we can't parallelize these.
         jobs.select("recovery-image").after("host-image");
@@ -733,15 +763,29 @@ async fn main() -> Result<()> {
         .after("host-stamp")
         .after("recovery-stamp");
 
-    // Run `cargo xtask verify-libraries --release`. (This was formerly run in
-    // the build-and-test Buildomat job, but this fits better here where we've
-    // already built most of the binaries.)
-    jobs.push_command(
-        "verify-libraries",
-        Command::new(&cargo).args(["xtask", "verify-libraries", "--release"]),
-    )
-    .after("host-package")
-    .after("recovery-package");
+    if args.verify_debug_libraries {
+        // Run `nice cargo xtask verify-libraries`. This builds *all* binaries
+        // in the workspace in debug mode and verifies them against the rules in
+        // .cargo/xtask.toml.
+        //
+        // This does not directly contribute to building or verifying the TUF
+        // repo and is hence optional; this check runs in CI beause we want to
+        // ensure that if you build a debug binary, you can copy it onto a test
+        // rack without unexpected dependencies, and it lives here because we
+        // are essentially using unused CPU while waiting for the OS images to
+        // build. (Adding this to other jobs would make them take longer but not
+        // save this job any time.)
+        jobs.push_command(
+            "verify-libraries",
+            Command::new("nice").args([
+                cargo.as_str(),
+                "xtask",
+                "verify-libraries",
+            ]),
+        )
+        .after("host-libraries")
+        .after("recovery-libraries");
+    }
 
     for env in hubris::Environment::ALL {
         jobs.push(
@@ -834,6 +878,60 @@ impl Target {
                 "-R", // recovery image
             ],
         }
+    }
+
+    async fn verify_libraries(
+        self,
+        xtask_config: Arc<XtaskConfig>,
+        package_manifest: Arc<Config>,
+        target_dir: Utf8PathBuf,
+    ) -> Result<()> {
+        // `verify_executable_libraries` uses std::process::Command, so run this
+        // in a blocking task.
+        tokio::task::spawn_blocking(move || {
+            let preset_name =
+                self.as_str().parse().context("could not parse preset name")?;
+            let preset = package_manifest
+                .target
+                .presets
+                .get(&preset_name)
+                .with_context(|| {
+                    format!("preset {preset_name} not found in config")
+                })?;
+            let mut errors = BTreeMap::new();
+            for package in package_manifest.packages_to_build(preset).0.values()
+            {
+                let PackageSource::Local { rust: Some(p), .. } =
+                    &package.source
+                else {
+                    continue;
+                };
+                let dir = if p.release { "release" } else { "debug" };
+                let dir = target_dir.join(dir);
+                for bin in &p.binary_names {
+                    verify_executable_libraries(
+                        &xtask_config,
+                        &dir.join(bin),
+                        &mut errors,
+                    )
+                    .with_context(|| {
+                        format!("failed to verify libraries for {bin}")
+                    })?;
+                }
+            }
+            ensure!(
+                errors.is_empty(),
+                "Found library issues:\n{concat}",
+                concat = errors
+                    .iter()
+                    .flat_map(|(bin, es)| es.iter().map(move |e| (bin, e)))
+                    .map(|(bin, e)| format!("- {bin}: {e}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+            Ok(())
+        })
+        .await?
     }
 }
 

--- a/dev-tools/xtask/src/verify_libraries.rs
+++ b/dev-tools/xtask/src/verify_libraries.rs
@@ -6,14 +6,11 @@ use anyhow::{Context, Result, bail};
 use camino::Utf8Path;
 use cargo_metadata::Message;
 use clap::Parser;
-use dev_tools_common::{CargoLocation, cargo_command};
-use fs_err as fs;
-use serde::Deserialize;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    io::BufReader,
-    process::{Command, Stdio},
+use dev_tools_common::{
+    CargoLocation, XtaskConfig, cargo_command, verify_executable_libraries,
 };
+use fs_err as fs;
+use std::{io::BufReader, process::Stdio};
 use swrite::{SWrite, swriteln};
 
 use crate::load_workspace;
@@ -23,74 +20,6 @@ pub struct Args {
     /// Build in release mode
     #[clap(long)]
     release: bool,
-}
-
-#[derive(Deserialize, Debug)]
-struct LibraryConfig {
-    binary_allow_list: Option<BTreeSet<String>>,
-}
-
-#[derive(Deserialize, Debug)]
-struct XtaskConfig {
-    libraries: BTreeMap<String, LibraryConfig>,
-}
-
-#[derive(Debug)]
-enum LibraryError {
-    Unexpected(String),
-    NotAllowed(String),
-}
-
-/// Verify that the binary at the provided path complies with the rules laid out
-/// in the xtask.toml config file. Errors are pushed to a hashmap so that we can
-/// display to a user the entire list of issues in one go.
-fn verify_executable(
-    config: &XtaskConfig,
-    path: &Utf8Path,
-    errors: &mut BTreeMap<String, Vec<LibraryError>>,
-) -> Result<()> {
-    let binary = path.file_name().context("basename of executable")?;
-
-    let command = Command::new("elfedit")
-        .args(["-o", "simple", "-r", "-e", "dyn:tag NEEDED"])
-        .arg(path)
-        .output()
-        .context("exec elfedit")?;
-
-    if !command.status.success() {
-        bail!("Failed to execute elfedit successfully {}", command.status);
-    }
-
-    let stdout = String::from_utf8(command.stdout)?;
-    // `elfedit -o simple -r -e "dyn:tag NEEDED" /file/path` will return
-    // a new line seperated list of required libraries so we walk over
-    // them looking for a match in our configuration file. If we find
-    // the library we make sure the binary is allowed to pull it in via
-    // the whitelist.
-    for library in stdout.lines() {
-        let library_config = match config.libraries.get(library.trim()) {
-            Some(config) => config,
-            None => {
-                errors
-                    .entry(binary.to_string())
-                    .or_default()
-                    .push(LibraryError::Unexpected(library.to_string()));
-
-                continue;
-            }
-        };
-
-        if let Some(allowed) = &library_config.binary_allow_list {
-            if !allowed.contains(binary) {
-                errors
-                    .entry(binary.to_string())
-                    .or_default()
-                    .push(LibraryError::NotAllowed(library.to_string()));
-            }
-        }
-    }
-
-    Ok(())
 }
 
 pub fn run_cmd(args: Args) -> Result<()> {
@@ -120,7 +49,7 @@ pub fn run_cmd(args: Args) -> Result<()> {
         if let Message::CompilerArtifact(artifact) = message? {
             // We are only interested in artifacts that are binaries
             if let Some(executable) = artifact.executable {
-                verify_executable(&config, &executable, &mut errors)?;
+                verify_executable_libraries(&config, &executable, &mut errors)?;
             }
         }
     }
@@ -134,13 +63,8 @@ pub fn run_cmd(args: Args) -> Result<()> {
         let mut msg = String::new();
         errors.iter().for_each(|(binary, errors)| {
             swriteln!(msg, "{binary}");
-            errors.iter().for_each(|error| match error {
-                LibraryError::Unexpected(lib) => {
-                    swriteln!(msg, "\tUNEXPECTED dependency on {lib}");
-                }
-                LibraryError::NotAllowed(lib) => {
-                    swriteln!(msg, "\tNEEDS {lib} but is not allowed");
-                }
+            errors.iter().for_each(|error| {
+                swriteln!(msg, "\t{error}");
             });
         });
 


### PR DESCRIPTION
Closes #7149.

Prior to this change we ran the `verify-libraries` xtask on _release_ binaries. This appeared like an optimal choice at the time, but I realized that we were no longer testing that debug binaries required only expected dynamic libraries (which ended up regressing for a bit), and because of the differences in how omicron-package and the `verify-libraries` xtask compiled the software we weren't even testing the actual binaries we shipped. More details in #7149.

This adds two new tasks to releng, `host-libraries` and `recovery-libraries`, which runs the verify-libraries check on all the binaries produced by omicron-package. The `verify-libraries` releng task now compiles and checks _debug_ binaries after all of the `cargo build` tasks needed for the repo are done.

When approaching this I initially was going to move `cargo xtask verify-libraries` back to the build-and-test job, because I was annoyed that local runs of `cargo xtask releng` was running a lengthy check I didn't care about. However that would have added about 6-8 minutes to the runtime of that test (the bins can't be built at the same time as the tests, otherwise the bins end up being linked against test-only libraries that pull in dynamic libraries we explicitly don't want). The whole reason it was moved to this task in the first place is because it was basically "free": the second half-ish of the releng process is building OS images which is mostly network/disk IO and barely uses any CPU. So instead of moving it I added an off-by-default option to enable this check, and added it to the Buildomat job definition.