### PR TITLE
Oximeter: add producer cardinality metric.

### DIFF
--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -758,7 +758,9 @@ mod tests {
     use omicron_test_utils::dev::poll::wait_for_condition;
     use omicron_test_utils::dev::poll::wait_for_watch_channel_condition;
     use omicron_test_utils::dev::test_setup_log;
+    use oximeter::Sample;
     use oximeter::types::ProducerResults;
+    use oximeter::types::ProducerResultsItem;
     use oximeter_types::producer::ProducerDetails;
     use reqwest::StatusCode;
     use std::net::Ipv6Addr;
@@ -909,6 +911,35 @@ mod tests {
         }
     }
 
+    /// A producer that always responds successfully with two samples.
+    struct LiveProducer;
+
+    impl ProducerApi for LiveProducer {
+        type Context = Arc<AtomicUsize>;
+
+        async fn collect(
+            request_context: RequestContext<Self::Context>,
+            _: Path<IdPath>,
+        ) -> Result<HttpResponseOk<ProducerResults>, HttpError> {
+            request_context.context().fetch_add(1, Ordering::SeqCst);
+
+            #[derive(oximeter::Target)]
+            struct TestTarget {
+                id: Uuid,
+            }
+            #[derive(oximeter::Metric)]
+            struct TestMetric {
+                datum: u64,
+            }
+
+            let target = TestTarget { id: Uuid::nil() };
+            Ok(HttpResponseOk(vec![ProducerResultsItem::Ok(vec![
+                Sample::new(&target, &TestMetric { datum: 1 }).unwrap(),
+                Sample::new(&target, &TestMetric { datum: 2 }).unwrap(),
+            ])]))
+        }
+    }
+
     /// A producer that always responds with a 500.
     struct DedProducer;
 
@@ -942,10 +973,10 @@ mod tests {
         .await
         .unwrap();
 
-        // Spawn the mock server that always reports empty statistics.
+        // Spawn the mock server that always reports dummy statistics.
         let collection_count = Arc::new(AtomicUsize::new(0));
         let server = ServerBuilder::new(
-            producer_api_mod::api_description::<EmptyProducer>().unwrap(),
+            producer_api_mod::api_description::<LiveProducer>().unwrap(),
             collection_count.clone(),
             log.new(slog::o!("component" => "dropshot")),
         )
@@ -977,6 +1008,7 @@ mod tests {
             .statistics();
         let stats = rx.await.unwrap();
         let count = stats.collections.datum.value() as usize;
+        let samples_collected = stats.samples_collected.datum.value();
 
         // Exactly `N_COLLECTIONS` collections ran: nothing is in flight when
         // `run_n_collections` returns, and the long collection interval
@@ -990,6 +1022,16 @@ mod tests {
             producer server itself ({server_count})"
         );
         assert!(stats.failed_collections.is_empty());
+
+        let producer_samples_collected = 2 * N_COLLECTIONS;
+        assert_eq!(
+            samples_collected, producer_samples_collected,
+            "number of samples collected by the collection \
+            task ({samples_collected}) differs from the expected count of \
+            {producer_samples_collected}; the dummy producer produces two \
+            samples per collection"
+        );
+
         logctx.cleanup_successful();
     }
 

--- a/oximeter/collector/src/collection_task.rs
+++ b/oximeter/collector/src/collection_task.rs
@@ -825,6 +825,7 @@ impl CollectionTask {
                         _ => 0,
                     })
                     .sum();
+                self.stats.samples_collected.datum += n_samples;
                 let success = SuccessfulCollection {
                     started_at,
                     time_queued,

--- a/oximeter/collector/src/self_stats.rs
+++ b/oximeter/collector/src/self_stats.rs
@@ -25,6 +25,7 @@ pub use self::oximeter_collector::DatabaseQueueDepth;
 pub use self::oximeter_collector::DatabaseSamplesDropped;
 pub use self::oximeter_collector::FailedCollections;
 pub use self::oximeter_collector::OximeterCollector;
+pub use self::oximeter_collector::SamplesCollected;
 
 /// The interval on which we report self statistics
 pub const COLLECTION_INTERVAL: Duration = Duration::from_secs(60);
@@ -148,6 +149,7 @@ pub struct CollectionTaskStats {
     pub collector: OximeterCollector,
     pub collections: Collections,
     pub failed_collections: BTreeMap<FailureReason, FailedCollections>,
+    pub samples_collected: SamplesCollected,
 }
 
 impl CollectionTaskStats {
@@ -165,6 +167,13 @@ impl CollectionTaskStats {
                 datum: Cumulative::new(0),
             },
             failed_collections: BTreeMap::new(),
+            samples_collected: SamplesCollected {
+                producer_id: producer.id,
+                producer_ip: producer.address.ip(),
+                producer_port: producer.address.port(),
+                base_route: "".into(),
+                datum: Cumulative::new(0),
+            },
         }
     }
 
@@ -192,6 +201,9 @@ impl CollectionTaskStats {
             each.producer_port = new_port;
             each.datum = Cumulative::new(0);
         }
+        self.samples_collected.producer_ip = new_ip;
+        self.samples_collected.producer_port = new_port;
+        self.samples_collected.datum = Cumulative::new(0);
     }
 
     pub fn failures_for_reason(
@@ -217,13 +229,17 @@ impl CollectionTaskStats {
                 Err(s) => ProducerResultsItem::Err(s),
             }
         }
-        let mut samples = Vec::with_capacity(1 + self.failed_collections.len());
+        let mut samples = Vec::with_capacity(2 + self.failed_collections.len());
         samples.push(to_item(Sample::new(&self.collector, &self.collections)));
         samples.extend(
             self.failed_collections
                 .values()
                 .map(|metric| to_item(Sample::new(&self.collector, metric))),
         );
+        samples.push(to_item(Sample::new(
+            &self.collector,
+            &self.samples_collected,
+        )));
         samples
     }
 }

--- a/oximeter/oximeter/schema/oximeter-collector.toml
+++ b/oximeter/oximeter/schema/oximeter-collector.toml
@@ -44,6 +44,15 @@ versions = [
     { added_in = 1, fields = [ "collector_sink" ] }
 ]
 
+[[metrics]]
+name = "samples_collected"
+description = "Total number of samples collected from a producer"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [ "base_route", "producer_id", "producer_ip", "producer_port" ] }
+]
+
 [fields.base_route]
 type = "string"
 description = "Base HTTP route used to request data from the producer"


### PR DESCRIPTION
Oximeter drops samples when its database insertion queue fills up. As described in #10552, this can happen even when average oximeter throughput isn't very high if a few producers emit large numbers of metrics at the same time. To offer better operational visibility into high-cardinality producers, this patch adds a new `oximeter_collector:samples` metric that counts the cumulative number of samples produced by each producer. This will allow operators/support to identify potential causes of dropped metrics, and adjust producer or consumer behavior to fix. Although note that the relevant knobs (producer cardinality, producer sample interval, oximeter queue size) aren't configurable today.

Note: this metric could technically, mostly be reconstructed from clickhouse. But there's no single `producer_id` field in clickhouse today, and counting cardinality requires joining across multiple field and measurement tables. Given the trivial cost to implement the new metric and minimal overhead, I think it's worth including.

Part of #10552.