### PR TITLE
Fix PgNumeric -> ByteCount conversion

### DIFF
--- a/nexus/db-model/src/bytecount.rs
+++ b/nexus/db-model/src/bytecount.rs
@@ -79,22 +79,32 @@ impl TryFrom<diesel::pg::data_types::PgNumeric> for ByteCount {
     ) -> Result<Self, Self::Error> {
         match num {
             diesel::pg::data_types::PgNumeric::Positive {
-                weight: _,
+                // How many digits come before the decimal point?
+                weight,
+                // How many significant digits are there?
                 scale,
+                // The digits in this number, stored in base 10000
                 digits,
             } => {
                 // fail if there are digits to right of decimal place -
                 // ByteCount is a whole number
                 if scale != 0 {
-                    bail!("PgNumeric::Positive scale is {}", scale);
+                    bail!("PgNumeric::Positive scale is {scale}");
                 }
 
                 let mut result: i64 = 0;
-                let mut multiplier = 1;
 
-                for digit in digits.iter().rev() {
+                // `weight` stores how many "digits" come before the decimal
+                // point, but remember "digits" are stored in base 10000.
+                let Some(mut multiplier) =
+                    10000_i64.checked_pow(weight.try_into()?)
+                else {
+                    bail!("overflow for multiplier weight {weight}");
+                };
+
+                for digit in digits.iter() {
                     result += i64::from(*digit) * multiplier;
-                    multiplier *= 10000;
+                    multiplier /= 10000;
                 }
 
                 let result: external::ByteCount = result.try_into()?;
@@ -163,7 +173,7 @@ mod test {
         //   The digits in this number, stored in base 10000
 
         let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
-            weight: 1,
+            weight: 0,
             scale: 0,
             digits: vec![1],
         }
@@ -171,7 +181,15 @@ mod test {
         assert_eq!(result.unwrap().to_bytes(), 1);
 
         let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
-            weight: 5,
+            weight: 0,
+            scale: 0,
+            digits: vec![999],
+        }
+        .try_into();
+        assert_eq!(result.unwrap().to_bytes(), 999);
+
+        let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
+            weight: 1,
             scale: 0,
             digits: vec![1, 0],
         }
@@ -179,7 +197,15 @@ mod test {
         assert_eq!(result.unwrap().to_bytes(), 10000);
 
         let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
-            weight: 9,
+            weight: 1,
+            scale: 0,
+            digits: vec![1],
+        }
+        .try_into();
+        assert_eq!(result.unwrap().to_bytes(), 10000);
+
+        let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
+            weight: 2,
             scale: 0,
             digits: vec![1, 0, 0],
         }
@@ -187,7 +213,15 @@ mod test {
         assert_eq!(result.unwrap().to_bytes(), 100000000);
 
         let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
-            weight: 9,
+            weight: 2,
+            scale: 0,
+            digits: vec![1],
+        }
+        .try_into();
+        assert_eq!(result.unwrap().to_bytes(), 100000000);
+
+        let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
+            weight: 2,
             scale: 0,
             digits: vec![1, 0, 9999],
         }
@@ -195,7 +229,7 @@ mod test {
         assert_eq!(result.unwrap().to_bytes(), 100009999);
 
         let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
-            weight: 11,
+            weight: 2,
             scale: 0,
             digits: vec![512, 512, 512],
         }
@@ -203,12 +237,44 @@ mod test {
         assert_eq!(result.unwrap().to_bytes(), 51205120512);
 
         let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
-            weight: 12,
+            weight: 2,
             scale: 0,
             digits: vec![9999, 9999, 9999],
         }
         .try_into();
         assert_eq!(result.unwrap().to_bytes(), 999999999999);
+
+        let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
+            weight: 3,
+            scale: 0,
+            digits: vec![5, 7357, 1072, 0],
+        }
+        .try_into();
+        assert_eq!(result.unwrap().to_bytes(), 5735710720000);
+
+        let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
+            weight: 3,
+            scale: 0,
+            digits: vec![5, 7357, 1072],
+        }
+        .try_into();
+        assert_eq!(result.unwrap().to_bytes(), 5735710720000);
+
+        let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
+            weight: 2,
+            scale: 0,
+            digits: vec![1147, 1421, 4400],
+        }
+        .try_into();
+        assert_eq!(result.unwrap().to_bytes(), 114714214400);
+
+        let result: IntoResult = diesel::pg::data_types::PgNumeric::Positive {
+            weight: 2,
+            scale: 0,
+            digits: vec![183, 5427, 4304],
+        }
+        .try_into();
+        assert_eq!(result.unwrap().to_bytes(), 18354274304);
     }
 
     #[test]


### PR DESCRIPTION
We saw another instance-start that was stuck during allocation, exhaustively searching for a set of local storage allocations that would fit. This particular case did not match any of the previous ones, and further digging showed that the returned value for local storage usage from `zpool_get_for_sled_reservation` were off by a factor of 10000:

    ZPOOL_ID                              LOCAL_STORAGE_USAGE
    b5cd737a-ebaf-461e-a7a8-8b13246475d5  573571072

The real value here according to the database was 5735710720000.

`zpool_get_for_sled_reservation` will convert a returned PgNumeric into a ByteCount, so we dumped out the PgNumeric value returned from CRDB:

    { weight: 3, scale: 0, digits: [5, 7357, 1072] }

Adding that to the existing unit tests for the conversion reproduced the problem:

    assertion `left == right` failed
      left: 573571072
     right: 5735710720000

Our conversion code was ignoring the weight field in PgNumeric, and this should be used to compute the multiplier for the base 10000 digits. Fix this, and the unit tests, and add more unit tests exercising different weights.

Fixes #10772