### PR TITLE
[tools] fix publisher handling in prerequisite and opte install scripts

### DIFF
--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -736,9 +736,11 @@ async fn main() -> Result<()> {
                 download_opte_p5p(&logger, &client, &ov.commit, &p5p_path),
             );
 
-            image_cmd = image_cmd
-                .arg("-p")
-                .arg(format!("helios-dev=file://{p5p_path}"));
+            // The OPTE CI p5p publishes under the "helios" publisher, so
+            // this adds it as an extra origin alongside the incorporation
+            // and the helios pkg repo.
+            image_cmd =
+                image_cmd.arg("-p").arg(format!("helios=file://{p5p_path}"));
         }
 
         let image_job_name = format!("{target}-image");

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -170,7 +170,10 @@ function install_packages {
     for p in system/library/gcc-runtime system/library/g++-runtime; do
         # buildmat runners do not yet have a new enough `pkg` for -o
         #v=$(pkg list -Ho release $p)
-        v=$(pkg list -H -F tsv $p | awk '{split($2, a, "-"); print a[1]}')
+        # Split on tabs. With default whitespace splitting, the
+        # "(publisher)" annotation that pkg appends to the name field for
+        # packages from a non-preferred publisher shifts the version to $3.
+        v=$(pkg list -H -F tsv $p | awk -F'\t' '{split($2, a, "-"); print a[1]}')
         ((v < RTVER)) && packages+=($p@latest)
     done
 

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -168,12 +168,7 @@ function install_packages {
     # latest.
     RTVER=13
     for p in system/library/gcc-runtime system/library/g++-runtime; do
-        # buildmat runners do not yet have a new enough `pkg` for -o
-        #v=$(pkg list -Ho release $p)
-        # Split on tabs. With default whitespace splitting, the
-        # "(publisher)" annotation that pkg appends to the name field for
-        # packages from a non-preferred publisher shifts the version to $3.
-        v=$(pkg list -H -F tsv $p | awk -F'\t' '{split($2, a, "-"); print a[1]}')
+        v=$(pkg list -Ho release "$p")
         ((v < RTVER)) && packages+=($p@latest)
     done
 

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -92,7 +92,8 @@ if [[ "x$OPTE_COMMIT" != "x" ]]; then
     curl -fL -o "$P5P_PATH" "$P5P_URL"
 
     RC=0
-    pfexec pkg install -g "$P5P_PATH" pkg://helios-dev/driver/network/opte || RC=$?
+    # The OPTE CI p5p publishes under the "helios" publisher.
+    pfexec pkg install -g "$P5P_PATH" pkg://helios/driver/network/opte || RC=$?
     if [[ "$RC" -eq 0 ]]; then
         echo "xde driver installed from override p5p"
     elif [[ "$RC" -eq 4 ]]; then


### PR DESCRIPTION
﻿Two helios-publisher bugs in tools scripts, found while running them on my machine locally
with a non-default publisher layout (on-nightly preferred for local illumos builds).

install_builder_prerequisites.sh: `pkg list -F tsv` emits the publisher annotation "(publisher)" inside the tab-separated name field for packages from a non-preferred publisher. Parsing with default whitespace splitting shifted the version from $2 to $3, so the comparison saw "(helios)" and failed with "helios: unbound variable" under set -u. We now query the release field directly with `pkg list -Ho release` (buildomat runners are on helios3 now, so pkg is versioned new enough for -o), removing the annotation entirely.

install_opte.sh: the override p5p install referenced `pkg://helios-dev/driver/network/opte`, but OPTE CI had already switched its p5p publisher from helios-dev to helios (oxidecomputer/opte#945) before the reference landed in #10472, so the pattern never matched any allowable packages. We now point at pkg://helios.

CI and default-publisher setups (including buildomat) are unaffected by the prerequisite change, and the opte override path only runs when OPTE_COMMIT is set, which main never does.