### PR TITLE
[nexus] skip deleted ereports when determining latest ENA

### DIFF
--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -235,6 +235,7 @@ impl DataStore {
     ) -> Result<Option<EreportId>, Error> {
         let ena = dsl::ereport
             .filter(dsl::restart_id.eq(restart_id.into_untyped_uuid()))
+            .filter(dsl::time_deleted.is_null())
             .order_by(dsl::ena.desc())
             .limit(1)
             .select(dsl::ena)

--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -228,6 +228,15 @@ impl DataStore {
             .select((dsl::restart_id, dsl::ena))
     }
 
+    /// Returns an [`EreportId`] with the latest ENA that exists for the given
+    /// [`EreporterRestartUuid`], or [`None`] if no (non-deleted)ereports exist
+    /// with that restart ID.
+    ///
+    /// This is used when inserting a batch of ereports, in order to determine
+    /// the most recent ENA to use in a subsequent request for more ereports
+    /// from that reporter. This is intentionally a separate query than the CTE
+    /// that inserts the batch, as additional ereports with a greater ENA may
+    /// have been inserted concurrently.
     async fn latest_ena_for_restart_on_conn(
         &self,
         restart_id: EreporterRestartUuid,


### PR DESCRIPTION
As @smklein pointed out in [this comment][1], the `Datastore::lates_ena_for_restart_on_conn` query does not filter out ereports `WHERE time_deleted IS NOT NULL`, and it probably should be doing that. I didn't see the comment on #10746 until after I clicked the "merge" button on that branch due to github UI jankiness, so this PR fixes it. I also added a quick doc comment.

[1]: https://github.com/oxidecomputer/omicron/pull/10746#discussion_r3530327055