### PR TITLE
[bgp-config] fix `test_bgp_config_by_name` announce id type

### DIFF
--- a/nexus/db-queries/src/db/datastore/bgp.rs
+++ b/nexus/db-queries/src/db/datastore/bgp.rs
@@ -1757,7 +1757,9 @@ mod tests {
                         description: description.clone(),
                     },
                     asn,
-                    bgp_announce_set_id: NameOrId::Id(announce_id),
+                    bgp_announce_set_id: NameOrId::Id(
+                        announce_id.into_untyped_uuid(),
+                    ),
                     vrf: None,
                     shaper: None,
                     checker: None,


### PR DESCRIPTION
Fixes a mismerge between #10609 and #10654.

Only `test_bgp_config_by_name` is affected.