### PR TITLE
Oximeter: add queue depth metric.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10285,6 +10285,7 @@ dependencies = [
  "oximeter-api",
  "oximeter-client",
  "oximeter-db",
+ "oximeter-test-utils",
  "oximeter-types",
  "proptest",
  "qorb",

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -50,6 +50,7 @@ nexus-client.workspace = true
 expectorate.workspace = true
 httpmock.workspace = true
 omicron-test-utils.workspace = true
+oximeter-test-utils.workspace = true
 openapi-lint.workspace = true
 openapiv3.workspace = true
 proptest.workspace = true

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -13,7 +13,6 @@ use crate::collection_task::ForcedCollectionError;
 use crate::probes;
 use crate::results_sink;
 use crate::self_stats;
-use crate::self_stats::DatabaseSamplesDropped;
 use anyhow::anyhow;
 use chrono::DateTime;
 use chrono::Utc;
@@ -23,7 +22,6 @@ use nexus_client::types::IdSortMode;
 use omicron_common::backoff;
 use omicron_common::backoff::BackoffError;
 use oximeter::Sample;
-use oximeter::types::Cumulative;
 use oximeter::types::ProducerResultsItem;
 use oximeter_db::Client;
 use oximeter_db::DbWrite;
@@ -47,8 +45,6 @@ use std::ops::Bound;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::interval;
@@ -146,12 +142,12 @@ impl OximeterAgent {
             collector_port: address.port(),
         };
 
-        let drop_counter = Arc::new(AtomicU64::new(0));
+        let collector_stats = self_stats::CollectorStats::new(Utc::now());
 
         // Spawn the task for aggregating and inserting all metrics to a
         // single node ClickHouse installation.
         tokio::spawn({
-            let drop_counter = drop_counter.clone();
+            let sink_stats = collector_stats.single_stats.clone();
             async move {
                 crate::results_sink::database_batcher(
                     insertion_log,
@@ -159,7 +155,7 @@ impl OximeterAgent {
                     db_config.batch_size,
                     Duration::from_secs(db_config.batch_interval),
                     collection_task_wrapper.single_rx,
-                    drop_counter,
+                    sink_stats,
                 )
                 .await
             }
@@ -195,23 +191,17 @@ impl OximeterAgent {
             &log,
         );
 
-        let cluster_drop_counter = Arc::new(AtomicU64::new(0));
-
         // Spawn the task for aggregating and inserting all metrics to a
         // replicated cluster ClickHouse installation
         tokio::spawn({
-            let cluster_drop_counter = cluster_drop_counter.clone();
-            async move {
-                results_sink::database_batcher(
-                    insertion_log_cluster,
-                    cluster_client,
-                    db_config.batch_size,
-                    Duration::from_secs(db_config.batch_interval),
-                    collection_task_wrapper.cluster_rx,
-                    cluster_drop_counter,
-                )
-                .await
-            }
+            results_sink::database_batcher(
+                insertion_log_cluster,
+                cluster_client,
+                db_config.batch_size,
+                Duration::from_secs(db_config.batch_interval),
+                collection_task_wrapper.cluster_rx,
+                collector_stats.cluster_stats.clone(),
+            )
         });
 
         let self_ = Self {
@@ -225,84 +215,12 @@ impl OximeterAgent {
             last_refresh_time: Arc::new(Mutex::new(None)),
         };
 
-        // Periodically emit self-stats about dropped samples.
-        //
-        // Note: If oximeter isn't able to write metrics to ClickHouse,
-        // self-stats about oximeter's inability to write metrics will
-        // also never reach ClickHouse. However, we may still be able to
-        // emit these metrics if the write path to ClickHouse is partially
-        // degraded. And because the relevant counters live in oximeter's
-        // memory, even if ClickHouse becomes fully unavailable and then
-        // recovers, the metrics will also eventually reach the database.
-        //
-        // TODO: Emit a metric about failed database writes as well.
-        tokio::spawn({
-            let mut drop_ticker = interval(self_stats::COLLECTION_INTERVAL);
-            let start_time = Utc::now();
-            async move {
-                loop {
-                    drop_ticker.tick().await;
-
-                    let single_metric = DatabaseSamplesDropped {
-                        datum: Cumulative::with_start_time(
-                            start_time,
-                            drop_counter.load(Ordering::Relaxed),
-                        ),
-                        collector_sink: "clickhouse-single".into(),
-                    };
-                    let single_sample = match Sample::new(
-                        &collection_target,
-                        &single_metric,
-                    ) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            error!(
-                                log,
-                                "failed to build single-node samples_dropped sample";
-                                InlineErrorChain::new(&e),
-                            );
-                            continue;
-                        }
-                    };
-
-                    let cluster_metric = DatabaseSamplesDropped {
-                        datum: Cumulative::with_start_time(
-                            start_time,
-                            cluster_drop_counter.load(Ordering::Relaxed),
-                        ),
-                        collector_sink: "clickhouse-cluster".into(),
-                    };
-                    let cluster_sample = match Sample::new(
-                        &collection_target,
-                        &cluster_metric,
-                    ) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            error!(
-                                log,
-                                "failed to build clustered samples_dropped sample";
-                                InlineErrorChain::new(&e),
-                            );
-                            continue;
-                        }
-                    };
-
-                    let _ = collection_task_wrapper
-                        .wrapper_tx
-                        .send(
-                            CollectionTaskOutput {
-                                results: vec![ProducerResultsItem::Ok(vec![
-                                    single_sample,
-                                    cluster_sample,
-                                ])],
-                                was_forced_collection: false,
-                            },
-                            &log,
-                        )
-                        .await;
-                }
-            }
-        });
+        tokio::spawn(emit_self_stats(
+            collector_stats,
+            collection_target,
+            collection_task_wrapper.wrapper_tx,
+            log,
+        ));
 
         Ok(self_)
     }
@@ -367,7 +285,10 @@ impl OximeterAgent {
                 client.init_replicated_db().await?;
             }
 
-            let drop_counter = Arc::new(AtomicU64::new(0));
+            let sink_stats = Arc::new(self_stats::CollectorSinkStats::new(
+                "standalone".into(),
+                Utc::now(),
+            ));
 
             // Spawn the task for aggregating and inserting all metrics
             tokio::spawn(async move {
@@ -377,7 +298,7 @@ impl OximeterAgent {
                     db_config.batch_size,
                     Duration::from_secs(db_config.batch_interval),
                     collection_task_wrapper.single_rx,
-                    drop_counter,
+                    sink_stats,
                 )
                 .await
             });
@@ -622,6 +543,55 @@ impl CollectionTaskSenderWrapper {
             );
         };
         Ok(())
+    }
+}
+
+// Emit stats about the collector agent.
+//
+// Note: If oximeter isn't able to write metrics to ClickHouse,
+// self-stats about oximeter's inability to write metrics will
+// also never reach ClickHouse. However, we may still be able to
+// emit these metrics if the write path to ClickHouse is partially
+// degraded. And because the relevant counters live in oximeter's
+// memory, even if ClickHouse becomes fully unavailable and then
+// recovers, the metrics will also eventually reach the database.
+//
+// TODO(#10552): Emit a metric about failed database writes as well.
+async fn emit_self_stats(
+    collector_stats: self_stats::CollectorStats,
+    collection_target: self_stats::OximeterCollector,
+    wrapper_tx: CollectionTaskSenderWrapper,
+    log: Logger,
+) {
+    let mut sink_stats_ticker = interval(self_stats::COLLECTION_INTERVAL);
+    loop {
+        sink_stats_ticker.tick().await;
+
+        let mut samples: Vec<Sample> = Vec::new();
+
+        for sink_stats in
+            [&collector_stats.single_stats, &collector_stats.cluster_stats]
+        {
+            match sink_stats.samples(&collection_target) {
+                Ok(s) => samples.extend(s),
+                Err(e) => error!(
+                    log,
+                    "failed to build database sink self-stats";
+                    "sink" => sink_stats.label.clone(),
+                    InlineErrorChain::new(&e),
+                ),
+            };
+        }
+
+        let _ = wrapper_tx
+            .send(
+                CollectionTaskOutput {
+                    results: vec![ProducerResultsItem::Ok(samples)],
+                    was_forced_collection: false,
+                },
+                &log,
+            )
+            .await;
     }
 }
 

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -13,6 +13,7 @@ use crate::collection_task::ForcedCollectionError;
 use crate::probes;
 use crate::results_sink;
 use crate::self_stats;
+use crate::self_stats::DatabaseSamplesDropped;
 use anyhow::anyhow;
 use chrono::DateTime;
 use chrono::Utc;
@@ -21,6 +22,9 @@ use nexus_client::Client as NexusClient;
 use nexus_client::types::IdSortMode;
 use omicron_common::backoff;
 use omicron_common::backoff::BackoffError;
+use oximeter::Sample;
+use oximeter::types::Cumulative;
+use oximeter::types::ProducerResultsItem;
 use oximeter_db::Client;
 use oximeter_db::DbWrite;
 use oximeter_types::producer::ProducerDetails;
@@ -43,8 +47,11 @@ use std::ops::Bound;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::sync::mpsc;
+use tokio::time::interval;
 use uuid::Uuid;
 
 /// The internal agent the oximeter server uses to collect metrics from producers.
@@ -93,7 +100,7 @@ impl OximeterAgent {
             "collector_ip" => address.ip().to_string(),
         ));
         let insertion_log = log.new(o!("component" => "results-sink"));
-        let instertion_log_cluster =
+        let insertion_log_cluster =
             log.new(o!("component" => "results-sink-cluster"));
 
         // Determine the version of the database.
@@ -139,17 +146,23 @@ impl OximeterAgent {
             collector_port: address.port(),
         };
 
+        let drop_counter = Arc::new(AtomicU64::new(0));
+
         // Spawn the task for aggregating and inserting all metrics to a
         // single node ClickHouse installation.
-        tokio::spawn(async move {
-            crate::results_sink::database_batcher(
-                insertion_log,
-                client,
-                db_config.batch_size,
-                Duration::from_secs(db_config.batch_interval),
-                collection_task_wrapper.single_rx,
-            )
-            .await
+        tokio::spawn({
+            let drop_counter = drop_counter.clone();
+            async move {
+                crate::results_sink::database_batcher(
+                    insertion_log,
+                    client,
+                    db_config.batch_size,
+                    Duration::from_secs(db_config.batch_interval),
+                    collection_task_wrapper.single_rx,
+                    drop_counter,
+                )
+                .await
+            }
         });
 
         // Our internal testing rack will be running a ClickHouse cluster
@@ -182,29 +195,114 @@ impl OximeterAgent {
             &log,
         );
 
+        let cluster_drop_counter = Arc::new(AtomicU64::new(0));
+
         // Spawn the task for aggregating and inserting all metrics to a
         // replicated cluster ClickHouse installation
-        tokio::spawn(async move {
-            results_sink::database_batcher(
-                instertion_log_cluster,
-                cluster_client,
-                db_config.batch_size,
-                Duration::from_secs(db_config.batch_interval),
-                collection_task_wrapper.cluster_rx,
-            )
-            .await
+        tokio::spawn({
+            let cluster_drop_counter = cluster_drop_counter.clone();
+            async move {
+                results_sink::database_batcher(
+                    insertion_log_cluster,
+                    cluster_client,
+                    db_config.batch_size,
+                    Duration::from_secs(db_config.batch_interval),
+                    collection_task_wrapper.cluster_rx,
+                    cluster_drop_counter,
+                )
+                .await
+            }
         });
 
         let self_ = Self {
             id,
-            log,
+            log: log.clone(),
             collection_target,
-            result_sender: collection_task_wrapper.wrapper_tx,
+            result_sender: collection_task_wrapper.wrapper_tx.clone(),
             collection_tasks: Arc::new(Mutex::new(BTreeMap::new())),
             refresh_interval,
             refresh_task: Arc::new(Mutex::new(None)),
             last_refresh_time: Arc::new(Mutex::new(None)),
         };
+
+        // Periodically emit self-stats about dropped samples.
+        //
+        // Note: If oximeter isn't able to write metrics to ClickHouse,
+        // self-stats about oximeter's inability to write metrics will
+        // also never reach ClickHouse. However, we may still be able to
+        // emit these metrics if the write path to ClickHouse is partially
+        // degraded. And because the relevant counters live in oximeter's
+        // memory, even if ClickHouse becomes fully unavailable and then
+        // recovers, the metrics will also eventually reach the database.
+        //
+        // TODO: Emit a metric about failed database writes as well.
+        tokio::spawn({
+            let mut drop_ticker = interval(self_stats::COLLECTION_INTERVAL);
+            let start_time = Utc::now();
+            async move {
+                loop {
+                    drop_ticker.tick().await;
+
+                    let single_metric = DatabaseSamplesDropped {
+                        datum: Cumulative::with_start_time(
+                            start_time,
+                            drop_counter.load(Ordering::Relaxed),
+                        ),
+                        collector_sink: "clickhouse-single".into(),
+                    };
+                    let single_sample = match Sample::new(
+                        &collection_target,
+                        &single_metric,
+                    ) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!(
+                                log,
+                                "failed to build single-node samples_dropped sample";
+                                InlineErrorChain::new(&e),
+                            );
+                            continue;
+                        }
+                    };
+
+                    let cluster_metric = DatabaseSamplesDropped {
+                        datum: Cumulative::with_start_time(
+                            start_time,
+                            cluster_drop_counter.load(Ordering::Relaxed),
+                        ),
+                        collector_sink: "clickhouse-cluster".into(),
+                    };
+                    let cluster_sample = match Sample::new(
+                        &collection_target,
+                        &cluster_metric,
+                    ) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!(
+                                log,
+                                "failed to build clustered samples_dropped sample";
+                                InlineErrorChain::new(&e),
+                            );
+                            continue;
+                        }
+                    };
+
+                    let _ = collection_task_wrapper
+                        .wrapper_tx
+                        .send(
+                            CollectionTaskOutput {
+                                results: vec![ProducerResultsItem::Ok(vec![
+                                    single_sample,
+                                    cluster_sample,
+                                ])],
+                                was_forced_collection: false,
+                            },
+                            &log,
+                        )
+                        .await;
+                }
+            }
+        });
 
         Ok(self_)
     }
@@ -269,6 +367,8 @@ impl OximeterAgent {
                 client.init_replicated_db().await?;
             }
 
+            let drop_counter = Arc::new(AtomicU64::new(0));
+
             // Spawn the task for aggregating and inserting all metrics
             tokio::spawn(async move {
                 results_sink::database_batcher(
@@ -277,6 +377,7 @@ impl OximeterAgent {
                     db_config.batch_size,
                     Duration::from_secs(db_config.batch_interval),
                     collection_task_wrapper.single_rx,
+                    drop_counter,
                 )
                 .await
             });

--- a/oximeter/collector/src/results_sink.rs
+++ b/oximeter/collector/src/results_sink.rs
@@ -24,6 +24,8 @@ use slog_error_chain::InlineErrorChain;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
@@ -41,6 +43,7 @@ pub async fn database_batcher(
     batch_size: usize,
     batch_interval: Duration,
     mut rx: mpsc::Receiver<CollectionTaskOutput>,
+    dropped_counter: Arc<AtomicU64>,
 ) {
     // Construct a handoff point between the batch task here, and the database
     // insertion task.
@@ -118,6 +121,7 @@ pub async fn database_batcher(
                                 "sample buffer full, dropped oldest samples";
                                 "n_dropped" => n_dropped,
                             );
+                            dropped_counter.fetch_add(n_dropped as u64, Ordering::Relaxed);
                         }
                     }
                     None => {
@@ -311,6 +315,7 @@ pub async fn logger(log: Logger, mut rx: mpsc::Receiver<CollectionTaskOutput>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use omicron_test_utils::dev::test_setup_log;
     use proptest::prelude::*;
     use tokio::time::timeout;
 
@@ -421,5 +426,43 @@ mod tests {
                 }).expect_err("Should not be notified");
             }
         }
+    }
+
+    #[tokio::test]
+    async fn batcher_increments_dropped_counter() {
+        let logctx = test_setup_log("batcher_increments_dropped_counter");
+        let log = &logctx.log;
+
+        // Construct a database batcher with a dummy ClickHouse client.
+        let client = Client::new("[::1]:0".parse().unwrap(), log);
+        let (tx, rx) = mpsc::channel(1);
+        let counter = Arc::new(AtomicU64::new(0));
+        let batcher = tokio::spawn(database_batcher(
+            log.clone(),
+            client,
+            BATCH_SIZE,
+            Duration::from_secs(3600),
+            rx,
+            counter.clone(),
+        ));
+
+        // Insert `want_dropped` too many samples into the batcher.
+        let want_dropped = 50;
+        let samples = (0..MAX_BUFFER_SIZE + want_dropped)
+            .map(|_| oximeter_test_utils::make_sample())
+            .collect();
+        tx.send(CollectionTaskOutput {
+            results: vec![ProducerResultsItem::Ok(samples)],
+            was_forced_collection: false,
+        })
+        .await
+        .unwrap();
+
+        // Drop the sender so that the batcher loop exits.
+        drop(tx);
+        batcher.await.unwrap();
+
+        assert_eq!(counter.load(Ordering::Relaxed), want_dropped as u64);
+        logctx.cleanup_successful();
     }
 }

--- a/oximeter/collector/src/results_sink.rs
+++ b/oximeter/collector/src/results_sink.rs
@@ -9,7 +9,9 @@
 
 use crate::collection_task::CollectionTaskOutput;
 use crate::probes;
+use crate::self_stats;
 use oximeter::Sample;
+use oximeter::histogram::Record;
 use oximeter::queue::BoundedQueue;
 use oximeter::types::ProducerResultsItem;
 use oximeter_db::Client;
@@ -24,8 +26,6 @@ use slog_error_chain::InlineErrorChain;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
@@ -43,7 +43,7 @@ pub async fn database_batcher(
     batch_size: usize,
     batch_interval: Duration,
     mut rx: mpsc::Receiver<CollectionTaskOutput>,
-    dropped_counter: Arc<AtomicU64>,
+    sink_stats: Arc<self_stats::CollectorSinkStats>,
 ) {
     // Construct a handoff point between the batch task here, and the database
     // insertion task.
@@ -112,7 +112,7 @@ pub async fn database_batcher(
                         probes::results__sink__item__processed!(|| n_samples);
 
                         // Append the current batch to the handoff buffer.
-                        let n_dropped =
+                        let (n_dropped, queue_depth) =
                             batch_tx.send_and_notify(batch, was_forced_collection);
                         if n_dropped > 0 {
                             probes::dropped__old__samples!(|| n_dropped);
@@ -121,8 +121,13 @@ pub async fn database_batcher(
                                 "sample buffer full, dropped oldest samples";
                                 "n_dropped" => n_dropped,
                             );
-                            dropped_counter.fetch_add(n_dropped as u64, Ordering::Relaxed);
+                            *sink_stats.samples_dropped.lock().unwrap() += n_dropped.try_into().unwrap();
                         }
+                        // Note: Histogram::u64::sample should never error.
+                        // The `sample` method only returns a `HistogramError`
+                        // if its argument is non-finite, and `u64` values are
+                        // always finite.
+                        sink_stats.queue_depth.lock().unwrap().sample(queue_depth.try_into().unwrap()).unwrap();
                     }
                     None => {
                         warn!(log, "result queue closed, exiting");
@@ -199,7 +204,7 @@ impl<T> BatchSender<T> {
         &self,
         samples: Vec<T>,
         was_forced_collection: bool,
-    ) -> usize {
+    ) -> (usize, usize) {
         let mut batch = self.handoff.batch.lock().unwrap();
 
         let n_dropped = batch.extend(samples);
@@ -208,7 +213,7 @@ impl<T> BatchSender<T> {
         if was_forced_collection || batch.len() >= self.batch_size {
             self.notify_inserter();
         }
-        n_dropped
+        (n_dropped, batch.len())
     }
 }
 
@@ -315,6 +320,7 @@ pub async fn logger(log: Logger, mut rx: mpsc::Receiver<CollectionTaskOutput>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
     use omicron_test_utils::dev::test_setup_log;
     use proptest::prelude::*;
     use tokio::time::timeout;
@@ -327,7 +333,7 @@ mod tests {
         let (batch_tx, batch_rx) = batch_handoff::<()>(BATCH_SIZE);
         let n_samples = 3;
         let samples = vec![(); n_samples];
-        let n_dropped = batch_tx.send_and_notify(samples, true);
+        let (n_dropped, _) = batch_tx.send_and_notify(samples, true);
         assert_eq!(n_dropped, 0);
         assert_eq!(batch_tx.handoff.batch.lock().unwrap().len(), n_samples);
 
@@ -353,7 +359,7 @@ mod tests {
             // Insert the first batch of samples.
             let (batch_tx, batch_rx) = batch_handoff::<usize>(BATCH_SIZE);
             let samples = (0..current_size).collect();
-            let n_dropped = batch_tx.send_and_notify(samples, false);
+            let (n_dropped, _) = batch_tx.send_and_notify(samples, false);
             let expected_n_dropped = current_size.saturating_sub(MAX_BUFFER_SIZE);
             let expected_n_samples = current_size.min(MAX_BUFFER_SIZE);
             assert_eq!(n_dropped, expected_n_dropped);
@@ -389,7 +395,7 @@ mod tests {
             // Push the new set of samples, which start at the end of the first
             // batch, even if we've dropped some.
             let new_samples = (current_size..(current_size + new_size)).collect();
-            let n_dropped = batch_tx.send_and_notify(new_samples, false);
+            let (n_dropped, _) = batch_tx.send_and_notify(new_samples, false);
 
             // We expect to drop all the samples beyond the maximum buffer size.
             // We need to include what we have in the buffer already (some of
@@ -436,14 +442,17 @@ mod tests {
         // Construct a database batcher with a dummy ClickHouse client.
         let client = Client::new("[::1]:0".parse().unwrap(), log);
         let (tx, rx) = mpsc::channel(1);
-        let counter = Arc::new(AtomicU64::new(0));
+        let sink_stats = Arc::new(self_stats::CollectorSinkStats::new(
+            "test".into(),
+            Utc::now(),
+        ));
         let batcher = tokio::spawn(database_batcher(
             log.clone(),
             client,
             BATCH_SIZE,
             Duration::from_secs(3600),
             rx,
-            counter.clone(),
+            sink_stats.clone(),
         ));
 
         // Insert `want_dropped` too many samples into the batcher.
@@ -462,7 +471,13 @@ mod tests {
         drop(tx);
         batcher.await.unwrap();
 
-        assert_eq!(counter.load(Ordering::Relaxed), want_dropped as u64);
+        let samples_dropped = sink_stats.samples_dropped.lock().unwrap();
+        assert_eq!(samples_dropped.value(), want_dropped as u64);
+
+        let queue_depth = sink_stats.queue_depth.lock().unwrap();
+        assert_eq!(queue_depth.n_samples(), 1);
+        assert_eq!(queue_depth.max(), MAX_BUFFER_SIZE as u64);
+
         logctx.cleanup_successful();
     }
 }

--- a/oximeter/collector/src/self_stats.rs
+++ b/oximeter/collector/src/self_stats.rs
@@ -5,17 +5,23 @@
 //! Metrics oximeter reports about itself
 
 use crate::ProducerEndpoint;
+use chrono::DateTime;
+use chrono::Utc;
 use oximeter::MetricsError;
 use oximeter::Sample;
+use oximeter::histogram::Histogram;
 use oximeter::types::Cumulative;
 use oximeter::types::ProducerResultsItem;
 use reqwest::StatusCode;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 oximeter::use_timeseries!("oximeter-collector.toml");
 pub use self::oximeter_collector::Collections;
+pub use self::oximeter_collector::DatabaseQueueDepth;
 pub use self::oximeter_collector::DatabaseSamplesDropped;
 pub use self::oximeter_collector::FailedCollections;
 pub use self::oximeter_collector::OximeterCollector;
@@ -69,6 +75,70 @@ impl FailureReason {
             }
             Self::Other(c) => Cow::Owned(c.as_u16().to_string()),
         }
+    }
+}
+
+pub struct CollectorStats {
+    pub single_stats: Arc<CollectorSinkStats>,
+    pub cluster_stats: Arc<CollectorSinkStats>,
+}
+
+impl CollectorStats {
+    pub fn new(start_time: DateTime<Utc>) -> Self {
+        Self {
+            single_stats: Arc::new(CollectorSinkStats::new(
+                "clickhouse-single".into(),
+                start_time,
+            )),
+            cluster_stats: Arc::new(CollectorSinkStats::new(
+                "clickhouse-cluster".into(),
+                start_time,
+            )),
+        }
+    }
+}
+
+pub struct CollectorSinkStats {
+    pub label: String,
+    pub samples_dropped: Mutex<Cumulative<u64>>,
+    pub queue_depth: Mutex<Histogram<u64>>,
+}
+
+impl CollectorSinkStats {
+    pub fn new(label: String, start_time: DateTime<Utc>) -> Self {
+        // Note: `span_decades(0, 5)` produces a log-linear histogram that spans
+        // [0, 1_000_000). As of this writing, the collector's `BoundedQueue` is
+        // sized at a fixed 100_000 (batch_size of 1000 * MAX_BUFFER_SIZE_MULTIPLIER
+        // of 100), but we set a higher cap here so that we don't saturate it if we
+        // choose a larger queue later on.
+        let mut queue_depth =
+            Histogram::span_decades(0, 5).expect("histogram bounds are valid");
+        queue_depth.set_start_time(start_time);
+        Self {
+            label,
+            samples_dropped: Mutex::new(Cumulative::with_start_time(
+                start_time, 0,
+            )),
+            queue_depth: Mutex::new(queue_depth),
+        }
+    }
+
+    pub fn samples(
+        &self,
+        collection_target: &OximeterCollector,
+    ) -> Result<Vec<Sample>, MetricsError> {
+        let drop_metric = DatabaseSamplesDropped {
+            datum: *self.samples_dropped.lock().unwrap(),
+            collector_sink: self.label.clone().into(),
+        };
+        let queue_metric = DatabaseQueueDepth {
+            datum: self.queue_depth.lock().unwrap().clone(),
+            collector_sink: self.label.clone().into(),
+        };
+        Ok(vec![
+            Sample::new(collection_target, &drop_metric)?,
+            Sample::new(collection_target, &queue_metric)?,
+        ])
     }
 }
 

--- a/oximeter/collector/src/self_stats.rs
+++ b/oximeter/collector/src/self_stats.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 oximeter::use_timeseries!("oximeter-collector.toml");
 pub use self::oximeter_collector::Collections;
+pub use self::oximeter_collector::DatabaseSamplesDropped;
 pub use self::oximeter_collector::FailedCollections;
 pub use self::oximeter_collector::OximeterCollector;
 

--- a/oximeter/oximeter/schema/oximeter-collector.toml
+++ b/oximeter/oximeter/schema/oximeter-collector.toml
@@ -26,6 +26,15 @@ versions = [
     { added_in = 1, fields = [ "base_route", "producer_id", "producer_ip", "producer_port", "reason" ] }
 ]
 
+[[metrics]]
+name = "database_samples_dropped"
+description = "Total number of samples dropped from the database queue"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [ "collector_sink" ] }
+]
+
 [fields.base_route]
 type = "string"
 description = "Base HTTP route used to request data from the producer"
@@ -41,6 +50,10 @@ description = "IP address of the oximeter collector instance"
 [fields.collector_port]
 type = "u16"
 description = "Port of the oximeter collector instance"
+
+[fields.collector_sink]
+type = "string"
+description = "Name of collector metrics destination"
 
 [fields.producer_id]
 type = "uuid"

--- a/oximeter/oximeter/schema/oximeter-collector.toml
+++ b/oximeter/oximeter/schema/oximeter-collector.toml
@@ -28,9 +28,18 @@ versions = [
 
 [[metrics]]
 name = "database_samples_dropped"
-description = "Total number of samples dropped from the database queue"
+description = "Total number of samples dropped from the database insertion queue"
 units = "count"
 datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [ "collector_sink" ] }
+]
+
+[[metrics]]
+name = "database_queue_depth"
+description = "Size of the database insertion queue, sampled at queue insert time"
+units = "count"
+datum_type = "histogram_u64"
 versions = [
     { added_in = 1, fields = [ "collector_sink" ] }
 ]


### PR DESCRIPTION
In #10683, we added a metric counting the number of samples evicted from the oximeter collector's database_batcher queue. Operators can use that metric to detect that samples are being lost, but not that samples are potentially about to be lost. In other words, we have to wait for something to go wrong to take action.

This patch adds a queue depth metric to the collector as well: a histogram recording the current length of the queue each time we push a new batch of samples onto it. Operators can use this metric to detect when the queue depth is approaching its maximum length.

Part of #10552.

Note: builds on #10683. Can just review the second commit, or review both commits here and ignore #10683.

And I promise I'm almost done thinking about #10552. This is one of the last papercuts before I'll feel like this is sorted.