### PR TITLE
[gateway-client] progenitor replace SpIdentifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,7 @@ dependencies = [
  "futures",
  "gateway-client",
  "gateway-messages",
+ "gateway-types",
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",

--- a/clients/gateway-client/src/lib.rs
+++ b/clients/gateway-client/src/lib.rs
@@ -67,7 +67,6 @@ progenitor::generate_api!(
         RotImageDetails = { derives = [PartialEq, Eq, PartialOrd, Ord] },
         SpComponentCaboose = { derives = [PartialEq, Eq] },
         SpComponentInfo = { derives = [PartialEq, Eq] },
-        SpIdentifier = { derives = [Copy, PartialEq, Hash, Eq] },
         SpUpdateStatus = { derives = [PartialEq, Hash, Eq] },
         UpdatePreparationProgress = { derives = [PartialEq, Hash, Eq] },
     },
@@ -82,27 +81,14 @@ progenitor::generate_api!(
         Ena = ereport_types::Ena,
         Ereport = ereport_types::Ereport,
         Ereports = ereport_types::Ereports,
-        SpType = gateway_types::component::SpType,
-        TaskDump = gateway_types::task_dump::TaskDump,
+        SpIdentifier = gateway_types::component::SpIdentifier,
         SpIgnition = gateway_types::ignition::SpIgnition,
         SpIgnitionSystemType = gateway_types::ignition::SpIgnitionSystemType,
-        SpState = gateway_types::component::SpState
+        SpState = gateway_types::component::SpState,
+        SpType = gateway_types::component::SpType,
+        TaskDump = gateway_types::task_dump::TaskDump,
     },
 );
-
-// Override the impl of Ord for SpIdentifier because the default one orders the
-// fields in a different order than people are likely to want.
-impl Ord for crate::types::SpIdentifier {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.type_.cmp(&other.type_).then(self.slot.cmp(&other.slot))
-    }
-}
-
-impl PartialOrd for crate::types::SpIdentifier {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
 
 #[derive(Debug, thiserror::Error)]
 pub enum HostPhase1HashError {

--- a/dev-tools/omdb/src/bin/omdb/mgs.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs.rs
@@ -13,9 +13,9 @@ use clap::Subcommand;
 use futures::StreamExt;
 use gateway_client::types::SpComponentCaboose;
 use gateway_client::types::SpComponentInfo;
-use gateway_client::types::SpIdentifier;
 use gateway_client::types::SpIgnitionInfo;
 use gateway_types::component::PowerState;
+use gateway_types::component::SpIdentifier;
 use gateway_types::component::SpState;
 use gateway_types::ignition::SpIgnition;
 use gateway_types::ignition::SpIgnitionSystemType;
@@ -153,7 +153,7 @@ async fn cmd_mgs_inventory(
             }
         }))
         .then(async move |sp_id| {
-            c.sp_get(&sp_id.type_, sp_id.slot)
+            c.sp_get(&sp_id.typ, sp_id.slot)
                 .await
                 .with_context(|| format!("fetching info about SP {:?}", sp_id))
                 .map(|s| (sp_id, s))
@@ -190,7 +190,7 @@ fn sp_type_to_str(s: &SpType) -> &'static str {
 }
 
 fn sp_to_string(s: &SpIdentifier) -> String {
-    format!("{} {}", sp_type_to_str(&s.type_), s.slot)
+    format!("{} {}", sp_type_to_str(&s.typ), s.slot)
 }
 
 fn show_sp_ids(sp_ids: &[SpIdentifier]) -> Result<(), anyhow::Error> {
@@ -204,7 +204,7 @@ fn show_sp_ids(sp_ids: &[SpIdentifier]) -> Result<(), anyhow::Error> {
 
     impl From<&SpIdentifier> for SpIdRow {
         fn from(id: &SpIdentifier) -> Self {
-            SpIdRow { type_: sp_type_to_str(&id.type_), slot: id.slot }
+            SpIdRow { type_: sp_type_to_str(&id.typ), slot: id.slot }
         }
     }
 
@@ -250,7 +250,7 @@ fn show_sps_from_ignition(
                 }
             };
             IgnitionRow {
-                type_: sp_type_to_str(&value.id.type_),
+                type_: sp_type_to_str(&value.id.typ),
                 slot: value.id.slot,
                 system_type,
                 power,
@@ -287,7 +287,7 @@ fn show_sp_states(
     impl<'a> From<&'a (SpIdentifier, SpState)> for SpStateRow<'a> {
         fn from((id, v): &'a (SpIdentifier, SpState)) -> Self {
             SpStateRow {
-                type_: sp_type_to_str(&id.type_),
+                type_: sp_type_to_str(&id.typ),
                 slot: id.slot,
                 model: v.model.clone(),
                 serial: v.serial_number.clone(),
@@ -337,7 +337,7 @@ async fn show_sp_details(
 ) -> Result<(), anyhow::Error> {
     println!(
         "SP DETAILS: type {:?} slot {}\n",
-        sp_type_to_str(&sp_id.type_),
+        sp_type_to_str(&sp_id.typ),
         sp_id.slot
     );
 
@@ -485,7 +485,7 @@ async fn show_sp_details(
     }
 
     let component_list = mgs_client
-        .sp_component_list(&sp_id.type_, sp_id.slot)
+        .sp_component_list(&sp_id.typ, sp_id.slot)
         .await
         .with_context(|| format!("fetching components for SP {:?}", sp_id));
     let list = match component_list {
@@ -574,7 +574,7 @@ async fn show_sp_details(
         for i in 0..1 {
             let r = mgs_client
                 .sp_component_caboose_get(
-                    &sp_id.type_,
+                    &sp_id.typ,
                     sp_id.slot,
                     &c.component,
                     i,
@@ -584,7 +584,7 @@ async fn show_sp_details(
                     format!(
                         "get caboose for sp type {:?} sp slot {} \
                         component {:?} slot {}",
-                        sp_id.type_, sp_id.slot, &c.component, i
+                        sp_id.typ, sp_id.slot, &c.component, i
                     )
                 });
             match r {

--- a/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
@@ -38,7 +38,7 @@ use crate::mgs::sensors::{
 use crate::mgs::sp_to_string;
 use clap::Args;
 use gateway_client::types::MeasurementKind;
-use gateway_client::types::SpIdentifier;
+use gateway_types::component::SpIdentifier;
 use multimap::MultiMap;
 use std::collections::HashMap;
 use std::fs::File;
@@ -559,42 +559,42 @@ impl Dashboard {
 
     fn up(&mut self) {
         let selected_kind = self.kinds[self.selected_kind];
-        let type_ = self.sps[self.selected_sp].type_;
+        let type_ = self.sps[self.selected_sp].typ;
 
         if let Some(flipped) = self.flipped.get_mut(&selected_kind) {
             flipped.previous();
             return;
         }
 
-        for sp in self.sps.iter().filter(|&s| s.type_ == type_) {
+        for sp in self.sps.iter().filter(|&s| s.typ == type_) {
             self.graphs.get_mut(&(*sp, selected_kind)).unwrap().previous();
         }
     }
 
     fn down(&mut self) {
         let selected_kind = self.kinds[self.selected_kind];
-        let type_ = self.sps[self.selected_sp].type_;
+        let type_ = self.sps[self.selected_sp].typ;
 
         if let Some(flipped) = self.flipped.get_mut(&selected_kind) {
             flipped.next();
             return;
         }
 
-        for sp in self.sps.iter().filter(|&s| s.type_ == type_) {
+        for sp in self.sps.iter().filter(|&s| s.typ == type_) {
             self.graphs.get_mut(&(*sp, selected_kind)).unwrap().next();
         }
     }
 
     fn esc(&mut self) {
         let selected_kind = self.kinds[self.selected_kind];
-        let type_ = self.sps[self.selected_sp].type_;
+        let type_ = self.sps[self.selected_sp].typ;
 
         if let Some(flipped) = self.flipped.get_mut(&selected_kind) {
             flipped.unselect();
             return;
         }
 
-        for sp in self.sps.iter().filter(|&s| s.type_ == type_) {
+        for sp in self.sps.iter().filter(|&s| s.typ == type_) {
             self.graphs.get_mut(&(*sp, selected_kind)).unwrap().unselect();
         }
     }
@@ -636,7 +636,7 @@ impl Dashboard {
 
     fn flip(&mut self) {
         let selected_kind = self.kinds[self.selected_kind];
-        let type_ = self.sps[self.selected_sp].type_;
+        let type_ = self.sps[self.selected_sp].typ;
 
         if self.flipped.remove(&selected_kind).is_some() {
             return;
@@ -649,7 +649,7 @@ impl Dashboard {
         if let Some(ndx) = graph.selected() {
             let mut from = vec![];
 
-            for sp in self.sps.iter().filter(|&s| s.type_ == type_) {
+            for sp in self.sps.iter().filter(|&s| s.typ == type_) {
                 from.push((
                     self.graphs.get(&(*sp, selected_kind)).unwrap(),
                     sp_to_string(sp),

--- a/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
@@ -9,7 +9,7 @@ use clap::Args;
 use gateway_client::types::MeasurementErrorCode;
 use gateway_client::types::MeasurementKind;
 use gateway_client::types::SpComponentDetails;
-use gateway_client::types::SpIdentifier;
+use gateway_types::component::SpIdentifier;
 use gateway_types::ignition::SpIgnition;
 use multimap::MultiMap;
 use nexus_types::inventory::SpType;
@@ -94,7 +94,7 @@ pub(crate) struct SensorsArgs {
 
 impl SensorsArgs {
     fn matches_sp(&self, sp: &SpIdentifier) -> bool {
-        match sp.type_ {
+        match sp.typ {
             SpType::Sled => {
                 let matched = if !self.sled.is_empty() {
                     self.sled.contains(&sp.slot)
@@ -328,7 +328,7 @@ async fn sp_info_mgs(
         .iter()
         .filter_map(|ignition| {
             if matches!(ignition.details, SpIgnition::Present { .. })
-                && ignition.id.type_ == SpType::Sled
+                && ignition.id.typ == SpType::Sled
             {
                 if args.matches_sp(&ignition.id) {
                     return Some(ignition.id);
@@ -339,12 +339,12 @@ async fn sp_info_mgs(
         .collect::<Vec<_>>();
 
     if args.switches {
-        sp_list.push(SpIdentifier { type_: SpType::Switch, slot: 0 });
-        sp_list.push(SpIdentifier { type_: SpType::Switch, slot: 1 });
+        sp_list.push(SpIdentifier { typ: SpType::Switch, slot: 0 });
+        sp_list.push(SpIdentifier { typ: SpType::Switch, slot: 1 });
     }
 
     if args.psc {
-        sp_list.push(SpIdentifier { type_: SpType::Power, slot: 0 });
+        sp_list.push(SpIdentifier { typ: SpType::Power, slot: 0 });
     }
 
     sp_list.sort();
@@ -354,7 +354,7 @@ async fn sp_info_mgs(
     let mut handles = vec![];
     for sp_id in sp_list {
         let handle =
-            tokio::spawn(sp_info(mgs_client.clone(), sp_id.type_, sp_id.slot));
+            tokio::spawn(sp_info(mgs_client.clone(), sp_id.typ, sp_id.slot));
 
         handles.push((sp_id, handle));
     }
@@ -439,7 +439,7 @@ fn sp_info_csv<R: std::io::Read>(
             bail!("invalid slot in \"{field}\"");
         })?;
 
-        let sp = SpIdentifier { type_, slot };
+        let sp = SpIdentifier { typ: type_, slot };
 
         if args.matches_sp(&sp) {
             sps.push(Some(sp));
@@ -679,7 +679,7 @@ async fn sp_read_sensors(
 
     for (component, ids) in work.iter() {
         for (value, id) in mgs_client
-            .sp_component_get(&id.type_, id.slot, component.device())
+            .sp_component_get(&id.typ, id.slot, component.device())
             .await?
             .iter()
             .filter_map(|detail| match detail {
@@ -865,7 +865,7 @@ pub(crate) async fn cmd_mgs_sensors(
         for sp in &sps {
             print_value(format!(
                 "{}-{}",
-                crate::mgs::sp_type_to_str(&sp.type_).to_uppercase(),
+                crate::mgs::sp_type_to_str(&sp.typ).to_uppercase(),
                 sp.slot
             ));
         }

--- a/dev-tools/reconfigurator-sp-updater/src/main.rs
+++ b/dev-tools/reconfigurator-sp-updater/src/main.rs
@@ -219,10 +219,10 @@ impl Inventory {
             }),
         )
         .then(async move |sp_id| {
-            c.sp_get(&sp_id.type_, sp_id.slot)
+            c.sp_get(&sp_id.typ, sp_id.slot)
                 .await
                 .with_context(|| format!("fetching info about SP {:?}", sp_id))
-                .map(|s| (sp_id.type_, sp_id.slot, s))
+                .map(|s| (sp_id.typ, sp_id.slot, s))
         })
         .collect::<Vec<Result<_, _>>>()
         .await

--- a/gateway-cli/Cargo.toml
+++ b/gateway-cli/Cargo.toml
@@ -28,5 +28,6 @@ uuid.workspace = true
 
 gateway-client.workspace = true
 gateway-messages.workspace = true
+gateway-types.workspace = true
 omicron-workspace-hack.workspace = true
 slog-error-chain.workspace = true

--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -14,9 +14,9 @@ use gateway_client::types::IgnitionCommand;
 use gateway_client::types::InstallinatorImageId;
 use gateway_client::types::PowerState;
 use gateway_client::types::SpComponentFirmwareSlot;
-use gateway_client::types::SpIdentifier;
 use gateway_client::types::SpUpdateStatus;
 use gateway_client::types::UpdateAbortBody;
+use gateway_types::component::SpIdentifier;
 use omicron_uuid_kinds::MupdateUuid;
 use serde::Serialize;
 use slog::Drain;
@@ -322,11 +322,11 @@ fn sp_identifier_from_str(s: &str) -> Result<SpIdentifier> {
         bail!(BAD_FORMAT);
     }
     Ok(SpIdentifier {
-        type_: type_.parse().map_err(|s| {
+        typ: type_.parse().map_err(|s| {
             anyhow!("failed to parse {type_} as an SpType: {s}")
         })?,
         slot: slot.parse().map_err(|err| {
-            anyhow!("failed to parse slot {slot} as a u32: {err}")
+            anyhow!("failed to parse slot {slot} as a u16: {err}")
         })?,
     })
 }
@@ -396,13 +396,13 @@ async fn main_impl() -> Result<()> {
 
     match args.command {
         Command::State { sp } => {
-            let info = client.sp_get(&sp.type_, sp.slot).await?.into_inner();
+            let info = client.sp_get(&sp.typ, sp.slot).await?.into_inner();
             dumper.dump(&info)?;
         }
         Command::Ignition { sp } => {
             if let Some(sp) = sp {
                 let info =
-                    client.ignition_get(&sp.type_, sp.slot).await?.into_inner();
+                    client.ignition_get(&sp.typ, sp.slot).await?.into_inner();
                 dumper.dump(&info)?;
             } else {
                 let info = client.ignition_list().await?.into_inner();
@@ -410,13 +410,13 @@ async fn main_impl() -> Result<()> {
             }
         }
         Command::IgnitionCommand { sp, command } => {
-            client.ignition_command(&sp.type_, sp.slot, command).await?;
+            client.ignition_command(&sp.typ, sp.slot, command).await?;
         }
         Command::ComponentActiveSlot { sp, component, set_slot, persist } => {
             if let Some(slot) = set_slot {
                 client
                     .sp_component_active_slot_set(
-                        &sp.type_,
+                        &sp.typ,
                         sp.slot,
                         &component,
                         persist,
@@ -425,9 +425,7 @@ async fn main_impl() -> Result<()> {
                     .await?;
             } else {
                 let info = client
-                    .sp_component_active_slot_get(
-                        &sp.type_, sp.slot, &component,
-                    )
+                    .sp_component_active_slot_get(&sp.typ, sp.slot, &component)
                     .await?
                     .into_inner();
                 dumper.dump(&info)?;
@@ -459,11 +457,11 @@ async fn main_impl() -> Result<()> {
                     verbose: startup_verbose,
                 };
                 client
-                    .sp_startup_options_set(&sp.type_, sp.slot, &options)
+                    .sp_startup_options_set(&sp.typ, sp.slot, &options)
                     .await?;
             } else {
                 let info = client
-                    .sp_startup_options_get(&sp.type_, sp.slot)
+                    .sp_startup_options_get(&sp.typ, sp.slot)
                     .await?
                     .into_inner();
                 dumper.dump(&info)?;
@@ -478,7 +476,7 @@ async fn main_impl() -> Result<()> {
         } => {
             if clear {
                 client
-                    .sp_installinator_image_id_delete(&sp.type_, sp.slot)
+                    .sp_installinator_image_id_delete(&sp.typ, sp.slot)
                     .await?;
             } else {
                 // clap guarantees these are not `None` when `clear` is false.
@@ -487,7 +485,7 @@ async fn main_impl() -> Result<()> {
                 let control_plane = control_plane.unwrap().to_string();
                 client
                     .sp_installinator_image_id_set(
-                        &sp.type_,
+                        &sp.typ,
                         sp.slot,
                         &InstallinatorImageId {
                             update_id,
@@ -499,22 +497,20 @@ async fn main_impl() -> Result<()> {
             }
         }
         Command::Inventory { sp } => {
-            let info = client
-                .sp_component_list(&sp.type_, sp.slot)
-                .await?
-                .into_inner();
+            let info =
+                client.sp_component_list(&sp.typ, sp.slot).await?.into_inner();
             dumper.dump(&info)?;
         }
         Command::ComponentDetails { sp, component } => {
             let info = client
-                .sp_component_get(&sp.type_, sp.slot, &component)
+                .sp_component_get(&sp.typ, sp.slot, &component)
                 .await?
                 .into_inner();
             dumper.dump(&info)?;
         }
         Command::ComponentClearStatus { sp, component } => {
             client
-                .sp_component_clear_status(&sp.type_, sp.slot, &component)
+                .sp_component_clear_status(&sp.typ, sp.slot, &component)
                 .await?;
         }
         Command::UsartAttach {
@@ -527,7 +523,7 @@ async fn main_impl() -> Result<()> {
         } => {
             let upgraded = client
                 .sp_component_serial_console_attach(
-                    &sp.type_,
+                    &sp.typ,
                     sp.slot,
                     SERIAL_CONSOLE_COMPONENT,
                 )
@@ -558,7 +554,7 @@ async fn main_impl() -> Result<()> {
         Command::UsartDetach { sp } => {
             client
                 .sp_component_serial_console_detach(
-                    &sp.type_,
+                    &sp.typ,
                     sp.slot,
                     SERIAL_CONSOLE_COMPONENT,
                 )
@@ -583,7 +579,7 @@ async fn main_impl() -> Result<()> {
         }
         Command::UpdateStatus { sp, component } => {
             let info = client
-                .sp_component_update_status(&sp.type_, sp.slot, &component)
+                .sp_component_update_status(&sp.typ, sp.slot, &component)
                 .await?
                 .into_inner();
             dumper.dump(&info)?;
@@ -591,19 +587,17 @@ async fn main_impl() -> Result<()> {
         Command::UpdateAbort { sp, component, update_id } => {
             let body = UpdateAbortBody { id: update_id };
             client
-                .sp_component_update_abort(
-                    &sp.type_, sp.slot, &component, &body,
-                )
+                .sp_component_update_abort(&sp.typ, sp.slot, &component, &body)
                 .await?;
         }
         Command::PowerState { sp, new_power_state } => {
             if let Some(power_state) = new_power_state {
                 client
-                    .sp_power_state_set(&sp.type_, sp.slot, power_state)
+                    .sp_power_state_set(&sp.typ, sp.slot, power_state)
                     .await?;
             } else {
                 let info = client
-                    .sp_power_state_get(&sp.type_, sp.slot)
+                    .sp_power_state_get(&sp.typ, sp.slot)
                     .await?
                     .into_inner();
                 dumper.dump(&info)?;
@@ -612,10 +606,10 @@ async fn main_impl() -> Result<()> {
         Command::Reset { sp } => {
             let component =
                 gateway_messages::SpComponent::SP_ITSELF.const_as_str();
-            client.sp_component_reset(&sp.type_, sp.slot, component).await?;
+            client.sp_component_reset(&sp.typ, sp.slot, component).await?;
         }
         Command::ResetComponent { sp, component } => {
-            client.sp_component_reset(&sp.type_, sp.slot, &component).await?;
+            client.sp_component_reset(&sp.typ, sp.slot, &component).await?;
         }
     }
 
@@ -635,14 +629,14 @@ async fn update(
 
     client
         .sp_component_update(
-            &sp.type_, sp.slot, component, slot, &update_id, image,
+            &sp.typ, sp.slot, component, slot, &update_id, image,
         )
         .await
         .context("failed to start update")?;
 
     loop {
         let status = client
-            .sp_component_update_status(&sp.type_, sp.slot, component)
+            .sp_component_update_status(&sp.typ, sp.slot, component)
             .await
             .context("failed to get update status")?
             .into_inner();

--- a/gateway-types/versions/src/initial/component.rs
+++ b/gateway-types/versions/src/initial/component.rs
@@ -36,6 +36,7 @@ pub enum SpType {
     Copy,
     PartialEq,
     Eq,
+    Hash,
     PartialOrd,
     Ord,
     Serialize,

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -154,7 +154,7 @@ impl<'a> Collector<'a> {
             // First, fetch the state of the SP.  If that fails, report the
             // error but continue.
             let result =
-                client.sp_get(&sp.type_, sp.slot).await.with_context(|| {
+                client.sp_get(&sp.typ, sp.slot).await.with_context(|| {
                     format!(
                         "MGS {:?}: fetching state of SP {:?}",
                         client.baseurl(),
@@ -172,7 +172,7 @@ impl<'a> Collector<'a> {
             // Record the state that we found.
             let Some(baseboard_id) = in_progress.found_sp_state(
                 client.baseurl(),
-                sp.type_,
+                sp.typ,
                 sp.slot,
                 sp_state,
             ) else {
@@ -186,13 +186,13 @@ impl<'a> Collector<'a> {
             // collected already. Generally, we'd only get here for the first
             // MGS client.  Assuming that one succeeds, the other(s) will skip
             // this loop.
-            if matches!(sp.type_, SpType::Sled) {
+            if matches!(sp.typ, SpType::Sled) {
                 if !in_progress
                     .found_host_phase_1_active_slot_already(&baseboard_id)
                 {
                     let result = client
                         .sp_component_active_slot_get(
-                            &sp.type_,
+                            &sp.typ,
                             sp.slot,
                             SpComponent::HOST_CPU_BOOT_FLASH.const_as_str(),
                         )
@@ -256,7 +256,7 @@ impl<'a> Collector<'a> {
 
                     let result = client
                         .host_phase_1_flash_hash_calculate_with_timeout(
-                            sp.type_,
+                            sp.typ,
                             sp.slot,
                             phase1_slot,
                             PHASE1_HASH_TIMEOUT,
@@ -313,9 +313,7 @@ impl<'a> Collector<'a> {
                 };
 
                 let result = client
-                    .sp_component_caboose_get(
-                        &sp.type_, sp.slot, component, slot,
-                    )
+                    .sp_component_caboose_get(&sp.typ, sp.slot, component, slot)
                     .await
                     .with_context(|| {
                         format!(
@@ -362,12 +360,12 @@ impl<'a> Collector<'a> {
 
                 let result = match which {
                     RotPageWhich::Cmpa => client
-                        .sp_rot_cmpa_get(&sp.type_, sp.slot, component)
+                        .sp_rot_cmpa_get(&sp.typ, sp.slot, component)
                         .await
                         .map(|response| response.into_inner().base64_data),
                     RotPageWhich::CfpaActive => client
                         .sp_rot_cfpa_get(
-                            &sp.type_,
+                            &sp.typ,
                             sp.slot,
                             component,
                             &GetCfpaParams { slot: RotCfpaSlot::Active },
@@ -376,7 +374,7 @@ impl<'a> Collector<'a> {
                         .map(|response| response.into_inner().base64_data),
                     RotPageWhich::CfpaInactive => client
                         .sp_rot_cfpa_get(
-                            &sp.type_,
+                            &sp.typ,
                             sp.slot,
                             component,
                             &GetCfpaParams { slot: RotCfpaSlot::Inactive },
@@ -385,7 +383,7 @@ impl<'a> Collector<'a> {
                         .map(|response| response.into_inner().base64_data),
                     RotPageWhich::CfpaScratch => client
                         .sp_rot_cfpa_get(
-                            &sp.type_,
+                            &sp.typ,
                             sp.slot,
                             component,
                             &GetCfpaParams { slot: RotCfpaSlot::Scratch },

--- a/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
@@ -6,8 +6,8 @@
 
 use chrono::Utc;
 use gateway_client::types::SpComponentCaboose;
-use gateway_client::types::SpIdentifier;
 use gateway_types::component::PowerState;
+use gateway_types::component::SpIdentifier;
 use gateway_types::component::SpState;
 use gateway_types::rot::RotSlot;
 use gateway_types::rot::RotState;
@@ -252,7 +252,7 @@ impl TestBoards {
                 let slot = slot as u16;
                 boards
                     .insert_unique(TestBoard {
-                        id: SpIdentifier { type_, slot },
+                        id: SpIdentifier { typ: type_, slot },
                         sled_id: SledUuid::new_v4(),
                         serial,
                         sp_board,
@@ -268,7 +268,7 @@ impl TestBoards {
     /// Get the sled ID of a particular sled by SP slot number.
     pub fn sled_id(&self, sp_slot: u16) -> Option<SledUuid> {
         self.boards.iter().find_map(|b| {
-            (b.id.type_ == SpType::Sled && b.id.slot == sp_slot)
+            (b.id.typ == SpType::Sled && b.id.slot == sp_slot)
                 .then_some(b.sled_id)
         })
     }
@@ -565,7 +565,7 @@ impl TestBoards {
             let sled_type = board_to_sled(&board.sp_board);
             updates
                 .insert_unique(ExpectedUpdate {
-                    sp_type: board.id.type_,
+                    sp_type: board.id.typ,
                     sp_slot: board.id.slot,
                     component: MgsUpdateComponent::Sp,
                     expected_serial: board.serial,
@@ -574,12 +574,12 @@ impl TestBoards {
                 .expect("boards are unique");
             updates
                 .insert_unique(ExpectedUpdate {
-                    sp_type: board.id.type_,
+                    sp_type: board.id.typ,
                     sp_slot: board.id.slot,
                     component: MgsUpdateComponent::Rot,
                     expected_serial: board.serial,
                     expected_artifact: test_artifact_for_artifact_kind(
-                        match board.id.type_ {
+                        match board.id.typ {
                             SpType::Sled => ArtifactKind::GIMLET_ROT_IMAGE_B,
                             SpType::Power => ArtifactKind::PSC_ROT_IMAGE_B,
                             SpType::Switch => ArtifactKind::SWITCH_ROT_IMAGE_B,
@@ -590,12 +590,12 @@ impl TestBoards {
                 .expect("boards are unique");
             updates
                 .insert_unique(ExpectedUpdate {
-                    sp_type: board.id.type_,
+                    sp_type: board.id.typ,
                     sp_slot: board.id.slot,
                     component: MgsUpdateComponent::RotBootloader,
                     expected_serial: board.serial,
                     expected_artifact: test_artifact_for_artifact_kind(
-                        match board.id.type_ {
+                        match board.id.typ {
                             SpType::Sled => ArtifactKind::GIMLET_ROT_STAGE0,
                             SpType::Power => ArtifactKind::PSC_ROT_STAGE0,
                             SpType::Switch => ArtifactKind::SWITCH_ROT_STAGE0,
@@ -605,10 +605,10 @@ impl TestBoards {
                 })
                 .expect("boards are unique");
 
-            if board.id.type_ == SpType::Sled {
+            if board.id.typ == SpType::Sled {
                 updates
                     .insert_unique(ExpectedUpdate {
-                        sp_type: board.id.type_,
+                        sp_type: board.id.typ,
                         sp_slot: board.id.slot,
                         component: MgsUpdateComponent::HostOs,
                         expected_serial: board.serial,
@@ -910,7 +910,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
         v: ArtifactVersion,
     ) -> Self {
         self.sp_active_version_exceptions
-            .insert(SpIdentifier { type_, slot }, v);
+            .insert(SpIdentifier { typ: type_, slot }, v);
         self
     }
 
@@ -920,7 +920,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
         slot: u16,
     ) -> bool {
         self.sp_active_version_exceptions
-            .contains_key(&SpIdentifier { type_, slot })
+            .contains_key(&SpIdentifier { typ: type_, slot })
     }
 
     pub fn rot_versions(
@@ -940,7 +940,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
         v: ArtifactVersion,
     ) -> Self {
         self.rot_active_version_exceptions
-            .insert(SpIdentifier { type_, slot }, v);
+            .insert(SpIdentifier { typ: type_, slot }, v);
         self
     }
 
@@ -951,7 +951,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
         s: RotSlot,
     ) -> Self {
         self.rot_active_slot_exceptions
-            .insert(SpIdentifier { type_, slot: sp_slot }, s);
+            .insert(SpIdentifier { typ: type_, slot: sp_slot }, s);
         self
     }
 
@@ -962,7 +962,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
         s: RotSlot,
     ) -> Self {
         self.rot_persistent_boot_preference_exceptions
-            .insert(SpIdentifier { type_, slot: sp_slot }, s);
+            .insert(SpIdentifier { typ: type_, slot: sp_slot }, s);
         self
     }
 
@@ -972,7 +972,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
         slot: u16,
     ) -> bool {
         self.rot_active_version_exceptions
-            .contains_key(&SpIdentifier { type_, slot })
+            .contains_key(&SpIdentifier { typ: type_, slot })
     }
 
     pub fn stage0_versions(
@@ -991,7 +991,8 @@ impl<'a> TestBoardCollectionBuilder<'a> {
         slot: u16,
         v: ArtifactVersion,
     ) -> Self {
-        self.stage0_version_exceptions.insert(SpIdentifier { type_, slot }, v);
+        self.stage0_version_exceptions
+            .insert(SpIdentifier { typ: type_, slot }, v);
         self
     }
 
@@ -1001,7 +1002,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
         slot: u16,
     ) -> bool {
         self.stage0_version_exceptions
-            .contains_key(&SpIdentifier { type_, slot })
+            .contains_key(&SpIdentifier { typ: type_, slot })
     }
 
     pub fn gimlet_host_phase_1_artifacts(
@@ -1099,7 +1100,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
 
             let sp_state = SpState {
                 // We assume a valid model ID for sleds
-                model: match sp_id.type_ {
+                model: match sp_id.typ {
                     SpType::Sled => {
                         // The RKTH is expected to be different between
                         // Cosmo and Gimlet so we can use that here.
@@ -1109,7 +1110,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
                             GIMLET_SLED_MODEL.to_string()
                         }
                     }
-                    _ => format!("dummy_{}", sp_id.type_),
+                    _ => format!("dummy_{}", sp_id.typ),
                 },
                 serial_number: serial.to_string(),
                 ..dummy_sp_state.clone()
@@ -1118,12 +1119,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
             let sled_model = OxideSled::try_from_model(&sp_state.model);
 
             let baseboard_id = builder
-                .found_sp_state(
-                    "test",
-                    sp_id.type_,
-                    sp_id.slot,
-                    sp_state.clone(),
-                )
+                .found_sp_state("test", sp_id.typ, sp_id.slot, sp_state.clone())
                 .unwrap();
             let sp_active_version = self
                 .sp_active_version_exceptions
@@ -1246,7 +1242,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
                     .unwrap();
             }
 
-            if board.id.type_ == SpType::Sled {
+            if board.id.typ == SpType::Sled {
                 let phase_1_active_artifact = self
                     .host_exceptions
                     .get(&board.id.slot)

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -78,7 +78,8 @@ impl SpEreportIngester {
         &mut self,
         opctx: &OpContext,
     ) -> SpEreportIngesterStatus {
-        use gateway_client::types::{SpIdentifier, SpIgnitionInfo};
+        use gateway_client::types::SpIgnitionInfo;
+        use gateway_types::component::SpIdentifier;
         use gateway_types::ignition::SpIgnition;
 
         let mut status = SpEreportIngesterStatus::default();
@@ -161,7 +162,7 @@ impl SpEreportIngester {
 
             status.sps_found += 1;
 
-            let SpIdentifier { type_, slot } = id;
+            let SpIdentifier { typ: type_, slot } = id;
             let sp_result = tasks
                 .spawn({
                     let opctx = opctx.child(BTreeMap::from([

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -4622,7 +4622,6 @@
         ]
       },
       "SpIdentifier": {
-        "description": "`SpIdentifier`\n\n<details><summary>JSON schema</summary>\n\n```json { \"type\": \"object\", \"required\": [ \"slot\", \"type\" ], \"properties\": { \"slot\": { \"type\": \"integer\", \"format\": \"uint16\", \"minimum\": 0.0 }, \"type\": { \"$ref\": \"#/components/schemas/SpType\" } } } ``` </details>",
         "type": "object",
         "properties": {
           "slot": {

--- a/support-bundle-collection/src/steps/sled_cubby.rs
+++ b/support-bundle-collection/src/steps/sled_cubby.rs
@@ -12,7 +12,7 @@ use anyhow::Context;
 use anyhow::bail;
 use camino::Utf8Path;
 use gateway_client::Client as MgsClient;
-use gateway_client::types::SpIdentifier;
+use gateway_types::component::SpIdentifier;
 use gateway_types::component::SpType;
 use nexus_db_model::Sled;
 use omicron_uuid_kinds::GenericUuid;
@@ -86,9 +86,9 @@ async fn write_sled_cubby_info(
         let mut sled_info = BTreeMap::new();
         for sp in available_sps
             .into_iter()
-            .filter(|sp| matches!(sp.type_, SpType::Sled))
+            .filter(|sp| matches!(sp.typ, SpType::Sled))
         {
-            match mgs_client.sp_get(&sp.type_, sp.slot).await {
+            match mgs_client.sp_get(&sp.typ, sp.slot).await {
                 Ok(s) => {
                     let sp_state = s.into_inner();
                     if let Some(sled) =
@@ -112,7 +112,7 @@ async fn write_sled_cubby_info(
                     error!(log,
                         "Failed to get SP state for sled_info.json";
                         "cubby" => sp.slot,
-                        "component" => %sp.type_,
+                        "component" => %sp.typ,
                         "error" => InlineErrorChain::new(&e)
                     );
                 }

--- a/support-bundle-collection/src/steps/sp_dumps.rs
+++ b/support-bundle-collection/src/steps/sp_dumps.rs
@@ -16,7 +16,7 @@ use base64::Engine;
 use camino::Utf8Path;
 use futures::FutureExt;
 use gateway_client::Client as MgsClient;
-use gateway_client::types::SpIdentifier;
+use gateway_types::component::SpIdentifier;
 
 pub async fn spawn_collection_steps(
     collection: &BundleCollection,
@@ -76,7 +76,7 @@ async fn collect_sp_dump(
     }
 
     save_sp_dumps(collection, mgs_client, sp, dir).await.with_context(
-        || format!("failed to save SP dump from: {} {}", sp.type_, sp.slot),
+        || format!("failed to save SP dump from: {} {}", sp.typ, sp.slot),
     )?;
 
     Ok(CollectionStepOutput::None)
@@ -96,7 +96,7 @@ async fn save_sp_dumps(
 ) -> anyhow::Result<()> {
     let fetch_dumps = async {
         let dump_count = mgs_client
-            .sp_task_dump_count(&sp.type_, sp.slot)
+            .sp_task_dump_count(&sp.typ, sp.slot)
             .await
             .context("failed to get task dump count from SP")?
             .into_inner();
@@ -104,7 +104,7 @@ async fn save_sp_dumps(
         let mut dumps = Vec::with_capacity(dump_count as usize);
         for i in 0..dump_count {
             let task_dump = mgs_client
-                .sp_task_dump_get(&sp.type_, sp.slot, i)
+                .sp_task_dump_get(&sp.typ, sp.slot, i)
                 .await
                 .with_context(|| {
                     format!("failed to get task dump {i} from SP")
@@ -123,7 +123,7 @@ async fn save_sp_dumps(
         result = fetch_dumps => result?,
     };
 
-    let output_dir = sp_dumps_dir.join(format!("{}_{}", sp.type_, sp.slot));
+    let output_dir = sp_dumps_dir.join(format!("{}_{}", sp.typ, sp.slot));
     tokio::fs::create_dir_all(&output_dir).await.with_context(|| {
         format!("Failed to create output directory {output_dir}")
     })?;

--- a/wicket-common/src/example.rs
+++ b/wicket-common/src/example.rs
@@ -74,8 +74,8 @@ impl ExampleRackSetupData {
 
         let mut inventory = MgsV1Inventory {
             sps: vec![
-                SpInventory::new(SpIdentifier { slot: 1, type_: SpType::Sled }),
-                SpInventory::new(SpIdentifier { slot: 5, type_: SpType::Sled }),
+                SpInventory::new(SpIdentifier { slot: 1, typ: SpType::Sled }),
+                SpInventory::new(SpIdentifier { slot: 5, typ: SpType::Sled }),
             ],
         };
 
@@ -128,12 +128,12 @@ impl ExampleRackSetupData {
 
         let bootstrap_sleds = btreeset![
             BootstrapSledDescription {
-                id: SpIdentifier { slot: 1, type_: SpType::Sled },
+                id: SpIdentifier { slot: 1, typ: SpType::Sled },
                 baseboard: our_baseboard.clone(),
                 bootstrap_ip: Some(Ipv6Addr::LOCALHOST)
             },
             BootstrapSledDescription {
-                id: SpIdentifier { slot: 5, type_: SpType::Sled },
+                id: SpIdentifier { slot: 5, typ: SpType::Sled },
                 baseboard: Baseboard::Gimlet {
                     model: "model2".into(),
                     revision: 5,

--- a/wicket-common/src/inventory.rs
+++ b/wicket-common/src/inventory.rs
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Re-export these types from gateway_client, so that users are oblivious to
-// where these types come from.
+// Re-export these types from gateway_client and gateway_types, so that users
+// are oblivious to where these types come from.
 pub use gateway_client::types::{
-    SpComponentCaboose, SpComponentInfo, SpComponentPresence, SpIdentifier,
+    SpComponentCaboose, SpComponentInfo, SpComponentPresence,
 };
-pub use gateway_types::component::{SpState, SpType};
+pub use gateway_types::component::{SpIdentifier, SpState, SpType};
 pub use gateway_types::ignition::{SpIgnition, SpIgnitionSystemType};
 pub use gateway_types::rot::{RotSlot, RotState};
 use omicron_common::snake_case_result;
@@ -71,7 +71,7 @@ impl SledInventory {
             .sps
             .iter()
             .filter_map(|sp| {
-                if sp.id.type_ != SpType::Sled {
+                if sp.id.typ != SpType::Sled {
                     return None;
                 }
 

--- a/wicket/src/cli/rack_setup/config_toml.rs
+++ b/wicket/src/cli/rack_setup/config_toml.rs
@@ -216,7 +216,7 @@ fn build_sleds_array(sleds: &BTreeSet<BootstrapSledDescription>) -> Array {
 
     for sled in sleds {
         // We should never get a non-sled from wicketd; if we do, filter it out.
-        if sled.id.type_ != SpType::Sled {
+        if sled.id.typ != SpType::Sled {
             continue;
         }
 

--- a/wicket/src/cli/rack_update.rs
+++ b/wicket/src/cli/rack_update.rs
@@ -599,7 +599,7 @@ fn write_status_table(
             };
 
             ComponentRow {
-                type_: c.id.type_.to_string(),
+                type_: c.id.typ.to_string(),
                 slot: c.id.slot,
                 state: c.state.to_string(),
                 progress,
@@ -626,7 +626,7 @@ fn write_status_table(
             writeln!(
                 out,
                 "\n{} {} ({}): {}",
-                component.id.type_,
+                component.id.typ,
                 component.id.slot,
                 component.state,
                 exit_message.message,
@@ -669,7 +669,7 @@ impl ClearArgs {
                     .cleared
                     .iter()
                     .map(|sp| {
-                        ComponentId::from_sp_type_and_slot(sp.type_, sp.slot)
+                        ComponentId::from_sp_type_and_slot(sp.typ, sp.slot)
                             .map(|id| id.to_string())
                     })
                     .collect::<Result<Vec<_>>>()
@@ -678,7 +678,7 @@ impl ClearArgs {
                     .no_update_data
                     .iter()
                     .map(|sp| {
-                        ComponentId::from_sp_type_and_slot(sp.type_, sp.slot)
+                        ComponentId::from_sp_type_and_slot(sp.typ, sp.slot)
                             .map(|id| id.to_string())
                     })
                     .collect::<Result<Vec<_>>>()

--- a/wicket/src/state/inventory.rs
+++ b/wicket/src/state/inventory.rs
@@ -61,7 +61,7 @@ impl Inventory {
 
         for sp in mgs_inventory.sps {
             let i = sp.id.slot;
-            let type_ = sp.id.type_;
+            let type_ = sp.id.typ;
             let sp = Sp {
                 ignition: sp.ignition,
                 state: sp.state,

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -28,13 +28,13 @@ impl From<ComponentId> for SpIdentifier {
     fn from(id: ComponentId) -> Self {
         match id {
             ComponentId::Sled(i) => {
-                SpIdentifier { type_: SpType::Sled, slot: u16::from(i) }
+                SpIdentifier { typ: SpType::Sled, slot: u16::from(i) }
             }
             ComponentId::Psc(i) => {
-                SpIdentifier { type_: SpType::Power, slot: u16::from(i) }
+                SpIdentifier { typ: SpType::Power, slot: u16::from(i) }
             }
             ComponentId::Switch(i) => {
-                SpIdentifier { type_: SpType::Switch, slot: u16::from(i) }
+                SpIdentifier { typ: SpType::Switch, slot: u16::from(i) }
             }
         }
     }
@@ -199,7 +199,7 @@ impl WicketdManager {
                 create_wicketd_client(&log, addr, WICKETD_TIMEOUT);
             let sp: SpIdentifier = component_id.into();
             let response = match update_client
-                .post_abort_update(&sp.type_, sp.slot, &options)
+                .post_abort_update(&sp.typ, sp.slot, &options)
                 .await
             {
                 Ok(_) => Ok(()),
@@ -266,7 +266,7 @@ impl WicketdManager {
             let client = create_wicketd_client(&log, addr, WICKETD_TIMEOUT);
             let sp: SpIdentifier = component_id.into();
             let res =
-                client.post_ignition_command(&sp.type_, sp.slot, command).await;
+                client.post_ignition_command(&sp.typ, sp.slot, command).await;
             // We don't return errors or success values, as there's nobody to
             // return them to. How do we relay this result to the user?
             slog::info!(

--- a/wicketd/src/helpers.rs
+++ b/wicketd/src/helpers.rs
@@ -26,7 +26,7 @@ impl<'a> From<&'a SpIdentifier> for SpIdentifierDisplay {
 
 impl fmt::Display for SpIdentifierDisplay {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0.type_ {
+        match self.0.typ {
             SpType::Sled => write!(f, "sled {}", self.0.slot),
             SpType::Switch => write!(f, "switch {}", self.0.slot),
             SpType::Power => write!(f, "PSC {}", self.0.slot),

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -706,7 +706,7 @@ impl WicketdApi for WicketdApiImpl {
                     // locations where we could be running: scrimlets can only be in
                     // cubbies 14 or 16, so we refuse to update either of those.
                     let target_is_scrimlet = matches!(
-                        (target.type_, target.slot),
+                        (target.typ, target.slot),
                         (SpType::Sled, 14 | 16)
                     );
                     if target_is_scrimlet {
@@ -882,7 +882,7 @@ impl WicketdApi for WicketdApiImpl {
         let options = body.into_inner();
 
         let our_switch_slot = match rqctx.local_switch_id().await {
-            Some(SpIdentifier { slot, type_: SpType::Switch }) => match slot {
+            Some(SpIdentifier { slot, typ: SpType::Switch }) => match slot {
                 0 => SwitchSlot::Switch0,
                 1 => SwitchSlot::Switch1,
                 _ => {

--- a/wicketd/src/mgs/inventory.rs
+++ b/wicketd/src/mgs/inventory.rs
@@ -300,7 +300,7 @@ async fn sp_fetching_task(
             }
         }
 
-        let state = match mgs_client.sp_get(&id.type_, id.slot).await {
+        let state = match mgs_client.sp_get(&id.typ, id.slot).await {
             Ok(response) => response.into_inner(),
             Err(err) => {
                 warn!(
@@ -350,7 +350,7 @@ async fn sp_fetching_task(
 
         if prev_state.as_ref() != Some(&state) || components.is_none() {
             components =
-                match mgs_client.sp_component_list(&id.type_, id.slot).await {
+                match mgs_client.sp_component_list(&id.typ, id.slot).await {
                     Ok(response) => {
                         mgs_received = Instant::now();
                         Some(response.into_inner().components)
@@ -369,7 +369,7 @@ async fn sp_fetching_task(
         if prev_state.as_ref() != Some(&state) || caboose_active.is_none() {
             caboose_active = match mgs_client
                 .sp_component_caboose_get(
-                    &id.type_,
+                    &id.typ,
                     id.slot,
                     SpComponent::SP_ITSELF.const_as_str(),
                     0,
@@ -394,7 +394,7 @@ async fn sp_fetching_task(
         if prev_state.as_ref() != Some(&state) || caboose_inactive.is_none() {
             caboose_inactive = match mgs_client
                 .sp_component_caboose_get(
-                    &id.type_,
+                    &id.typ,
                     id.slot,
                     SpComponent::SP_ITSELF.const_as_str(),
                     1,
@@ -420,7 +420,7 @@ async fn sp_fetching_task(
             if prev_state.as_ref() != Some(&state) || rot.caboose_a.is_none() {
                 rot.caboose_a = match mgs_client
                     .sp_component_caboose_get(
-                        &id.type_,
+                        &id.typ,
                         id.slot,
                         SpComponent::ROT.const_as_str(),
                         0,
@@ -445,7 +445,7 @@ async fn sp_fetching_task(
             if prev_state.as_ref() != Some(&state) || rot.caboose_b.is_none() {
                 rot.caboose_b = match mgs_client
                     .sp_component_caboose_get(
-                        &id.type_,
+                        &id.typ,
                         id.slot,
                         SpComponent::ROT.const_as_str(),
                         1,
@@ -471,7 +471,7 @@ async fn sp_fetching_task(
                 if prev_state.as_ref() != Some(&state) || v.is_none() {
                     rot.caboose_stage0 = match mgs_client
                         .sp_component_caboose_get(
-                            &id.type_,
+                            &id.typ,
                             id.slot,
                             SpComponent::STAGE0.const_as_str(),
                             0,
@@ -498,7 +498,7 @@ async fn sp_fetching_task(
                 if prev_state.as_ref() != Some(&state) || v.is_none() {
                     rot.caboose_stage0next = match mgs_client
                         .sp_component_caboose_get(
-                            &id.type_,
+                            &id.typ,
                             id.slot,
                             SpComponent::STAGE0.const_as_str(),
                             1,

--- a/wicketd/src/transceivers.rs
+++ b/wicketd/src/transceivers.rs
@@ -4,7 +4,7 @@
 
 //! Fetching transceiver state from the SP.
 
-use gateway_client::types::SpIdentifier;
+use gateway_types::component::SpIdentifier;
 use sled_agent_types::early_networking::SwitchSlot;
 use slog::{Logger, debug, error};
 use slog_error_chain::InlineErrorChain;
@@ -68,7 +68,7 @@ impl Handle {
     /// This panics if called with an `SpIdentifier` that doesn't have an
     /// `SpType::Switch`.
     pub(crate) fn set_local_switch_id(&self, switch: SpIdentifier) {
-        let SpIdentifier { slot, type_: SpType::Switch } = switch else {
+        let SpIdentifier { slot, typ: SpType::Switch } = switch else {
             panic!("Should only be called with SpType::Switch");
         };
         let slot = match slot {

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -391,7 +391,7 @@ impl UpdateTracker {
             let event_report =
                 update_data.event_buffer.lock().unwrap().generate_report();
             let inner: &mut BTreeMap<_, _> =
-                event_reports.entry(sp.type_).or_default();
+                event_reports.entry(sp.typ).or_default();
             inner.insert(sp.slot, event_report);
         }
 
@@ -872,7 +872,7 @@ impl UpdateDriver {
         }
 
         let (rot_a, rot_b, sp_artifacts, rot_bootloader) =
-            match update_cx.sp.type_ {
+            match update_cx.sp.typ {
                 SpType::Sled => (
                     &plan.gimlet_rot_a,
                     &plan.gimlet_rot_b,
@@ -937,7 +937,7 @@ impl UpdateDriver {
                     let caboose = update_cx
                         .mgs_client
                         .sp_component_caboose_get(
-                            &update_cx.sp.type_,
+                            &update_cx.sp.typ,
                             update_cx.sp.slot,
                             SpComponent::SP_ITSELF.const_as_str(),
                             sp_firmware_slot,
@@ -1181,7 +1181,7 @@ impl UpdateDriver {
             )
             .register();
 
-        if update_cx.sp.type_ == SpType::Sled {
+        if update_cx.sp.typ == SpType::Sled {
             self.register_sled_steps(
                 update_cx,
                 &mut engine,
@@ -1227,7 +1227,7 @@ impl UpdateDriver {
                 async |_cx| {
                     let state = update_cx
                         .mgs_client
-                        .sp_get(&update_cx.sp.type_, update_cx.sp.slot)
+                        .sp_get(&update_cx.sp.typ, update_cx.sp.slot)
                         .await
                         .map(|response| response.into_inner())
                         .map_err(|error| UpdateTerminalError::SpGetFailed {
@@ -1433,7 +1433,7 @@ impl UpdateDriver {
                     update_cx
                         .mgs_client
                         .sp_installinator_image_id_set(
-                            &update_cx.sp.type_,
+                            &update_cx.sp.typ,
                             update_cx.sp.slot,
                             &installinator_image_id,
                         )
@@ -1471,7 +1471,7 @@ impl UpdateDriver {
                     update_cx
                         .mgs_client
                         .sp_startup_options_set(
-                            &update_cx.sp.type_,
+                            &update_cx.sp.typ,
                             update_cx.sp.slot,
                             &HostStartupOptions {
                                 boot_net: false,
@@ -1545,7 +1545,7 @@ impl UpdateDriver {
                 if let Err(err) = update_cx
                     .mgs_client
                         .sp_installinator_image_id_delete(
-                            &update_cx.sp.type_,
+                            &update_cx.sp.typ,
                             update_cx.sp.slot,
                         )
                         .await
@@ -1595,7 +1595,7 @@ impl UpdateDriver {
                     update_cx
                         .mgs_client
                         .sp_startup_options_set(
-                            &update_cx.sp.type_,
+                            &update_cx.sp.typ,
                             update_cx.sp.slot,
                             &HostStartupOptions {
                                 boot_net: false,
@@ -1764,7 +1764,7 @@ impl RotInterrogation {
     ) -> bool {
         let sp_caboose = client
             .sp_component_caboose_get(
-                &self.sp.type_,
+                &self.sp.typ,
                 self.sp.slot,
                 SpComponent::SP_ITSELF.const_as_str(),
                 0,
@@ -1785,7 +1785,7 @@ impl RotInterrogation {
             // trying an update
             None => false,
             Some(caboose) => match caboose.version.parse::<Version>() {
-                Ok(vers) => match self.sp.type_ {
+                Ok(vers) => match self.sp.typ {
                     SpType::Sled => vers >= MIN_GIMLET_VERSION,
                     SpType::Switch => vers >= MIN_SWITCH_VERSION,
                     SpType::Power => vers >= MIN_PSC_VERSION,
@@ -1922,7 +1922,7 @@ impl UpdateContext {
         let stage0_fwid = match self
             .mgs_client
             .sp_rot_boot_info(
-                &self.sp.type_,
+                &self.sp.typ,
                 self.sp.slot,
                 SpComponent::ROT.const_as_str(),
                 &GetRotBootInfoParams {
@@ -1964,7 +1964,7 @@ impl UpdateContext {
         let caboose = self
             .mgs_client
             .sp_component_caboose_get(
-                &self.sp.type_,
+                &self.sp.typ,
                 self.sp.slot,
                 SpComponent::STAGE0.const_as_str(),
                 0,
@@ -2063,7 +2063,7 @@ impl UpdateContext {
         let caboose = self
             .mgs_client
             .sp_component_caboose_get(
-                &self.sp.type_,
+                &self.sp.typ,
                 self.sp.slot,
                 SpComponent::ROT.const_as_str(),
                 rot_active_slot,
@@ -2121,7 +2121,7 @@ impl UpdateContext {
         let cmpa = match self
             .mgs_client
             .sp_rot_cmpa_get(
-                &self.sp.type_,
+                &self.sp.typ,
                 self.sp.slot,
                 SpComponent::ROT.const_as_str(),
             )
@@ -2174,7 +2174,7 @@ impl UpdateContext {
         let cfpa = self
             .mgs_client
             .sp_rot_cfpa_get(
-                &self.sp.type_,
+                &self.sp.typ,
                 self.sp.slot,
                 SpComponent::ROT.const_as_str(),
                 &gateway_client::types::GetCfpaParams {
@@ -2431,7 +2431,7 @@ impl UpdateContext {
         // installinator tells us it has failed.
         if let Err(err) = self
             .mgs_client
-            .sp_host_phase2_progress_delete(&self.sp.type_, self.sp.slot)
+            .sp_host_phase2_progress_delete(&self.sp.typ, self.sp.slot)
             .await
         {
             warn!(
@@ -2470,7 +2470,7 @@ impl UpdateContext {
     ) {
         match self
             .mgs_client
-            .sp_host_phase2_progress_get(&self.sp.type_, self.sp.slot)
+            .sp_host_phase2_progress_get(&self.sp.typ, self.sp.slot)
             .await
             .map(|response| response.into_inner())
         {
@@ -2513,7 +2513,7 @@ impl UpdateContext {
     ) -> Result<StepResult<()>, UpdateTerminalError> {
         info!(self.log, "moving host to {power_state:?}");
         self.mgs_client
-            .sp_power_state_set(&self.sp.type_, self.sp.slot, power_state)
+            .sp_power_state_set(&self.sp.typ, self.sp.slot, power_state)
             .await
             .map(|response| response.into_inner())
             .map_err(|error| UpdateTerminalError::UpdatePowerStateFailed {
@@ -2525,7 +2525,7 @@ impl UpdateContext {
     async fn get_rot_boot_info(&self) -> anyhow::Result<RotState> {
         self.mgs_client
             .sp_rot_boot_info(
-                &self.sp.type_,
+                &self.sp.typ,
                 self.sp.slot,
                 SpComponent::ROT.const_as_str(),
                 &GetRotBootInfoParams {
@@ -2543,11 +2543,7 @@ impl UpdateContext {
         component: &str,
     ) -> anyhow::Result<u16> {
         self.mgs_client
-            .sp_component_active_slot_get(
-                &self.sp.type_,
-                self.sp.slot,
-                component,
-            )
+            .sp_component_active_slot_get(&self.sp.typ, self.sp.slot, component)
             .await
             .context("failed to get component active slot")
             .map(|res| res.into_inner().slot)
@@ -2561,7 +2557,7 @@ impl UpdateContext {
     ) -> anyhow::Result<()> {
         self.mgs_client
             .sp_component_active_slot_set(
-                &self.sp.type_,
+                &self.sp.typ,
                 self.sp.slot,
                 component,
                 persist,
@@ -2574,7 +2570,7 @@ impl UpdateContext {
 
     async fn reset_sp_component(&self, component: &str) -> anyhow::Result<()> {
         self.mgs_client
-            .sp_component_reset(&self.sp.type_, self.sp.slot, component)
+            .sp_component_reset(&self.sp.typ, self.sp.slot, component)
             .await
             .context("failed to reset SP")
             .map(|res| res.into_inner())
@@ -2597,7 +2593,7 @@ impl UpdateContext {
             let status = self
                 .mgs_client
                 .sp_component_update_status(
-                    &self.sp.type_,
+                    &self.sp.typ,
                     self.sp.slot,
                     component,
                 )
@@ -2814,7 +2810,7 @@ impl<'a> SpComponentUpdateContext<'a> {
                     update_cx
                         .mgs_client
                         .sp_component_update(
-                            &update_cx.sp.type_,
+                            &update_cx.sp.typ,
                             update_cx.sp.slot,
                             component_name,
                             firmware_slot,

--- a/wicketd/tests/integration_tests/inventory.rs
+++ b/wicketd/tests/integration_tests/inventory.rs
@@ -122,7 +122,7 @@ async fn test_inventory() {
             response,
             vec![
                 BootstrapSledDescription {
-                    id: SpIdentifier { type_: SpType::Sled, slot: 0 },
+                    id: SpIdentifier { typ: SpType::Sled, slot: 0 },
                     baseboard: Baseboard::Gimlet {
                         identifier: "SimGimlet00".to_string(),
                         model: "i86pc".to_string(),
@@ -131,7 +131,7 @@ async fn test_inventory() {
                     bootstrap_ip: None
                 },
                 BootstrapSledDescription {
-                    id: SpIdentifier { type_: SpType::Sled, slot: 1 },
+                    id: SpIdentifier { typ: SpType::Sled, slot: 1 },
                     baseboard: Baseboard::Gimlet {
                         identifier: "SimGimlet01".to_string(),
                         model: "i86pc".to_string(),

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -153,7 +153,7 @@ async fn test_updates() {
         "all expected installable kinds present"
     );
 
-    let target_sp = SpIdentifier { type_: SpType::Sled, slot: 0 };
+    let target_sp = SpIdentifier { typ: SpType::Sled, slot: 0 };
 
     // Ensure wicketd knows our target_sp (which is simulated) is online and
     // available to update.
@@ -231,7 +231,7 @@ async fn test_updates() {
 
         let event_report = wicketd_testctx
             .wicketd_client
-            .get_update_sp(&target_sp.type_, target_sp.slot)
+            .get_update_sp(&target_sp.typ, target_sp.slot)
             .await
             .expect("get_update_sp successful")
             .into_inner();
@@ -335,12 +335,9 @@ async fn test_updates() {
         assert_eq!(
             response.expect("expected Ok response"),
             ClearUpdateStateResponse {
-                cleared: btreeset![SpIdentifier {
-                    type_: SpType::Sled,
-                    slot: 0
-                }],
+                cleared: btreeset![SpIdentifier { typ: SpType::Sled, slot: 0 }],
                 no_update_data: btreeset![SpIdentifier {
-                    type_: SpType::Sled,
+                    typ: SpType::Sled,
                     slot: 1
                 }],
             }
@@ -370,7 +367,7 @@ async fn test_updates() {
     // Check to see that the update state for SP 0 was cleared.
     let event_report = wicketd_testctx
         .wicketd_client
-        .get_update_sp(&target_sp.type_, target_sp.slot)
+        .get_update_sp(&target_sp.typ, target_sp.slot)
         .await
         .expect("get_update_sp successful")
         .into_inner();
@@ -785,7 +782,7 @@ async fn test_update_races() {
         .expect("bytes read and archived");
 
     // Now start an update.
-    let sp = SpIdentifier { slot: 0, type_: SpType::Sled };
+    let sp = SpIdentifier { slot: 0, typ: SpType::Sled };
     let sps: BTreeSet<_> = vec![sp].into_iter().collect();
 
     let (sender, receiver) = oneshot::channel();


### PR DESCRIPTION
I remember seeing this at the time I started at Oxide, and feeling like we'd need to address this some way or the other. Turns out exposing this as part of the wicketd commissioning API would mean we'd have to create yet another copy of the type...

This type has never actually changed, and I don't think it's ever going to change, so let's just have one canonical copy of the type that lives in gateway-types-versions.

A couple of notes:

* The generated type had a custom `Ord` impl. The canonical type's `Ord` impl matches it.
* The canonical type now gains a `Hash` impl.
