### PR TITLE
[bgp-config] Return 409 on create conflict instead of idempotent 200

### DIFF
--- a/nexus/db-queries/src/db/datastore/bgp.rs
+++ b/nexus/db-queries/src/db/datastore/bgp.rs
@@ -110,67 +110,6 @@ impl DataStore {
                         BgpAnnounceSetUuid::from_untyped_uuid(announce_set_id),
                     );
 
-                    let BgpConfig {
-                        identity,
-                        asn,
-                        bgp_announce_set_id,
-                        vrf,
-                        shaper,
-                        checker,
-                        max_paths,
-                    } = config.clone();
-
-                    // Idempotency:
-                    // Check to see if an exact match for the config already exists
-                    let query = dsl::bgp_config
-                        .filter(dsl::name.eq(identity.name.to_string()))
-                        .filter(dsl::description.eq(identity.description.to_string()))
-                        .filter(dsl::asn.eq(asn))
-                        .filter(dsl::bgp_announce_set_id.eq(bgp_announce_set_id))
-                        .filter(dsl::max_paths.eq(max_paths))
-                        .into_boxed();
-
-                    let query = match vrf {
-                        Some(v) => query.filter(dsl::vrf.eq(v)),
-                        None => query.filter(dsl::vrf.is_null()),
-                    };
-
-                    let query = match shaper {
-                        Some(v) => query.filter(dsl::shaper.eq(v)),
-                        None => query.filter(dsl::shaper.is_null()),
-                    };
-
-                    let query = match checker {
-                        Some(v) => query.filter(dsl::checker.eq(v)),
-                        None => query.filter(dsl::checker.is_null()),
-                    };
-
-                    let matching_config = match query
-                        .filter(dsl::time_deleted.is_null())
-                        .select(BgpConfig::as_select())
-                        .first_async::<BgpConfig>(&conn)
-                        .await {
-                            Ok(v)  => Ok(Some(v)),
-                            Err(e) => {
-                                match e {
-                                    diesel::result::Error::NotFound => {
-                                        info!(opctx.log, "no matching bgp config found");
-                                        Ok(None)
-                                    }
-                                    _ => {
-                                        let msg = "error while checking if bgp config exists";
-                                        error!(opctx.log, "{msg}"; "error" => ?e);
-                                        Err(err.bail(Error::internal_error(msg)))
-                                    }
-                                }
-                            }
-                        }?;
-
-                    // If so, we're done!
-                    if let Some(existing_config) = matching_config {
-                        return Ok(existing_config);
-                    }
-
                     // TODO: remove once per-switch-multi-asn support is added
                     // Bail if a conflicting config for this ASN already exists.
                     // This is a temporary measure until multi-asn-per-switch is supported.
@@ -241,6 +180,33 @@ impl DataStore {
                     public_error_from_diesel(e, ErrorHandler::Server)
                 }
             })
+    }
+
+    /// Creates a BGP config, or returns the active config with the requested
+    /// name. Rack initialization uses deterministic names and may replay this
+    /// step after a previous create committed but before handoff completed.
+    pub async fn bgp_config_ensure(
+        &self,
+        opctx: &OpContext,
+        config: &networking::BgpConfigCreate,
+    ) -> CreateResult<BgpConfig> {
+        let conflict = match self.bgp_config_create(opctx, config).await {
+            Ok(created) => return Ok(created),
+            Err(error @ Error::Conflict { .. }) => error,
+            Err(error) => return Err(error),
+        };
+
+        match self
+            .bgp_config_get(
+                opctx,
+                &NameOrId::Name(config.identity.name.clone()),
+            )
+            .await
+        {
+            Ok(existing) => Ok(existing),
+            Err(Error::ObjectNotFound { .. }) => Err(conflict),
+            Err(error) => Err(error),
+        }
     }
 
     pub async fn bgp_config_update(
@@ -1082,7 +1048,6 @@ mod tests {
     use crate::db::pub_test_utils::TestDatabase;
     use nexus_db_lookup::LookupPath;
     use nexus_db_model::SwitchPortBgpPeerConfig;
-    use nexus_types::external_api::networking::BgpConfigCreate;
     use nexus_types::external_api::networking::BgpConfigSelector;
     use nexus_types::external_api::networking::BgpPeer;
     use omicron_common::api::external::IdentityMetadataCreateParams;
@@ -1095,6 +1060,100 @@ mod tests {
     use sled_agent_types::early_networking::MaxPathConfig;
     use sled_agent_types::early_networking::RouterLifetimeConfig;
     use std::net::IpAddr;
+
+    #[tokio::test]
+    async fn test_bgp_config_create_conflicts() {
+        let logctx = dev::test_setup_log("test_bgp_config_create_conflicts");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let announce_set_id = datastore
+            .bgp_create_announce_set(
+                &opctx,
+                &networking::BgpAnnounceSetCreate {
+                    identity: IdentityMetadataCreateParams {
+                        name: "announce-set".parse().unwrap(),
+                        description: String::from("a test announce set"),
+                    },
+                    announcement: Vec::new(),
+                },
+            )
+            .await
+            .expect("create BGP announce set")
+            .0
+            .identity
+            .id;
+
+        let config = networking::BgpConfigCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "config".parse().unwrap(),
+                description: String::from("a test config"),
+            },
+            asn: 47,
+            bgp_announce_set_id: NameOrId::Id(
+                announce_set_id.into_untyped_uuid(),
+            ),
+            vrf: None,
+            shaper: None,
+            checker: None,
+            max_paths: Default::default(),
+        };
+
+        let created = datastore
+            .bgp_config_create(&opctx, &config)
+            .await
+            .expect("create BGP config");
+
+        let conflicting_configs = [
+            ("identical config", config.clone()),
+            (
+                "duplicate name",
+                networking::BgpConfigCreate { asn: 48, ..config.clone() },
+            ),
+            (
+                "duplicate ASN",
+                networking::BgpConfigCreate {
+                    identity: IdentityMetadataCreateParams {
+                        name: "other-config".parse().unwrap(),
+                        description: String::from("another test config"),
+                    },
+                    ..config.clone()
+                },
+            ),
+        ];
+
+        for (description, conflicting_config) in conflicting_configs {
+            let error = datastore
+                .bgp_config_create(&opctx, &conflicting_config)
+                .await
+                .expect_err(description);
+            assert!(
+                matches!(error, Error::Conflict { .. }),
+                "unexpected error for {description}: {error}",
+            );
+        }
+
+        let ensured = datastore
+            .bgp_config_ensure(&opctx, &config)
+            .await
+            .expect("ensure existing BGP config");
+        assert_eq!(ensured.identity.id, created.identity.id);
+
+        let different_name = networking::BgpConfigCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "ensure-other-config".parse().unwrap(),
+                description: String::from("another test config"),
+            },
+            ..config
+        };
+        assert!(matches!(
+            datastore.bgp_config_ensure(&opctx, &different_name).await,
+            Err(Error::Conflict { .. }),
+        ));
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
 
     #[tokio::test]
     async fn test_update_bgp_config() {
@@ -1808,119 +1867,6 @@ mod tests {
                 .await
                 .is_err()
         );
-
-        db.terminate().await;
-        logctx.cleanup_successful();
-    }
-
-    #[tokio::test]
-    async fn test_bgp_config_create_idempotency() {
-        let logctx = dev::test_setup_log("test_bgp_config_create_idempotency");
-        let db = TestDatabase::new_with_datastore(&logctx.log).await;
-        let (opctx, datastore) = (db.opctx(), db.datastore());
-
-        let bgp_announce_set_id = datastore
-            .bgp_create_announce_set(
-                &opctx,
-                &networking::BgpAnnounceSetCreate {
-                    identity: IdentityMetadataCreateParams {
-                        name: "announce-set".parse().unwrap(),
-                        description: String::from("the first announce set"),
-                    },
-                    announcement: Vec::default(),
-                },
-            )
-            .await
-            .expect("create bgp announce set")
-            .0
-            .identity
-            .id;
-
-        datastore
-            .bgp_create_announce_set(
-                &opctx,
-                &networking::BgpAnnounceSetCreate {
-                    identity: IdentityMetadataCreateParams {
-                        name: "other-announce-set".parse().unwrap(),
-                        description: String::from("another announce set"),
-                    },
-                    announcement: Vec::default(),
-                },
-            )
-            .await
-            .expect("create other bgp announce set");
-
-        let bgp_config = networking::BgpConfigCreate {
-            identity: IdentityMetadataCreateParams {
-                name: "config-name".parse().unwrap(),
-                description: String::from("a test config"),
-            },
-            asn: 47,
-            bgp_announce_set_id: NameOrId::Id(
-                bgp_announce_set_id.into_untyped_uuid(),
-            ),
-            vrf: None,
-            shaper: None,
-            checker: None,
-            max_paths: MaxPathConfig::new(1).unwrap(),
-        };
-
-        let created = datastore
-            .bgp_config_create(&opctx, &bgp_config)
-            .await
-            .expect("create bgp config");
-
-        // Subsequent creates should succeed if all fields match
-        let replayed = datastore
-            .bgp_config_create(&opctx, &bgp_config)
-            .await
-            .expect("replay identical bgp config create");
-        assert_eq!(created.identity.id, replayed.identity.id);
-
-        // Subsequent creates should fail if any field is different
-        type Mutation = (&'static str, fn(&mut BgpConfigCreate));
-        let mutations: &[Mutation] = &[
-            ("identity.name", |config| {
-                config.identity.name = "other-config-name".parse().unwrap();
-            }),
-            ("identity.description", |config| {
-                config.identity.description =
-                    String::from("another description");
-            }),
-            ("asn", |config| {
-                config.asn = 48;
-            }),
-            ("bgp_announce_set_id", |config| {
-                config.bgp_announce_set_id =
-                    NameOrId::Name("other-announce-set".parse().unwrap());
-            }),
-            ("vrf", |config| {
-                config.vrf = Some("other-vrf".parse().unwrap());
-            }),
-            ("shaper", |config| {
-                config.shaper = Some(String::from("other shaper"));
-            }),
-            ("checker", |config| {
-                config.checker = Some(String::from("other checker"));
-            }),
-            ("max_paths", |config| {
-                config.max_paths = MaxPathConfig::new(2).unwrap();
-            }),
-        ];
-
-        for &(field, mutate) in mutations {
-            let mut conflicting_config = bgp_config.clone();
-            mutate(&mut conflicting_config);
-
-            let error = datastore
-                .bgp_config_create(&opctx, &conflicting_config)
-                .await
-                .expect_err(&format!("{field} should affect idempotency"));
-            assert!(
-                matches!(error, Error::Conflict { .. }),
-                "changing {field} returned an unexpected error: {error:?}"
-            );
-        }
 
         db.terminate().await;
         logctx.cleanup_successful();

--- a/nexus/db-queries/src/db/datastore/bgp.rs
+++ b/nexus/db-queries/src/db/datastore/bgp.rs
@@ -143,8 +143,13 @@ impl DataStore {
                             match e {
                                 diesel::result::Error::DatabaseError(kind, _) => {
                                     match kind {
+                                        // The only unique index on active rows is the
+                                        // name index, so this is a name collision.
                                         diesel::result::DatabaseErrorKind::UniqueViolation => {
-                                            err.bail(Error::conflict("a field that must be unique conflicts with an existing record"))
+                                            err.bail(Error::ObjectAlreadyExists {
+                                                type_name: ResourceType::BgpConfig,
+                                                object_name: config.name().to_string(),
+                                            })
                                         },
                                         // technically we don't use Foreign Keys but it doesn't hurt to match on them
                                         // instead of returning a 500 by default in the event that we do switch to Foreign Keys
@@ -192,7 +197,10 @@ impl DataStore {
     ) -> CreateResult<BgpConfig> {
         let conflict = match self.bgp_config_create(opctx, config).await {
             Ok(created) => return Ok(created),
-            Err(error @ Error::Conflict { .. }) => error,
+            Err(
+                error @ (Error::Conflict { .. }
+                | Error::ObjectAlreadyExists { .. }),
+            ) => error,
             Err(error) => return Err(error),
         };
 
@@ -1104,11 +1112,15 @@ mod tests {
             .await
             .expect("create BGP config");
 
+        // The identical and duplicate-ASN cases hit the ASN guard, which runs
+        // before the insert, so only the duplicate-name case reaches the
+        // unique name index.
         let conflicting_configs = [
-            ("identical config", config.clone()),
+            ("identical config", config.clone(), false),
             (
                 "duplicate name",
                 networking::BgpConfigCreate { asn: 48, ..config.clone() },
+                true,
             ),
             (
                 "duplicate ASN",
@@ -1119,18 +1131,23 @@ mod tests {
                     },
                     ..config.clone()
                 },
+                false,
             ),
         ];
 
-        for (description, conflicting_config) in conflicting_configs {
+        for (description, conflicting_config, expect_already_exists) in
+            conflicting_configs
+        {
             let error = datastore
                 .bgp_config_create(&opctx, &conflicting_config)
                 .await
                 .expect_err(description);
-            assert!(
-                matches!(error, Error::Conflict { .. }),
-                "unexpected error for {description}: {error}",
-            );
+            let matched = if expect_already_exists {
+                matches!(error, Error::ObjectAlreadyExists { .. })
+            } else {
+                matches!(error, Error::Conflict { .. })
+            };
+            assert!(matched, "unexpected error for {description}: {error}");
         }
 
         let ensured = datastore

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -423,9 +423,8 @@ impl super::Nexus {
                 },
             }?;
 
-            match self
-                .db_datastore
-                .bgp_config_create(
+            self.db_datastore
+                .bgp_config_ensure(
                     &opctx,
                     &networking::BgpConfigCreate {
                         identity: IdentityMetadataCreateParams {
@@ -444,16 +443,12 @@ impl super::Nexus {
                     },
                 )
                 .await
-            {
-                Ok(_) => Ok(()),
-                Err(e) => match e {
-                    Error::ObjectAlreadyExists { .. } => Ok(()),
-                    _ => Err(Error::internal_error(&format!(
-                        "unable to set bgp config for as {}: {e}",
+                .map_err(|error| {
+                    Error::internal_error(&format!(
+                        "unable to set bgp config for as {}: {error}",
                         bgp_config.asn
-                    ))),
-                },
-            }?;
+                    ))
+                })?;
         }
 
         for (idx, uplink_config) in rack_network_config.ports.iter().enumerate()

--- a/nexus/tests/integration_tests/switch_port.rs
+++ b/nexus/tests/integration_tests/switch_port.rs
@@ -113,6 +113,18 @@ async fn test_port_settings_basic_crud(ctx: &ControlPlaneTestContext) {
     .await
     .unwrap();
 
+    NexusRequest::expect_failure_with_body(
+        client,
+        StatusCode::CONFLICT,
+        Method::POST,
+        "/v1/system/networking/bgp",
+        &bgp_config,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap();
+
     // Create port settings
     let mut settings =
         SwitchPortSettingsCreate::new(IdentityMetadataCreateParams {


### PR DESCRIPTION
Followup to #10781. Not sure we want to do this, but I wanted to see what it looks like. #10781 fixes the field-by-field idempotence comparison. This one tries removing the idempotence behavior entirely, so `POST /v1/system/networking/bgp` works like other create endpoints in the API — 409 on a name or ASN conflict, even when the payload matches the existing config exactly.  A name collision also now returns the standard `already exists: bgp-config "as47”` error like other create endpoints, instead of the generic "a field that must be unique conflicts with an existing record" (the ASN conflict keeps its more specific message).

As far as I can tell, the idempotence behavior is there for rack initialization, which replays BGP config creation if RSS retries the handoff after a partial failure. It was added in #4822 and re-added in #6362 after the ASN guard broke it ("Elsewhere in Nexus our logic relies on this code being idempotent"): https://github.com/oxidecomputer/omicron/pull/6362#discussion_r1725649402

But #10765 shows what happens to that kind of comparison over time: you have to make sure to add new fields to the comparison as they're added to the create body. #10781 fixes the comparison (and the exhaustive destructuring helps avoid issues in the future), but the git history suggests the main thing the unusual semantics are doing is supporting retries in rack initialization.

This PR gives rack init its own special path instead: `bgp_config_ensure` attempts the create and, on conflict, returns the existing config with the requested name. Rack init uses deterministic `as{asn}` names, replays the same persisted RSS request, and completes before the external API server even starts, so name-based replay seems safe there. This matches how the adjacent rack setup steps (address lots, announce sets, port settings) already work: none of them do field-by-field comparison either, they just eat `ObjectAlreadyExists` errors. And it lets us delete the ~50-line exact-match query from the datastore.

The other check in the existing create path is the one blocking a second active config with the same ASN, which is done with a query inside the transaction rather than a unique index (the index on active ASNs is non-unique, unlike the one on active names). Making that index unique would be the more natural way to enforce the rule and could simplify this further, but we can't safely add it: the API permitted duplicate active ASNs between Oct 2023 (#3986) and Aug 2024 (#6362), and we can't really audit deployed racks for leftover duplicates, so the migration could fail the schema upgrade.

The open question for me is whether this change might mess up users’ existing automation. Consumers we control are fine: rack init is handled above, and [`transit`](https://github.com/oxidecomputer/transit) (which calls create unconditionally and relies on the idempotent 200 for no-op applies) would need a small update. But if customer automation assumes a repeated POST succeeds, they will have to update their code. The endpoint has behaved this way since early 2024 and we may have told someone to rely on it.