### PR TITLE
Catch exhaustive local storage allocation searches

### DIFF
--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -7365,7 +7365,7 @@ pub(in crate::db::datastore) mod test {
             .await
             .unwrap();
 
-        assert_eq!(previously_target_vmm.state, SledResourceVmmState::Active,);
+        assert_eq!(previously_target_vmm.state, SledResourceVmmState::Active);
 
         db.terminate().await;
         logctx.cleanup_successful();
@@ -7429,19 +7429,18 @@ pub(in crate::db::datastore) mod test {
             .await
             .unwrap();
 
-        assert_eq!(previously_target_vmm.state, SledResourceVmmState::Active,);
+        assert_eq!(previously_target_vmm.state, SledResourceVmmState::Active);
 
         db.terminate().await;
         logctx.cleanup_successful();
     }
 
-    // Ensure that Nexus does not perform an exhaustive search through all
-    // possible local storage allocations if a rendezvous dataset is marked
-    // no_provision = true.
+    // Ensure that Nexus does not perform an instance reservation with local
+    // storage if a rendezvous dataset is marked no_provision = true.
     #[tokio::test]
-    async fn local_storage_allocation_no_exhaustive_search_no_provision() {
+    async fn local_storage_allocation_no_reserve_no_provision() {
         let logctx = dev::test_setup_log(
-            "local_storage_allocation_no_exhaustive_search_no_provision",
+            "local_storage_allocation_no_reserve_no_provision",
         );
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
@@ -7504,7 +7503,7 @@ pub(in crate::db::datastore) mod test {
         )
         .await;
 
-        // Now attempt the reservation. This should complete quickly!
+        // Now attempt the reservation.
 
         let instance =
             Instance::from_local_storage_test_instance(&config.instances[0]);
@@ -7548,12 +7547,12 @@ pub(in crate::db::datastore) mod test {
         logctx.cleanup_successful();
     }
 
-    // Ensure that Nexus does not perform an exhaustive search through all
-    // possible local storage allocations if a rendezvous dataset is tombstoned.
+    // Ensure that Nexus does not perform an instance reservation with local
+    // storage if a rendezvous dataset is tombstoned.
     #[tokio::test]
-    async fn local_storage_allocation_no_exhaustive_search_tombstoned() {
+    async fn local_storage_allocation_no_reserve_tombstoned() {
         let logctx = dev::test_setup_log(
-            "local_storage_allocation_no_exhaustive_search_tombstoned",
+            "local_storage_allocation_no_reserve_tombstoned",
         );
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
@@ -7615,7 +7614,7 @@ pub(in crate::db::datastore) mod test {
         )
         .await;
 
-        // Now attempt the reservation. This should complete quickly!
+        // Now attempt the reservation.
 
         let instance =
             Instance::from_local_storage_test_instance(&config.instances[0]);
@@ -7659,12 +7658,12 @@ pub(in crate::db::datastore) mod test {
         logctx.cleanup_successful();
     }
 
-    // Ensure that Nexus does not perform an exhaustive search through all
-    // possible local storage allocations if a sled is expunged.
+    // Ensure that Nexus does not perform an instance reservation with local
+    // storage if a sled is expunged.
     #[tokio::test]
-    async fn local_storage_allocation_no_exhaustive_search_sled_expunge() {
+    async fn local_storage_allocation_no_reserve_sled_expunge() {
         let logctx = dev::test_setup_log(
-            "local_storage_allocation_no_exhaustive_search_sled_expunge",
+            "local_storage_allocation_no_reserve_sled_expunge",
         );
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
@@ -7722,7 +7721,7 @@ pub(in crate::db::datastore) mod test {
 
         set_sled_expunged(datastore, &opctx, config.sleds[0].sled_id).await;
 
-        // Now attempt the reservation. This should complete quickly!
+        // Now attempt the reservation.
 
         let instance =
             Instance::from_local_storage_test_instance(&config.instances[0]);
@@ -7766,12 +7765,12 @@ pub(in crate::db::datastore) mod test {
         logctx.cleanup_successful();
     }
 
-    // Ensure that Nexus does not perform an exhaustive search through all
-    // possible local storage allocations if a physical disk is expunged.
+    // Ensure that Nexus does not perform an instance reservation with local
+    // storage if a physical disk is expunged.
     #[tokio::test]
-    async fn local_storage_allocation_no_exhaustive_search_disk_expunge() {
+    async fn local_storage_allocation_no_reserve_disk_expunge() {
         let logctx = dev::test_setup_log(
-            "local_storage_allocation_no_exhaustive_search_disk_expunge",
+            "local_storage_allocation_no_reserve_disk_expunge",
         );
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
@@ -7834,7 +7833,7 @@ pub(in crate::db::datastore) mod test {
         )
         .await;
 
-        // Now attempt the reservation. This should complete quickly!
+        // Now attempt the reservation.
 
         let instance =
             Instance::from_local_storage_test_instance(&config.instances[0]);
@@ -7949,7 +7948,222 @@ pub(in crate::db::datastore) mod test {
             .await;
         }
 
-        // Now attempt the reservation. This should complete quickly!
+        // Now attempt the reservation.
+
+        let instance =
+            Instance::from_local_storage_test_instance(&config.instances[0]);
+
+        datastore
+            .sled_reservation_create_inner(
+                &opctx,
+                instance.id,
+                PropolisUuid::new_v4(),
+                instance.resources(),
+                db::model::SledReservationConstraints::none(),
+                SledReservationReason::Start,
+            )
+            .await
+            .unwrap();
+
+        let allocation_records: Vec<_> = {
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            use nexus_db_schema::schema::local_storage_unencrypted_dataset_allocation::dsl;
+
+            dsl::local_storage_unencrypted_dataset_allocation
+                .filter(dsl::time_deleted.is_null())
+                .select(db::model::LocalStorageUnencryptedDatasetAllocation::as_select())
+                .load_async(&*conn)
+                .await
+                .unwrap()
+        };
+
+        assert_eq!(allocation_records.len(), 5);
+
+        validate_local_storage_allocations(&datastore).await;
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // Ensure Nexus successfully performs an instance reservation even if some
+    // datasets are tombstoned.
+    #[tokio::test]
+    async fn local_storage_allocation_partial_tombstone() {
+        let logctx =
+            dev::test_setup_log("local_storage_allocation_partial_tombstone");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let config = LocalStorageTest {
+            sleds: vec![LocalStorageTestSled {
+                sled_id: SledUuid::new_v4(),
+                sled_serial: String::from("sled"),
+                u2s: (0..10)
+                    .map(|i| LocalStorageTestSledU2 {
+                        physical_disk_id: PhysicalDiskUuid::new_v4(),
+                        physical_disk_serial: format!("sled-phys{i}"),
+
+                        zpool_id: ZpoolUuid::new_v4(),
+                        control_plane_storage_buffer:
+                            external::ByteCount::from_gibibytes_u32(250),
+
+                        inventory_total_size:
+                            external::ByteCount::from_gibibytes_u32(1024),
+
+                        crucible_dataset_id: DatasetUuid::new_v4(),
+                        crucible_dataset_addr: format!(
+                            "[fd00:1122:3344:101::{i}]:12345"
+                        )
+                        .parse()
+                        .unwrap(),
+
+                        local_storage_unencrypted_dataset_id:
+                            DatasetUuid::new_v4(),
+                    })
+                    .collect(),
+            }],
+            affinity_groups: vec![],
+            anti_affinity_groups: vec![],
+            instances: vec![LocalStorageTestInstance {
+                id: InstanceUuid::new_v4(),
+                name: String::from("local"),
+                affinity: None,
+                ncpus: 16,
+                memory: external::ByteCount::from_gibibytes_u32(32),
+                // Note here that only 5 local storage disks are requested.
+                disks: (0..5)
+                    .map(|i| LocalStorageTestInstanceDisk {
+                        id: Uuid::new_v4(),
+                        name: external::Name::try_from(format!("local-{i}"))
+                            .unwrap(),
+                        size: external::ByteCount::from_gibibytes_u32(128),
+                    })
+                    .collect(),
+            }],
+        };
+
+        setup_local_storage_allocation_test(&opctx, datastore, &config).await;
+
+        // Before attempting sled reservation, tombstone every other disk
+
+        for i in 0..5 {
+            set_local_storage_unencrypted_dataset_tombstoned(
+                datastore,
+                config.sleds[0].u2s[i * 2].local_storage_unencrypted_dataset_id,
+            )
+            .await;
+        }
+
+        // Now attempt the reservation.
+
+        let instance =
+            Instance::from_local_storage_test_instance(&config.instances[0]);
+
+        datastore
+            .sled_reservation_create_inner(
+                &opctx,
+                instance.id,
+                PropolisUuid::new_v4(),
+                instance.resources(),
+                db::model::SledReservationConstraints::none(),
+                SledReservationReason::Start,
+            )
+            .await
+            .unwrap();
+
+        let allocation_records: Vec<_> = {
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            use nexus_db_schema::schema::local_storage_unencrypted_dataset_allocation::dsl;
+
+            dsl::local_storage_unencrypted_dataset_allocation
+                .filter(dsl::time_deleted.is_null())
+                .select(db::model::LocalStorageUnencryptedDatasetAllocation::as_select())
+                .load_async(&*conn)
+                .await
+                .unwrap()
+        };
+
+        assert_eq!(allocation_records.len(), 5);
+
+        validate_local_storage_allocations(&datastore).await;
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // Ensure Nexus successfully performs an instance reservation even if some
+    // physical disks are expunged.
+    #[tokio::test]
+    async fn local_storage_allocation_partial_expunge() {
+        let logctx =
+            dev::test_setup_log("local_storage_allocation_partial_expunge");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let config = LocalStorageTest {
+            sleds: vec![LocalStorageTestSled {
+                sled_id: SledUuid::new_v4(),
+                sled_serial: String::from("sled"),
+                u2s: (0..10)
+                    .map(|i| LocalStorageTestSledU2 {
+                        physical_disk_id: PhysicalDiskUuid::new_v4(),
+                        physical_disk_serial: format!("sled-phys{i}"),
+
+                        zpool_id: ZpoolUuid::new_v4(),
+                        control_plane_storage_buffer:
+                            external::ByteCount::from_gibibytes_u32(250),
+
+                        inventory_total_size:
+                            external::ByteCount::from_gibibytes_u32(1024),
+
+                        crucible_dataset_id: DatasetUuid::new_v4(),
+                        crucible_dataset_addr: format!(
+                            "[fd00:1122:3344:101::{i}]:12345"
+                        )
+                        .parse()
+                        .unwrap(),
+
+                        local_storage_unencrypted_dataset_id:
+                            DatasetUuid::new_v4(),
+                    })
+                    .collect(),
+            }],
+            affinity_groups: vec![],
+            anti_affinity_groups: vec![],
+            instances: vec![LocalStorageTestInstance {
+                id: InstanceUuid::new_v4(),
+                name: String::from("local"),
+                affinity: None,
+                ncpus: 16,
+                memory: external::ByteCount::from_gibibytes_u32(32),
+                // Note here that only 5 local storage disks are requested.
+                disks: (0..5)
+                    .map(|i| LocalStorageTestInstanceDisk {
+                        id: Uuid::new_v4(),
+                        name: external::Name::try_from(format!("local-{i}"))
+                            .unwrap(),
+                        size: external::ByteCount::from_gibibytes_u32(128),
+                    })
+                    .collect(),
+            }],
+        };
+
+        setup_local_storage_allocation_test(&opctx, datastore, &config).await;
+
+        // Before attempting sled reservation, expunge every other disk
+
+        for i in 0..5 {
+            set_disk_expunged(
+                datastore,
+                &opctx,
+                config.sleds[0].u2s[i * 2].physical_disk_id,
+            )
+            .await;
+        }
+
+        // Now attempt the reservation.
 
         let instance =
             Instance::from_local_storage_test_instance(&config.instances[0]);

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -1443,6 +1443,18 @@ impl DataStore {
                                 info!(&log, "reservation succeeded!");
                                 return Ok(resource);
                             }
+
+                            // If an insert fails to add any rows, Log that this
+                            // is happening.  Ending up here is expected during
+                            // concurrent reservations requiring local storage
+                            // allocations, but repeatedly ending up here
+                            // without pruning any allocations is likely a bug.
+
+                            info!(
+                                &log,
+                                "sled_insert_resource_query executed but \
+                                inserted 0 rows",
+                            );
                         }
 
                         Err(diesel::result::Error::DatabaseError(
@@ -4533,6 +4545,28 @@ pub(in crate::db::datastore) mod test {
             .unwrap();
     }
 
+    async fn set_local_storage_unencrypted_dataset_tombstoned(
+        datastore: &DataStore,
+        local_storage_unencrypted_dataset_id: DatasetUuid,
+    ) {
+        use nexus_db_schema::schema::rendezvous_local_storage_unencrypted_dataset::dsl;
+
+        let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+        diesel::update(dsl::rendezvous_local_storage_unencrypted_dataset)
+            .filter(
+                dsl::id
+                    .eq(to_db_typed_uuid(local_storage_unencrypted_dataset_id)),
+            )
+            .set((
+                dsl::time_tombstoned.eq(Utc::now()),
+                dsl::blueprint_id_when_tombstoned.eq(Uuid::new_v4()),
+            ))
+            .execute_async(&*conn)
+            .await
+            .unwrap();
+    }
+
     async fn set_local_storage_unencrypted_allocation(
         datastore: &DataStore,
         disk_id: Uuid,
@@ -4599,6 +4633,40 @@ pub(in crate::db::datastore) mod test {
 
             assert_eq!(rows_updated, 1);
         }
+    }
+
+    async fn set_sled_expunged(
+        datastore: &DataStore,
+        opctx: &OpContext,
+        sled_id: SledUuid,
+    ) {
+        let (.., authz_sled) = LookupPath::new(opctx, datastore)
+            .sled_id(sled_id)
+            .lookup_for(authz::Action::Modify)
+            .await
+            .expect("sled must exist");
+
+        datastore
+            .sled_set_policy_to_expunged(opctx, &authz_sled)
+            .await
+            .unwrap();
+    }
+
+    async fn set_disk_expunged(
+        datastore: &DataStore,
+        opctx: &OpContext,
+        physical_disk_id: PhysicalDiskUuid,
+    ) {
+        let conn = datastore.pool_connection_authorized(opctx).await.unwrap();
+
+        use nexus_db_schema::schema::physical_disk::dsl;
+
+        diesel::update(dsl::physical_disk)
+            .filter(dsl::id.eq(to_db_typed_uuid(physical_disk_id)))
+            .set(dsl::disk_policy.eq(PhysicalDiskPolicy::Expunged))
+            .execute_async(&*conn)
+            .await
+            .unwrap();
     }
 
     async fn create_test_instance(
@@ -7359,6 +7427,449 @@ pub(in crate::db::datastore) mod test {
             .unwrap();
 
         assert_eq!(previously_target_vmm.state, SledResourceVmmState::Active,);
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // Ensure that Nexus does not perform an exhaustive search through all
+    // possible local storage allocations if a rendezvous dataset is marked
+    // no_provision = true.
+    #[tokio::test]
+    async fn local_storage_allocation_no_exhaustive_search_no_provision() {
+        let logctx = dev::test_setup_log(
+            "local_storage_allocation_no_exhaustive_search_no_provision",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let config = LocalStorageTest {
+            sleds: vec![LocalStorageTestSled {
+                sled_id: SledUuid::new_v4(),
+                sled_serial: String::from("sled"),
+                u2s: (0..10)
+                    .map(|i| LocalStorageTestSledU2 {
+                        physical_disk_id: PhysicalDiskUuid::new_v4(),
+                        physical_disk_serial: format!("sled-phys{i}"),
+
+                        zpool_id: ZpoolUuid::new_v4(),
+                        control_plane_storage_buffer:
+                            external::ByteCount::from_gibibytes_u32(250),
+
+                        inventory_total_size:
+                            external::ByteCount::from_gibibytes_u32(1024),
+
+                        crucible_dataset_id: DatasetUuid::new_v4(),
+                        crucible_dataset_addr: format!(
+                            "[fd00:1122:3344:101::{i}]:12345"
+                        )
+                        .parse()
+                        .unwrap(),
+
+                        local_storage_unencrypted_dataset_id:
+                            DatasetUuid::new_v4(),
+                    })
+                    .collect(),
+            }],
+            affinity_groups: vec![],
+            anti_affinity_groups: vec![],
+            instances: vec![LocalStorageTestInstance {
+                id: InstanceUuid::new_v4(),
+                name: String::from("local"),
+                affinity: None,
+                ncpus: 16,
+                memory: external::ByteCount::from_gibibytes_u32(32),
+                disks: (0..10)
+                    .map(|i| LocalStorageTestInstanceDisk {
+                        id: Uuid::new_v4(),
+                        name: external::Name::try_from(format!("local-{i}"))
+                            .unwrap(),
+                        size: external::ByteCount::from_gibibytes_u32(128),
+                    })
+                    .collect(),
+            }],
+        };
+
+        setup_local_storage_allocation_test(&opctx, datastore, &config).await;
+
+        // Before attempting sled reservation, mark the rendezvous dataset
+        // no_provision.
+
+        set_local_storage_unencrypted_dataset_no_provision(
+            datastore,
+            config.sleds[0].u2s[0].local_storage_unencrypted_dataset_id,
+        )
+        .await;
+
+        // Now attempt the reservation. This should complete quickly!
+
+        let instance =
+            Instance::from_local_storage_test_instance(&config.instances[0]);
+
+        let result = datastore
+            .sled_reservation_create_inner(
+                &opctx,
+                instance.id,
+                PropolisUuid::new_v4(),
+                instance.resources(),
+                db::model::SledReservationConstraints::none(),
+                SledReservationReason::Start,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(SledReservationTransactionError::Reservation(
+                SledReservationError::NotFound
+            )),
+        ));
+
+        let allocation_records: Vec<_> = {
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            use nexus_db_schema::schema::local_storage_unencrypted_dataset_allocation::dsl;
+
+            dsl::local_storage_unencrypted_dataset_allocation
+                .filter(dsl::time_deleted.is_null())
+                .select(db::model::LocalStorageUnencryptedDatasetAllocation::as_select())
+                .load_async(&*conn)
+                .await
+                .unwrap()
+        };
+
+        assert!(allocation_records.is_empty());
+
+        validate_local_storage_allocations(&datastore).await;
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // Ensure that Nexus does not perform an exhaustive search through all
+    // possible local storage allocations if a rendezvous dataset is tombstoned.
+    #[tokio::test]
+    async fn local_storage_allocation_no_exhaustive_search_tombstoned() {
+        let logctx = dev::test_setup_log(
+            "local_storage_allocation_no_exhaustive_search_tombstoned",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let config = LocalStorageTest {
+            sleds: vec![LocalStorageTestSled {
+                sled_id: SledUuid::new_v4(),
+                sled_serial: String::from("sled"),
+                u2s: (0..10)
+                    .map(|i| LocalStorageTestSledU2 {
+                        physical_disk_id: PhysicalDiskUuid::new_v4(),
+                        physical_disk_serial: format!("sled-phys{i}"),
+
+                        zpool_id: ZpoolUuid::new_v4(),
+                        control_plane_storage_buffer:
+                            external::ByteCount::from_gibibytes_u32(250),
+
+                        inventory_total_size:
+                            external::ByteCount::from_gibibytes_u32(1024),
+
+                        crucible_dataset_id: DatasetUuid::new_v4(),
+                        crucible_dataset_addr: format!(
+                            "[fd00:1122:3344:101::{i}]:12345"
+                        )
+                        .parse()
+                        .unwrap(),
+
+                        local_storage_unencrypted_dataset_id:
+                            DatasetUuid::new_v4(),
+                    })
+                    .collect(),
+            }],
+            affinity_groups: vec![],
+            anti_affinity_groups: vec![],
+            instances: vec![LocalStorageTestInstance {
+                id: InstanceUuid::new_v4(),
+                name: String::from("local"),
+                affinity: None,
+                ncpus: 16,
+                memory: external::ByteCount::from_gibibytes_u32(32),
+                disks: (0..10)
+                    .map(|i| LocalStorageTestInstanceDisk {
+                        id: Uuid::new_v4(),
+                        name: external::Name::try_from(format!("local-{i}"))
+                            .unwrap(),
+                        size: external::ByteCount::from_gibibytes_u32(128),
+                    })
+                    .collect(),
+            }],
+        };
+
+        setup_local_storage_allocation_test(&opctx, datastore, &config).await;
+
+        // Before attempting sled reservation, tombstone the rendezvous dataset
+
+        set_local_storage_unencrypted_dataset_tombstoned(
+            datastore,
+            config.sleds[0].u2s[0].local_storage_unencrypted_dataset_id,
+        )
+        .await;
+
+        // Now attempt the reservation. This should complete quickly!
+
+        let instance =
+            Instance::from_local_storage_test_instance(&config.instances[0]);
+
+        let result = datastore
+            .sled_reservation_create_inner(
+                &opctx,
+                instance.id,
+                PropolisUuid::new_v4(),
+                instance.resources(),
+                db::model::SledReservationConstraints::none(),
+                SledReservationReason::Start,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(SledReservationTransactionError::Reservation(
+                SledReservationError::NotFound
+            )),
+        ));
+
+        let allocation_records: Vec<_> = {
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            use nexus_db_schema::schema::local_storage_unencrypted_dataset_allocation::dsl;
+
+            dsl::local_storage_unencrypted_dataset_allocation
+                .filter(dsl::time_deleted.is_null())
+                .select(db::model::LocalStorageUnencryptedDatasetAllocation::as_select())
+                .load_async(&*conn)
+                .await
+                .unwrap()
+        };
+
+        assert!(allocation_records.is_empty());
+
+        validate_local_storage_allocations(&datastore).await;
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // Ensure that Nexus does not perform an exhaustive search through all
+    // possible local storage allocations if a sled is expunged.
+    #[tokio::test]
+    async fn local_storage_allocation_no_exhaustive_search_sled_expunge() {
+        let logctx = dev::test_setup_log(
+            "local_storage_allocation_no_exhaustive_search_sled_expunge",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let config = LocalStorageTest {
+            sleds: vec![LocalStorageTestSled {
+                sled_id: SledUuid::new_v4(),
+                sled_serial: String::from("sled"),
+                u2s: (0..10)
+                    .map(|i| LocalStorageTestSledU2 {
+                        physical_disk_id: PhysicalDiskUuid::new_v4(),
+                        physical_disk_serial: format!("sled-phys{i}"),
+
+                        zpool_id: ZpoolUuid::new_v4(),
+                        control_plane_storage_buffer:
+                            external::ByteCount::from_gibibytes_u32(250),
+
+                        inventory_total_size:
+                            external::ByteCount::from_gibibytes_u32(1024),
+
+                        crucible_dataset_id: DatasetUuid::new_v4(),
+                        crucible_dataset_addr: format!(
+                            "[fd00:1122:3344:101::{i}]:12345"
+                        )
+                        .parse()
+                        .unwrap(),
+
+                        local_storage_unencrypted_dataset_id:
+                            DatasetUuid::new_v4(),
+                    })
+                    .collect(),
+            }],
+            affinity_groups: vec![],
+            anti_affinity_groups: vec![],
+            instances: vec![LocalStorageTestInstance {
+                id: InstanceUuid::new_v4(),
+                name: String::from("local"),
+                affinity: None,
+                ncpus: 16,
+                memory: external::ByteCount::from_gibibytes_u32(32),
+                disks: (0..10)
+                    .map(|i| LocalStorageTestInstanceDisk {
+                        id: Uuid::new_v4(),
+                        name: external::Name::try_from(format!("local-{i}"))
+                            .unwrap(),
+                        size: external::ByteCount::from_gibibytes_u32(128),
+                    })
+                    .collect(),
+            }],
+        };
+
+        setup_local_storage_allocation_test(&opctx, datastore, &config).await;
+
+        // Before attempting sled reservation, expunge the sled
+
+        set_sled_expunged(datastore, &opctx, config.sleds[0].sled_id).await;
+
+        // Now attempt the reservation. This should complete quickly!
+
+        let instance =
+            Instance::from_local_storage_test_instance(&config.instances[0]);
+
+        let result = datastore
+            .sled_reservation_create_inner(
+                &opctx,
+                instance.id,
+                PropolisUuid::new_v4(),
+                instance.resources(),
+                db::model::SledReservationConstraints::none(),
+                SledReservationReason::Start,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(SledReservationTransactionError::Reservation(
+                SledReservationError::NotFound
+            )),
+        ));
+
+        let allocation_records: Vec<_> = {
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            use nexus_db_schema::schema::local_storage_unencrypted_dataset_allocation::dsl;
+
+            dsl::local_storage_unencrypted_dataset_allocation
+                .filter(dsl::time_deleted.is_null())
+                .select(db::model::LocalStorageUnencryptedDatasetAllocation::as_select())
+                .load_async(&*conn)
+                .await
+                .unwrap()
+        };
+
+        assert!(allocation_records.is_empty());
+
+        validate_local_storage_allocations(&datastore).await;
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // Ensure that Nexus does not perform an exhaustive search through all
+    // possible local storage allocations if a physical disk is expunged.
+    #[tokio::test]
+    async fn local_storage_allocation_no_exhaustive_search_disk_expunge() {
+        let logctx = dev::test_setup_log(
+            "local_storage_allocation_no_exhaustive_search_disk_expunge",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let config = LocalStorageTest {
+            sleds: vec![LocalStorageTestSled {
+                sled_id: SledUuid::new_v4(),
+                sled_serial: String::from("sled"),
+                u2s: (0..10)
+                    .map(|i| LocalStorageTestSledU2 {
+                        physical_disk_id: PhysicalDiskUuid::new_v4(),
+                        physical_disk_serial: format!("sled-phys{i}"),
+
+                        zpool_id: ZpoolUuid::new_v4(),
+                        control_plane_storage_buffer:
+                            external::ByteCount::from_gibibytes_u32(250),
+
+                        inventory_total_size:
+                            external::ByteCount::from_gibibytes_u32(1024),
+
+                        crucible_dataset_id: DatasetUuid::new_v4(),
+                        crucible_dataset_addr: format!(
+                            "[fd00:1122:3344:101::{i}]:12345"
+                        )
+                        .parse()
+                        .unwrap(),
+
+                        local_storage_unencrypted_dataset_id:
+                            DatasetUuid::new_v4(),
+                    })
+                    .collect(),
+            }],
+            affinity_groups: vec![],
+            anti_affinity_groups: vec![],
+            instances: vec![LocalStorageTestInstance {
+                id: InstanceUuid::new_v4(),
+                name: String::from("local"),
+                affinity: None,
+                ncpus: 16,
+                memory: external::ByteCount::from_gibibytes_u32(32),
+                disks: (0..10)
+                    .map(|i| LocalStorageTestInstanceDisk {
+                        id: Uuid::new_v4(),
+                        name: external::Name::try_from(format!("local-{i}"))
+                            .unwrap(),
+                        size: external::ByteCount::from_gibibytes_u32(128),
+                    })
+                    .collect(),
+            }],
+        };
+
+        setup_local_storage_allocation_test(&opctx, datastore, &config).await;
+
+        // Before attempting sled reservation, expunge a disk
+
+        set_disk_expunged(
+            datastore,
+            &opctx,
+            config.sleds[0].u2s[0].physical_disk_id,
+        )
+        .await;
+
+        // Now attempt the reservation. This should complete quickly!
+
+        let instance =
+            Instance::from_local_storage_test_instance(&config.instances[0]);
+
+        let result = datastore
+            .sled_reservation_create_inner(
+                &opctx,
+                instance.id,
+                PropolisUuid::new_v4(),
+                instance.resources(),
+                db::model::SledReservationConstraints::none(),
+                SledReservationReason::Start,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(SledReservationTransactionError::Reservation(
+                SledReservationError::NotFound
+            )),
+        ));
+
+        let allocation_records: Vec<_> = {
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            use nexus_db_schema::schema::local_storage_unencrypted_dataset_allocation::dsl;
+
+            dsl::local_storage_unencrypted_dataset_allocation
+                .filter(dsl::time_deleted.is_null())
+                .select(db::model::LocalStorageUnencryptedDatasetAllocation::as_select())
+                .load_async(&*conn)
+                .await
+                .unwrap()
+        };
+
+        assert!(allocation_records.is_empty());
+
+        validate_local_storage_allocations(&datastore).await;
 
         db.terminate().await;
         logctx.cleanup_successful();

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -578,7 +578,8 @@ impl<'a> CompleteLocalStorageAllocationLists<'a> {
             for allocation in &incomplete_allocation_list.allocations {
                 match zpools_for_sled.get(&allocation.pool_id) {
                     Some(zpool_for_sled) => {
-                        // Zpool still exists, does it still have room?
+                        // Zpool still exists and is still a valid target, does
+                        // it still have room?
 
                         if !zpool_for_sled.has_room_for_allocation(
                             allocation.required_dataset_size,
@@ -590,7 +591,9 @@ impl<'a> CompleteLocalStorageAllocationLists<'a> {
                     }
 
                     None => {
-                        // Zpool doesn't exist anymore!
+                        // Zpool doesn't exist anymore or it's no longer a valid
+                        // target (for example due to being marked
+                        // no_provision).
                         return false;
                     }
                 }

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -1447,7 +1447,7 @@ impl DataStore {
                                 return Ok(resource);
                             }
 
-                            // If an insert fails to add any rows, Log that this
+                            // If an insert fails to add any rows, log that this
                             // is happening.  Ending up here is expected during
                             // concurrent reservations requiring local storage
                             // allocations, but repeatedly ending up here

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -7877,4 +7877,113 @@ pub(in crate::db::datastore) mod test {
         db.terminate().await;
         logctx.cleanup_successful();
     }
+
+    // Ensure Nexus successfully performs an instance reservation even if some
+    // datasets are marked no_provision.
+    #[tokio::test]
+    async fn local_storage_allocation_partial_no_provision() {
+        let logctx = dev::test_setup_log(
+            "local_storage_allocation_partial_no_provision",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let config = LocalStorageTest {
+            sleds: vec![LocalStorageTestSled {
+                sled_id: SledUuid::new_v4(),
+                sled_serial: String::from("sled"),
+                u2s: (0..10)
+                    .map(|i| LocalStorageTestSledU2 {
+                        physical_disk_id: PhysicalDiskUuid::new_v4(),
+                        physical_disk_serial: format!("sled-phys{i}"),
+
+                        zpool_id: ZpoolUuid::new_v4(),
+                        control_plane_storage_buffer:
+                            external::ByteCount::from_gibibytes_u32(250),
+
+                        inventory_total_size:
+                            external::ByteCount::from_gibibytes_u32(1024),
+
+                        crucible_dataset_id: DatasetUuid::new_v4(),
+                        crucible_dataset_addr: format!(
+                            "[fd00:1122:3344:101::{i}]:12345"
+                        )
+                        .parse()
+                        .unwrap(),
+
+                        local_storage_unencrypted_dataset_id:
+                            DatasetUuid::new_v4(),
+                    })
+                    .collect(),
+            }],
+            affinity_groups: vec![],
+            anti_affinity_groups: vec![],
+            instances: vec![LocalStorageTestInstance {
+                id: InstanceUuid::new_v4(),
+                name: String::from("local"),
+                affinity: None,
+                ncpus: 16,
+                memory: external::ByteCount::from_gibibytes_u32(32),
+                // Note here that only 5 local storage disks are requested.
+                disks: (0..5)
+                    .map(|i| LocalStorageTestInstanceDisk {
+                        id: Uuid::new_v4(),
+                        name: external::Name::try_from(format!("local-{i}"))
+                            .unwrap(),
+                        size: external::ByteCount::from_gibibytes_u32(128),
+                    })
+                    .collect(),
+            }],
+        };
+
+        setup_local_storage_allocation_test(&opctx, datastore, &config).await;
+
+        // Before attempting sled reservation, mark every other disk as
+        // no_provision
+
+        for i in 0..5 {
+            set_local_storage_unencrypted_dataset_no_provision(
+                datastore,
+                config.sleds[0].u2s[i * 2].local_storage_unencrypted_dataset_id,
+            )
+            .await;
+        }
+
+        // Now attempt the reservation. This should complete quickly!
+
+        let instance =
+            Instance::from_local_storage_test_instance(&config.instances[0]);
+
+        datastore
+            .sled_reservation_create_inner(
+                &opctx,
+                instance.id,
+                PropolisUuid::new_v4(),
+                instance.resources(),
+                db::model::SledReservationConstraints::none(),
+                SledReservationReason::Start,
+            )
+            .await
+            .unwrap();
+
+        let allocation_records: Vec<_> = {
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            use nexus_db_schema::schema::local_storage_unencrypted_dataset_allocation::dsl;
+
+            dsl::local_storage_unencrypted_dataset_allocation
+                .filter(dsl::time_deleted.is_null())
+                .select(db::model::LocalStorageUnencryptedDatasetAllocation::as_select())
+                .load_async(&*conn)
+                .await
+                .unwrap()
+        };
+
+        assert_eq!(allocation_records.len(), 5);
+
+        validate_local_storage_allocations(&datastore).await;
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
 }

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -1447,17 +1447,11 @@ impl DataStore {
                                 return Ok(resource);
                             }
 
-                            // If an insert fails to add any rows, log that this
-                            // is happening.  Ending up here is expected during
-                            // concurrent reservations requiring local storage
-                            // allocations, but repeatedly ending up here
-                            // without pruning any allocations is likely a bug.
-
-                            info!(
-                                &log,
-                                "sled_insert_resource_query executed but \
-                                inserted 0 rows",
-                            );
+                            // Ending up here without inserting any rows is
+                            // expected during concurrent reservations requiring
+                            // local storage allocations, but repeatedly ending
+                            // up here without pruning any allocations is likely
+                            // a bug.
                         }
 
                         Err(diesel::result::Error::DatabaseError(

--- a/nexus/db-queries/src/db/datastore/zpool.rs
+++ b/nexus/db-queries/src/db/datastore/zpool.rs
@@ -481,15 +481,24 @@ impl DataStore {
                             .is_null(),
                     )
                     .filter(
+                        rendezvous_local_storage_unencrypted_dataset::no_provision
+                            .eq(false),
+                    )
+                    .filter(
                         rendezvous_local_storage_unencrypted_dataset::pool_id.eq(dsl::id),
                     )
                     .single_value(),
-                //
+                // Return the ID: this query must have the same filter
+                // conditions as the previous one that returns size_used.
                 rendezvous_local_storage_unencrypted_dataset::table
                     .select(rendezvous_local_storage_unencrypted_dataset::id)
                     .filter(
                         rendezvous_local_storage_unencrypted_dataset::time_tombstoned
                             .is_null(),
+                    )
+                    .filter(
+                        rendezvous_local_storage_unencrypted_dataset::no_provision
+                            .eq(false),
                     )
                     .filter(
                         rendezvous_local_storage_unencrypted_dataset::pool_id.eq(dsl::id),


### PR DESCRIPTION
An exhaustive local storage allocation search occurs when

- a sled reservation requires local storage to be allocated

- a `sled_insert_resource_query` fails to insert any rows for a particular reservation attempt.

- the iterator that produces the next set of allocations to try is _not_ pruned based on what caused the insert query to fail

There are several sentinels that would be returned when the insert query fails for reasons such as a concurrent reservation consuming VMM resources or invalidating an affinity / anti-affinity policy, but for failed local storage allocations there is no such sentinel. Insertion does not occur if `INSERT_VALID` does not contain a 1, and this occurs for a few reasons if local storage allocations are required: add three tests for these cases.

This caught one exhaustive search when `no_provision` was set for the rendezvous dataset. The other cases did not exhaustively search but if (when) the instance allocation routines are changed this will prevent regressions sneaking in.