### PR TITLE
[nexus] Delete empty file for alert_subscription background task

### DIFF
--- a/nexus/src/app/background/tasks/alert_subscription.rs
+++ b/nexus/src/app/background/tasks/alert_subscription.rs
@@ -1,4 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-


### PR DESCRIPTION
👋 Just a small thing I ran into while I was experimenting with background tasks. The `alert_subscription` task is empty -- seems like it was created empty by accident back in 2025 in https://github.com/oxidecomputer/omicron/pull/8169 (see [the diff here](https://github.com/oxidecomputer/omicron/pull/8169/files#diff-3c914f36d0eee35aa1e75284107bb786b48c647e2ce93bfc5dbf994ae222bdea)), and then recently in https://github.com/oxidecomputer/omicron/pull/10708 it gained the MPL license header via the automation which ensures that all source files have the header (see [the diff here](https://github.com/oxidecomputer/omicron/pull/10708/files#diff-3c914f36d0eee35aa1e75284107bb786b48c647e2ce93bfc5dbf994ae222bdea)). 

This PR deletes just deletes the file since there's nothing in it 😄 