### PR TITLE
Fix a couple of bad uses of `check_if_exists`

### DIFF
--- a/nexus/db-queries/src/db/datastore/alert_rx.rs
+++ b/nexus/db-queries/src/db/datastore/alert_rx.rs
@@ -28,7 +28,6 @@ use crate::db::model::WebhookSecret;
 use crate::db::pagination::Paginator;
 use crate::db::pagination::paginated;
 use crate::db::pagination::paginated_multicolumn;
-use crate::db::update_and_check::UpdateAndCheck;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use diesel::prelude::*;
 use nexus_auth::authz::ApiResource;
@@ -350,20 +349,19 @@ impl DataStore {
             endpoint: params.endpoint.as_ref().map(ToString::to_string),
             time_modified: chrono::Utc::now(),
         };
-        let updated = diesel::update(rx_dsl::alert_receiver)
+        diesel::update(rx_dsl::alert_receiver)
             .filter(rx_dsl::id.eq(rx_id))
             .filter(rx_dsl::time_deleted.is_null())
             .set(update)
-            .check_if_exists(rx_id)
-            .execute_and_check(&conn)
+            .returning(AlertReceiver::as_returning())
+            .get_result_async(&*conn)
             .await
             .map_err(|e| {
                 public_error_from_diesel(
                     e,
                     ErrorHandler::NotFoundByResource(authz_rx),
                 )
-            })?;
-        Ok(updated.found)
+            })
     }
 
     pub async fn alert_rx_list(
@@ -1172,6 +1170,7 @@ mod test {
     use nexus_db_lookup::LookupPath;
     use nexus_types::alert::test_alerts;
     use omicron_common::api::external::IdentityMetadataCreateParams;
+    use omicron_common::api::external::IdentityMetadataUpdateParams;
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::AlertUuid;
 
@@ -1200,6 +1199,79 @@ mod test {
             )
             .await
             .expect("cant create ye webhook receiver!!!!")
+    }
+
+    #[tokio::test]
+    async fn test_webhook_rx_update_succeeds() {
+        let logctx = dev::test_setup_log("test_webhook_rx_update_succeeds");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+        let rx = create_receiver(datastore, opctx, "updated", Vec::new()).await;
+        let (authz_rx, _) = LookupPath::new(opctx, datastore)
+            .alert_receiver_id(rx.rx.id())
+            .fetch()
+            .await
+            .expect("receiver must exist");
+
+        let updated = datastore
+            .webhook_rx_update(
+                opctx,
+                &authz_rx,
+                alert::WebhookReceiverUpdate {
+                    identity: IdentityMetadataUpdateParams {
+                        name: None,
+                        description: Some("new description".to_string()),
+                    },
+                    endpoint: None,
+                },
+            )
+            .await
+            .expect("updating an existing receiver must succeed");
+        assert_eq!(updated.identity.description, "new description");
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn test_webhook_rx_update_fails_when_receiver_deleted() {
+        let logctx = dev::test_setup_log(
+            "test_webhook_rx_update_fails_when_receiver_deleted",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+        let rx = create_receiver(datastore, opctx, "deleted", Vec::new()).await;
+        let (authz_rx, db_rx) = LookupPath::new(opctx, datastore)
+            .alert_receiver_id(rx.rx.id())
+            .fetch()
+            .await
+            .expect("receiver must exist");
+
+        datastore
+            .webhook_rx_delete(opctx, &authz_rx, &db_rx)
+            .await
+            .expect("receiver must be deleted");
+        let err = datastore
+            .webhook_rx_update(
+                opctx,
+                &authz_rx,
+                alert::WebhookReceiverUpdate {
+                    identity: IdentityMetadataUpdateParams {
+                        name: None,
+                        description: Some("updated".to_string()),
+                    },
+                    endpoint: None,
+                },
+            )
+            .await
+            .expect_err("updating a deleted receiver must fail");
+        assert!(
+            matches!(err, Error::ObjectNotFound { .. }),
+            "expected ObjectNotFound, got {err:?}",
+        );
+
+        db.terminate().await;
+        logctx.cleanup_successful();
     }
 
     async fn create_alert<A: nexus_types::alert::AlertPayload>(

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -770,6 +770,13 @@ impl DataStore {
                     )
                 })?;
 
+        // `check_if_exists` fetches by ID without applying the other
+        // filters from the query, so a soft-deleted instance is returned as
+        // `NotUpdatedButExists`.
+        if found.time_deleted().is_some() {
+            return Err(authz_instance.not_found());
+        }
+
         slog::info!(
             opctx.log,
             "set intended instance state";
@@ -1752,6 +1759,14 @@ impl DataStore {
                     locked_gen: new_gen,
                 })
             }
+            // Check for deletion before interpreting the retained updater ID.
+            // `check_if_exists` returns soft-deleted rows as existing.
+            UpdateAndQueryResult {
+                status: UpdateStatus::NotUpdatedButExists,
+                ref found,
+            } if found.time_deleted().is_some() => {
+                Err(UpdaterLockError::Query(authz_instance.not_found()))
+            }
             // The generation has advanced past the generation at which the
             // lock was held. This means that we have already inherited the
             // lock. Return `Ok(false)` here for idempotency.
@@ -2595,6 +2610,79 @@ mod tests {
             .expect("instance should remain deleted");
 
         // Clean up.
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn test_updating_deleted_instance_fails() {
+        let logctx =
+            dev::test_setup_log("test_updating_deleted_instance_fails");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+        let (authz_project, _) = create_test_project(&datastore, &opctx).await;
+        let authz_instance = create_test_instance(
+            &datastore,
+            &opctx,
+            &authz_project,
+            "my-great-instance",
+        )
+        .await;
+
+        datastore
+            .instance_update_runtime(
+                &InstanceUuid::from_untyped_uuid(authz_instance.id()),
+                &InstanceRuntimeState {
+                    time_updated: Utc::now(),
+                    generation: Generation(external::Generation::from_u32(2)),
+                    propolis_id: None,
+                    dst_propolis_id: None,
+                    migration_id: None,
+                    nexus_state: InstanceState::NoVmm,
+                    time_last_auto_restarted: None,
+                },
+            )
+            .await
+            .expect("instance must become deletable");
+        let parent_lock = datastore
+            .instance_updater_lock(&opctx, &authz_instance, Uuid::new_v4())
+            .await
+            .expect("instance must be locked");
+        datastore
+            .project_delete_instance(&opctx, &authz_instance)
+            .await
+            .expect("instance must be deleted");
+
+        let err = datastore
+            .instance_set_intended_state(
+                &opctx,
+                &authz_instance,
+                InstanceIntendedState::Running,
+            )
+            .await
+            .expect_err("updating a deleted instance must fail");
+        assert!(
+            matches!(err, Error::ObjectNotFound { .. }),
+            "expected ObjectNotFound, got {err:?}",
+        );
+
+        let err = datastore
+            .instance_updater_inherit_lock(
+                &opctx,
+                &authz_instance,
+                parent_lock,
+                Uuid::new_v4(),
+            )
+            .await
+            .expect_err("inheriting a deleted instance's lock must fail");
+        assert!(
+            matches!(
+                err,
+                UpdaterLockError::Query(Error::ObjectNotFound { .. })
+            ),
+            "expected ObjectNotFound, got {err:?}",
+        );
+
         db.terminate().await;
         logctx.cleanup_successful();
     }

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -1759,8 +1759,9 @@ impl DataStore {
                     locked_gen: new_gen,
                 })
             }
-            // Check for deletion before interpreting the retained updater ID.
-            // `check_if_exists` returns soft-deleted rows as existing.
+            // Because `check_if_exists` will return records that have been
+            // soft-deleted, we must check for `time_deleted` before considering
+            // whether the lock has been successfully inherited.
             UpdateAndQueryResult {
                 status: UpdateStatus::NotUpdatedButExists,
                 ref found,


### PR DESCRIPTION
While reviewing #10785 with the robot, I found a misuse of `check_if_exists`, so @hawkw suggested I check for other cases, and there were a few. 

`check_if_exists()` runs an update alongside a `found` query that selects by primary key without applying the update’s other filters. Soft deletion leaves the row in the table with `time_deleted` set, so `found` still sees it even when `time_deleted IS NULL` prevents the update. The result is `NotUpdatedButExists`. This is on purpose: some callers need to distinguish between soft-deleted rows and actually missing rows. For example, a deletion might consider a soft-deleted row a success for idempotency while a missing row is an error.

The callers fixed in this PR were not handling that distinction:

- Instance intended-state updates returned the soft-deleted record as though the update had succeeded
- For lock inheritance, the soft-deleted row still contained the parent saga’s updater ID. The method therefore returned `AlreadyLocked`, which normally means another saga holds the lock, even though the instance had been deleted.

Both now check `time_deleted` explicitly and return a NotFound error if it's non-null. Webhook receiver updates do not need the distinction, so there we drop the `check_if_exists` and use `UPDATE ... RETURNING` and report both missing and soft-deleted as `ObjectNotFound`.

The added datastore tests fail without these fixes and pass with them.