### PR TITLE
Avoid TOCTTOU issues when allocating IPs from a linked pool

### DIFF
--- a/nexus/db-model/src/external_ip.rs
+++ b/nexus/db-model/src/external_ip.rs
@@ -236,6 +236,18 @@ impl TryFrom<ExternalIp> for SourceNatConfigGeneric {
     }
 }
 
+/// The resource an external IP is being allocated for.
+#[derive(Debug, Clone)]
+pub enum IpAllocationTarget {
+    /// A silo-owned external IP: instance SNAT / ephemeral, probe ephemeral, or
+    /// a floating IP. Allocation verifies the pool is still linked to this silo
+    /// and assigned to silos.
+    Silo { silo_id: Uuid },
+    /// A system-service external IP, i.e., an Omicron zone. Allocation verifies
+    /// the pool is still assigned to system services.
+    SystemService,
+}
+
 /// An incomplete external IP, used to store state required for issuing the
 /// database query that selects an available IP and stores the resulting record.
 #[derive(Debug, Clone)]
@@ -245,7 +257,7 @@ pub struct IncompleteExternalIp {
     description: Option<String>,
     time_created: DateTime<Utc>,
     kind: IpKind,
-    is_service: bool,
+    target: IpAllocationTarget,
     is_probe: bool,
     parent_id: Option<Uuid>,
     pool_id: Uuid,
@@ -262,6 +274,7 @@ impl IncompleteExternalIp {
         id: Uuid,
         instance_id: Uuid,
         pool_id: Uuid,
+        silo_id: Uuid,
     ) -> Self {
         let kind = IpKind::SNat;
         Self {
@@ -270,7 +283,7 @@ impl IncompleteExternalIp {
             description: None,
             time_created: Utc::now(),
             kind,
-            is_service: false,
+            target: IpAllocationTarget::Silo { silo_id },
             is_probe: false,
             parent_id: Some(instance_id),
             pool_id,
@@ -281,7 +294,7 @@ impl IncompleteExternalIp {
         }
     }
 
-    pub fn for_ephemeral(id: Uuid, pool_id: Uuid) -> Self {
+    pub fn for_ephemeral(id: Uuid, pool_id: Uuid, silo_id: Uuid) -> Self {
         let kind = IpKind::Ephemeral;
         Self {
             id,
@@ -289,7 +302,7 @@ impl IncompleteExternalIp {
             description: None,
             time_created: Utc::now(),
             kind,
-            is_service: false,
+            target: IpAllocationTarget::Silo { silo_id },
             parent_id: None,
             is_probe: false,
             pool_id,
@@ -304,6 +317,7 @@ impl IncompleteExternalIp {
         id: Uuid,
         instance_id: Uuid,
         pool_id: Uuid,
+        silo_id: Uuid,
     ) -> Self {
         let kind = IpKind::Ephemeral;
         Self {
@@ -312,7 +326,7 @@ impl IncompleteExternalIp {
             description: None,
             time_created: Utc::now(),
             kind: IpKind::Ephemeral,
-            is_service: false,
+            target: IpAllocationTarget::Silo { silo_id },
             is_probe: true,
             parent_id: Some(instance_id),
             pool_id,
@@ -329,6 +343,7 @@ impl IncompleteExternalIp {
         description: &str,
         project_id: Uuid,
         pool_id: Uuid,
+        silo_id: Uuid,
     ) -> Self {
         let kind = IpKind::Floating;
         Self {
@@ -337,7 +352,7 @@ impl IncompleteExternalIp {
             description: Some(description.to_string()),
             time_created: Utc::now(),
             kind,
-            is_service: false,
+            target: IpAllocationTarget::Silo { silo_id },
             is_probe: false,
             parent_id: None,
             pool_id,
@@ -355,6 +370,7 @@ impl IncompleteExternalIp {
         project_id: Uuid,
         explicit_ip: IpAddr,
         pool_id: Uuid,
+        silo_id: Uuid,
     ) -> Self {
         let kind = IpKind::Floating;
         Self {
@@ -363,7 +379,7 @@ impl IncompleteExternalIp {
             description: Some(description.to_string()),
             time_created: Utc::now(),
             kind,
-            is_service: false,
+            target: IpAllocationTarget::Silo { silo_id },
             is_probe: false,
             parent_id: None,
             pool_id,
@@ -424,7 +440,7 @@ impl IncompleteExternalIp {
             description,
             time_created: Utc::now(),
             kind,
-            is_service: true,
+            target: IpAllocationTarget::SystemService,
             is_probe: false,
             parent_id: Some(zone_id.into_untyped_uuid()),
             pool_id,
@@ -455,8 +471,21 @@ impl IncompleteExternalIp {
         &self.kind
     }
 
-    pub fn is_service(&self) -> &bool {
-        &self.is_service
+    pub fn is_service(&self) -> bool {
+        match self.target {
+            IpAllocationTarget::Silo { .. } => false,
+            IpAllocationTarget::SystemService => true,
+        }
+    }
+
+    /// The silo that owns this external IP, if it is a silo-owned IP.
+    ///
+    /// Returns `None` for system-service IPs.
+    pub fn silo_id(&self) -> Option<&Uuid> {
+        match &self.target {
+            IpAllocationTarget::Silo { silo_id } => Some(silo_id),
+            IpAllocationTarget::SystemService => None,
+        }
     }
 
     pub fn is_probe(&self) -> &bool {

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -7,6 +7,7 @@
 use super::DataStore;
 use super::SQL_BATCH_SIZE;
 use crate::authz;
+use crate::authz::ApiResource;
 use crate::context::OpContext;
 use crate::db::collection_attach::AttachError;
 use crate::db::collection_attach::DatastoreAttachTarget;
@@ -52,6 +53,7 @@ use omicron_common::api::external::Error;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
+use omicron_common::api::external::LookupType;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::UpdateResult;
 use omicron_common::api::external::http_pagination::PaginatedBy;
@@ -136,12 +138,14 @@ impl DataStore {
         instance_id: InstanceUuid,
         pool_id: Uuid,
     ) -> CreateResult<ExternalIp> {
+        let silo_id = opctx.authn.silo_required()?.id();
         let data = IncompleteExternalIp::for_instance_source_nat(
             ip_id,
             instance_id.into_untyped_uuid(),
             pool_id,
+            silo_id,
         );
-        self.allocate_external_ip(opctx, data).await
+        self.allocate_external_ip(opctx, data, LookupType::ById(pool_id)).await
     }
 
     /// Create an Ephemeral IP address for a probe.
@@ -161,12 +165,15 @@ impl DataStore {
                 ip_version,
             )
             .await?;
+        let silo_id = opctx.authn.silo_required()?.id();
+        let pool_lookup = authz_pool.lookup_type().clone();
         let data = IncompleteExternalIp::for_ephemeral_probe(
             ip_id,
             probe_id,
             authz_pool.id(),
+            silo_id,
         );
-        self.allocate_external_ip(opctx, data).await
+        self.allocate_external_ip(opctx, data, pool_lookup).await
     }
 
     /// Create an Ephemeral IP address for an instance.
@@ -206,11 +213,17 @@ impl DataStore {
             )
             .await?;
 
-        let data = IncompleteExternalIp::for_ephemeral(ip_id, authz_pool.id());
+        let silo_id = opctx.authn.silo_required()?.id();
+        let pool_lookup = authz_pool.lookup_type().clone();
+        let data = IncompleteExternalIp::for_ephemeral(
+            ip_id,
+            authz_pool.id(),
+            silo_id,
+        );
 
         // We might not be able to acquire a new IP, but in the event of an
         // idempotent or double attach this failure is allowed.
-        let temp_ip = self.allocate_external_ip(opctx, data).await;
+        let temp_ip = self.allocate_external_ip(opctx, data, pool_lookup).await;
         if let Err(e) = temp_ip {
             // Use the pool's version for lookup when the request didn't
             // specify one. This handles the case where an explicit pool was
@@ -327,6 +340,7 @@ impl DataStore {
             "project_id" => %project_id,
         );
 
+        let silo_id = opctx.authn.silo_required()?.id();
         let data = if let Some(ip) = explicit_ip {
             IncompleteExternalIp::for_floating_explicit(
                 ip_id,
@@ -335,6 +349,7 @@ impl DataStore {
                 project_id,
                 ip,
                 authz_pool.id(),
+                silo_id,
             )
         } else {
             IncompleteExternalIp::for_floating(
@@ -343,29 +358,39 @@ impl DataStore {
                 &identity.description,
                 project_id,
                 authz_pool.id(),
+                silo_id,
             )
         };
 
-        self.allocate_external_ip(opctx, data).await
+        let pool_lookup = authz_pool.lookup_type().clone();
+        self.allocate_external_ip(opctx, data, pool_lookup).await
     }
 
     async fn allocate_external_ip(
         &self,
         opctx: &OpContext,
         data: IncompleteExternalIp,
+        pool_lookup: LookupType,
     ) -> CreateResult<ExternalIp> {
         let conn = self.pool_connection_authorized(opctx).await?;
-        let ip = Self::allocate_external_ip_on_connection(&conn, data)
-            .await
-            .map_err(|err| err.into_public_ignore_retries())?;
+        let ip =
+            Self::allocate_external_ip_on_connection(&conn, data, pool_lookup)
+                .await
+                .map_err(|err| err.into_public_ignore_retries())?;
         Ok(ip)
     }
 
     /// Variant of [Self::allocate_external_ip] which may be called from a
     /// transaction context.
+    ///
+    /// `pool_lookup` describes how the pool being allocated from was looked up
+    /// originally. This is used to generate a correct error message when the
+    /// pool isn't found or is no longer linked, which depends on how the API
+    /// request specifed the pool in the first place.
     pub(crate) async fn allocate_external_ip_on_connection(
         conn: &async_bb8_diesel::Connection<DbConnection>,
         data: IncompleteExternalIp,
+        pool_lookup: LookupType,
     ) -> Result<ExternalIp, TransactionError<Error>> {
         // Name needs to be cloned out here (if present) to give users a
         // sensible error message on name collision.
@@ -426,7 +451,10 @@ impl DataStore {
                         ))
                     } else {
                         TransactionError::CustomError(
-                            crate::db::queries::external_ip::from_diesel(e),
+                            crate::db::queries::external_ip::from_diesel(
+                                e,
+                                pool_lookup.clone(),
+                            ),
                         )
                     }
                 }
@@ -435,7 +463,10 @@ impl DataStore {
                         return TransactionError::Database(e);
                     }
                     TransactionError::CustomError(
-                        crate::db::queries::external_ip::from_diesel(e),
+                        crate::db::queries::external_ip::from_diesel(
+                            e,
+                            pool_lookup.clone(),
+                        ),
                     )
                 }
             }
@@ -460,7 +491,8 @@ impl DataStore {
             zone_id,
             zone_kind,
         );
-        self.allocate_external_ip(opctx, data).await
+        self.allocate_external_ip(opctx, data, LookupType::ById(pool.id()))
+            .await
     }
 
     /// Variant of [Self::external_ip_allocate_omicron_zone] which may be called
@@ -479,7 +511,12 @@ impl DataStore {
             zone_id,
             zone_kind,
         );
-        Self::allocate_external_ip_on_connection(conn, data).await
+        Self::allocate_external_ip_on_connection(
+            conn,
+            data,
+            LookupType::ById(service_pool.id()),
+        )
+        .await
     }
 
     /// List one page of all external IPs allocated to internal services

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -582,10 +582,10 @@ impl DataStore {
 
         let (authz_pool, pool_version) = match pool {
             Some(authz_pool) => {
-                self.ip_pool_fetch_link(opctx, authz_pool.id())
-                    .await
-                    .map_err(|_| authz_pool.not_found())?;
-
+                // We intentionally skip checking the silo / pool link here.
+                // That's now done in the `NextExternalIp` allocation query
+                // itself, which has a CTE arm that ensures the link exists. We
+                // do still fetch the pool to validate its type and IP version.
                 let pool_record = {
                     ip_pool::table
                         .filter(ip_pool::id.eq(authz_pool.id()))

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -667,18 +667,22 @@ impl DataStore {
             zone_config.id,
             zone_config.zone_type.kind(),
         );
-        Self::allocate_external_ip_on_connection(conn, db_ip).await.map_err(
-            |err| {
-                error!(
-                    log,
-                    "Initializing Rack: Failed to allocate \
-                     IP address for {}",
-                     zone_report_str;
-                    "err" => %err,
-                );
-                RackInitError::AddingIp(err.into_public_ignore_retries())
-            },
-        )?;
+        Self::allocate_external_ip_on_connection(
+            conn,
+            db_ip,
+            LookupType::ById(service_pool.db_pool.id()),
+        )
+        .await
+        .map_err(|err| {
+            error!(
+                log,
+                "Initializing Rack: Failed to allocate \
+                 IP address for {}",
+                 zone_report_str;
+                "err" => %err,
+            );
+            RackInitError::AddingIp(err.into_public_ignore_retries())
+        })?;
 
         self.create_network_interface_raw_conn(conn, db_nic)
             .await

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -71,12 +71,22 @@ const NIC_IS_MISSING_IP_STACK_SENTINEL: &'static str = "nic-missing-ip-stack";
 const NIC_IS_MISSING_IP_STACK_ERROR_MESSAGE: &'static str = "Cannot assign an external IP address from this IP \
     Pool because the network interface does not have an \
     IP stack of the same IP version as the pool.";
+// Emitted by the allocation query's check that the pool is still linked to the
+// silo, since we resolve the pool in an earlier query.
+const POOL_NOT_ASSIGNABLE_SENTINEL: &'static str = "pool-not-assignable";
 
 /// Translates a generic pool error to an external error.
-pub fn from_diesel(e: DieselError) -> external::Error {
+///
+/// `pool_lookup` describes how the IP pool we're allocating from was looked up
+/// originally, so we can produce the right error message when it's not linked.
+pub fn from_diesel(
+    e: DieselError,
+    pool_lookup: external::LookupType,
+) -> external::Error {
     let sentinels = [
         REALLOCATION_WITH_DIFFERENT_IP_SENTINEL,
         NIC_IS_MISSING_IP_STACK_SENTINEL,
+        POOL_NOT_ASSIGNABLE_SENTINEL,
     ];
     if let Some(sentinel) = matches_sentinel(&e, &sentinels) {
         match sentinel {
@@ -89,6 +99,10 @@ pub fn from_diesel(e: DieselError) -> external::Error {
                 return external::Error::invalid_request(
                     NIC_IS_MISSING_IP_STACK_ERROR_MESSAGE,
                 );
+            }
+            POOL_NOT_ASSIGNABLE_SENTINEL => {
+                return pool_lookup
+                    .into_not_found(external::ResourceType::IpPool);
             }
             // Fall-through to the generic error conversion.
             _ => {}
@@ -210,13 +224,17 @@ pub struct NextExternalIp {
     // is snat.
     n_ports_per_chunk: i32,
     now: DateTime<Utc>,
+    // Cached projection of `ip`'s allocation target, stored here so that we can
+    // bind it as a query parameter with a lifetime tied to the query fragment.
+    is_service: bool,
 }
 
 impl NextExternalIp {
     pub fn new(ip: IncompleteExternalIp) -> Self {
         let now = Utc::now();
         let n_ports_per_chunk = i32::from(NUM_SOURCE_NAT_PORTS);
-        Self { ip, n_ports_per_chunk, now }
+        let is_service = ip.is_service();
+        Self { ip, n_ports_per_chunk, now, is_service }
     }
 
     // Push the top-level SELECT clauses used in the `next_external_ip` CTE.
@@ -281,7 +299,7 @@ impl NextExternalIp {
         out.push_sql(", ");
 
         // is_service flag
-        out.push_bind_param::<sql_types::Bool, bool>(self.ip.is_service())?;
+        out.push_bind_param::<sql_types::Bool, bool>(&self.is_service)?;
         out.push_sql(" AS ");
         out.push_identifier(dsl::is_service::NAME)?;
         out.push_sql(", ");
@@ -749,6 +767,74 @@ impl NextExternalIp {
         );
         Ok(())
     }
+
+    // Push a subquery that verifies the IP Pool we're allocating from is still
+    // available for this allocation, failing with a bool-cast error if not.
+    //
+    // The caller resolves the pool in a separate query before we run this one,
+    // so without this check, it's possible for the silo and pool to be unlinked
+    // before we actually insert the record with this query.
+    //
+    // For a silo-owned IP, the pool must still be linked to the owning silo and
+    // assigned to silos. For a system-service IP, it must still be assigned for
+    // system services.
+    fn push_verify_pool_still_assignable<'a>(
+        &'a self,
+        mut out: AstPass<'_, 'a, Pg>,
+    ) -> QueryResult<()> {
+        match self.ip.silo_id() {
+            Some(silo_id) => {
+                out.push_sql(
+                    "SELECT CAST(\
+                        CASE WHEN \
+                            EXISTS(\
+                                SELECT 1 FROM ip_pool_resource \
+                                WHERE ip_pool_id = ",
+                );
+                out.push_bind_param::<sql_types::Uuid, _>(self.ip.pool_id())?;
+                out.push_sql(" AND resource_type = 'silo' AND resource_id = ");
+                out.push_bind_param::<sql_types::Uuid, _>(silo_id)?;
+                out.push_sql(
+                    ") \
+                            AND (\
+                                SELECT assignment FROM ip_pool \
+                                WHERE id = ",
+                );
+                out.push_bind_param::<sql_types::Uuid, _>(self.ip.pool_id())?;
+                out.push_sql(
+                    " AND time_deleted IS NULL\
+                            ) = 'silos' \
+                        THEN 'TRUE' \
+                        ELSE ",
+                );
+                out.push_bind_param::<sql_types::Text, _>(
+                    POOL_NOT_ASSIGNABLE_SENTINEL,
+                )?;
+                out.push_sql(" END AS BOOL)");
+            }
+            None => {
+                out.push_sql(
+                    "SELECT CAST(\
+                        CASE WHEN \
+                            (\
+                                SELECT assignment FROM ip_pool \
+                                WHERE id = ",
+                );
+                out.push_bind_param::<sql_types::Uuid, _>(self.ip.pool_id())?;
+                out.push_sql(
+                    " AND time_deleted IS NULL\
+                            ) = 'system_services' \
+                        THEN 'TRUE' \
+                        ELSE ",
+                );
+                out.push_bind_param::<sql_types::Text, _>(
+                    POOL_NOT_ASSIGNABLE_SENTINEL,
+                )?;
+                out.push_sql(" END AS BOOL)");
+            }
+        }
+        Ok(())
+    }
 }
 
 impl QueryId for NextExternalIp {
@@ -862,6 +948,12 @@ impl QueryFragment<Pg> for NextExternalIp {
             out.push_sql(") ");
         }
 
+        // Push the subquery that verifies the IP Pool is still assignable to the
+        // resource we're allocating for.
+        out.push_sql(", pool_still_assignable AS MATERIALIZED(");
+        self.push_verify_pool_still_assignable(out.reborrow())?;
+        out.push_sql(") ");
+
         // Select the contents of the actual record that was created or updated.
         out.push_sql("SELECT * FROM external_ip");
 
@@ -879,6 +971,7 @@ impl RunQueryDsl<DbConnection> for NextExternalIp {}
 #[cfg(test)]
 mod tests {
     use crate::authz;
+    use crate::db::datastore::DataStore;
     use crate::db::datastore::SERVICE_IPV4_POOL_NAME;
     use crate::db::explain::ExplainableAsync as _;
     use crate::db::identity::Resource;
@@ -892,6 +985,7 @@ mod tests {
     use diesel::sql_types;
     use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
     use dropshot::test_util::LogContext;
+    use nexus_db_errors::TransactionError;
     use nexus_db_lookup::LookupPath;
     use nexus_db_model::ByteCount;
     use nexus_db_model::ExternalIp;
@@ -914,6 +1008,8 @@ mod tests {
     use omicron_common::address::NUM_SOURCE_NAT_PORTS;
     use omicron_common::api::external::Error;
     use omicron_common::api::external::IdentityMetadataCreateParams;
+    use omicron_common::api::external::LookupType;
+    use omicron_common::api::external::ResourceType;
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::ExternalIpUuid;
     use omicron_uuid_kinds::GenericUuid;
@@ -1779,6 +1875,152 @@ mod tests {
         context.success().await;
     }
 
+    // The allocation query guards against a pool being unlinked from the silo
+    // between the caller's pool resolution and the allocation itself. This test
+    // simulates concurrently unlinking the pool between those two, to check
+    // that we fail to create the external IP correctly in that case.
+    #[tokio::test]
+    async fn next_external_ip_guard_rejects_unlinked_silo_pool() {
+        let context = TestContext::new(
+            "next_external_ip_guard_rejects_unlinked_silo_pool",
+        )
+        .await;
+
+        let range = IpRange::try_from((
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 0, 0, 3),
+        ))
+        .unwrap();
+        let (_authz_pool, pool) =
+            context.create_ip_pool("default", range, true).await;
+        let silo_id = context.db.opctx().authn.silo_required().unwrap().id();
+        let conn = context
+            .db
+            .datastore()
+            .pool_connection_authorized(context.db.opctx())
+            .await
+            .unwrap();
+
+        // Query should succeed while the pool / silo are still linked.
+        let data = IncompleteExternalIp::for_ephemeral(
+            Uuid::new_v4(),
+            pool.id(),
+            silo_id,
+        );
+        DataStore::allocate_external_ip_on_connection(
+            &conn,
+            data,
+            LookupType::ById(pool.id()),
+        )
+        .await
+        .expect("should allocate while the pool is linked to the silo");
+
+        // Simulate concurrent unlink of the pool and silo.
+        {
+            use nexus_db_schema::schema::ip_pool_resource::dsl;
+            diesel::delete(dsl::ip_pool_resource)
+                .filter(dsl::ip_pool_id.eq(pool.id()))
+                .filter(dsl::resource_id.eq(silo_id))
+                .execute_async(&*conn)
+                .await
+                .expect("failed to unlink pool and silo");
+        }
+
+        // Now this should fail, since we've hit the TOCTTOU we're protecting
+        // against.
+        let data = IncompleteExternalIp::for_ephemeral(
+            Uuid::new_v4(),
+            pool.id(),
+            silo_id,
+        );
+        let result = DataStore::allocate_external_ip_on_connection(
+            &conn,
+            data,
+            LookupType::ById(pool.id()),
+        )
+        .await;
+        match result {
+            Err(TransactionError::CustomError(Error::ObjectNotFound {
+                type_name,
+                ..
+            })) => assert_eq!(type_name, ResourceType::IpPool),
+            other => panic!(
+                "expected ObjectNotFound for IpPool once unlinked, got {other:?}"
+            ),
+        }
+
+        context.success().await;
+    }
+
+    // Tests that we fail if the pool has been reassigned to system services
+    // between resolution and allocation.
+    #[tokio::test]
+    async fn next_external_ip_guard_rejects_reassigned_silo_pool() {
+        let context = TestContext::new(
+            "next_external_ip_guard_rejects_reassigned_silo_pool",
+        )
+        .await;
+
+        let range = IpRange::try_from((
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 0, 0, 3),
+        ))
+        .unwrap();
+        let (authz_pool, pool) =
+            context.create_ip_pool("default", range, true).await;
+        let authz_silo = context.db.opctx().authn.silo_required().unwrap();
+        let silo_id = authz_silo.id();
+        let conn = context
+            .db
+            .datastore()
+            .pool_connection_authorized(context.db.opctx())
+            .await
+            .unwrap();
+
+        // Concurrently reassign to system services.
+        context
+            .db
+            .datastore()
+            .ip_pool_unlink_silo(context.db.opctx(), &authz_pool, &authz_silo)
+            .await
+            .unwrap();
+        context
+            .db
+            .datastore()
+            .ip_pool_assign(
+                context.db.opctx(),
+                &authz_pool,
+                &pool,
+                IpPoolAssignment::SystemServices,
+            )
+            .await
+            .expect("Should reassign to system services");
+
+        let data = IncompleteExternalIp::for_ephemeral(
+            Uuid::new_v4(),
+            pool.id(),
+            silo_id,
+        );
+        let result = DataStore::allocate_external_ip_on_connection(
+            &conn,
+            data,
+            LookupType::ById(pool.id()),
+        )
+        .await;
+        match result {
+            Err(TransactionError::CustomError(Error::ObjectNotFound {
+                type_name,
+                ..
+            })) => assert_eq!(type_name, ResourceType::IpPool),
+            other => panic!(
+                "expected ObjectNotFound for IpPool once reassigned, got \
+                 {other:?}"
+            ),
+        }
+
+        context.success().await;
+    }
+
     #[tokio::test]
     async fn test_ensure_pool_exhaustion_does_not_use_other_pool() {
         let context = TestContext::new(
@@ -1851,8 +2093,13 @@ mod tests {
         let db = TestDatabase::new_with_pool(&logctx.log).await;
         let conn = db.pool().claim().await.unwrap();
         let params = [
-            IncompleteExternalIp::for_ephemeral(Uuid::new_v4(), Uuid::new_v4()),
+            IncompleteExternalIp::for_ephemeral(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+            ),
             IncompleteExternalIp::for_instance_source_nat(
+                Uuid::new_v4(),
                 Uuid::new_v4(),
                 Uuid::new_v4(),
                 Uuid::new_v4(),
@@ -1879,6 +2126,7 @@ mod tests {
             "",
             uuid::uuid!("789fdb15-9790-4df1-9d06-c1ecd72c94ae"),
             uuid::uuid!("37bdd6f6-0adb-46ad-8e5b-083b928ace56"),
+            uuid::uuid!("6d97b968-93bd-42d4-84b3-2c8fbc47e2f8"),
         );
         let query = NextExternalIp::new(params);
         expectorate_query_contents(
@@ -1897,6 +2145,7 @@ mod tests {
             uuid::uuid!("789fdb15-9790-4df1-9d06-c1ecd72c94ae"),
             "10.0.0.1".parse().unwrap(),
             uuid::uuid!("37bdd6f6-0adb-46ad-8e5b-083b928ace56"),
+            uuid::uuid!("6d97b968-93bd-42d4-84b3-2c8fbc47e2f8"),
         );
         let query = NextExternalIp::new(params);
         expectorate_query_contents(
@@ -1912,6 +2161,7 @@ mod tests {
             uuid::uuid!("45633e04-3087-47eb-9d1e-8436fb090108"),
             uuid::uuid!("789fdb15-9790-4df1-9d06-c1ecd72c94ae"),
             uuid::uuid!("9fcfee03-173e-4aff-92a3-2fc9da49c008"),
+            uuid::uuid!("6d97b968-93bd-42d4-84b3-2c8fbc47e2f8"),
         );
         let query = NextExternalIp::new(params);
         expectorate_query_contents(

--- a/nexus/db-queries/tests/output/next_automatic_floating_ip.sql
+++ b/nexus/db-queries/tests/output/next_automatic_floating_ip.sql
@@ -132,6 +132,26 @@ WITH
         id = (SELECT ip_pool_range_id FROM next_external_ip) AND time_deleted IS NULL
       RETURNING
         id
+    ),
+  pool_still_assignable
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          CASE
+          WHEN EXISTS(
+            SELECT
+              1
+            FROM
+              ip_pool_resource
+            WHERE
+              ip_pool_id = $21 AND resource_type = 'silo' AND resource_id = $22
+          )
+          AND (SELECT assignment FROM ip_pool WHERE id = $23 AND time_deleted IS NULL) = 'silos'
+          THEN 'TRUE'
+          ELSE $24
+          END
+            AS BOOL
+        )
     )
 SELECT
   *

--- a/nexus/db-queries/tests/output/next_explicit_floating_ip.sql
+++ b/nexus/db-queries/tests/output/next_explicit_floating_ip.sql
@@ -97,6 +97,26 @@ WITH
         id = (SELECT ip_pool_range_id FROM next_external_ip) AND time_deleted IS NULL
       RETURNING
         id
+    ),
+  pool_still_assignable
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          CASE
+          WHEN EXISTS(
+            SELECT
+              1
+            FROM
+              ip_pool_resource
+            WHERE
+              ip_pool_id = $21 AND resource_type = 'silo' AND resource_id = $22
+          )
+          AND (SELECT assignment FROM ip_pool WHERE id = $23 AND time_deleted IS NULL) = 'silos'
+          THEN 'TRUE'
+          ELSE $24
+          END
+            AS BOOL
+        )
     )
 SELECT
   *

--- a/nexus/db-queries/tests/output/next_instance_snat_ip.sql
+++ b/nexus/db-queries/tests/output/next_instance_snat_ip.sql
@@ -211,6 +211,26 @@ WITH
               parent_id = $29 AND time_deleted IS NULL AND is_primary
           )
             AS nic
+    ),
+  pool_still_assignable
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          CASE
+          WHEN EXISTS(
+            SELECT
+              1
+            FROM
+              ip_pool_resource
+            WHERE
+              ip_pool_id = $30 AND resource_type = 'silo' AND resource_id = $31
+          )
+          AND (SELECT assignment FROM ip_pool WHERE id = $32 AND time_deleted IS NULL) = 'silos'
+          THEN 'TRUE'
+          ELSE $33
+          END
+            AS BOOL
+        )
     )
 SELECT
   *

--- a/nexus/db-queries/tests/output/next_omicron_zone_snat_ip.sql
+++ b/nexus/db-queries/tests/output/next_omicron_zone_snat_ip.sql
@@ -120,6 +120,19 @@ WITH
               parent_id = $23 AND time_deleted IS NULL AND is_primary
           )
             AS nic
+    ),
+  pool_still_assignable
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          CASE
+          WHEN (SELECT assignment FROM ip_pool WHERE id = $24 AND time_deleted IS NULL)
+          = 'system_services'
+          THEN 'TRUE'
+          ELSE $25
+          END
+            AS BOOL
+        )
     )
 SELECT
   *


### PR DESCRIPTION
- Add a check in the external IP allocation query that checks the pool is linked correctly, e.g., to the silo of the current request or for system services.
- Fixes a part of #8992, but not all of it. There are still races with the internet gateway stuff still has problems.