### PR TITLE
Oximeter: add metric to track database insert errors.

### DIFF
--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -555,8 +555,6 @@ impl CollectionTaskSenderWrapper {
 // degraded. And because the relevant counters live in oximeter's
 // memory, even if ClickHouse becomes fully unavailable and then
 // recovers, the metrics will also eventually reach the database.
-//
-// TODO(#10552): Emit a metric about failed database writes as well.
 async fn emit_self_stats(
     collector_stats: self_stats::CollectorStats,
     collection_target: self_stats::OximeterCollector,

--- a/oximeter/collector/src/results_sink.rs
+++ b/oximeter/collector/src/results_sink.rs
@@ -64,6 +64,7 @@ pub async fn database_batcher(
         log.new(slog::o!("component" => "database-inserter")),
         client,
         batch_rx,
+        sink_stats.clone(),
     ));
 
     // Spawn a timer for ensuring we periodically notify the inserter to
@@ -246,6 +247,7 @@ async fn database_inserter(
     log: Logger,
     client: Client,
     batch_rx: BatchReceiver<Sample>,
+    sink_stats: Arc<self_stats::CollectorSinkStats>,
 ) {
     loop {
         // Wait for a notification that there are samples to insert, and consume
@@ -278,6 +280,7 @@ async fn database_inserter(
                     "failed to insert some results into metric DB";
                     err,
                 );
+                sink_stats.insert_errors.lock().unwrap().increment();
             }
         }
     }

--- a/oximeter/collector/src/self_stats.rs
+++ b/oximeter/collector/src/self_stats.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 
 oximeter::use_timeseries!("oximeter-collector.toml");
 pub use self::oximeter_collector::Collections;
+pub use self::oximeter_collector::DatabaseInsertsFailed;
 pub use self::oximeter_collector::DatabaseQueueDepth;
 pub use self::oximeter_collector::DatabaseSamplesDropped;
 pub use self::oximeter_collector::FailedCollections;
@@ -102,6 +103,7 @@ pub struct CollectorSinkStats {
     pub label: String,
     pub samples_dropped: Mutex<Cumulative<u64>>,
     pub queue_depth: Mutex<Histogram<u64>>,
+    pub insert_errors: Mutex<Cumulative<u64>>,
 }
 
 impl CollectorSinkStats {
@@ -120,6 +122,9 @@ impl CollectorSinkStats {
                 start_time, 0,
             )),
             queue_depth: Mutex::new(queue_depth),
+            insert_errors: Mutex::new(Cumulative::with_start_time(
+                start_time, 0,
+            )),
         }
     }
 
@@ -135,9 +140,14 @@ impl CollectorSinkStats {
             datum: self.queue_depth.lock().unwrap().clone(),
             collector_sink: self.label.clone().into(),
         };
+        let insert_metric = DatabaseInsertsFailed {
+            datum: *self.insert_errors.lock().unwrap(),
+            collector_sink: self.label.clone().into(),
+        };
         Ok(vec![
             Sample::new(collection_target, &drop_metric)?,
             Sample::new(collection_target, &queue_metric)?,
+            Sample::new(collection_target, &insert_metric)?,
         ])
     }
 }

--- a/oximeter/oximeter/schema/oximeter-collector.toml
+++ b/oximeter/oximeter/schema/oximeter-collector.toml
@@ -36,6 +36,15 @@ versions = [
 ]
 
 [[metrics]]
+name = "database_inserts_failed"
+description = "Total number of failed inserts into the database"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [ "collector_sink" ] }
+]
+
+[[metrics]]
 name = "database_queue_depth"
 description = "Size of the database insertion queue, sampled at queue insert time"
 units = "count"


### PR DESCRIPTION
When oximeter fails to insert a batch of samples into clickhouse, it logs a warning. However, operators/support would have to check those logs, or notice gaps in metrics, in order to detect that database writes are failing. Operators will probably notice if clickhouse is totally unavailable, but sporadic failed writes would be harder to detect.

This patch adds an `oximeter_collector:database_inserts_failed` metric that counts the total number of failed clickhouse inserts. As for related self-stats metrics, we obviously can't write this metric to clickhouse if clickhouse is unavailable. But if clickhouse is merely degraded, or temporarily unavailable, the metric will eventually come through.

Part of #10552.

Note: I think this is the last thing I wanted to get done before closing #10552. I think I'll file a separate issue for sizing the database_batcher queue, but that should be easier to think about once this set of metrics lands in a release, and we can look at production data more easily.