### PR TITLE
[ntp-admin] SMF service should explicitly depend on chrony setup

### DIFF
--- a/smf/chrony-setup/manifest.xml
+++ b/smf/chrony-setup/manifest.xml
@@ -33,7 +33,7 @@
     -->
     <propval name="boundary_pool" type="astring" value="" />
     <!--
-        Upstream NTP server. May be specifid more than once. (At least one is
+        Upstream NTP server. May be specified more than once. (At least one is
         required for boundary NTP zones; internal NTP zones instead use
         `boundary_pool` above to find the boundary NTP servers.)
     -->

--- a/smf/ntp-admin/manifest.xml
+++ b/smf/ntp-admin/manifest.xml
@@ -21,6 +21,11 @@
   <service_fmri value='svc:/oxide/ntp:default' />
   </dependency>
 
+  <dependency name='chrony-setup' grouping='require_all' restart_on='refresh'
+    type='service'>
+  <service_fmri value='svc:/oxide/chrony-setup:default' />
+  </dependency>
+
   <exec_method type='method' name='start'
     exec='/opt/oxide/lib/svc/manifest/ntp-admin.sh'
     timeout_seconds='0' />


### PR DESCRIPTION
Just a small change for correctness. We want to make sure ntp-admin depends on chrony having been configured, not just the NTP service being online. Also, the refresh behaviour on configuration being changed should be preserved.

I tagged a bunch of people who've worked on this service for a review. Wasn't exactly sure who to request a review from here.