### PR TITLE
Update from samael 0.0.19 to 0.0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.11.0",
  "cexpr",
@@ -11875,9 +11875,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -13030,9 +13030,9 @@ dependencies = [
 
 [[package]]
 name = "samael"
-version = "0.0.19"
+version = "0.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20498fc95ccfe0f015d003aa86084b042cc672a9a41fa2bea4ab7d7e3239348"
+checksum = "3507857cc308877abafd0db18e30b2852623db961006ba38b402e0eff048ee7f"
 dependencies = [
  "base64 0.22.1",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -779,7 +779,7 @@ rustls = "0.23.40"
 rustls-pemfile = "2.2.0"
 rustyline = "14.0.0"
 rustix = "1.1.2"
-samael = { version = "0.0.19", features = ["xmlsec"] }
+samael = { version = "0.0.22", features = ["xmlsec"] }
 schemars = "0.8.22"
 scopeguard = "1.2.0"
 secrecy = "0.10.3"
@@ -1146,3 +1146,4 @@ path = "workspace-hack"
 [patch."https://github.com/oxidecomputer/omicron"]
 omicron-uuid-kinds = { path = "uuid-kinds" }
 omicron-common = { path = "common" }
+

--- a/nexus/auth/src/authn/silos.rs
+++ b/nexus/auth/src/authn/silos.rs
@@ -7,6 +7,9 @@
 use anyhow::{Result, anyhow};
 use base64::Engine;
 use dropshot::HttpError;
+use samael::crypto::AllowedSignatureAlgorithm;
+use samael::crypto::CertificateDer;
+use samael::crypto::ReduceMode;
 use samael::metadata::ContactPerson;
 use samael::metadata::ContactType;
 use samael::metadata::EntityDescriptor;
@@ -109,7 +112,7 @@ impl SamlIdentityProvider {
             // sign authn request if keys were supplied
             let pkey = openssl::pkey::PKey::private_key_from_der(&key)
                 .map_err(|e| anyhow!(e.to_string()))?;
-            authn_request.signed_redirect(&encoded_relay_state, pkey)
+            authn_request.signed_redirect(&encoded_relay_state, &pkey)
         } else {
             authn_request.redirect(&encoded_relay_state)
         }
@@ -143,11 +146,27 @@ impl SamlIdentityProvider {
         sp_builder.acs_url(self.acs_url.clone());
         sp_builder.slo_url(self.slo_url.clone());
 
-        if let Some(cert) = &self.public_cert_bytes()? {
-            if let Ok(parsed) = openssl::x509::X509::from_der(&cert) {
-                sp_builder.certificate(Some(parsed));
-            }
+        if let Some(cert) = self.public_cert_bytes()? {
+            sp_builder.certificate(CertificateDer::from(cert));
         }
+
+        sp_builder.allowed_signature_algorithms(vec![
+            // List taken from Signature section of
+            // https://www.w3.org/TR/xmldsig-core1/#sec-AlgID, removing
+            // discouraged items.
+
+            // Required
+            AllowedSignatureAlgorithm::RsaSha256,
+            AllowedSignatureAlgorithm::EcdsaSha256,
+            // Optional
+            AllowedSignatureAlgorithm::RsaSha224,
+            AllowedSignatureAlgorithm::RsaSha384,
+            AllowedSignatureAlgorithm::RsaSha512,
+            AllowedSignatureAlgorithm::EcdsaSha224,
+            AllowedSignatureAlgorithm::EcdsaSha384,
+            AllowedSignatureAlgorithm::EcdsaSha512,
+            AllowedSignatureAlgorithm::DsaSha256,
+        ]);
 
         Ok(sp_builder.build()?)
     }
@@ -278,50 +297,22 @@ impl SamlIdentityProvider {
         }
 
         let assertion = service_provider
-            .parse_base64_response(&saml_post.saml_response, None)
+            .parse_base64_response_with_mode(
+                &saml_post.saml_response,
+                // We don't track the list of possible request ids, so this is
+                // None.
+                None,
+                // _Only_ signed content is retained, and all other notes are
+                // removed. Note in this process the ds:Signature notes
+                // themselves are also removed.
+                ReduceMode::default(),
+            )
             .map_err(|e| {
                 HttpError::for_bad_request(
                     None,
                     format!("could not extract SAMLResponse assertion! {}", e),
                 )
             })?;
-
-        // If the response isn't signed, then parse_response above will fail.
-        // Every assertion should also be signed. Check the signature and digest
-        // schemes against an explicit allow list.
-        let assertion_signature = assertion.signature.ok_or_else(|| {
-            HttpError::for_bad_request(
-                None,
-                "assertion is missing signature!".to_string(),
-            )
-        })?;
-
-        match assertion_signature.signed_info.signature_method.algorithm.value()  {
-            // List taken from Signature section of
-            // https://www.w3.org/TR/xmldsig-core1/#sec-AlgID, removing
-            // discouraged items.
-
-            // Required
-            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" |
-            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256" |
-            // Optional
-            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha224" |
-            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384" |
-            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512" |
-            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha224" |
-            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384" |
-            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512" |
-            "http://www.w3.org/2009/xmldsig11#dsa-sha256" => {}
-
-            signature_algorithm => {
-                return Err(
-                    HttpError::for_bad_request(
-                        None,
-                        format!("signature algorithm {} is not allowed", signature_algorithm),
-                    )
-                );
-            }
-        }
 
         // What is being asserted? Extract subject
         let subject = assertion.subject.ok_or_else(|| {

--- a/nexus/tests/integration_tests/data/saml_response_signed_with_sha1.xml
+++ b/nexus/tests/integration_tests/data/saml_response_signed_with_sha1.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_f2f02ca12d7292f8a4e03b7b99d71a45f8896c2677" IssueInstant="2022-05-04T15:36:12.631Z" Destination="https://customer.site/oxide_rack/saml">
+  <saml:Issuer>https://some.idp.test/oxide_rack/</saml:Issuer>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <ds:Reference URI="#_f2f02ca12d7292f8a4e03b7b99d71a45f8896c2677">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>qcCs4y5yK0F22qpABjaYkScQNB8YlOVlXEpmdyfB6hY=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>hmov/ywH4g4KEv1AobXJGszzgDGVLmh1hg0E4XxxQTzw7uFu27L7uI8bptF/kipO
+6+j7FWpiO2cBZ9IVnkfWkMjLBhO2XgYd0s8qW1zTwWvx8Uw9ZEA6Cp/TqOcaRsxf
+Hu6v7KHrr9jCBglHIwY+oPE7P9MjNvQiiD3PbcOP7nzd62o5pdrUJTzALFIHyIJu
+SEyCqmB0x5xIR7u97TPLZFpuIb32Y5ENDVYKVNyQFKhW3XY7u503XKInd3qwMxGN
+9VnYwhuIpf+bkeAPtMm2RsJ5tYiKUPXcrf/Em7ECsPg6gDOTDUbJUC7JkPu4c/pv
+b+MOJssuhN3AX/+tIvFrtw==</ds:SignatureValue>
+    <ds:KeyInfo>
+      <ds:X509Data>
+        <ds:X509Certificate>MIIDXjCCAkagAwIBAgIUFKla2OTQGUbt5QzyjGiAoBjk3ZgwDQYJKoZIhvcNAQEL
+BQAwRzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJh
+bmNpc2NvMRMwEQYDVQQDEwpveGlkZS50ZXN0MB4XDTI0MTAzMTE4MDUwMFoXDTI0
+MTAzMTE4MDYwMFowRzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQH
+Ew1TYW4gRnJhbmNpc2NvMRMwEQYDVQQDEwpveGlkZS50ZXN0MIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv0V30ZQfnhf3kJKKctzGAhjXISBjZ9BA59tQ
+96/jJNvZLh7wEHm5lYNcTmBuBtv8MEcECrMgVovaJ3DGNsHWtTf/q/PWOrec6/Ms
+MmY+hFGJ6s+lv02BqKupp4I+DN+saGZFCXHR6Nvm/kdrwbEJbfi1GfhFIxtWw57Z
+k9EBYuo/t70s1Xm2zWGdiPxL2xOeKJmh482Yosawy1fJ2GwU4whvRAx1eMLjxEOW
+/nU6Wse1Is3e5k2+ZfMo+EtDG1JTsJWZ3rybq+F/QJxffrE/SHWMN/h24crywsED
+varvkE4czx7Onst7wXnN20FPcP0dFa9+ei+N9SgPrTosVQSSSwIDAQABo0IwQDAO
+BgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU+dwnGLdq
+QPRgq6b25EUIELlppFcwDQYJKoZIhvcNAQELBQADggEBAA62Yv5U7fp/TqpKOghT
+PA+RAqwIHMqWIYGE32tiF9XH7u9JjtIkN5whu4L8yMjxnJ+wqZ1MQOHyipH/729P
+qVpAkUjqbx+++Va8zVKDDGVOPO4n4mBGWST73PYYKpp3pUknbwdhbISOrTF/A/hQ
+STQg3BD1ui4C+x8mqtmmL7z2w5Jc8Kt3sAxSvL0lJ8QpP7WZ+GKJ4989K6KIta/V
+uoi95D+LEOhxARtUHFiCl15boZZtiEuPDzwp2ebYa8WuhjpjWzf/zvA1kc39zFIR
+Cn4SR8fX7EAu3T1/w1NBBRK5/m+ePHohzTOdhiRXZ8EqhICx4mAsAdhlu78U3BWW
+2LQ=
+</ds:X509Certificate>
+      </ds:X509Data>
+    </ds:KeyInfo>
+  </ds:Signature>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_a8d644a6c83fc56337b0330d8b0ff684978a5fe56c" IssueInstant="2022-05-04T15:36:12.556Z">
+    <saml:Issuer>https://some.idp.test/oxide_rack/</saml:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+        <ds:Reference URI="#_a8d644a6c83fc56337b0330d8b0ff684978a5fe56c">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue>kLLhHLTkRH1h5sHv870sZ24QecQnyLMQ2vvIMhss7ZU=</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue>NtH4BeWgD6t+epYYYmK19HaCkY6pzvoBZuXjsbY1X4AJmNSJ4CPSXJ9jg4XpvSu8
+kj+jBZTfWQS4C2jWqgjCLLVNXOpGcC7cJz5vyuEHKsbJuH2L1Ks4/t9abNOQGpIa
+BWJcZHxyP5lSS763pLoSah9gS1hLrFhBDulQOpeOPAykaGHmpwWMATDne+dSNQYF
+23/xrgIHbxlLdj9DjbQTdZD71QWLBVBq3w/lb/ibLEjuH+rtjBKVbHBYhHrJ4TW9
+XJGRfrrfbN8ypX5S9zljy22ysRrQ+wqjVSHajxyPPP0Vy2DJbuuLr4hW3n4N6F3Z
+FYIPjoF6pI+3l1onnpmArQ==</ds:SignatureValue>
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>MIIDXjCCAkagAwIBAgIUFKla2OTQGUbt5QzyjGiAoBjk3ZgwDQYJKoZIhvcNAQEL
+BQAwRzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJh
+bmNpc2NvMRMwEQYDVQQDEwpveGlkZS50ZXN0MB4XDTI0MTAzMTE4MDUwMFoXDTI0
+MTAzMTE4MDYwMFowRzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQH
+Ew1TYW4gRnJhbmNpc2NvMRMwEQYDVQQDEwpveGlkZS50ZXN0MIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv0V30ZQfnhf3kJKKctzGAhjXISBjZ9BA59tQ
+96/jJNvZLh7wEHm5lYNcTmBuBtv8MEcECrMgVovaJ3DGNsHWtTf/q/PWOrec6/Ms
+MmY+hFGJ6s+lv02BqKupp4I+DN+saGZFCXHR6Nvm/kdrwbEJbfi1GfhFIxtWw57Z
+k9EBYuo/t70s1Xm2zWGdiPxL2xOeKJmh482Yosawy1fJ2GwU4whvRAx1eMLjxEOW
+/nU6Wse1Is3e5k2+ZfMo+EtDG1JTsJWZ3rybq+F/QJxffrE/SHWMN/h24crywsED
+varvkE4czx7Onst7wXnN20FPcP0dFa9+ei+N9SgPrTosVQSSSwIDAQABo0IwQDAO
+BgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU+dwnGLdq
+QPRgq6b25EUIELlppFcwDQYJKoZIhvcNAQELBQADggEBAA62Yv5U7fp/TqpKOghT
+PA+RAqwIHMqWIYGE32tiF9XH7u9JjtIkN5whu4L8yMjxnJ+wqZ1MQOHyipH/729P
+qVpAkUjqbx+++Va8zVKDDGVOPO4n4mBGWST73PYYKpp3pUknbwdhbISOrTF/A/hQ
+STQg3BD1ui4C+x8mqtmmL7z2w5Jc8Kt3sAxSvL0lJ8QpP7WZ+GKJ4989K6KIta/V
+uoi95D+LEOhxARtUHFiCl15boZZtiEuPDzwp2ebYa8WuhjpjWzf/zvA1kc39zFIR
+Cn4SR8fX7EAu3T1/w1NBBRK5/m+ePHohzTOdhiRXZ8EqhICx4mAsAdhlu78U3BWW
+2LQ=
+</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </ds:Signature>
+    <saml:Subject>
+      <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">some@customer.com</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData NotOnOrAfter="3923-09-01T02:16:12.556Z" Recipient="https://customer.site/oxide_rack/saml"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2022-05-04T15:36:12.556Z" NotOnOrAfter="3923-09-01T02:16:12.556Z"/>
+    <saml:AuthnStatement AuthnInstant="2022-05-04T15:36:12.556Z" SessionNotOnOrAfter="3923-09-01T02:16:12.556Z" SessionIndex="_samling_4356273_859641652">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="groups" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml:AttributeValue>SRE</saml:AttributeValue>
+        <saml:AttributeValue>Admins</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -968,33 +968,22 @@ fn test_reject_unsigned_saml_response() {
     assert!(result.is_err());
 }
 
-// Test accepting a correct SAML response that contains a XML comment in
-// saml:NameID, and ensuring that the full text node is extracted (and not a
-// substring).
+// Test rejecting a correct SAML response that contains a XML comment in
+// saml:NameID.
 //
-// This used to be a test that _rejected_ such responses, but a change to an
-// upstream dependency (quick-xml) caused the behavior around text nodes with
-// embedded comments to change. Specifically, consider:
+// This used to be a test that _accepted_ such responses, but a change to samael
+// caused it to reject this test's response document. An example of an embedded
+// comment is:
 //
 // <saml:NameId>user@example.com<!--comment-->.evil.com</saml:NameId>
 //
-// What should the text node for this element be?
+// Outright rejecting documents with comments will protect us from the
+// vulnerability.
 //
-// * Some XML parsing libraries just return "user@example.com". That leads to a
-//   vulnerability, where an attacker can get a response signed with a
-//   different email address than intended.
-// * Some XML libraries return "user@example.com.evil.com". This is safe,
-//   because the text after the comment hasn't been dropped. This is the behavior
-//   with quick-xml 0.30, and the one that we're testing here.
-// * Some XML libraries are unable to deserialize the document. This is also
-//   safe (and not particularly problematic because typically SAML responses
-//   aren't going to contain comments), and was the behavior with quick-xml
-//   0.23.
-//
-// See:
+// See also:
 // https://duo.com/blog/duo-finds-saml-vulnerabilities-affecting-multiple-implementations
 #[test]
-fn test_handle_saml_response_with_xml_comment() {
+fn test_reject_saml_response_with_xml_comment() {
     let silo_saml_identity_provider = SamlIdentityProvider {
         idp_metadata_document_string: SAML_RESPONSE_IDP_DESCRIPTOR.to_string(),
 
@@ -1029,9 +1018,7 @@ fn test_handle_saml_response_with_xml_comment() {
         ),
     );
 
-    let (authenticated_subject, _) =
-        result.expect("expected validation to succeed");
-    assert_eq!(authenticated_subject.external_id, "some@customer.com");
+    assert!(result.is_err());
 }
 
 // Test receiving a correct SAML response that has group attributes

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -751,6 +751,8 @@ pub const SAML_RESPONSE_UNSIGNED: &str =
     include_str!("data/saml_response_unsigned.xml");
 pub const SAML_RESPONSE_WITH_COMMENT: &str =
     include_str!("data/saml_response_with_comment.xml");
+pub const SAML_RESPONSE_SIGNED_WITH_SHA1: &str =
+    include_str!("data/saml_response_signed_with_sha1.xml");
 pub const SAML_RESPONSE_WITH_GROUPS: &str =
     include_str!("data/saml_response_with_groups.xml");
 
@@ -1002,6 +1004,45 @@ fn test_reject_saml_response_with_xml_comment() {
     let body_bytes = serde_urlencoded::to_string(SamlLoginPost {
         saml_response: base64::engine::general_purpose::STANDARD
             .encode(&SAML_RESPONSE_WITH_COMMENT),
+        relay_state: None,
+    })
+    .unwrap();
+
+    let result = silo_saml_identity_provider.authenticated_subject(
+        &body_bytes,
+        // Set max_issue_delay so that SAMLResponse is valid
+        Some(
+            chrono::Utc::now()
+                - "2022-05-04T15:36:12.631Z"
+                    .parse::<chrono::DateTime<chrono::Utc>>()
+                    .unwrap()
+                + chrono::Duration::seconds(60),
+        ),
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_reject_saml_response_with_insecure_signature_algo() {
+    let silo_saml_identity_provider = SamlIdentityProvider {
+        idp_metadata_document_string: SAML_RESPONSE_IDP_DESCRIPTOR.to_string(),
+
+        idp_entity_id: "https://some.idp.test/oxide_rack/".to_string(),
+        sp_client_id: "https://customer.site/oxide_rack/saml".to_string(),
+        acs_url: "https://customer.site/oxide_rack/saml".to_string(),
+        slo_url: "http://slo".to_string(),
+        technical_contact_email: "technical@fake".to_string(),
+
+        public_cert: None,
+        private_key: None,
+
+        group_attribute_name: None,
+    };
+
+    let body_bytes = serde_urlencoded::to_string(SamlLoginPost {
+        saml_response: base64::engine::general_purpose::STANDARD
+            .encode(&SAML_RESPONSE_SIGNED_WITH_SHA1),
         relay_state: None,
     })
     .unwrap();


### PR DESCRIPTION
This update broke a few tests because of samael's new behaviour of removing parts of the XML documents (in a process they call reducing) if they aren't signed. Notably this reducing process includes removing the signature nodes themselves, meaning Nexus cannot check the signature algorithm and reject the deprecated ones. Luckily the ServiceProvider builder now accepts an allowed signature algorithms list, and the values in the enum of allowed algorithms match the existing list we were checking against.

There's also a behaviour change: this new version of samael will return a signature error for XML documents with comments. This means that instead of Nexus accepting SAML Responses with comments in them and correctly figuring out the canonicalized content, they will now be rejected, which still keeps us safe from the original vulnerability mentioned by the failing test comments, but could potentially cause an issue if a customer's IDP is sending documents with comments in them. This seems worth the tradeoff as version 0.0.22 contains what looks like a few security related fixes that we should pull in.

Fixes #10702