### PR TITLE
[nexus] fix busy loop due to race condition in SP ereport ingestion

### DIFF
--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -173,29 +173,18 @@ impl DataStore {
         reporter: fm::Reporter,
     ) -> Result<Option<EreportId>, Error> {
         opctx.authorize(authz::Action::ListChildren, &authz::FLEET).await?;
-        self.latest_ereport_id_on_conn(
-            &*self.pool_connection_authorized(opctx).await?,
-            reporter,
-        )
-        .await
-    }
-
-    async fn latest_ereport_id_on_conn(
-        &self,
-        conn: &async_bb8_diesel::Connection<DbConnection>,
-        reporter: fm::Reporter,
-    ) -> Result<Option<EreportId>, Error> {
+        let conn = self.pool_connection_authorized(opctx).await?;
         let result = match reporter {
             fm::Reporter::Sp { sp_type, slot } => {
                 let sp_type = sp_type.into();
                 let slot = SpMgsSlot::from(SqlU16::new(slot));
                 Self::sp_latest_ereport_id_query(sp_type, slot)
-                    .get_result_async(conn)
+                    .get_result_async(&*conn)
                     .await
             }
             fm::Reporter::HostOs { sled, .. } => {
                 Self::host_latest_ereport_id_query(sled)
-                    .get_result_async(conn)
+                    .get_result_async(&*conn)
                     .await
             }
         };
@@ -237,6 +226,23 @@ impl DataStore {
             .order_by((dsl::time_collected.desc(), dsl::ena.desc()))
             .limit(1)
             .select((dsl::restart_id, dsl::ena))
+    }
+
+    async fn latest_ena_for_restart_on_conn(
+        &self,
+        restart_id: EreporterRestartUuid,
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+    ) -> Result<Option<EreportId>, Error> {
+        let ena = dsl::ereport
+            .filter(dsl::restart_id.eq(restart_id.into_untyped_uuid()))
+            .order_by(dsl::ena.desc())
+            .limit(1)
+            .select(dsl::ena)
+            .first_async(conn)
+            .await
+            .optional()
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
+        Ok(ena.map(|DbEna(ena)| EreportId { restart_id, ena }))
     }
 
     /// Inserts the provided tranche of `ereports` into the `ereport` table, and
@@ -302,13 +308,12 @@ impl DataStore {
                 ),
             )
         })?;
-
         let latest = self
-            .latest_ereport_id_on_conn(&conn, reporter)
+            .latest_ena_for_restart_on_conn(restart_id, &*conn)
             .await
             .map_err(|e| {
                 e.internal_context(format!(
-                    "failed to refresh latest ereport ID for {reporter}",
+                    "failed to get latest ENA for restart {restart_id}"
                 ))
             })?;
         Ok((created, latest))

--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -309,7 +309,7 @@ impl DataStore {
             )
         })?;
         let latest = self
-            .latest_ena_for_restart_on_conn(restart_id, &*conn)
+            .latest_ena_for_restart_on_conn(restart_id, &conn)
             .await
             .map_err(|e| {
                 e.internal_context(format!(

--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -252,17 +252,11 @@ impl DataStore {
     /// # Returns
     ///
     /// This function returns a tuple containing the number of new `ereport`
-    /// rows that were created, along with the newest [`EreportId`] for the same
-    /// reporter index as the inserted ereports.
+    /// rows that were created, along with the newest [`EreportId`] to use for a
+    /// subsequent request to ingest ereports from the same reporter. This may
+    /// be a newer ENA than the highest ENA in the inserted ereports, if
+    /// additional ereports were inserted concurrently.
     ///
-    /// The returned ereport ID is intended to provide the caller with the
-    /// latest ENA to use in a subsequent request to ingest ereports from the
-    /// same reporter. In some cases, it may:
-    ///
-    /// - be a newer ENA than the highest ENA in the inserted ereports, if
-    ///   additional ereports were inserted concurrently
-    /// - have a different restart ID than the one provided, if ereports from
-    ///   a newer restart of that reporter were inserted concurrently
     // Since all the arguments to this function are newtypes with pretty clear
     // meanings (e.g. `rack_id`, `restart_id`, and `collector_id` are all
     // different typed UUIDs), I'm not convinced that factoring stuff out into a

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -443,8 +443,11 @@ mod tests {
     use super::*;
     use nexus_db_queries::db::pagination::Paginator;
     use nexus_test_utils_macros::nexus_test;
+    use omicron_common::api::external::Error;
+    use omicron_test_utils::dev::poll;
     use omicron_uuid_kinds::GenericUuid;
     use std::collections::BTreeSet;
+    use std::time::Duration;
     use uuid::uuid;
 
     type ControlPlaneTestContext =
@@ -811,13 +814,29 @@ mod tests {
             "3e0e701d-79cc-4d1a-a742-e0410324b1de"
         ));
 
-        let clients = GatewayClient::resolve_all_gateways(
-            &opctx.log,
-            &nexus.internal_resolver,
+        let clients = poll::wait_for_condition(
+            || async {
+                let gateways = GatewayClient::resolve_all_gateways(
+                    &opctx.log,
+                    &nexus.internal_resolver,
+                )
+                .await
+                .map_err(|e| poll::CondCheckError::<Error>::NotYet {
+                    status: Some(e.to_string()),
+                })?
+                .collect::<Vec<_>>();
+                if gateways.is_empty() {
+                    return Err(poll::CondCheckError::<Error>::NotYet {
+                        status: Some("no gateways resolved".to_string()),
+                    });
+                }
+                Ok(gateways)
+            },
+            &Duration::from_millis(200),
+            &Duration::from_secs(60),
         )
         .await
-        .expect("MGS clients should resolve")
-        .collect::<Vec<_>>();
+        .unwrap();
 
         // Request all the ereports from the simulated SP and insert them into
         // the database, as though we have already ingested them.
@@ -921,7 +940,7 @@ mod tests {
 
         // Generously longer than a terminating ingestion pass (a couple of
         // HTTP requests and a handful of database queries) could ever take.
-        const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+        const TIMEOUT: std::time::Duration = Duration::from_secs(60);
         let status = tokio::time::timeout(
             TIMEOUT,
             ingester.ingest_sp_ereports(

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -444,6 +444,7 @@ mod tests {
     use nexus_db_queries::db::pagination::Paginator;
     use nexus_test_utils_macros::nexus_test;
     use omicron_uuid_kinds::GenericUuid;
+    use std::collections::BTreeSet;
     use uuid::uuid;
 
     type ControlPlaneTestContext =
@@ -738,6 +739,261 @@ mod tests {
         .await;
     }
 
+    /// Regression test for the potential busy loop described in
+    /// [omicron#10738](https://github.com/oxidecomputer/omicron/issues/10738).
+    ///
+    /// This issue describes an issue that can occur when multiple Nexuses
+    /// ingest ereports from two different restarts of a given SP, where the
+    /// wall clock time at which the ereports from a later restart are inserted
+    /// into the database is *earlier* than the wall clock time at which
+    /// ereports from the current restart are inserted.
+    ///
+    /// > I think the `ingest_sp_ereports` function may be broken in this case:
+    /// > - Suppose an SP has `Restart ID = X`, Nexus A queries for ereports...
+    /// > - After the query starts, the SP restarts with `Restart ID = Y`,
+    /// >   Nexus B queries for ereports...
+    /// > - Suppose `Restart ID = Y` is the "steady-state" of the SP
+    /// >
+    /// > If the ereport insertion order is:
+    /// > - Nexus B inserts ereports for `Restart ID = Y` (at time T1)
+    /// > - Nexus A inserts ereports for `Restart ID = X` (at time T2 > T1)
+    /// > - Nexus A's request for ereports is still pending when Nexus B
+    /// >   inserts ereports for `Restart ID = Y`
+    /// >
+    /// > Then Nexus erroneously will think "Restart ID X > Y", which is untrue.
+    /// > This is possible because the timestamps we're collecting here are
+    /// > based on Nexus' wall-clock, which is queried after the request for
+    /// > ereports.
+    /// >
+    /// > I think in `ingest_sp_ereports` this could potentially cause Nexus to
+    /// > be stuck in a busy loop...
+    /// >
+    /// > - Nexus thinks restart ID = X is latest, so it sets up params with
+    /// >   restart ID = X
+    /// > - Nexus sends a request to the SP asking for ereports, the SP
+    /// >   responds "I'm restart ID = Y, here are my ereports"
+    /// > - If the SP doesn't have new ereports, then `ereports_insert` runs,
+    /// >   and inserts no new ereports -- so latest doesn't change (recall:
+    /// >   the original set of ereports for restart ID Y already got inserted
+    /// >   by Nexus B)
+    /// > - `ingest_sp_ereports` sets the new "params" value, but the in-DB
+    /// >   notion of latest is still from the now-dead restart ID X
+    /// > - Go to step (1). Turn the CPU into a space heater until more
+    /// >   ereports arrive from the SP
+    ///
+    /// Rather than racing two ingesters, this test constructs the racy outcome
+    /// directly. The test first asks the simulated SP for its current restart
+    /// ID and buffered ereports, and then inserts those ereports into the
+    /// database at T1, followed by ereports with a fabricated "previous"
+    /// restart ID at T2 > T1. This simulates a situation where one Nexus is
+    /// holding in memory a batch of ereports from the "earlier" restart in
+    /// memory and inserts them into the database at a wall-clock time later
+    /// than the ereports collected from the "current" restart.
+    #[nexus_test(server = crate::Server)]
+    async fn test_sp_ereport_ingestion_stale_restart_id(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let nexus = &cptestctx.server.server_context().nexus;
+        let datastore = nexus.datastore();
+        let opctx = OpContext::for_tests(
+            cptestctx.logctx.log.clone(),
+            datastore.clone(),
+        );
+
+        // Sled 0's simulated SP.
+        let sp_type = nexus_types::inventory::SpType::Sled;
+        let sp_slot = 0;
+        let reporter =
+            nexus_types::fm::ereport::Reporter::Sp { sp_type, slot: sp_slot };
+        // A restart ID the SP has never heard of, standing in for the restart
+        // that preceded its current one.
+        let stale_restart_id = EreporterRestartUuid::from_untyped_uuid(uuid!(
+            "3e0e701d-79cc-4d1a-a742-e0410324b1de"
+        ));
+
+        let clients = GatewayClient::resolve_all_gateways(
+            &opctx.log,
+            &nexus.internal_resolver,
+        )
+        .await
+        .expect("MGS clients should resolve")
+        .collect::<Vec<_>>();
+
+        // Request all the ereports from the simulated SP and insert them into
+        // the database, as though we have already ingested them.
+        let ereport_types::Ereports { restart_id: current_restart_id, reports } =
+            clients
+                .first()
+                .expect("at least one MGS client should be resolved")
+                .client
+                .sp_ereports_ingest(
+                    &sp_type,
+                    sp_slot,
+                    None,
+                    // Request the maximum possible limit to ensure all ereports
+                    // that the SP simulator would possibly return are included.
+                    std::num::NonZeroU32::new(255).unwrap(),
+                    &EreporterRestartUuid::nil(),
+                    None,
+                )
+                .await
+                .expect("probing the SP's ereports via MGS should succeed")
+                .into_inner();
+        let current_restart_ereports = reports.items;
+        assert!(
+            !current_restart_ereports.is_empty(),
+            "/!\\ TEST IS BROKEN! /!\\\n\
+            this test requires the simulated SP to have ereports; if the \
+             configuration for the SP simulator has changed to have no \
+             ereports, this test cannot reproduce the bug! please change the \
+             config file back!",
+        );
+        assert_ne!(current_restart_id, stale_restart_id);
+
+        // "Nexus B" ingested the SP's entire current buffer a little while
+        // ago...
+        let time_current = Utc::now() - chrono::TimeDelta::seconds(10);
+        // ...and "Nexus A" inserted ereports from the SP's previous
+        // incarnation afterwards, because it queried the SP before the
+        // restart but timestamped the ereports with its own wall clock at
+        // insertion time.
+        let time_stale = Utc::now();
+        let rack_id = nexus.rack_id();
+
+        // Insert the ereports previously collected by "Nexus B" from the
+        // current restart. Imagine that this is actually a previous iteration
+        // of the ereport ingester loop. It isn't actually, but the behavior
+        // will be the same, and we cannot easily pause the loop mid-execution.
+        datastore
+            .ereports_insert(
+                &opctx,
+                current_restart_id,
+                time_current,
+                nexus.id(),
+                rack_id,
+                reporter,
+                current_restart_ereports.iter().map(|ereport| {
+                    EreportData::from_sp_ereport(
+                        &opctx.log,
+                        current_restart_id,
+                        ereport.clone(),
+                    )
+                }),
+            )
+            .await
+            .expect("ereports should be inserted");
+
+        // Now, imagine that Nexus A finally wakes up, with a batch of ereports
+        // from the SP's *previous* restart still in memory, and inserts them
+        // into the database at a wall-clock time after when Nexus B inserted
+        // ereports from the current restart.
+        let stale_restart_enas = BTreeSet::from_iter(Some(Ena::from(1)));
+        datastore
+            .ereports_insert(
+                &opctx,
+                stale_restart_id,
+                time_stale,
+                OmicronZoneUuid::new_v4(),
+                rack_id,
+                reporter,
+                vec![(
+                    Ena::from(1),
+                    EreportData {
+                        // these don't matter...
+                        serial_number: None,
+                        part_number: None,
+                        // since it's ENA 1, let's imagine it's a loss report
+                        class: Some("ereport.data_loss.possible".to_string()),
+                        report: serde_json::json!({"lost": null}),
+                    },
+                )],
+            )
+            .await
+            .expect(
+                "ereports from simulated previous restart should be inserted",
+            );
+
+        let ingester = Ingester {
+            datastore: datastore.clone(),
+            nexus_id: nexus.id(),
+            rack_id: nexus.rack_id(),
+        };
+
+        // Generously longer than a terminating ingestion pass (a couple of
+        // HTTP requests and a handful of database queries) could ever take.
+        const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+        let status = tokio::time::timeout(
+            TIMEOUT,
+            ingester.ingest_sp_ereports(
+                opctx.child(BTreeMap::new()),
+                &clients,
+                sp_type,
+                sp_slot,
+            ),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "ingest_sp_ereports did not terminate within {TIMEOUT:?}; it \
+                 is busy-looping, re-requesting ereports with the stale \
+                 restart ID {stale_restart_id:?} while the SP keeps \
+                 responding with already-ingested ereports from restart \
+                 {current_restart_id:?} (omicron#10738)",
+            )
+        });
+
+        // Make sure that the test reproduced the conditions necessary for the
+        // bug, and did not pass incorrectly.
+        //
+        // First, the ingestion request should not have inserted any new ENAs
+        // into the database, as doing so would have made the current ENA
+        // "latest" again.
+        let expected_current_restart_enas = current_restart_ereports
+            .iter()
+            .map(|e| e.ena)
+            .collect::<BTreeSet<_>>();
+        let db_current_restart_enas =
+            restart_ereports_fetch(datastore, &opctx, current_restart_id)
+                .await
+                .keys()
+                .copied()
+                .collect::<BTreeSet<_>>();
+        assert_eq!(
+            db_current_restart_enas, expected_current_restart_enas,
+            "/!\\ TEST IS BROKEN! /!\\\n\
+            the ingestion attempt should not have created any new ENAs from \
+            the current restart ID that were not previously in the database. \
+            if it has, this test has 'passed' without reproducing the \
+            conditions necessary for the bug to occur! this probably means \
+            that the SP simulator has somehow produced additional ereports \
+            when it was not asked to, which should not happen!",
+        );
+        // Second, the expected ereports from the "previous" restart must exist.
+        let db_stale_restart_enas =
+            restart_ereports_fetch(datastore, &opctx, stale_restart_id)
+                .await
+                .keys()
+                .copied()
+                .collect::<BTreeSet<_>>();
+        assert_eq!(
+            db_stale_restart_enas, stale_restart_enas,
+            "/!\\ TEST IS BROKEN! /!\\\n\
+            ENAs from the 'stale' previous restart are somehow missing from \
+            the database. this test has 'passed' without reproducing the \
+            conditions necessary for the bug to occur!",
+        );
+        // An MGS request error would also (spuriously) break the loop; fail
+        // loudly rather than passing without having exercised the scenario.
+        assert_eq!(
+            &status.errors,
+            &Vec::<String>::new(),
+            "/!\\ TEST IS BROKEN! /!\\\n\
+            MGS unexpectedly returned an error in response to an ereport \
+            ingestion request! this test has 'passed' without reproducing the \
+            conditions necessary for the bug to occur!",
+        );
+    }
+
     struct ExpectedReporter {
         serial: &'static str,
         part: &'static str,
@@ -783,17 +1039,16 @@ mod tests {
         }
     }
 
-    async fn check_sp_ereports_exist(
+    async fn restart_ereports_fetch(
         datastore: &DataStore,
         opctx: &OpContext,
         restart_id: EreporterRestartUuid,
-        expected_ereports: &[ExpectedEreport],
-    ) {
+    ) -> BTreeMap<Ena, nexus_db_model::Ereport> {
         let mut paginator = Paginator::new(
             std::num::NonZeroU32::new(100).unwrap(),
             dropshot::PaginationOrder::Ascending,
         );
-        let mut found_ereports = BTreeMap::new();
+        let mut ereports = BTreeMap::new();
         while let Some(p) = paginator.next() {
             let batch = datastore
                 .ereport_list_by_restart(
@@ -804,12 +1059,23 @@ mod tests {
                 .await
                 .expect("should be able to query for ereports");
             paginator = p.found_batch(&batch, &|ereport| ereport.ena);
-            found_ereports.extend(
+            ereports.extend(
                 batch
                     .into_iter()
                     .map(|ereport| (Ena::from(ereport.ena), ereport)),
             );
         }
+        ereports
+    }
+
+    async fn check_sp_ereports_exist(
+        datastore: &DataStore,
+        opctx: &OpContext,
+        restart_id: EreporterRestartUuid,
+        expected_ereports: &[ExpectedEreport],
+    ) {
+        let found_ereports =
+            restart_ereports_fetch(datastore, opctx, restart_id).await;
         assert_eq!(
             expected_ereports.len(),
             found_ereports.len(),


### PR DESCRIPTION
Issue #10738 describes a bug @smklein noticed in the
`sp_ereport_ingester` background task. Currently the
`DataStore::ereports_insert` method returns the `EreportId` (ENA +
restart ID tuple) for the "latest" ereport from the reporter that
produced the inserted batch of ereports, which is determined based on
the wall clock time at which the ereports were received. The returned
`EreportId` is then used as the starting ENA and expected restart ID for
a subsequent request to the SP. Because the latest ereport ID is
determined using wall-clock time, it is possible for a situation to
occur where another Nexus is holding in memory a batch of ereports
received from a *previous* restart of that SP, is delayed in inserting
them, and then inserts those ereports at a *later* wall clock time than
when a batch of ereports from the actual current restart is inserted. If
this occurs, the *previous* restart will appear to be "latest", rather
than the current one, which can cause the Nexus which just inserted a
batch of ereports from the *current* restart to busy-loop when it
requests ereports with the old restart ID, and receives the *same* batch
of ereports it already inserted on its previous iteration. Since no new
ereports are inserted when the same batch is received again, nothing
updates the "latest" ereport from that SP, and the unfortunate Nexus
keeps spinning until the SP resets again and unsticks it. This is quite
unfortunate, although this case should be unlikely in practice.

In commit 945a5adc2e43dd370c10fe0abf12bde60aed90e2, I've added a test
that reproduces this bug artificially, and makes a call to
`DataStore::ereports_insert` loop forever. This test fails on `main`.

Commit 7ee866c5b7e6060abd64758080d7ab693ba3eab5 fixes the bug by
changing the `ereports_insert` method to instead return an `EreportId`
with the latest ENA from *the restart ID of the ereports that were
inserted*. That way, subsequent ingestion loop iterations no longer rely
on wall-clock time to determine what restart ID to send. If the SP has
restarted, Nexus will still ask it for the restart ID it returned in
response to a previous request, but this just causes Nexus to update the
restart ID when it inserts any ereports received from the *new* restart.
Wall clock time is still used to determine the *initial* "latest"
ereport ID to request at the top of the loop, but that's fine now, since
if it's not the current restart, we will update our understanding of the
current restart as soon as we've received a response from the SP.
Essentially, this approach changes the ingestion loop from treating the
database as the source of truth for what the current restart ID is, to
using *the SP itself* as the source of truth...which is how this
protocol was always designed to work from the beginning, and how I
described it working in RFD 520. I just messed it up while actually
implementing it.

Fixes #10738.