### PR TITLE
Add skywalking-eyes license scanner action

### DIFF
--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o errexit
 set -o pipefail

--- a/.github/buildomat/ci-env.sh
+++ b/.github/buildomat/ci-env.sh
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 # Setup shared across Buildomat CI builds.
 #
 # This file contains environment variables shared across Buildomat CI jobs.

--- a/.github/buildomat/jobs/a4x2-deploy.sh
+++ b/.github/buildomat/jobs/a4x2-deploy.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "a4x2-deploy"
 #: variety = "basic"

--- a/.github/buildomat/jobs/a4x2-deploy.sh
+++ b/.github/buildomat/jobs/a4x2-deploy.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "a4x2-deploy"
 #: variety = "basic"

--- a/.github/buildomat/jobs/a4x2-prepare.sh
+++ b/.github/buildomat/jobs/a4x2-prepare.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "a4x2-prepare"
 #: variety = "basic"

--- a/.github/buildomat/jobs/a4x2-prepare.sh
+++ b/.github/buildomat/jobs/a4x2-prepare.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "a4x2-prepare"
 #: variety = "basic"

--- a/.github/buildomat/jobs/build-and-test-helios.sh
+++ b/.github/buildomat/jobs/build-and-test-helios.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "build-and-test (helios)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/build-and-test-helios.sh
+++ b/.github/buildomat/jobs/build-and-test-helios.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "build-and-test (helios)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "build-and-test (ubuntu-22.04)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "build-and-test (ubuntu-22.04)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/check-features.sh
+++ b/.github/buildomat/jobs/check-features.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "check-features (helios)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/check-features.sh
+++ b/.github/buildomat/jobs/check-features.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "check-features (helios)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "clippy (helios)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "clippy (helios)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "helios / deploy"
 #: variety = "basic"

--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "helios / deploy"
 #: variety = "basic"

--- a/.github/buildomat/jobs/omicron-common.sh
+++ b/.github/buildomat/jobs/omicron-common.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "omicron-common (helios)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/omicron-common.sh
+++ b/.github/buildomat/jobs/omicron-common.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "omicron-common (helios)"
 #: variety = "basic"

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "helios / package"
 #: variety = "basic"

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "helios / package"
 #: variety = "basic"

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -2,7 +2,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 #:
 #: name = "helios / build TUF repo"
 #: variety = "basic"

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #:
 #: name = "helios / build TUF repo"
 #: variety = "basic"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,24 @@
+# To run this check locally, install SkyWalking Eyes
+# (https://github.com/apache/skywalking-eyes). On macOS you can `brew install
+# license-eye` and run `license-eye header check` or `license-eye header fix`.
+
+name: license-check
+
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  license:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # see omicron#4461
+      - name: Check License Header
+        uses: apache/skywalking-eyes/header@e9f91c35e4d4ae4420f722aa6598c4a13cc69093 # v0.8.0

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,16 @@
+header:
+  # default is 80; allow shebangs and XML prologs before the header
+  license-location-threshold: 120
+  license:
+    spdx-id: MPL-2.0
+
+  paths:
+    - '**/*.rs'
+    - '**/*.sh'
+
+  paths-ignore:
+    - 'target'
+    - 'out'
+    - 'workspace-hack'
+    - '**/*.md'
+    - 'LICENSE'

--- a/end-to-end-tests/src/bin/bootstrap.rs
+++ b/end-to-end-tests/src/bin/bootstrap.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use anyhow::Result;
 use end_to_end_tests::helpers::ctx::{ClientParams, Context};
 use end_to_end_tests::helpers::{

--- a/end-to-end-tests/src/bin/commtest.rs
+++ b/end-to-end-tests/src/bin/commtest.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use anyhow::{Result, anyhow};
 use clap::{Parser, Subcommand};
 use end_to_end_tests::helpers::icmp::ping4_test_run;

--- a/end-to-end-tests/src/bin/dhcp-server.rs
+++ b/end-to-end-tests/src/bin/dhcp-server.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! This is a dirt simple DHCP server for handing out addresses in a given
 //! range. Leases do not expire. If the server runs out of addresses, it
 //! panics. This is a stopgap program to hand out addresses to VMs in CI. It's

--- a/end-to-end-tests/src/helpers/cli.rs
+++ b/end-to-end-tests/src/helpers/cli.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 /// An Oxide color theme for your clap-based CLIs
 pub fn oxide_cli_style() -> clap::builder::Styles {
     clap::builder::Styles::styled()

--- a/end-to-end-tests/src/helpers/icmp.rs
+++ b/end-to-end-tests/src/helpers/icmp.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use colored::*;
 use internet_checksum::Checksum;
 use serde::{Deserialize, Serialize};

--- a/end-to-end-tests/src/helpers/mod.rs
+++ b/end-to-end-tests/src/helpers/mod.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 pub mod cli;
 pub mod ctx;
 pub mod icmp;

--- a/end-to-end-tests/src/instance_launch.rs
+++ b/end-to-end-tests/src/instance_launch.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![cfg(test)]
 
 use crate::helpers::{ctx::Context, generate_name};

--- a/end-to-end-tests/src/lib.rs
+++ b/end-to-end-tests/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 pub mod helpers;
 
 mod instance_launch;

--- a/end-to-end-tests/src/no_spoof.rs
+++ b/end-to-end-tests/src/no_spoof.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Validates that legacy spoof-based authentication does not work
 #![cfg(test)]
 

--- a/end-to-end-tests/src/noop_blueprint.rs
+++ b/end-to-end-tests/src/noop_blueprint.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Test that generating a new blueprint on a freshly-installed system will not
 //! change anything.
 

--- a/env.sh
+++ b/env.sh
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 # omicron environment file: source this file to set up your PATH to use the
 # various tools in the Omicron workspace where this file lives.  The test suite
 # and other commands expect these copies of these tools to be on your PATH.

--- a/illumos-utils/src/coreadm.rs
+++ b/illumos-utils/src/coreadm.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::{ExecutionError, execute};
 use std::process::Command;
 

--- a/illumos-utils/src/dumpadm.rs
+++ b/illumos-utils/src/dumpadm.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::{ExecutionError, execute};
 use camino::Utf8PathBuf;
 use slog_error_chain::SlogInlineError;

--- a/nexus/auth/src/lib.rs
+++ b/nexus/auth/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 pub mod authn;
 pub mod authz;
 pub mod context;

--- a/nexus/db-model/src/affinity.rs
+++ b/nexus/db-model/src/affinity.rs
@@ -1,8 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/5.0/.
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! Database representation of affinity and anti-affinity groups
 

--- a/nexus/db-model/src/allow_list.rs
+++ b/nexus/db-model/src/allow_list.rs
@@ -1,8 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/5.0/.
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! Database representation of allowed source IP address, for implementing basic
 //! IP allowlisting.

--- a/nexus/db-model/src/audit_log.rs
+++ b/nexus/db-model/src/audit_log.rs
@@ -1,8 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/5.0/.
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use std::net::IpAddr;
 

--- a/nexus/db-model/src/bootstore.rs
+++ b/nexus/db-model/src/bootstore.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use chrono::{DateTime, Utc};
 use nexus_db_schema::schema::{bootstore_config, bootstore_keys};
 use serde::{Deserialize, Serialize};

--- a/nexus/db-model/src/internet_gateway.rs
+++ b/nexus/db-model/src/internet_gateway.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::Generation;
 use crate::DatastoreCollectionConfig;
 use db_macros::Resource;

--- a/nexus/db-model/src/quota.rs
+++ b/nexus/db-model/src/quota.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::ByteCount;
 use chrono::{DateTime, Utc};
 use nexus_db_schema::schema::silo_quotas;

--- a/nexus/db-model/src/silo_auth_settings.rs
+++ b/nexus/db-model/src/silo_auth_settings.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::SqlU32;
 use chrono::{DateTime, Utc};
 use nexus_db_schema::schema::silo_auth_settings;

--- a/nexus/db-model/src/sled_instance.rs
+++ b/nexus/db-model/src/sled_instance.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::Name;
 use crate::VmmState;
 use chrono::{DateTime, Utc};

--- a/nexus/db-model/src/utilization.rs
+++ b/nexus/db-model/src/utilization.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::ByteCount;
 use crate::Name;
 use nexus_db_schema::schema::silo_utilization;

--- a/nexus/db-queries/src/db/datastore/bootstore.rs
+++ b/nexus/db-queries/src/db/datastore/bootstore.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::DataStore;
 use crate::context::OpContext;
 use async_bb8_diesel::AsyncRunQueryDsl;

--- a/nexus/db-queries/src/db/datastore/image.rs
+++ b/nexus/db-queries/src/db/datastore/image.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::authz;
 use crate::authz::ApiResource;
 use crate::context::OpContext;

--- a/nexus/db-queries/src/db/datastore/multicast/members.rs
+++ b/nexus/db-queries/src/db/datastore/multicast/members.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Multicast group member management operations.
 //!
 //! Database operations for managing multicast group memberships, including

--- a/nexus/db-queries/src/db/datastore/quota.rs
+++ b/nexus/db-queries/src/db/datastore/quota.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::DataStore;
 use crate::authz;
 use crate::context::OpContext;

--- a/nexus/db-queries/src/db/datastore/silo_auth_settings.rs
+++ b/nexus/db-queries/src/db/datastore/silo_auth_settings.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::DataStore;
 use crate::authz;
 use crate::context::OpContext;

--- a/nexus/db-queries/src/db/datastore/sled_instance.rs
+++ b/nexus/db-queries/src/db/datastore/sled_instance.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::DataStore;
 
 use crate::authz;

--- a/nexus/db-queries/src/db/datastore/switch.rs
+++ b/nexus/db-queries/src/db/datastore/switch.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::DataStore;
 use crate::authz;
 use crate::context::OpContext;

--- a/nexus/db-queries/src/db/datastore/utilization.rs
+++ b/nexus/db-queries/src/db/datastore/utilization.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::DataStore;
 use crate::authz;
 use crate::context::OpContext;

--- a/nexus/src/app/background/tasks/alert_subscription.rs
+++ b/nexus/src/app/background/tasks/alert_subscription.rs
@@ -1,0 +1,4 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+

--- a/nexus/src/app/sled_instance.rs
+++ b/nexus/src/app/sled_instance.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use nexus_db_lookup::lookup;
 use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;

--- a/nexus/src/app/ssh_key.rs
+++ b/nexus/src/app/ssh_key.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use nexus_db_lookup::LookupPath;
 use nexus_db_lookup::lookup;
 use nexus_db_queries::authz;

--- a/nexus/src/app/switch.rs
+++ b/nexus/src/app/switch.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use nexus_db_lookup::LookupPath;
 use nexus_db_lookup::lookup;
 use nexus_db_model::Switch;

--- a/nexus/src/cidata.rs
+++ b/nexus/src/cidata.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use fatfs::{FatType, FileSystem, FormatVolumeOptions, FsOptions};
 use nexus_db_queries::db::{identity::Resource, model::Instance};
 use num_integer::Integer;

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -1,3 +1,4 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 

--- a/nexus/src/populate.rs
+++ b/nexus/src/populate.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Nexus startup task to load hardcoded data into the database
 //!
 //! Initial populating of the CockroachDB database happens in two different ways:

--- a/nexus/test-utils-macros/src/lib.rs
+++ b/nexus/test-utils-macros/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use proc_macro::TokenStream;
 use quote::quote;
 use std::collections::HashSet as Set;

--- a/nexus/tests/integration_tests/multicast/instances.rs
+++ b/nexus/tests/integration_tests/multicast/instances.rs
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/
-//
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 // Copyright 2025 Oxide Computer Company
 
 //! Tests multicast group + instance integration.

--- a/nexus/tests/integration_tests/probe.rs
+++ b/nexus/tests/integration_tests/probe.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use dropshot::HttpErrorResponseBody;
 use http::{Method, StatusCode};
 use nexus_test_utils::{

--- a/nexus/tests/integration_tests/quotas.rs
+++ b/nexus/tests/integration_tests/quotas.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use anyhow::Error;
 use dropshot::HttpErrorResponseBody;
 use dropshot::test_util::ClientTestContext;

--- a/nexus/tests/integration_tests/ssh_keys.rs
+++ b/nexus/tests/integration_tests/ssh_keys.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Sanity-tests for public SSH keys
 
 use http::{StatusCode, method::Method};

--- a/nexus/tests/integration_tests/users_builtin.rs
+++ b/nexus/tests/integration_tests/users_builtin.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Sanity-tests for built-in users
 
 use dropshot::ResultsPage;

--- a/nexus/tests/integration_tests/utilization.rs
+++ b/nexus/tests/integration_tests/utilization.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use dropshot::test_util::ClientTestContext;
 use http::Method;
 use http::StatusCode;

--- a/oximeter/db/benches/backup_field_tables.sh
+++ b/oximeter/db/benches/backup_field_tables.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #
 # Dump ClickHouse field and schema tables to disk in native format. Run against
 # a test rack with realistic oximeter data. Used to capture test data for

--- a/oximeter/db/benches/backup_measurement_tables.sh
+++ b/oximeter/db/benches/backup_measurement_tables.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #
 # Dump a partial ClickHouse measurement table (time-windowed slice) to disk in
 # native format. Run against a test rack with realistic oximeter data. Used to

--- a/oximeter/db/benches/load_field_tables.sh
+++ b/oximeter/db/benches/load_field_tables.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #
 # Load field table backups into a fresh ClickHouse for benchmarking.
 # Crashes if the destination database already contains data.

--- a/oximeter/db/benches/load_measurement_tables.sh
+++ b/oximeter/db/benches/load_measurement_tables.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #
 # Load a measurement table backup into a ClickHouse for benchmarking.
 # Crashes if the destination table already contains data.

--- a/oximeter/types/src/queue.rs
+++ b/oximeter/types/src/queue.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::collections::VecDeque;
 
 #[derive(Debug)]

--- a/package/src/dot.rs
+++ b/package/src/dot.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Visualize the package manifest using Graphviz
 
 use anyhow::anyhow;

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Common code shared between `omicron-package` and `thing-flinger` binaries.
 
 use camino::{Utf8Path, Utf8PathBuf};

--- a/sled-agent/src/bin/tofino-monitor.rs
+++ b/sled-agent/src/bin/tofino-monitor.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use signal_hook::consts::SIGHUP;
 use signal_hook::consts::SIGINT;
 use signal_hook::consts::SIGQUIT;

--- a/sled-agent/types/versions/src/add_attached_subnets/instance.rs
+++ b/sled-agent/types/versions/src/add_attached_subnets/instance.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::net::SocketAddr;
 
 use omicron_common::api::external::Hostname;

--- a/sled-diagnostics/src/contract_stub.rs
+++ b/sled-diagnostics/src/contract_stub.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Stub implementation for platfroms without libcontract(3lib).
 
 use std::collections::BTreeSet;

--- a/smf/clickhouse/method_script.sh
+++ b/smf/clickhouse/method_script.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -x
 set -o errexit

--- a/smf/cockroach-admin/method_script.sh
+++ b/smf/cockroach-admin/method_script.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -x
 set -o errexit

--- a/smf/cockroachdb/method_script.sh
+++ b/smf/cockroachdb/method_script.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -x
 set -o errexit

--- a/smf/ntp-admin/method_script.sh
+++ b/smf/ntp-admin/method_script.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -x
 set -o errexit

--- a/tools/ci_check_opte_ver.sh
+++ b/tools/ci_check_opte_ver.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 set -euo pipefail
 
 source tools/opte_version_override

--- a/tools/create_self_signed_cert.sh
+++ b/tools/create_self_signed_cert.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 # Creates a self-signed certificate.
 #

--- a/tools/delete-reservoir.sh
+++ b/tools/delete-reservoir.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 size=`pfexec /usr/lib/rsrvrctl -q | grep Free | awk '{print $3}'`
 let x=$size/1024

--- a/tools/ensure_buildomat_artifact.sh
+++ b/tools/ensure_buildomat_artifact.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #
 # Ensure a buildomat artifact is downloaded and available locally.
 

--- a/tools/include/force-git-over-https.sh
+++ b/tools/include/force-git-over-https.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #
 # The token authentication mechanism that affords us access to other private
 # repositories requires that we use HTTPS URLs for GitHub, rather than SSH.

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -eu
 

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #
 # Small tool to install OPTE and the xde kernel driver and ONU bits.
 

--- a/tools/install_prerequisites.sh
+++ b/tools/install_prerequisites.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -eu
 

--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -eu
 

--- a/tools/reflector/helpers.sh
+++ b/tools/reflector/helpers.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o pipefail
 set -o errexit

--- a/tools/renovate-post-upgrade.sh
+++ b/tools/renovate-post-upgrade.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 # This script is run after Renovate upgrades dependencies or lock files.
 

--- a/tools/scrimlet/create-softnpu-zone.sh
+++ b/tools/scrimlet/create-softnpu-zone.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -x
 set -e

--- a/tools/scrimlet/destroy-softnpu-zone.sh
+++ b/tools/scrimlet/destroy-softnpu-zone.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -x
 set -e

--- a/tools/uninstall_opte.sh
+++ b/tools/uninstall_opte.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #
 # Small tool to _uninstall_ OPTE and the xde kernel driver and ONU bits.
 #

--- a/tools/update_crucible.sh
+++ b/tools/update_crucible.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o pipefail
 set -o errexit

--- a/tools/update_dendrite.sh
+++ b/tools/update_dendrite.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o pipefail
 set -o errexit

--- a/tools/update_helpers.sh
+++ b/tools/update_helpers.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o pipefail
 set -o errexit

--- a/tools/update_lldp.sh
+++ b/tools/update_lldp.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o pipefail
 set -o errexit

--- a/tools/update_maghemite.sh
+++ b/tools/update_maghemite.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o pipefail
 set -o errexit

--- a/tools/update_propolis.sh
+++ b/tools/update_propolis.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o pipefail
 set -o errexit

--- a/tools/update_pumpkind.sh
+++ b/tools/update_pumpkind.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o pipefail
 set -o errexit

--- a/tools/update_transceiver_control.sh
+++ b/tools/update_transceiver_control.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 set -o pipefail
 set -o errexit

--- a/trust-quorum/types/versions/src/impls/salt.rs
+++ b/trust-quorum/types/versions/src/impls/salt.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use rand::{TryRngCore as _, rngs::OsRng};
 
 use crate::v1::crypto::Salt;

--- a/wicket/src/ui/widgets/fade.rs
+++ b/wicket/src/ui/widgets/fade.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::ui::defaults::style;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;


### PR DESCRIPTION
And fix em all.

I am not touching the copyright lines, but if it were up to me either would either:

* delete them all, or
* take the year out and make it part of the license header that `license-eye` enforces.

We're not using it consistently anyway. Claude says: "of 1993 .rs files, only 153 (~8%) carry the line".