### PR TITLE
[nexus] do not retry locking deleted instances

### DIFF
--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -1612,47 +1612,68 @@ impl DataStore {
                 "current_gen" => ?current_gen,
             );
 
-            (instance, did_lock) = diesel::update(dsl::instance)
-                .filter(dsl::time_deleted.is_null())
-                .filter(dsl::id.eq(instance_id))
-                // If the generation is the same as the captured generation when we
-                // read the instance record to check if it was not locked, we can
-                // lock this instance. This is because changing the `updater_id`
-                // field always increments the generation number. Therefore, we
-                // want the update query to succeed if and only if the
-                // generation number remains the same as the generation when we
-                // last fetched the instance. This query is used equivalently to
-                // an atomic compare-and-swap instruction in the implementation
-                // of a non-distributed, single-process mutex.
-                .filter(dsl::updater_gen.eq(current_gen))
-                .set((
-                    dsl::updater_gen.eq(locked_gen),
-                    dsl::updater_id.eq(Some(updater_id)),
-                ))
-                .check_if_exists::<Instance>(instance_id)
-                .execute_and_check(
-                    &*self.pool_connection_authorized(opctx).await?,
-                )
-                .await
-                .map(|r| {
-                    // If we successfully updated the instance record, we have
-                    // acquired the lock; otherwise, we haven't --- either because
-                    // our generation is stale, or because the instance is already locked.
-                    let locked = match r.status {
-                        UpdateStatus::Updated => true,
-                        UpdateStatus::NotUpdatedButExists => false,
-                    };
-                    (r.found, locked)
-                })
-                .map_err(|e| {
-                    public_error_from_diesel(
-                        e,
-                        ErrorHandler::NotFoundByLookup(
-                            ResourceType::Instance,
-                            LookupType::ById(instance_id),
-                        ),
+            let UpdateAndQueryResult { status, found } =
+                diesel::update(dsl::instance)
+                    .filter(dsl::time_deleted.is_null())
+                    .filter(dsl::id.eq(instance_id))
+                    // If the generation is the same as the captured generation
+                    // when we read the instance record to check if it was not
+                    // locked, we can lock this instance. This is because
+                    // changing the `updater_id` field always increments the
+                    // generation number. Therefore, we want the update query to
+                    // succeed if and only if the generation number remains the
+                    // same as the generation when we last fetched the instance.
+                    // This query is used equivalently to an atomic
+                    // compare-and-swap instruction in the implementation of a
+                    // non-distributed, single-process mutex.
+                    .filter(dsl::updater_gen.eq(current_gen))
+                    .set((
+                        dsl::updater_gen.eq(locked_gen),
+                        dsl::updater_id.eq(Some(updater_id)),
+                    ))
+                    .check_if_exists::<Instance>(instance_id)
+                    .execute_and_check(
+                        &*self.pool_connection_authorized(opctx).await?,
                     )
-                })?;
+                    .await
+                    .map_err(|e| {
+                        public_error_from_diesel(
+                            e,
+                            ErrorHandler::NotFoundByLookup(
+                                ResourceType::Instance,
+                                LookupType::ById(instance_id),
+                            ),
+                        )
+                    })?;
+
+            match status {
+                // If we successfully updated the instance record, we have
+                // acquired the lock.
+                UpdateStatus::Updated => {
+                    did_lock = true;
+                }
+                // If the instance record has been soft-deleted, return
+                // `NotFound` explicitly. `check_if_exists` does not know
+                // about soft-deletion, so it will still return that it
+                // `found` something even if its `time_deleted` is set.
+                UpdateStatus::NotUpdatedButExists
+                    if found.time_deleted().is_some() =>
+                {
+                    return Err(Error::not_found_by_id(
+                        ResourceType::Instance,
+                        &instance_id,
+                    )
+                    .into());
+                }
+                // Otherwise, the instance still exists but we haven't
+                // locked it --- either because our generation is stale, or
+                // because the instance is already locked.
+                UpdateStatus::NotUpdatedButExists => {
+                    did_lock = false;
+                }
+            };
+
+            instance = found;
         }
     }
 

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -2474,6 +2474,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_locking_a_deleted_instance_fails_even_if_locked() {
+        // Setup
+        let logctx = dev::test_setup_log(
+            "test_locking_a_deleted_instance_fails_even_if_locked",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+        let (authz_project, _) = create_test_project(&datastore, &opctx).await;
+        let authz_instance = create_test_instance(
+            &datastore,
+            &opctx,
+            &authz_project,
+            "my-great-instance",
+        )
+        .await;
+        let saga_id = Uuid::new_v4();
+
+        // Move the instance into an "okay-to-delete" state...
+        datastore
+            .instance_update_runtime(
+                &InstanceUuid::from_untyped_uuid(authz_instance.id()),
+                &InstanceRuntimeState {
+                    time_updated: Utc::now(),
+                    generation: Generation(external::Generation::from_u32(2)),
+                    propolis_id: None,
+                    dst_propolis_id: None,
+                    migration_id: None,
+                    nexus_state: InstanceState::NoVmm,
+                    time_last_auto_restarted: None,
+                },
+            )
+            .await
+            .expect("should update state successfully");
+
+        // attempt to lock the instance once.
+        let lock = dbg!(
+            datastore
+                .instance_updater_lock(&opctx, &authz_instance, saga_id)
+                .await
+        )
+        .expect("instance should be locked");
+        assert_eq!(lock.updater_id, saga_id);
+
+        // delete it...
+        dbg!(datastore.project_delete_instance(&opctx, &authz_instance).await)
+            .expect("instance should be deleted");
+
+        // ...and a subsequent atetmpt to lock the instance should realize it's
+        // gone.
+        let err = dbg!(
+            datastore
+                .instance_updater_lock(&opctx, &authz_instance, saga_id)
+                .await
+        )
+        .expect_err(
+            "instance_updater_lock should fail after the instance is deleted",
+        );
+        assert!(
+            matches!(
+                err,
+                UpdaterLockError::Query(Error::ObjectNotFound { .. })
+            ),
+            "expected locking a deleted instance to fail with \
+            `ObjectNotFound`, but got {err:?} instead"
+        );
+
+        // Clean up.
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
     async fn test_instance_updater_cant_unlock_someone_elses_instance_() {
         // Setup
         let logctx = dev::test_setup_log(

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -2059,6 +2059,89 @@ mod test {
         .await;
     }
 
+    // Regression test for
+    // <https://github.com/oxidecomputer/omicron/issues/10784>.
+    //
+    // This test ensures that start sagas unwind correctly when the instance to
+    // be updated is deleted before the saga attempts to lock it.
+    #[nexus_test(server = crate::Server)]
+    async fn test_start_saga_fails_when_instance_deleted(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let _project_id = setup_test_project(&cptestctx.external_client).await;
+        let nexus = &cptestctx.server.server_context().nexus;
+        let (_, params) = setup_active_vmm_destroyed_test(cptestctx).await;
+
+        // Delete the instance out from under the saga-to-be. Since the
+        // instance record still points at the (now destroyed) active VMM, it
+        // cannot yet be deleted through the external API, so manually update
+        // the DB record into a deletable state first.
+        let state = test_helpers::instance_fetch_by_name(
+            cptestctx,
+            INSTANCE_NAME,
+            PROJECT_NAME,
+        )
+        .await;
+        let instance = state.instance();
+        let instance_id = InstanceUuid::from_untyped_uuid(instance.id());
+        nexus
+            .datastore()
+            .instance_update_runtime(
+                &instance_id,
+                &InstanceRuntimeState {
+                    time_updated: Utc::now(),
+                    generation: Generation(
+                        instance.runtime().generation.0.next(),
+                    ),
+                    propolis_id: None,
+                    dst_propolis_id: None,
+                    migration_id: None,
+                    nexus_state: InstanceState::NoVmm,
+                    time_last_auto_restarted: None,
+                },
+            )
+            .await
+            .unwrap();
+        test_helpers::instance_delete_by_name(
+            cptestctx,
+            INSTANCE_NAME,
+            PROJECT_NAME,
+        )
+        .await;
+
+        // Now, run the start saga. If `siu_lock_instance` (incorrectly)
+        // retries the lock query forever when the instance is gone, the saga
+        // will never complete, so bound how long we wait for it.
+        const TIMEOUT: Duration = Duration::from_secs(60);
+        let dag = create_saga_dag::<SagaInstanceUpdate>(params).unwrap();
+        let running_saga = nexus
+            .sagas
+            .saga_prepare(dag)
+            .await
+            .expect("saga should prepare successfully")
+            .start()
+            .await
+            .expect("saga should start successfully");
+        let result = tokio::time::timeout(
+            TIMEOUT,
+            running_saga.wait_until_stopped(),
+        )
+        .await
+        .expect(
+            "a start saga must  complete within a reasonable period of time \
+             if the instance record has been deleted.",
+        )
+        .into_omicron_result();
+        let error = result.expect_err(
+            "start saga should fail when the instance has been deleted",
+        );
+        assert!(
+            matches!(error, Error::ObjectNotFound { .. }),
+            "expected the start saga to fail with `ObjectNotFound`, but saw: \
+             {error:#?}",
+        );
+    }
+
     // --- test helpers ---
 
     async fn setup_active_vmm_destroyed_test(

--- a/nexus/src/app/sagas/instance_update/start.rs
+++ b/nexus/src/app/sagas/instance_update/start.rs
@@ -113,14 +113,22 @@ async fn siu_lock_instance(
     // However, there is a third possible outcome of the query that attempts to
     // lock the instance record: we may encounter a database error that does NOT
     // indicate that the lock is already held. In that case, this action MUST
-    // continue retrying the lock operation forever until it either succeeds or
-    // indicates that another saga has the lock, in order to satisfy the
-    // distributed saga requirement that exuting an action must be idempotent.
-    // Retrying indefinitely is necessary to ensure idempotency because it is
+    // continue retrying the lock operation forever until one of the following
+    // occurs:
+    //
+    // 1. the action successfully acquires the lock,
+    // 2. the query indicates that the lock is already held by another saga,
+    // 3. we encounter an error that indicates that no attempts to acquire the
+    //    lock will *ever* succeed --- or, to put it plainly, we discover that
+    //    the instance has been deleted, in which case we can give up.
+    //
+    // This is necessary in order to satisfy the distributed saga requirement
+    // that exuting an action must be idempotent. Retrying transient database
+    // errors indefinitely is necessary to ensure idempotency because it is
     // possible that a previous execution of this action *did* succesfully
     // acquire the lock but crashed before it completed.
     //
-    // As aan example of why this is important, consider a particularly
+    // As an example of why this is important, consider a particularly
     // unlucky sequence of a Nexus crash followed by a transient database error
     // could leave the instance record permanently locked by this (now failed)
     // saga. The scenario in which this would occur is as follows:
@@ -146,6 +154,18 @@ async fn siu_lock_instance(
     // talk to the database, so we may as well retry. We will complain loudly if
     // we've been retrying for a long time, or if the error seems to be "our
     // fault" (a client error).
+    //
+    // `ObjectNotFound` errors, which indicate that the instance has been
+    // deleted, are the one error that does not indicate the instance has been
+    // locked by another saga but should NOT be retried. If the instance record
+    // is gone, we will never be able to lock it, and the saga will just retry
+    // forever until it is manually abandoned, which requires human
+    // intervention. Even if a previous execution of the action had acquired the
+    // lock before when the instance was deleted, it's safe to fail in this
+    // case, since the only consequence is that a deleted instance record would
+    // be left with a non-NULL updater lock ID. That seems a little messy, but
+    // is harmless, since nobody else is going to try to update a deleted
+    // instance either.
     backoff::retry_notify_ext(
         // This is an internal service query to CockroachDB.
         backoff::retry_policy_internal_service(),

--- a/nexus/src/app/sagas/instance_update/start.rs
+++ b/nexus/src/app/sagas/instance_update/start.rs
@@ -177,6 +177,23 @@ async fn siu_lock_instance(
                     );
                     Ok(None)
                 }
+                // If the instance has been deleted between when this saga
+                // started and when we attempted to lock it, we can just give
+                // up, since there's nothing necessary for us to do here.
+                Err(instance::UpdaterLockError::Query(
+                    err @ Error::ObjectNotFound { .. },
+                )) => {
+                    const MSG: &str = "instance no longer exists; giving up";
+                    info!(
+                        osagactx.log(),
+                        "instance update: {MSG}";
+                        "instance_id" => %instance_id,
+                        "saga_id" => %lock_id,
+                    );
+                    Err(backoff::BackoffError::permanent(
+                        err.internal_context(MSG),
+                    ))
+                }
                 // Retry database errors that *don't* indicate the lock
                 // is already held forever.
                 Err(instance::UpdaterLockError::Query(e)) => {

--- a/nexus/src/app/sagas/instance_update/start.rs
+++ b/nexus/src/app/sagas/instance_update/start.rs
@@ -123,7 +123,7 @@ async fn siu_lock_instance(
     //    the instance has been deleted, in which case we can give up.
     //
     // This is necessary in order to satisfy the distributed saga requirement
-    // that exuting an action must be idempotent. Retrying transient database
+    // that executing an action must be idempotent. Retrying transient database
     // errors indefinitely is necessary to ensure idempotency because it is
     // possible that a previous execution of this action *did* succesfully
     // acquire the lock but crashed before it completed.


### PR DESCRIPTION
Presently, the `siu_lock_instance()` saga action will retry the `instance_updater_lock` query indefinitely upon encountering any error that does *not* indicate that the instance is locked by another saga. This is necessary to ensure that the action is idempotent, as described in #10166 and fixed in #10177. However, there is *one* case where this behavior is incorrect, which is if the instance record has been *deleted* between when the saga was started and when it attempted to acquire the lock. If the instance has been deleted, the saga will retry an operation which can never succeed forever. This was first discovered in #10784.

In this case, it doesn't actually even *matter* if the instance record is locked or not, though it probably isn't. So, it is safe for the action to fail if it has been deleted, and prevents the saga from never completing.

Fixes #10784