### PR TITLE
fix: properly allocate adjacent single address external subnets

### DIFF
--- a/nexus/db-queries/src/db/datastore/external_subnet.rs
+++ b/nexus/db-queries/src/db/datastore/external_subnet.rs
@@ -3340,6 +3340,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn external_subnet_allocation_of_consecutive_single_addresses() {
+        let context = setup_external_subnet_test(
+            "external_subnet_allocation_of_consecutive_single_addresses",
+        )
+        .await;
+
+        // Add a member that permits allocating single addresses (/128s).
+        let member_subnet: IpNet = "2001:db8:4::/48".parse().unwrap();
+        context
+            .db
+            .datastore()
+            .add_subnet_pool_member(
+                context.db.opctx(),
+                &context.authz_pool,
+                &context.db_pool,
+                &SubnetPoolMemberAdd {
+                    subnet: member_subnet,
+                    min_prefix_length: Some(48),
+                    max_prefix_length: Some(128),
+                },
+            )
+            .await
+            .expect("able to add /128-capable pool member");
+
+        // Allocate two consecutive /128s. Only the new member can fit a /128,
+        // so both come from it, at its first two addresses.
+        let prefix_length = 128;
+        let mut subnets = Vec::with_capacity(2);
+        for i in 0..subnets.capacity() {
+            let subnet = context
+                .db
+                .datastore()
+                .create_external_subnet(
+                    context.db.opctx(),
+                    &DEFAULT_SILO_ID,
+                    &context.authz_project,
+                    ExternalSubnetCreate {
+                        identity: IdentityMetadataCreateParams {
+                            name: format!("single{i}").parse().unwrap(),
+                            description: String::new(),
+                        },
+                        allocator: ExternalSubnetAllocator::Auto {
+                            pool_selector: PoolSelector::Auto {
+                                ip_version: None,
+                            },
+                            prefix_length,
+                        },
+                    },
+                )
+                .await
+                .expect("able to allocate consecutive single-address subnets");
+            subnets.push(subnet);
+        }
+
+        // The two allocations must be distinct, and the second must be the
+        // address immediately following the first.
+        assert_ne!(subnets[0].subnet, subnets[1].subnet);
+        let first: IpNet = "2001:db8:4::/128".parse().unwrap();
+        let second: IpNet = "2001:db8:4::1/128".parse().unwrap();
+        assert_eq!(oxnet::IpNet::from(subnets[0].subnet), first);
+        assert_eq!(oxnet::IpNet::from(subnets[1].subnet), second);
+
+        context.db.terminate().await;
+        context.logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
     async fn external_subnet_allocation_takes_smallest_gap_in_member_middle() {
         let context = setup_external_subnet_test(
             "external_subnet_allocation_takes_smallest_gap_in_member_middle",

--- a/nexus/db-queries/src/db/datastore/external_subnet.rs
+++ b/nexus/db-queries/src/db/datastore/external_subnet.rs
@@ -3402,6 +3402,35 @@ mod tests {
         assert_eq!(oxnet::IpNet::from(subnets[0].subnet), first);
         assert_eq!(oxnet::IpNet::from(subnets[1].subnet), second);
 
+        // Explicitly request one of the /128s we just allocated to confirm
+        // we get the overlap error.
+        let err = context
+            .db
+            .datastore()
+            .create_external_subnet(
+                context.db.opctx(),
+                &DEFAULT_SILO_ID,
+                &context.authz_project,
+                ExternalSubnetCreate {
+                    identity: IdentityMetadataCreateParams {
+                        name: "explicit-dup".parse().unwrap(),
+                        description: String::new(),
+                    },
+                    allocator: ExternalSubnetAllocator::Explicit {
+                        subnet: first,
+                    },
+                },
+            )
+            .await
+            .expect_err("cannot explicitly request an allocated subnet");
+        let Error::InvalidRequest { message } = &err else {
+            panic!("Expected InvalidRequest, found {err:#?}");
+        };
+        assert_eq!(
+            message.external_message(),
+            SUBNET_OVERLAPS_EXISTING_ERR_MSG,
+        );
+
         context.db.terminate().await;
         context.logctx.cleanup_successful();
     }

--- a/nexus/db-queries/src/db/queries/external_subnet.rs
+++ b/nexus/db-queries/src/db/queries/external_subnet.rs
@@ -954,8 +954,8 @@ fn push_cte_to_select_next_subnet_from_pool(
                         family(subnet_end) = 4, \
                         '255.255.255.254'::INET,
                         'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe'::INET\
-                    ) + 1\
-                )\
+                    )\
+                ) + 1 \
             END AS gap_start, \
             CASE \
                 WHEN next_subnet_start IS NULL THEN member_end \
@@ -1161,14 +1161,27 @@ pub fn decode_insert_external_subnet_error(
                 public_error_from_diesel(e, ErrorHandler::Server)
             }
         }
-        DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
-            public_error_from_diesel(
-                e,
-                ErrorHandler::Conflict(
-                    ResourceType::ExternalSubnet,
-                    subnet_name,
-                ),
-            )
+        DieselError::DatabaseError(
+            DatabaseErrorKind::UniqueViolation,
+            info,
+        ) => {
+            match info.constraint_name() {
+                Some(EXTERNAL_SUBNET_NAME_CONSTRAINT) => {
+                    public_error_from_diesel(
+                        e,
+                        ErrorHandler::Conflict(
+                            ResourceType::ExternalSubnet,
+                            subnet_name,
+                        ),
+                    )
+                }
+                Some(EXTERNAL_SUBNET_SUBNET_CONSTRAINT)
+                | Some(EXTERNAL_SUBNET_ADDRESS_CONSTRAINT) => {
+                    Error::invalid_request(SUBNET_OVERLAPS_EXISTING_ERR_MSG)
+                }
+                // Any other unique violation is unexpected and indicates a bug.
+                _ => public_error_from_diesel(e, ErrorHandler::Server),
+            }
         }
         DieselError::NotFound => report_exhaustion(subnet),
         _ => public_error_from_diesel(e, ErrorHandler::Server),
@@ -1285,6 +1298,22 @@ The requested IP subnet is not contained in \
 const SUBNET_OVERLAPS_EXISTING_SENTINEL: &str = "overlap-existing";
 pub const SUBNET_OVERLAPS_EXISTING_ERR_MSG: &'static str =
     "The requested IP subnet overlaps with an existing external subnet";
+
+// Unique index names from `dbinit.sql`. CockroachDB reports these as the
+// constraint name on a unique violation, allowing us to match against them for
+// better error messaging.
+
+/// Uniqueness of (`project_id`, `name`).
+const EXTERNAL_SUBNET_NAME_CONSTRAINT: &str =
+    "external_subnet_project_id_name_key";
+
+/// Uniqueness of (`subnet`).
+const EXTERNAL_SUBNET_SUBNET_CONSTRAINT: &str =
+    "lookup_external_subnet_by_subnet";
+
+/// Uniqueness of (`first_address`, `last_address`).
+const EXTERNAL_SUBNET_ADDRESS_CONSTRAINT: &str =
+    "lookup_external_subnet_by_first_and_last_address";
 
 // Error sentinel emitted when we try to insert a subnet into a project that
 // has now been deleted.

--- a/nexus/db-queries/tests/output/insert_external_subnet_from_default_pool.sql
+++ b/nexus/db-queries/tests/output/insert_external_subnet_from_default_pool.sql
@@ -54,8 +54,8 @@ WITH
             '255.255.255.254'::INET,
             'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe'::INET
           )
-          + 1
         )
+        + 1
         END
           AS gap_start,
         CASE

--- a/nexus/db-queries/tests/output/insert_external_subnet_from_explicit_pool.sql
+++ b/nexus/db-queries/tests/output/insert_external_subnet_from_explicit_pool.sql
@@ -55,8 +55,8 @@ WITH
             '255.255.255.254'::INET,
             'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe'::INET
           )
-          + 1
         )
+        + 1
         END
           AS gap_start,
         CASE

--- a/nexus/db-queries/tests/output/insert_external_subnet_from_ip_version.sql
+++ b/nexus/db-queries/tests/output/insert_external_subnet_from_ip_version.sql
@@ -54,8 +54,8 @@ WITH
             '255.255.255.254'::INET,
             'ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe'::INET
           )
-          + 1
         )
+        + 1
         END
           AS gap_start,
         CASE


### PR DESCRIPTION
Updated the database logic to properly allow allocation of adjacent single address external subnets (e.g., /32, /128).

Closes #10748.