### PR TITLE
[nexus] Don't re-fetch a disk after committing attach/detach (fixes #10695)

### DIFF
--- a/nexus/db-queries/src/db/datastore/disk.rs
+++ b/nexus/db-queries/src/db/datastore/disk.rs
@@ -940,7 +940,7 @@ impl DataStore {
         authz_instance: &authz::Instance,
         authz_disk: &authz::Disk,
         max_disks: u32,
-    ) -> Result<(Instance, Disk), Error> {
+    ) -> Result<(Instance, model::Disk), Error> {
         use nexus_db_schema::schema::disk;
         use nexus_db_schema::schema::instance;
         use nexus_db_schema::schema::sled_resource_vmm;
@@ -1095,12 +1095,11 @@ impl DataStore {
 
         let conn = self.pool_connection_authorized(opctx).await?;
 
-        let instance = match query.attach_and_get_result_async(&conn).await {
-            Ok((instance, _db_disk)) => {
-                // We'll re-fetch the datastore::Disk later, so ignore the
-                // model::Disk here
-                instance
-            }
+        let (instance, db_disk) = match query
+            .attach_and_get_result_async(&conn)
+            .await
+        {
+            Ok((instance, db_disk)) => (instance, db_disk),
 
             Err(e) => match e {
                 AttachError::CollectionNotFound => {
@@ -1128,12 +1127,12 @@ impl DataStore {
                         api::external::DiskState::Attached(id)
                             if id == authz_instance.id() =>
                         {
-                            collection
+                            (collection, resource)
                         }
                         api::external::DiskState::Attaching(id)
                             if id == authz_instance.id() =>
                         {
-                            collection
+                            (collection, resource)
                         }
                         // Ok-to-attach disk states: Inspect the state to infer
                         // why we did not attach.
@@ -1239,9 +1238,21 @@ impl DataStore {
             },
         };
 
-        // Re-fetch the disk to get the updates
-        let disk = self.disk_get(&opctx, authz_disk.id()).await?;
-        Ok((instance, disk))
+        // NB: The attach mutation above is the *last fallible operation* in this
+        // method, and we return the `model::Disk` produced by the CTE directly.
+        //
+        // We deliberately do NOT re-fetch here to build a richer
+        // `datastore::Disk`: a re-fetch acquires an additional pool connection
+        // *after* the attach has already committed, and if that acquisition
+        // fails (e.g. under connection-pool exhaustion) the caller observes an
+        // error even though the disk is now attached. In a saga that is fatal:
+        // steno never runs the undo of a failed forward node, so the committed
+        // attach would leak and later wedge the unwind (see omicron#10695).
+        //
+        // Callers that need a `datastore::Disk` should upgrade the returned
+        // `model::Disk` via `disk_get`, in a context where a post-commit failure
+        // is recoverable (i.e. not from a saga action).
+        Ok((instance, db_disk))
     }
 
     pub async fn instance_detach_disk(
@@ -1249,7 +1260,7 @@ impl DataStore {
         opctx: &OpContext,
         authz_instance: &authz::Instance,
         authz_disk: &authz::Disk,
-    ) -> Result<Disk, Error> {
+    ) -> Result<model::Disk, Error> {
         use nexus_db_schema::schema::{disk, instance};
 
         opctx.authorize(authz::Action::Modify, authz_instance).await?;
@@ -1275,7 +1286,7 @@ impl DataStore {
 
         let conn = self.pool_connection_authorized(opctx).await?;
 
-        let _db_disk = Instance::detach_resource(
+        let db_disk = Instance::detach_resource(
             authz_instance.id(),
             authz_disk.id(),
             instance::table
@@ -1390,9 +1401,15 @@ impl DataStore {
             }
         })?;
 
-        let disk = self.disk_get(&opctx, authz_disk.id()).await?;
-
-        Ok(disk)
+        // NB: As with `instance_attach_disk`, the detach mutation above is the
+        // *last fallible operation* in this method: we return the `model::Disk`
+        // produced by the CTE directly rather than re-fetching. A post-commit
+        // re-fetch here would be especially dangerous because `instance_detach_disk`
+        // is used as a saga *undo* action (`sic_attach_disk_to_instance_undo`);
+        // steno gives undo actions a single attempt with no retry, so a failure
+        // after the detach commits would permanently wedge the unwind even
+        // though the detach succeeded (see omicron#10695).
+        Ok(db_disk)
     }
 
     pub async fn disk_update_runtime(

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1924,7 +1924,7 @@ impl super::Nexus {
         //   - Update the DB if the request succeeded (hopefully to "Attached").
         // - If the instance is not running...
         //   - Update the disk state in the DB to "Attached".
-        let (_instance, disk) = self
+        let (_instance, _db_disk) = self
             .db_datastore
             .instance_attach_disk(
                 &opctx,
@@ -1934,6 +1934,14 @@ impl super::Nexus {
             )
             .await?;
 
+        // `instance_attach_disk` returns a `model::Disk` and deliberately does
+        // not re-fetch a `datastore::Disk` internally (see omicron#10695): a
+        // re-fetch after the attach commits can fail (e.g. pool exhaustion) and
+        // would leak the committed attach if it ran inside a saga action. It is
+        // safe to upgrade to a `datastore::Disk` here, outside the mutation,
+        // because a failure in this API path is recoverable (the client can
+        // retry; attach is idempotent).
+        let disk = self.db_datastore.disk_get(&opctx, authz_disk.id()).await?;
         Ok(disk)
     }
 
@@ -1972,10 +1980,13 @@ impl super::Nexus {
         //   - Update the DB if the request succeeded (hopefully to "Detached").
         // - If the instance is not running...
         //   - Update the disk state in the DB to "Detached".
-        let disk = self
+        let _db_disk = self
             .db_datastore
             .instance_detach_disk(&opctx, &authz_instance, &authz_disk)
             .await?;
+        // As in `instance_attach_disk`, upgrade the returned `model::Disk` to a
+        // `datastore::Disk` outside the datastore mutation (see omicron#10695).
+        let disk = self.db_datastore.disk_get(&opctx, authz_disk.id()).await?;
         Ok(disk)
     }
 


### PR DESCRIPTION
Fixes #10695.

## Problem

Running many concurrent instance-creates (30 instances × 11 disks each on `london`) exhausts the qorb DB connection pool.  Some instance-create sagas then get permanently stuck mid-unwind, leaving instances wedged in `starting`.  The saga log shows a forward failure at `attach_disk_output` (*"all claims are used"*) and a permanent undo failure at a `local_storage_disk` create-record undo (*"disk cannot be deleted in state \"attached\""*).

## Root cause

`DataStore::instance_attach_disk` commits the disk→`Attached` transition via an atomic CTE and then does a **second, non-transactional `disk_get` re-fetch** (a fresh pool claim, acquired while still holding the CTE's connection) only to build the richer `datastore::Disk` return value.  Under pool exhaustion that re-fetch fails **after** the attach has committed.

steno runs a forward action once and **never runs the undo of a failed node**, so a disk left `Attached` by an attach whose re-fetch failed has no detach scheduled. During unwind its create-record undo then hits `project_delete_disk_no_auth` (which only permits `Detached`/`Faulted`/`Creating`) and fails permanently . . . steno stops the unwind at the first undo failure (`saga_stuck`), wedging the instance.  `instance_detach_disk` has the mirror problem and is used as a saga *undo* action, where a post-commit re-fetch failure turns a successful detach into a permanent undo failure.

## Change

Make the committing CTE the last fallible operation in both methods:

- `instance_attach_disk` / `instance_detach_disk` now return the `model::Disk` the CTE already produces (no post-commit re-fetch).
- The two API callers (`Nexus::instance_attach_disk` / `instance_detach_disk`) do the `datastore::Disk` upgrade via `disk_get`, where a post-commit failure is recoverable (client retries; both ops are idempotent).
- The instance-create saga discards the returned disk, so the re-fetch was pure waste there.

After this, the disk-attach/detach saga actions can only fail *before* they commit, so an overloaded instance-create fails cleanly and fully unwinds instead of leaking an `Attached` disk and wedging.

## Scope / non-goals

This removes the specific latent atomicity defect.  It does **not** make instance-create robust to sustained pool exhaustion in general (a detach *undo* can still fail to acquire a connection and stop an unwind) . . . that is an honest DB-unavailable failure better addressed at the pool/admission layer, and is out of scope here.

## Testing

Existing datastore coverage in `sled.rs` exercises attach (success + attach-blocked-while-starting) and detach; those callers discard the return value and are unaffected by the type change. I was not able to build the full workspace in my environment; CI should validate compilation.  A saga fault-injection test that fails the attach action *after* its DB commit and asserts a clean, leak-free unwind would be a good follow-up.

## Related

An automated audit found the same commit-then-fallible shape in several other sagas (see the linked issue comment) . . . notably `instance_create::sic_create_network_interface` (orphaned NIC), `snapshot_create::ssc_attach_disk_to_pantry`, and `vpc_create::svc_create_gateway`.  Those are left for follow-ups; the underlying invariant is: *a saga forward action must not perform a fallible operation after committing state.*
