### PR TITLE
Restore missing first line of license header in nexus/src/context.rs

### DIFF
--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -1,3 +1,4 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 


### PR DESCRIPTION
Hello! 👋 I've been reading and poking around in `nexus/src/context.rs` over the past weeks, and today by chance noticed that the first line of the license header was missing. As far as I can tell, it was accidentally removed in [this old PR from way back in 2023](https://github.com/oxidecomputer/omicron/pull/2530) (see [the diff for the file here](https://github.com/oxidecomputer/omicron/pull/2530/files#diff-5a2c045a788ce52d2612b2ffa2e163fe66cbee0fb72776cef9df4e9695262213)). 

Instead of opening an issue, I figured I'd just open a small PR to resurrect the line.

cc @sunshowers for 👀 since you worked on that PR :v: (and no judgement here, I've done this too) 