### PR TITLE
Oximeter: label relevant self-stats by producer kind.

### DIFF
--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -60,6 +60,17 @@ pub enum ProducerKind {
     ManagementGateway,
 }
 
+impl ProducerKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::SledAgent => "sled_agent",
+            Self::Service => "service",
+            Self::Instance => "instance",
+            Self::ManagementGateway => "management_gateway",
+        }
+    }
+}
+
 /// Information announced by a metric server, used so that clients can contact it and collect
 /// available metric data from it.
 #[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize, PartialEq)]

--- a/oximeter/collector/src/self_stats.rs
+++ b/oximeter/collector/src/self_stats.rs
@@ -161,6 +161,7 @@ impl CollectionTaskStats {
             collector,
             collections: Collections {
                 producer_id: producer.id,
+                producer_kind: producer.kind.as_str().into(),
                 producer_ip: producer.address.ip(),
                 producer_port: producer.address.port(),
                 base_route: "".into(),
@@ -169,6 +170,7 @@ impl CollectionTaskStats {
             failed_collections: BTreeMap::new(),
             samples_collected: SamplesCollected {
                 producer_id: producer.id,
+                producer_kind: producer.kind.as_str().into(),
                 producer_ip: producer.address.ip(),
                 producer_port: producer.address.port(),
                 base_route: "".into(),
@@ -213,6 +215,7 @@ impl CollectionTaskStats {
         self.failed_collections.entry(reason).or_insert_with(|| {
             FailedCollections {
                 producer_id: self.collections.producer_id,
+                producer_kind: self.collections.producer_kind.clone(),
                 producer_ip: self.collections.producer_ip,
                 producer_port: self.collections.producer_port,
                 base_route: self.collections.base_route.clone(),

--- a/oximeter/oximeter/schema/oximeter-collector.toml
+++ b/oximeter/oximeter/schema/oximeter-collector.toml
@@ -14,7 +14,7 @@ description = "Total number of successful collections from a producer"
 units = "count"
 datum_type = "cumulative_u64"
 versions = [
-    { added_in = 1, fields = [ "base_route", "producer_id", "producer_ip", "producer_port" ] }
+    { added_in = 1, fields = [ "base_route", "producer_id", "producer_kind", "producer_ip", "producer_port" ] }
 ]
 
 [[metrics]]
@@ -23,7 +23,7 @@ description = "Total number of failed collections from a producer"
 units = "count"
 datum_type = "cumulative_u64"
 versions = [
-    { added_in = 1, fields = [ "base_route", "producer_id", "producer_ip", "producer_port", "reason" ] }
+    { added_in = 1, fields = [ "base_route", "producer_id", "producer_kind", "producer_ip", "producer_port", "reason" ] }
 ]
 
 [[metrics]]
@@ -50,7 +50,7 @@ description = "Total number of samples collected from a producer"
 units = "count"
 datum_type = "cumulative_u64"
 versions = [
-    { added_in = 1, fields = [ "base_route", "producer_id", "producer_ip", "producer_port" ] }
+    { added_in = 1, fields = [ "base_route", "producer_id", "producer_kind", "producer_ip", "producer_port" ] }
 ]
 
 [fields.base_route]
@@ -76,6 +76,10 @@ description = "Name of collector metrics destination"
 [fields.producer_id]
 type = "uuid"
 description = "UUID of the metric producer instance"
+
+[fields.producer_kind]
+type = "string"
+description = "Kind of the metric producer instance"
 
 [fields.producer_ip]
 type = "ip_addr"


### PR DESCRIPTION
Realized I missed this in #10761.