### PR TITLE
[nexus] Collapse ready background task dependencies into one task activation

### DIFF
--- a/nexus/src/app/background/driver.rs
+++ b/nexus/src/app/background/driver.rs
@@ -769,4 +769,90 @@ mod test {
         // such a task that would allow us to reliably distinguish between these
         // two without also spending a lot of wall-clock time on this test.
     }
+
+
+    // Verifies that when multiple distinct dependencies become ready while an
+    // activation is already running, the task is activated only once afterward
+    // instead of once per ready dependency.
+    //
+    // The general idea/flow for the test is:
+    //
+    //   1. timeout-based activation (1) starts and pauses
+    //      1.1. dependency 1 becomes ready
+    //      1.2. dependency 2 becomes ready
+    //   2. activation (1) finishes
+    //   3. one dependency-triggered activation (2) starts
+    //   4. activation (2) finishes
+    //   5. no activation (3) should start
+    #[nexus_test(server = crate::Server)]
+    async fn test_distinct_ready_dependencies_are_collapsed(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let nexus = &cptestctx.server.server_context().nexus;
+        let datastore = nexus.datastore();
+        let opctx = OpContext::for_tests(
+            cptestctx.logctx.log.clone(),
+            datastore.clone(),
+        );
+
+        let mut driver = Driver::new();
+        let (wait_tx, wait_rx) = mpsc::channel(10);
+        let (task, mut ready_rx) = PausingTask::new(wait_rx);
+        let (dep_tx1, dep_rx1) = watch::channel(0);
+        let (dep_tx2, dep_rx2) = watch::channel(0);
+        let activator = Activator::new();
+        let task_handle = driver.register(TaskDefinition {
+            name: "t1",
+            description: "test task",
+            period: Duration::from_secs(300),
+            task_impl: Box::new(task),
+            opctx: opctx.child(std::collections::BTreeMap::new()),
+            watchers: vec![Box::new(dep_rx1), Box::new(dep_rx2)],
+            activator: &activator,
+        });
+
+        // Verify that the task started with the initial timeout-based
+        // activation.
+        assert_eq!(ready_rx.recv().await.unwrap(), 1);
+        let status = driver.task_status(&task_handle);
+        assert!(!status.last.has_completed());
+        let current = status.current.unwrap_running();
+        assert_eq!(current.iteration, 1);
+        assert_eq!(current.reason, ActivationReason::Timeout);
+
+        // While that activation is paused, make both dependencies ready.
+        dep_tx1.send_replace(1);
+        dep_tx2.send_replace(1);
+
+        // Unpause the task so that it completes and the select loop runs
+        // again.
+        wait_tx.send(()).await.unwrap();
+
+        // The two ready dependencies should be collapsed into one activation.
+        // First, verify that the next activation starts and was caused by a
+        // dependency.
+        assert_eq!(ready_rx.recv().await.unwrap(), 2);
+        let status = driver.task_status(&task_handle);
+        let current = status.current.unwrap_running();
+        assert_eq!(current.iteration, 2);
+        assert_eq!(current.reason, ActivationReason::Dependency);
+
+        // Next, unpause the task so that it completes and the select loop runs
+        // again.
+        wait_tx.send(()).await.unwrap();
+
+        // Finally, verify that no second dependency-triggered activation
+        // starts. We do that by waiting for a second and confirming that the
+        // task is idle and the last completed iteration is the same as in the
+        // previous step.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let status = driver.task_status(&task_handle);
+        // Currently, the following is_idle() assertion fails since there is no
+        // collapsing of distinct ready dependencies and the third activation
+        // already started.
+        assert!(status.current.is_idle());
+        assert!(status.last.has_completed());
+        assert_eq!(status.last.unwrap_completion().iteration, 2);
+        assert_matches!(ready_rx.try_recv(), Err(TryRecvError::Empty));
+    }
 }

--- a/nexus/src/app/background/driver.rs
+++ b/nexus/src/app/background/driver.rs
@@ -284,8 +284,14 @@ impl TaskExec {
         // signal from the Driver, or for one of our dependencies ("watch"
         // channels) to trigger an activation.
         loop {
-            let mut dependencies: FuturesUnordered<_> =
-                deps.iter_mut().map(|w| w.wait_for_change()).collect();
+            let deps_len = deps.len();
+            let mut dependencies = deps
+                .iter_mut()
+                .map(|w| w.wait_for_change())
+                .collect::<FuturesUnordered<_>>()
+                // Wait for one changed dependency, then collapse any others
+                // that are also ready into the same activation.
+                .ready_chunks(deps_len.max(1));
 
             tokio::select! {
                 _ = interval.tick() => {
@@ -296,7 +302,7 @@ impl TaskExec {
                     self.activate(ActivationReason::Signaled).await;
                 }
 
-                _ = dependencies.next(), if !dependencies.is_empty() => {
+                _ = dependencies.next(), if deps_len > 0 => {
                     self.activate(ActivationReason::Dependency).await;
                 }
             }
@@ -770,7 +776,6 @@ mod test {
         // two without also spending a lot of wall-clock time on this test.
     }
 
-
     // Verifies that when multiple distinct dependencies become ready while an
     // activation is already running, the task is activated only once afterward
     // instead of once per ready dependency.
@@ -847,9 +852,6 @@ mod test {
         // previous step.
         tokio::time::sleep(Duration::from_secs(1)).await;
         let status = driver.task_status(&task_handle);
-        // Currently, the following is_idle() assertion fails since there is no
-        // collapsing of distinct ready dependencies and the third activation
-        // already started.
         assert!(status.current.is_idle());
         assert!(status.last.has_completed());
         assert_eq!(status.last.unwrap_completion().iteration, 2);

--- a/nexus/src/app/background/driver.rs
+++ b/nexus/src/app/background/driver.rs
@@ -411,6 +411,8 @@ mod test {
     use nexus_db_queries::context::OpContext;
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::internal_api::views::ActivationReason;
+    use omicron_test_utils::dev::poll::{CondCheckError, wait_for_condition};
+    use std::cell::Cell;
     use std::time::Duration;
     use std::time::Instant;
     use tokio::sync::mpsc;
@@ -788,7 +790,7 @@ mod test {
     //   2. activation (1) finishes
     //   3. one dependency-triggered activation (2) starts
     //   4. activation (2) finishes
-    //   5. no activation (3) should start
+    //   5. no second dependency-triggered activation (3) should start
     #[nexus_test(server = crate::Server)]
     async fn test_distinct_ready_dependencies_are_collapsed(
         cptestctx: &ControlPlaneTestContext,
@@ -847,14 +849,55 @@ mod test {
         wait_tx.send(()).await.unwrap();
 
         // Finally, verify that no second dependency-triggered activation
-        // starts. We do that by waiting for a second and confirming that the
-        // task is idle and the last completed iteration is the same as in the
-        // previous step.
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        let status = driver.task_status(&task_handle);
-        assert!(status.current.is_idle());
-        assert!(status.last.has_completed());
-        assert_eq!(status.last.unwrap_completion().iteration, 2);
-        assert_matches!(ready_rx.try_recv(), Err(TryRecvError::Empty));
+        // starts. Iteration 2 may take some time to finish after being
+        // unpaused, so poll until the task becomes idle. If another activation
+        // starts first, verify that it was caused by something other than a
+        // dependency.
+
+        // We track the latest released iteration so that repeated polls do not
+        // queue release messages for future activations. Iteration 2 has
+        // already been released above, so that's the initial value.
+        let released_iteration = Cell::new(2);
+        wait_for_condition(
+            || async {
+                let status = driver.task_status(&task_handle);
+
+                if status.current.is_idle() {
+                    // Verify that iteration 2 has completed. If a later
+                    // iteration also completed, verify that it was not caused
+                    // by a dependency.
+                    let last = status.last.unwrap_completion();
+                    if last.iteration > 2 {
+                        assert_ne!(last.reason, ActivationReason::Dependency);
+                    }
+
+                    return Ok(());
+                }
+
+                // Iteration 2 is expected to be dependency-triggered and may
+                // still be finishing. Any later running activation must have
+                // been caused by something else, e.g. a timeout.
+                let current = status.current.unwrap_running();
+                let iteration = current.iteration;
+                if iteration > 2 {
+                    assert_ne!(current.reason, ActivationReason::Dependency);
+
+                    // Allow an unrelated activation, such as a timeout, to
+                    // finish so that the task can become idle.
+                    if released_iteration.get() < iteration {
+                        released_iteration.set(iteration);
+                        wait_tx.send(()).await.unwrap();
+                    }
+                }
+
+                Err(CondCheckError::<()>::NotYet {
+                    status: Some("waiting for task to become idle".to_string()),
+                })
+            },
+            &Duration::from_millis(100),
+            &Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
     }
 }


### PR DESCRIPTION
:wave: Hello! While experimenting with something else in background tasks (side-note: love this abstraction!), I noticed that the core `tokio::select!` loop in the driver runs an activation for a single ready dependency (the `dependencies.next(), if !dependencies.is_empty()` branch):

https://github.com/oxidecomputer/omicron/blob/fdf50ea48e0d0a67a93fb4f3bc4344be6b47deb8/nexus/src/app/background/driver.rs#L283-L303

In other words, if a task is waiting on watchers from multiple dependencies and if more than one of those dependencies is ready -- then a single `tokio::select!` will consume the readiness of only one of the watchers for the task activation while the other dependencies will remain ready for the next iteration of the `tokio::select!` loop. As a result, once the task completes, it will activate immediately once again on the next iteration of the loop for the next dependency that was ready. And so on and so on until all ready dependency notifications are consumed. 

Given the nature of background tasks (= they should be idempotent), it _feels_ like it should be okay to collapse all ready dependencies into a single activation instead of doing a burst of activations. This collapsing already happens for a _single_ dependency since a watch channel keeps only the last sent value i.e. multiple notifications on a single watch channel are collapsed into one by the channel itself. And there's even a test for verifying this single-dependency collapsing behavior in the driver:

https://github.com/oxidecomputer/omicron/blob/fdf50ea48e0d0a67a93fb4f3bc4344be6b47deb8/nexus/src/app/background/driver.rs#L729-L748

Luckily, once I started reading the `FuturesUnordered` docs -- I noticed that it provided a way which helps implement exactly that collapsing across distinct watch channels. There's [a neat `ReadyChunks` adapter](https://docs.rs/futures/latest/futures/stream/struct.FuturesUnordered.html#method.ready_chunks) which waits until at least one dependency future is ready, and then drains _all_ other dependency futures that are ready, up to the configured capacity. 

After giving it a try, it seems to work as expected so I'm opening a PR to offer this change for consideration. To be fair, this is not likely to happen/help often since only a few tasks have multiple dependencies ([`blueprint_planner` has 3](https://github.com/oxidecomputer/omicron/blob/fdf50ea48e0d0a67a93fb4f3bc4344be6b47deb8/nexus/src/app/background/init.rs#L600-L604), [`fm_analysis` has 2](https://github.com/oxidecomputer/omicron/blob/fdf50ea48e0d0a67a93fb4f3bc4344be6b47deb8/nexus/src/app/background/init.rs#L1167-L1170), and [`dns_propagation_*` has 2](https://github.com/oxidecomputer/omicron/blob/fdf50ea48e0d0a67a93fb4f3bc4344be6b47deb8/nexus/src/app/background/init.rs#L1422-L1425)). However, it seems like this change is aligned with how background tasks should work due to idempotency, and in the future there might be more tasks with multiple dependencies. 🔮 

I split the change into two commits:
- first, added a test which sets up a task with two dependencies, makes both ready, and checks that a single dependency-triggered activation happened (after the initial timeout-based activation). This test expectedly fails since notifications across distinct watch channels are not collapsed yet.
- switch to using the `ReadyChunks` adapter (with the capacity set to the number of dependencies) which collapses all ready dependencies into a single activation and thus makes the test pass