### PR TITLE
[db-queries] allow `paginated` to work with `join`s

### DIFF
--- a/nexus/db-queries/src/db/pagination.rs
+++ b/nexus/db-queries/src/db/pagination.rs
@@ -560,6 +560,8 @@ mod test {
     use std::num::NonZeroU32;
     use uuid::Uuid;
 
+    type BoxedQuery<T> = diesel::helper_types::IntoBoxed<'static, T, Pg>;
+
     mod schema {
         use diesel::prelude::*;
 

--- a/nexus/db-queries/src/db/pagination.rs
+++ b/nexus/db-queries/src/db/pagination.rs
@@ -37,27 +37,63 @@ type BoxedDslOutput<T> = diesel::internal::table_macro::BoxedSelectStatement<
 
 /// Uses `pagparams` to list a subset of rows in `table`, ordered by `column`.
 pub fn paginated<T, C, M>(
-    table: T,
+    query: T,
     column: C,
     pagparams: &DataPageParams<'_, M>,
-) -> BoxedQuery<T>
+) -> <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output
 where
-    // T is a table which can create a BoxedQuery.
-    T: diesel::Table,
-    T: query_methods::BoxedDsl<'static, Pg, Output = BoxedDslOutput<T>>,
-    // C is a column which appears in T.
+// T is a table^H^H^H^H^Hquery source which can create a BoxedQuery.
+    T: QuerySource,
+    T: AsQuery,
+    <T as QuerySource>::DefaultSelection:
+        Expression<SqlType = <T as AsQuery>::SqlType>,
+    T::Query: query_methods::BoxedDsl<'static, Pg>,
+// Required for...everything.
+    <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output: QueryDsl,
+// C is a column which appears in T.
     C: 'static + Column + Copy + ExpressionMethods + AppearsOnTable<T>,
-    // Required to compare the column with the marker type.
+// Required to compare the column with the marker type.
     C::SqlType: SqlType,
     M: Clone + AsExpression<C::SqlType>,
-    // Defines the methods which can be called on "query", and tells
-    // the compiler we're gonna output a BoxedQuery each time.
-    BoxedQuery<T>: query_methods::OrderDsl<Desc<C>, Output = BoxedQuery<T>>,
-    BoxedQuery<T>: query_methods::OrderDsl<Asc<C>, Output = BoxedQuery<T>>,
-    BoxedQuery<T>: query_methods::FilterDsl<Gt<C, M>, Output = BoxedQuery<T>>,
-    BoxedQuery<T>: query_methods::FilterDsl<Lt<C, M>, Output = BoxedQuery<T>>,
+// Defines the methods which can be called on "query", and tells
+// the compiler we're gonna output a BoxedQuery each time.
+//
+// Necessary for query.order(column.desc())
+    <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output:
+        query_methods::OrderDsl<
+            Desc<C>,
+            Output = <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output,
+        >,
+// Necessary for query.order(column.asc())
+    <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output:
+        query_methods::OrderDsl<
+            Asc<C>,
+            Output = <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output,
+        >,
+// Necessary for query.filter(column.gt(...))
+    <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output:
+        query_methods::FilterDsl<
+            Gt<C, M>,
+            Output =
+            <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output,
+        >,
+// Necessary for query.filter(column.lt(...))
+    <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output:
+        query_methods::FilterDsl<
+            Lt<C, M>,
+            Output = <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output,
+        >,
+// Necessary for `query.limit(...)`
+    <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output:
+        query_methods::LimitDsl<
+            Output = <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output,
+        >,
 {
-    let mut query = table.into_boxed().limit(pagparams.limit.get().into());
+    use query_methods::BoxedDsl;
+    let mut query = query
+        .as_query()
+        .internal_into_boxed()
+        .limit(pagparams.limit.get().into());
     let marker = pagparams.marker.map(|m| m.clone());
     match pagparams.direction {
         dropshot::PaginationOrder::Ascending => {

--- a/nexus/db-queries/src/db/pagination.rs
+++ b/nexus/db-queries/src/db/pagination.rs
@@ -23,19 +23,7 @@ use omicron_common::api::external::http_pagination::PaginatedBy;
 use ref_cast::RefCast;
 use std::num::NonZeroU32;
 
-// Shorthand alias for "the SQL type of the whole table".
-type TableSqlType<T> = <T as AsQuery>::SqlType;
-
-// Shorthand alias for the type made from "table.into_boxed()".
-type BoxedQuery<T> = diesel::helper_types::IntoBoxed<'static, T, Pg>;
-type BoxedDslOutput<T> = diesel::internal::table_macro::BoxedSelectStatement<
-    'static,
-    TableSqlType<T>,
-    diesel::internal::table_macro::FromClause<T>,
-    Pg,
->;
-
-/// Uses `pagparams` to list a subset of rows in `table`, ordered by `column`.
+/// Uses `pagparams` to list a subset of rows in `query`, ordered by `column`.
 pub fn paginated<T, C, M>(
     query: T,
     column: C,
@@ -74,8 +62,7 @@ where
     <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output:
         query_methods::FilterDsl<
             Gt<C, M>,
-            Output =
-            <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output,
+            Output = <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output,
         >,
 // Necessary for query.filter(column.lt(...))
     <T::Query as query_methods::BoxedDsl<'static, Pg>>::Output:


### PR DESCRIPTION
Many moons ago, I merged PR #6530, which allowed the `paginated_multicolumn` wrapper to work with a `query` expression which could be a table, *or* a join of two or more tables, rather than just a single table. This involved some extremely complex and unpleasant Diesel magic that, in hindsight, I have no no idea how I figured out, but it did work. However, the same change was never applied to the `paginated` function, just `paginated_multicolumn`. I guess that in the intervening two years, we have never needed to paginate a join on one column rather than two.

Well, now I need to do this. So this branch makes a similar change to `paginated`. This is basically copied from what I did to `paginated_multicolumn` in #6530, but slightly simpler because there are fewer columns which must be ordered. Hooray!