### PR TITLE
Don't show `Stage0Next` `FirstPageErased` as an error in wicket

### DIFF
--- a/wicket-common/src/inventory.rs
+++ b/wicket-common/src/inventory.rs
@@ -9,7 +9,7 @@ pub use gateway_client::types::{
 };
 pub use gateway_types::component::{SpIdentifier, SpState, SpType};
 pub use gateway_types::ignition::{SpIgnition, SpIgnitionSystemType};
-pub use gateway_types::rot::{RotSlot, RotState};
+pub use gateway_types::rot::{RotImageError, RotSlot, RotState};
 use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
 use omicron_common::snake_case_result;
 use omicron_common::snake_case_result::SnakeCaseResult;

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -31,6 +31,7 @@ use transceiver_controller::ReceiverPower;
 use transceiver_controller::SffComplianceCode;
 use transceiver_controller::VendorInfo;
 use transceiver_controller::message::ExtendedStatus;
+use wicket_common::inventory::RotImageError;
 use wicket_common::inventory::RotState;
 use wicket_common::inventory::SpComponentCaboose;
 use wicket_common::inventory::SpComponentInfo;
@@ -913,14 +914,37 @@ fn inventory_description(component: &Component) -> Text<'_> {
                     );
                 }
                 if let Some(e) = stage0next_error {
-                    spans.push(
-                        vec![
-                            nest_bullet(),
-                            Span::styled("Image status: ", label_style),
-                            Span::styled(format!("Error: {e:?}"), bad_style),
-                        ]
-                        .into(),
-                    );
+                    // `FirstPageErased` can be an expected state, marking
+                    // it as an error causes confusion
+                    match e {
+                        RotImageError::FirstPageErased => {
+                            spans.push(
+                                vec![
+                                    nest_bullet(),
+                                    Span::styled("Image status: ", label_style),
+                                    Span::styled(
+                                        format!("Expected: {e:?}"),
+                                        warn_style,
+                                    ),
+                                ]
+                                .into(),
+                            );
+                        }
+
+                        _ => {
+                            spans.push(
+                                vec![
+                                    nest_bullet(),
+                                    Span::styled("Image status: ", label_style),
+                                    Span::styled(
+                                        format!("Error: {e:?}"),
+                                        bad_style,
+                                    ),
+                                ]
+                                .into(),
+                            );
+                        }
+                    }
                 } else {
                     spans.push(
                         vec![


### PR DESCRIPTION
The stage0 update process involves writing to a region named `stage0next` before actually updating `stage0`. If stage0 has never been updated `stage0next` will be erased. This is a very common case because 1) sleds that come out of the factory will have an erased `stage0next` and 2) stage0 updates are infrequent. Display this case as a warning instead of an error in wicket. This does not change any behavior when `stage0next` is `FirstPageErased`.