### PR TITLE
[nexus] don't retry on non-retryable errors in some tests

### DIFF
--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -1489,14 +1489,22 @@ mod test {
                 let result =
                     dpd_client.nat_ipv4_list(&nat_subnet, None, None).await;
 
-                let data = result.map_err(|_| {
-                    poll::CondCheckError::<()>::NotYet { status: None }
-                })?;
+                let data = match result {
+                    Ok(data) => data,
+                    Err(error) if error.is_retryable() => {
+                        return Err(poll::CondCheckError::NotYet {
+                            status: None,
+                        });
+                    }
+                    Err(error) => {
+                        return Err(poll::CondCheckError::Failed(error));
+                    }
+                };
 
                 if data.items.len() == expected_nat_entries {
                     Ok(())
                 } else {
-                    Err(poll::CondCheckError::<()>::NotYet { status: None })
+                    Err(poll::CondCheckError::NotYet { status: None })
                 }
             },
             &poll_interval,
@@ -1545,16 +1553,24 @@ mod test {
 
                 info!(log, "nat_ipv4_list"; "result" => ?result);
 
-                let data = result.map_err(|_| {
-                    poll::CondCheckError::<()>::NotYet { status: None }
-                })?;
+                let data = match result {
+                    Ok(data) => data,
+                    Err(error) if error.is_retryable() => {
+                        return Err(poll::CondCheckError::NotYet {
+                            status: None,
+                        });
+                    }
+                    Err(error) => {
+                        return Err(poll::CondCheckError::Failed(error));
+                    }
+                };
 
                 if data.items.is_empty() {
                     error!(
                         log,
                         "we are expecting nat entries but none were found"
                     );
-                    Err(poll::CondCheckError::<()>::NotYet { status: None })
+                    Err(poll::CondCheckError::NotYet { status: None })
                 } else {
                     Ok(())
                 }

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -2857,15 +2857,16 @@ mod test {
                 // (Triggering reconciliation is idempotent, so it is safe to do
                 // on every iteration.)
                 if let Err(error) = client.nat_trigger_update().await {
+                    if !error.is_retryable() {
+                        return Err(poll::CondCheckError::Failed(error));
+                    }
                     slog::info!(
                         log,
                         "failed to trigger NAT reconciliation, will retry";
                         "switch" => ?switch,
                         InlineErrorChain::new(&error),
                     );
-                    return Err(poll::CondCheckError::<&'static str>::NotYet {
-                        status: None,
-                    });
+                    return Err(poll::CondCheckError::NotYet { status: None });
                 }
 
                 let result =
@@ -2877,15 +2878,17 @@ mod test {
                     "result" => ?result,
                 );
 
-                let data = result.map_err(|_| {
-                    // Use `&'static str` as the permanent error type so that it
-                    // implements `Display`, which is necessary for the
-                    // `poll::Error` to be `Display`...even though we never
-                    // return a `Permanent` error here. I love types.
-                    poll::CondCheckError::<&'static str>::NotYet {
-                        status: None,
+                let data = match result {
+                    Ok(data) => data,
+                    Err(error) if error.is_retryable() => {
+                        return Err(poll::CondCheckError::NotYet {
+                            status: None,
+                        });
                     }
-                })?;
+                    Err(error) => {
+                        return Err(poll::CondCheckError::Failed(error));
+                    }
+                };
                 let len = data.items.len();
                 if len != n {
                     slog::info!(
@@ -2895,9 +2898,7 @@ mod test {
                         "entries" => ?data.items,
                         "expected_len" => n,
                     );
-                    return Err(poll::CondCheckError::<&'static str>::NotYet {
-                        status: None,
-                    });
+                    return Err(poll::CondCheckError::NotYet { status: None });
                 }
 
                 Ok(())

--- a/nexus/test-utils/src/nexus_test.rs
+++ b/nexus/test-utils/src/nexus_test.rs
@@ -304,9 +304,10 @@ impl<N: NexusServer> ControlPlaneTestContext<N> {
             || async {
                 match dpd_client.switch_identifiers().await {
                     Ok(_) => Ok(()),
-                    Err(_) => Err(dev::poll::CondCheckError::<()>::NotYet {
-                        status: None,
-                    }),
+                    Err(error) if error.is_retryable() => {
+                        Err(dev::poll::CondCheckError::NotYet { status: None })
+                    }
+                    Err(error) => Err(dev::poll::CondCheckError::Failed(error)),
                 }
             },
             &Duration::from_millis(50),


### PR DESCRIPTION
Part of chasing down https://github.com/oxidecomputer/omicron/issues/10697. It looks like some other Dropshot service is grabbing this port in the interim. But we spin for the full 60 seconds when that happens (and we receive a 400), even though we can just fail right away.

This doesn't address the underlying issue, but at least makes our test runs that much faster when it happens.
