### PR TITLE
switch zone shell prompt: include the system name

### DIFF
--- a/smf/profile/bashrc
+++ b/smf/profile/bashrc
@@ -20,7 +20,7 @@ case "$_hst" in
                 _hstc+="$C_CYAN$_switchid"
         fi
         # Fetch the first system name from lldpd.  If not configured this defaults
-        # to the scrimlet serial number 
+        # to the scrimlet serial number
         _systemname=$(curl --max-time 1 -H 'api-version: 1.0.0' -s http://localhost:12230/interface/ \
             | /opt/ooce/bin/jq -r '.[0].system_info.system_name')
         if (( $? == 0 )) && [[ -n "$_systemname" ]]; then

--- a/smf/profile/bashrc
+++ b/smf/profile/bashrc
@@ -1,42 +1,52 @@
 
 C_RED='\[\033[01;31m\]'
 C_GREEN='\[\033[01;32m\]'
+C_MAG='\[\033[01;35m\]'
 C_CYAN='\[\033[01;36m\]'
 C_BLD='\[\033[1m\]'
 C_NUL='\[\033[00m\]'
 
 typeset _hst="$HOSTNAME"
 typeset _hstc="$C_RED$HOSTNAME"
+typeset _rack=""
+typeset _rackc=""
 case "$_hst" in
     oxz_switch)
-	# Try to determine which switch zone we are
-	_switchid=$(curl -H 'api-version: 1.0.0' -s http://localhost:12225/local/switch-id \
-	    | /opt/ooce/bin/jq -r .slot)
-	if (( $? == 0 )) && [[ -n "$_switchid" ]]; then
-		_hst+="$_switchid"
-		_hstc+="$C_CYAN$_switchid"
-	fi
-	;;
+        # Try to determine which switch zone we are
+        _switchid=$(curl -H 'api-version: 1.0.0' -s http://localhost:12225/local/switch-id \
+            | /opt/ooce/bin/jq -r .slot)
+        if (( $? == 0 )) && [[ -n "$_switchid" ]]; then
+                _hst+="$_switchid"
+                _hstc+="$C_CYAN$_switchid"
+        fi
+        # Fetch the first system name from lldpd.  If not configured this defaults
+        # to the scrimlet serial number 
+        _systemname=$(curl --max-time 1 -H 'api-version: 1.0.0' -s http://localhost:12230/interface/ \
+            | /opt/ooce/bin/jq -r '.[0].system_info.system_name')
+        if (( $? == 0 )) && [[ -n "$_systemname" ]]; then
+                _rack="[$_systemname]"
+                _rackc="[${C_MAG}${_systemname}${C_NUL}]"
+        fi
+        ;;
     oxz_*-*)
-	# Shorten the hostname by truncating the UUID so that the prompt
-	# doesn't take up an excessive amount of width
-	_hst="${HOSTNAME%%-*}"
-	_hstc="$C_RED${HOSTNAME%%-*}"
-	;;
+        # Shorten the hostname by truncating the UUID so that the prompt
+        # doesn't take up an excessive amount of width
+        _hst="${HOSTNAME%%-*}"
+        _hstc="$C_RED${HOSTNAME%%-*}"
+        ;;
 esac
 
 if [[ -n $SSH_CLIENT ]]; then
-	echo -ne "\033]0;${_hst} \007"
-	export PROMPT_COMMAND='history -a'
+        echo -ne "\033]0;${_hst} \007"
+        export PROMPT_COMMAND='history -a'
 fi
 
 case "$TERM" in
 xterm*|rxvt*|screen*|sun-color)
-	PS1="$C_GREEN\\u$C_NUL@$_hstc$C_NUL:$C_RED\\w$C_NUL$C_BLD\\\$$C_NUL "
+        PS1="$_rackc$C_GREEN\\u$C_NUL@$_hstc$C_NUL:$C_RED\\w$C_NUL$C_BLD\\\$$C_NUL "
         ;;
 *)
-	PS1="\\u@$_hst:\\w\\$ "
+        PS1="$_rack\\u@$_hst:\\w\\$ "
 esac
 
 export PS1
-


### PR DESCRIPTION
Fetch the first configured system_name from lldpd.  If no name has been configured this defaults to the serial number of the scrimlet which works as a fallback.

before:

    root@oxz_switch0:~#

after:

    [myrack]root@oxz_switch0:~#