### PR TITLE
Oximeter: cache compiled regex.

### DIFF
--- a/oximeter/types/versions/src/impls/schema.rs
+++ b/oximeter/types/versions/src/impls/schema.rs
@@ -89,7 +89,7 @@ where
 }
 
 fn validate_timeseries_name(s: &str) -> Result<&str, MetricsError> {
-    if regex::Regex::new(TIMESERIES_NAME_REGEX).unwrap().is_match(s) {
+    if TIMESERIES_NAME_REGEX.is_match(s) {
         Ok(s)
     } else {
         Err(MetricsError::InvalidTimeseriesName)

--- a/oximeter/types/versions/src/initial/schema.rs
+++ b/oximeter/types/versions/src/initial/schema.rs
@@ -10,11 +10,13 @@ use chrono::DateTime;
 use chrono::Utc;
 use parse_display::Display;
 use parse_display::FromStr;
+use regex::Regex;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::num::NonZeroU8;
+use std::sync::LazyLock;
 
 pub type TimeseriesKey = u64;
 
@@ -158,8 +160,12 @@ pub struct TimeseriesSchema {
 //  - Zero or more of the above, delimited by '-'.
 //
 // That describes the target/metric name, and the timeseries is two of those, joined with ':'.
-pub(crate) const TIMESERIES_NAME_REGEX: &str =
-    "^(([a-z]+[a-z0-9]*)(_([a-z0-9]+))*):(([a-z]+[a-z0-9]*)(_([a-z0-9]+))*)$";
+pub(crate) static TIMESERIES_NAME_REGEX: LazyLock<Regex> = LazyLock::new(
+    || {
+        Regex::new("^(([a-z]+[a-z0-9]*)(_([a-z0-9]+))*):(([a-z]+[a-z0-9]*)(_([a-z0-9]+))*)$")
+            .expect("timeseries name validation regex should be valid")
+    },
+);
 
 /// Authorization scope for a timeseries.
 ///


### PR DESCRIPTION
Per #10552, oximeter spends about 2/3 of its cpu time compiling `TIMESERIES_NAME_REGEX`. This happens because we check each incoming sample against the regex in `validate_timeseries_name`, and compile the regex each time that function is invoked. To fix, this patch compiles `TIMESERIES_NAME_REGEX` at most once using `LazyLock`.

Note: oximeter's observed cpu use isn't particularly high, but its throughput is more of a concern. When oximeter's database batcher receives samples faster than it can flush them from its queue, it drops old samples. So until we make a larger architectural change, such as sharding oximeter, we need to maintain high throughput in order to avoid dropping samples under high volume. This change alone may not avoid all dropped samples reported in #10552, but it should help, and has no obvious downsides.

Part of #10552.