### PR TITLE
sled-agent: minor cleanup/refactoring around `Disk`

### DIFF
--- a/sled-agent/config-reconciler/src/debug_collector/handle.rs
+++ b/sled-agent/config-reconciler/src/debug_collector/handle.rs
@@ -69,19 +69,16 @@ impl DebugCollector {
         for disk in disks {
             match disk.variant() {
                 DiskVariant::M2 => {
-                    // We only setup dump devices on real disks
-                    if !disk.is_synthetic() {
-                        match disk.dump_device_devfs_path(false) {
-                            Ok(path) => {
-                                m2_dump_slices.push(DumpSlicePath::from(path))
-                            }
-                            Err(err) => {
-                                warn!(
-                                    log,
-                                    "Error getting dump device devfs path";
-                                     err
-                                );
-                            }
+                    match disk.dump_device_devfs_path(false) {
+                        Ok(path) => {
+                            m2_dump_slices.push(DumpSlicePath::from(path))
+                        }
+                        Err(err) => {
+                            warn!(
+                                log,
+                                "Error getting dump device devfs path";
+                                 err
+                            );
                         }
                     }
                     let name = disk.zpool_name();

--- a/sled-agent/config-reconciler/src/internal_disks.rs
+++ b/sled-agent/config-reconciler/src/internal_disks.rs
@@ -1000,7 +1000,6 @@ mod tests {
                     dev_path: None,
                 },
                 slot: raw_disk.slot(),
-                variant: raw_disk.variant(),
                 identity: raw_disk.identity().clone(),
                 is_boot_disk: raw_disk.is_boot_disk(),
                 partitions: vec![],

--- a/sled-agent/config-reconciler/src/internal_disks.rs
+++ b/sled-agent/config-reconciler/src/internal_disks.rs
@@ -338,7 +338,7 @@ impl InternalDisks {
     ) -> Option<Result<Utf8PathBuf, Arc<PooledDiskError>>> {
         self.disks.iter().find_map(|disk| {
             if disk.slot == Some(slot) {
-                disk.boot_image_raw_devfs_path.clone()
+                Some(disk.boot_image_raw_devfs_path.clone())
             } else {
                 None
             }
@@ -477,7 +477,7 @@ mod internal_disk_details {
         // disks.
         pub(super) slot: Option<M2Slot>,
         pub(super) boot_image_raw_devfs_path:
-            Option<Result<Utf8PathBuf, Arc<PooledDiskError>>>,
+            Result<Utf8PathBuf, Arc<PooledDiskError>>,
     }
 
     // Special ID type for `InternalDiskDetails` that lets us guarantee we sort
@@ -537,20 +537,6 @@ impl From<&'_ Disk> for InternalDiskDetails {
                 );
             }
         };
-        // Synthetic disks panic if asked for their `slot()`, so filter
-        // them out first.
-        let slot = if disk.is_synthetic() {
-            None
-        } else {
-            M2Slot::try_from(disk.slot()).ok()
-        };
-
-        // Same story for devfs path.
-        let raw_devfs_path = if disk.is_synthetic() {
-            None
-        } else {
-            Some(disk.boot_image_devfs_path(true).map_err(Arc::new))
-        };
 
         Self {
             id: InternalDiskDetailsId {
@@ -558,8 +544,10 @@ impl From<&'_ Disk> for InternalDiskDetails {
                 is_boot_disk: disk.is_boot_disk(),
             },
             zpool_id,
-            slot,
-            boot_image_raw_devfs_path: raw_devfs_path,
+            slot: M2Slot::try_from(disk.slot()).ok(),
+            boot_image_raw_devfs_path: disk
+                .boot_image_devfs_path(true)
+                .map_err(Arc::new),
         }
     }
 }
@@ -586,7 +574,12 @@ impl InternalDiskDetails {
             },
             zpool_id,
             slot,
-            boot_image_raw_devfs_path: boot_image_raw_devfs_path.map(|p| Ok(p)),
+            // Treat `None` as a synthetic disk and insert an error here. Tests
+            // generally don't care about raw devfs paths, and those that do
+            // will need to pass in `Some(_)`.
+            boot_image_raw_devfs_path: boot_image_raw_devfs_path.ok_or_else(
+                || Arc::new(PooledDiskError::SyntheticDiskNoDevfsPath),
+            ),
         }
     }
 
@@ -922,15 +915,12 @@ mod tests {
         serial: String,
     }
 
-    impl From<ArbitraryInternalDiskDetailsId> for InternalDiskDetailsId {
+    impl From<ArbitraryInternalDiskDetailsId> for DiskIdentity {
         fn from(id: ArbitraryInternalDiskDetailsId) -> Self {
-            InternalDiskDetailsId {
-                identity: Arc::new(DiskIdentity {
-                    vendor: id.vendor,
-                    model: id.model,
-                    serial: id.serial,
-                }),
-                is_boot_disk: id.is_boot_disk,
+            DiskIdentity {
+                vendor: id.vendor,
+                model: id.model,
+                serial: id.serial,
             }
         }
     }
@@ -943,11 +933,15 @@ mod tests {
     ) {
         let disk_map: IdOrdMap<_> = values
             .into_iter()
-            .map(|id| InternalDiskDetails {
-                id: id.into(),
-                zpool_id: InternalZpoolUuid::new_v4(),
-                slot: None,
-                boot_image_raw_devfs_path: None,
+            .map(|id| {
+                let is_boot_disk = id.is_boot_disk;
+                InternalDiskDetails::fake_details(
+                    id.into(),
+                    InternalZpoolUuid::new_v4(),
+                    is_boot_disk,
+                    None,
+                    None,
+                )
             })
             .collect();
 

--- a/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
@@ -1085,7 +1085,6 @@ mod tests {
                     dev_path: None,
                 },
                 slot: raw_disk.slot(),
-                variant: raw_disk.variant(),
                 identity: raw_disk.identity().clone(),
                 is_boot_disk: raw_disk.is_boot_disk(),
                 partitions: vec![],

--- a/sled-hardware/src/disk.rs
+++ b/sled-hardware/src/disk.rs
@@ -60,6 +60,8 @@ pub enum PooledDiskError {
     CannotFormatM2NotImplemented,
     #[error(transparent)]
     NvmeFormatAndResize(#[from] NvmeFormattingError),
+    #[error("synthetic disks do not have a devfs path")]
+    SyntheticDiskNoDevfsPath,
 }
 
 /// A partition (or 'slice') of a disk.

--- a/sled-hardware/src/disk.rs
+++ b/sled-hardware/src/disk.rs
@@ -283,7 +283,6 @@ impl UnparsedDisk {
 pub struct PooledDisk {
     pub paths: DiskPaths,
     pub slot: i64,
-    pub variant: DiskVariant,
     pub identity: DiskIdentity,
     pub is_boot_disk: bool,
     pub partitions: Vec<Partition>,
@@ -327,7 +326,6 @@ impl PooledDisk {
         Ok(Self {
             paths: unparsed_disk.paths,
             slot: unparsed_disk.slot,
-            variant: unparsed_disk.variant,
             identity: unparsed_disk.identity,
             is_boot_disk: unparsed_disk.is_boot_disk,
             partitions,

--- a/sled-storage/src/disk.rs
+++ b/sled-storage/src/disk.rs
@@ -202,10 +202,6 @@ impl RawDisk {
         }
     }
 
-    pub fn is_real(&self) -> bool {
-        !self.is_synthetic()
-    }
-
     pub fn u2_zpool_path(&self) -> Result<Utf8PathBuf, PooledDiskError> {
         if !matches!(self.variant(), DiskVariant::U2) {
             return Err(PooledDiskError::UnexpectedVariant);

--- a/sled-storage/src/disk.rs
+++ b/sled-storage/src/disk.rs
@@ -310,17 +310,6 @@ impl Disk {
         Ok(disk)
     }
 
-    pub fn is_synthetic(&self) -> bool {
-        match self {
-            Self::Real(_) => false,
-            Self::Synthetic(_) => true,
-        }
-    }
-
-    pub fn is_real(&self) -> bool {
-        !self.is_synthetic()
-    }
-
     pub fn is_boot_disk(&self) -> bool {
         match self {
             Self::Real(disk) => disk.is_boot_disk,
@@ -366,7 +355,9 @@ impl Disk {
                 Partition::BootImage,
                 raw,
             ),
-            Self::Synthetic(_) => unreachable!(),
+            Self::Synthetic(_) => {
+                Err(PooledDiskError::SyntheticDiskNoDevfsPath)
+            }
         }
     }
 
@@ -380,7 +371,9 @@ impl Disk {
                 Partition::DumpDevice,
                 raw,
             ),
-            Self::Synthetic(_) => unreachable!(),
+            Self::Synthetic(_) => {
+                Err(PooledDiskError::SyntheticDiskNoDevfsPath)
+            }
         }
     }
 

--- a/sled-storage/src/disk.rs
+++ b/sled-storage/src/disk.rs
@@ -10,7 +10,7 @@ use derive_more::From;
 use iddqd::{IdOrdItem, id_upcast};
 use key_manager::StorageKeyRequester;
 use omicron_common::disk::{DiskIdentity, DiskVariant};
-use omicron_common::zpool_name::{ZpoolKind, ZpoolName};
+use omicron_common::zpool_name::ZpoolName;
 use omicron_uuid_kinds::ZpoolUuid;
 use sled_hardware::{
     DiskFirmware, Partition, PooledDisk, PooledDiskError, UnparsedDisk,
@@ -339,13 +339,7 @@ impl Disk {
     }
 
     pub fn variant(&self) -> DiskVariant {
-        match self {
-            Self::Real(disk) => disk.variant,
-            Self::Synthetic(disk) => match disk.zpool_name.kind() {
-                ZpoolKind::External => DiskVariant::U2,
-                ZpoolKind::Internal => DiskVariant::M2,
-            },
-        }
+        self.zpool_name().kind().into()
     }
 
     pub fn devfs_path(&self) -> &Utf8PathBuf {
@@ -423,7 +417,7 @@ impl From<Disk> for RawDisk {
                 pooled_disk.paths.devfs_path,
                 pooled_disk.paths.dev_path,
                 pooled_disk.slot,
-                pooled_disk.variant,
+                pooled_disk.zpool_name.kind().into(),
                 pooled_disk.identity,
                 pooled_disk.is_boot_disk,
                 pooled_disk.firmware,


### PR DESCRIPTION
I was poking around in here to remind myself of how some things worked, and did a little bit of cleanup:

1. Remove the `variant` field from `PooledDisk` (this information is now also present in the `ZpoolName`, so this field had become entirely superfluous)
2. Remove the `Disk::is_synthetic()` and `Disk::is_real()` methods. The only callers of these were using them to _avoid_ calling methods that panicked on synthetic disks, so instead, we change those methods to return errors. The callers should handle this fine, and it makes the synthetic disk abstraction a little less leaky.
3. Remove `RawDisk::is_real()` (no callers).