### PR TITLE
[ci] send GITHUB_TOKEN as part of curl request in ci_check_opte_ver.sh

### DIFF
--- a/.github/workflows/check-opte-ver.yml
+++ b/.github/workflows/check-opte-ver.yml
@@ -18,6 +18,8 @@ jobs:
         run: cargo install toml-cli@0.2.3
       - name: Check OPTE version and rev match
         run: ./tools/ci_check_opte_ver.sh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
   check-opte-override:
     runs-on: ubuntu-22.04

--- a/tools/ci_check_opte_ver.sh
+++ b/tools/ci_check_opte_ver.sh
@@ -54,7 +54,19 @@ API_VER=$(curl -s https://raw.githubusercontent.com/oxidecomputer/opte/"$OPTE_RE
 # above status, but then the observed output when this fails would be an opaque
 # "exited with status 22" or something. Help ourselves out and keep the response
 # head, printing that if something goes sideways instead.
-COMMIT_INFO_HEAD="$(curl -I -s "https://api.github.com/repos/oxidecomputer/opte/commits?per_page=1&sha=$OPTE_REV")"
+#
+# Unauthenticated API requests share a 60/IP/hour limit which can run into
+# issues on GitHub-hosted runners. If GITHUB_TOKEN is in the environment, use it
+# for the higher 1000/IP/hour limit. (CI sets this environment variable.)
+CURL_AUTH=()
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    CURL_AUTH=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+
+# The ${arr[@]+...} syntax avoids an "unbound variable" error under set -u when
+# the array is empty on bash < 4.4 (e.g., on macOS). See
+# https://mywiki.wooledge.org/BashFAQ/112.
+COMMIT_INFO_HEAD="$(curl -I -s ${CURL_AUTH[@]+"${CURL_AUTH[@]}"} "https://api.github.com/repos/oxidecomputer/opte/commits?per_page=1&sha=$OPTE_REV")"
 REV_COUNT=$(echo "$COMMIT_INFO_HEAD" | sed -n '/^[Ll]ink:/ s/.*"next".*page=\([0-9]*\).*"last".*/\1/p')
 
 if [ -z "$REV_COUNT" ]; then

--- a/tools/ci_check_opte_ver.sh
+++ b/tools/ci_check_opte_ver.sh
@@ -54,19 +54,18 @@ API_VER=$(curl -s https://raw.githubusercontent.com/oxidecomputer/opte/"$OPTE_RE
 # above status, but then the observed output when this fails would be an opaque
 # "exited with status 22" or something. Help ourselves out and keep the response
 # head, printing that if something goes sideways instead.
-#
+COMMIT_INFO_CURL=(curl -I -s)
+
 # Unauthenticated API requests share a 60/IP/hour limit which can run into
 # issues on GitHub-hosted runners. If GITHUB_TOKEN is in the environment, use it
 # for the higher 1000/IP/hour limit. (CI sets this environment variable.)
-CURL_AUTH=()
 if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-    CURL_AUTH=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    COMMIT_INFO_CURL+=(-H "Authorization: Bearer $GITHUB_TOKEN")
 fi
 
-# The ${arr[@]+...} syntax avoids an "unbound variable" error under set -u when
-# the array is empty on bash < 4.4 (e.g., on macOS). See
-# https://mywiki.wooledge.org/BashFAQ/112.
-COMMIT_INFO_HEAD="$(curl -I -s ${CURL_AUTH[@]+"${CURL_AUTH[@]}"} "https://api.github.com/repos/oxidecomputer/opte/commits?per_page=1&sha=$OPTE_REV")"
+COMMIT_INFO_CURL+=("https://api.github.com/repos/oxidecomputer/opte/commits?per_page=1&sha=$OPTE_REV")
+
+COMMIT_INFO_HEAD="$("${COMMIT_INFO_CURL[@]}")"
 REV_COUNT=$(echo "$COMMIT_INFO_HEAD" | sed -n '/^[Ll]ink:/ s/.*"next".*page=\([0-9]*\).*"last".*/\1/p')
 
 if [ -z "$REV_COUNT" ]; then


### PR DESCRIPTION
We could also switch this to using the `gh` CLI tool, but ehhh, it's nice that people can run it ad-hoc locally as well without necessarily having `gh` installed.
