### PR TITLE
update rust toolchain to 1.97.1

### DIFF
--- a/dev-tools/ls-apis/src/cargo.rs
+++ b/dev-tools/ls-apis/src/cargo.rs
@@ -232,7 +232,7 @@ impl Workspace {
                      the workspace root ({:?})",
                     self.name,
                     pkgname,
-                    &self.workspace_root,
+                    self.workspace_root,
                 )
             })?;
         let path = cargo_toml_parent(&relative_path, &manifest_path)?;

--- a/dev-tools/ls-apis/src/workspaces.rs
+++ b/dev-tools/ls-apis/src/workspaces.rs
@@ -542,7 +542,7 @@ fn load_dependent_repo(
             format!(
                 "locating workspace for {:?} (from {:?}) with \
                  `cargo locate-project`",
-                pkgname, &pkg.manifest_path
+                pkgname, pkg.manifest_path
             )
         })?;
     let workspace_manifest = Utf8Path::new(output.trim_end());

--- a/dev-tools/omdb/src/bin/omdb/clickhouse_admin.rs
+++ b/dev-tools/omdb/src/bin/omdb/clickhouse_admin.rs
@@ -83,7 +83,7 @@ impl ClickHouseAdminArgs {
         };
         eprintln!(
             "note: using {}clickhouse-admin URL {}",
-            maybe_replicated, &server_url
+            maybe_replicated, server_url
         );
 
         let client = Client::new(

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -301,7 +301,7 @@ impl DbUrlOptions {
         log: &slog::Logger,
     ) -> anyhow::Result<Arc<DataStore>> {
         let db_url = self.resolve_pg_url(omdb, log).await?;
-        eprintln!("note: using database URL {}", &db_url);
+        eprintln!("note: using database URL {}", db_url);
 
         let addrs = db_url.all_addresses()?;
         let pool = Arc::new(db::Pool::new_fixed_hosts(log, addrs));
@@ -6580,7 +6580,7 @@ async fn cmd_db_validate_volume_references(
                     // full table scan
                     conn.batch_execute_async(ALLOW_FULL_TABLE_SCAN_SQL).await?;
 
-                    let pattern = format!("%{}%", &snapshot_addr);
+                    let pattern = format!("%{}%", snapshot_addr);
 
                     use nexus_db_schema::schema::volume::dsl;
 

--- a/dev-tools/omdb/src/bin/omdb/mgs.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs.rs
@@ -83,7 +83,7 @@ impl MgsArgs {
                 format!("http://{}", addr)
             }
         };
-        eprintln!("note: using MGS URL {}", &mgs_url);
+        eprintln!("note: using MGS URL {}", mgs_url);
         Ok(gateway_client::Client::new(&mgs_url, log.clone()))
     }
 
@@ -584,7 +584,7 @@ async fn show_sp_details(
                     format!(
                         "get caboose for sp type {:?} sp slot {} \
                         component {:?} slot {}",
-                        sp_id.typ, sp_id.slot, &c.component, i
+                        sp_id.typ, sp_id.slot, c.component, i
                     )
                 });
             match r {

--- a/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
@@ -412,7 +412,7 @@ fn sp_info_csv<R: std::io::Read>(
         if &headers[ndx] != expected[ndx] {
             bail!(
                 "malformed headers: expected {}, found {} ({headers:?})",
-                &expected[ndx],
+                expected[ndx],
                 &headers[ndx]
             );
         }

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -709,7 +709,7 @@ impl NexusArgs {
                 format!("http://{}", addr)
             }
         };
-        eprintln!("note: using Nexus URL {}", &nexus_url);
+        eprintln!("note: using Nexus URL {}", nexus_url);
         let client =
             nexus_lockstep_client::Client::new(&nexus_url, log.clone());
 

--- a/dev-tools/omdb/src/bin/omdb/oximeter.rs
+++ b/dev-tools/omdb/src/bin/omdb/oximeter.rs
@@ -70,7 +70,7 @@ impl OximeterArgs {
                 format!("http://{}", addr)
             }
         };
-        eprintln!("note: using Oximeter URL {}", &oximeter_url);
+        eprintln!("note: using Oximeter URL {}", oximeter_url);
 
         let client = Client::new(
             &oximeter_url,

--- a/dev-tools/omicron-dev-lib/src/test_utils.rs
+++ b/dev-tools/omicron-dev-lib/src/test_utils.rs
@@ -26,7 +26,7 @@ pub fn verify_graceful_exit(
         .wait_timeout(TIMEOUT)
         .expect("failed to wait for process to exit")
         .unwrap_or_else(|| {
-            panic!("timed out waiting {:?} for process to exit", &TIMEOUT)
+            panic!("timed out waiting {:?} for process to exit", TIMEOUT)
         });
 
     assert!(!process_running(cmd_pid));

--- a/dev-tools/reconfigurator-exec-unsafe/src/main.rs
+++ b/dev-tools/reconfigurator-exec-unsafe/src/main.rs
@@ -149,7 +149,7 @@ impl ReconfiguratorExec {
             .with_context(|| format!("open {:?}", input_path))?;
         let bufread = std::io::BufReader::new(file);
         let blueprint: Blueprint = serde_json::from_reader(bufread)
-            .with_context(|| format!("read and parse {:?}", &input_path))?;
+            .with_context(|| format!("read and parse {:?}", input_path))?;
 
         // Check that the blueprint is the current system target.
         // (This is currently redundant with a check done early during blueprint

--- a/dev-tools/repl-utils/src/lib.rs
+++ b/dev-tools/repl-utils/src/lib.rs
@@ -30,12 +30,12 @@ pub fn run_repl_from_file<C: Parser>(
     run_one: &mut dyn FnMut(C) -> anyhow::Result<Option<String>>,
 ) -> anyhow::Result<()> {
     let file = File::open(&input_file)
-        .with_context(|| format!("open {:?}", &input_file))?;
+        .with_context(|| format!("open {:?}", input_file))?;
     let bufread = BufReader::new(file);
     let mut lines = bufread.lines().peekable();
     while let Some(line_res) = lines.next() {
         let line =
-            line_res.with_context(|| format!("read {:?}", &input_file))?;
+            line_res.with_context(|| format!("read {:?}", input_file))?;
 
         // Extract and handle multi-line comments.
         if line.starts_with('#') {
@@ -56,7 +56,7 @@ pub fn run_repl_from_file<C: Parser>(
                     break;
                 };
                 let next_line = next_res
-                    .with_context(|| format!("read {:?}", &input_file))?;
+                    .with_context(|| format!("read {:?}", input_file))?;
                 println!("> {}", next_line);
             }
 

--- a/dev-tools/schema/src/main.rs
+++ b/dev-tools/schema/src/main.rs
@@ -148,7 +148,7 @@ fn generate_base_schema(commit_or_tag: &str) -> Result<()> {
     // Resolve the commit/tag to a full commit hash
     let commit_hash =
         resolve_commit_or_tag(workspace_root.as_ref(), commit_or_tag)?;
-    println!("Resolved {} to commit {}", commit_or_tag, &commit_hash);
+    println!("Resolved {} to commit {}", commit_or_tag, commit_hash);
 
     // Get the dbinit.sql content from that commit
     let dbinit_content = get_dbinit_from_commit(&workspace_root, &commit_hash)?;

--- a/dev-tools/xtask/src/live_tests.rs
+++ b/dev-tools/xtask/src/live_tests.rs
@@ -44,7 +44,7 @@ pub fn run_cmd(_args: Args) -> Result<()> {
     eprintln!();
 
     std::fs::create_dir(&proto_root)
-        .with_context(|| format!("mkdir {:?}", &proto_root))?;
+        .with_context(|| format!("mkdir {:?}", proto_root))?;
 
     let mut command = cargo_command(CargoLocation::FromEnv);
 
@@ -80,7 +80,7 @@ pub fn run_cmd(_args: Args) -> Result<()> {
     command.arg(format!(
         "tar cf - Cargo.toml .config/nextest.toml live-tests | \
          tar xf - -C {:?}",
-        &proto_root
+        proto_root
     ));
     run_subcmd(command)?;
 
@@ -95,14 +95,14 @@ pub fn run_cmd(_args: Args) -> Result<()> {
     drop(tmpdir_root);
 
     eprint!("created: ");
-    println!("{}", &final_tarball);
+    println!("{}", final_tarball);
     eprintln!("\nTo use this:\n");
     eprintln!(
         "1. Copy the tarball to the switch zone in a deployed Omicron system.\n"
     );
     let raw = &[
         "scp \\",
-        &format!("{} \\", &final_tarball),
+        &format!("{} \\", final_tarball),
         "root@YOUR_SCRIMLET_GZ_IP:/zone/oxz_switch/root/root",
     ]
     .join("\n");

--- a/dns-server/src/bin/dns-db-dump.rs
+++ b/dns-server/src/bin/dns-db-dump.rs
@@ -23,13 +23,13 @@ fn main() -> Result<()> {
         .path(&arg.storage_path)
         .create_new(false)
         .open()
-        .with_context(|| format!("open {:?}", &arg.storage_path))?;
+        .with_context(|| format!("open {:?}", arg.storage_path))?;
 
     if !db.was_recovered() {
         bail!(
             "no database found at {:?} (sorry, this command likely just \
             created an empty database there)",
-            &arg.storage_path
+            arg.storage_path
         );
     }
 

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -237,7 +237,7 @@ fn dns_record_to_record(
             let tgt = Name::from_str(&target).map_err(|error| {
                 RequestError::ServFail(anyhow!(
                     "serialization failed due to bad SRV target {:?}: {:#}",
-                    &target,
+                    target,
                     error
                 ))
             })?;
@@ -252,7 +252,7 @@ fn dns_record_to_record(
             let nsdname = Name::from_str(&nsdname).map_err(|error| {
                 RequestError::ServFail(anyhow!(
                     "serialization failed due to bad NS dname {:?}: {:#}",
-                    &nsdname,
+                    nsdname,
                     error
                 ))
             })?;

--- a/dns-server/src/storage.rs
+++ b/dns-server/src/storage.rs
@@ -265,7 +265,7 @@ impl Store {
         );
 
         let db = sled::open(&config.storage_path).with_context(|| {
-            format!("open DNS database {:?}", &config.storage_path)
+            format!("open DNS database {:?}", config.storage_path)
         })?;
 
         Self::new_with_db(log, Arc::new(db), config)
@@ -570,7 +570,7 @@ impl Store {
             let tree = self
                 .db
                 .open_tree(&tree_name)
-                .with_context(|| format!("creating tree {:?}", &tree_name))?;
+                .with_context(|| format!("creating tree {:?}", tree_name))?;
 
             for (name, records) in &zone_config.records {
                 if records.is_empty() {

--- a/end-to-end-tests/src/helpers/ctx.rs
+++ b/end-to-end-tests/src/helpers/ctx.rs
@@ -168,11 +168,11 @@ impl ClientParams {
             Err(_) => ("http", None),
             Ok(path) => {
                 let cert_bytes = std::fs::read(&path).with_context(|| {
-                    format!("reading certificate from {:?}", &path)
+                    format!("reading certificate from {:?}", path)
                 })?;
                 let cert = reqwest::tls::Certificate::from_pem(&cert_bytes)
                     .with_context(|| {
-                        format!("parsing certificate from {:?}", &path)
+                        format!("parsing certificate from {:?}", path)
                     })?;
                 ("https", Some(cert))
             }

--- a/nexus/auth/src/authz/oso_generic.rs
+++ b/nexus/auth/src/authz/oso_generic.rs
@@ -68,7 +68,7 @@ impl OsoInitBuilder {
         info!(self.log, "registering Oso class"; "class" => &c.name);
         let name = c.name.clone();
         let new_element = self.class_names.insert(name.clone());
-        ensure!(new_element, "Oso class was already registered: {:?}", &name);
+        ensure!(new_element, "Oso class was already registered: {:?}", name);
         self.oso
             .register_class(c)
             .with_context(|| format!("registering Oso class {:?}", name))?;

--- a/nexus/db-model/src/role_assignment.rs
+++ b/nexus/db-model/src/role_assignment.rs
@@ -142,7 +142,7 @@ where
                     Error::internal_error(&format!(
                         "parsing database role assignment: \
                         unrecognized role name {:?}: {:#}",
-                        &role_asgn.role_name, error,
+                        role_asgn.role_name, error,
                     ))
                 })?,
         })

--- a/nexus/db-queries/src/db/datastore/dns.rs
+++ b/nexus/db-queries/src/db/datastore/dns.rs
@@ -687,7 +687,7 @@ impl DnsVersionUpdateBuilder {
             Err(Error::internal_error(&format!(
                 "DNS update ({:?}) attempted to remove name {:?} \
                 multiple times",
-                self.comment, &name,
+                self.comment, name,
             )))
         } else {
             assert!(self.names_removed.insert(name));

--- a/nexus/db-queries/src/db/datastore/identity_provider.rs
+++ b/nexus/db-queries/src/db/datastore/identity_provider.rs
@@ -60,7 +60,7 @@ impl DataStore {
                             omicron_common::api::external::Error::internal_error(
                                 &format!(
                                     "saml_identity_provider.try_into() failed! {}",
-                                    &e.to_string()
+                                    e
                                 )
                             )
                         )?

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -5714,7 +5714,7 @@ mod test {
         );
         println!(
             "all collections: {:?}\n",
-            &[
+            [
                 collection1.id,
                 collection2.id,
                 collection3.id,

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -2425,7 +2425,7 @@ mod test {
                          name, description, project ID, and {} ID:\
                          {name:?} {description:?} {project_id:?} {:?}\n{e}",
                         if is_service { "Service" } else { "Instance" },
-                        &ip.parent_id
+                        ip.parent_id
                     )
                 });
 

--- a/nexus/db-queries/src/policy_test/mod.rs
+++ b/nexus/db-queries/src/policy_test/mod.rs
@@ -345,7 +345,7 @@ async fn authorize_one_resource(
 
         for ctx_tuple in user_contexts.iter() {
             let (ref username, ref opctx) = **ctx_tuple;
-            write!(out, "  {:32}", &username)?;
+            write!(out, "  {:32}", username)?;
             for action in authz::Action::iter() {
                 let result = resource.do_authorize(opctx, action).await;
                 trace!(

--- a/nexus/db-queries/src/policy_test/resource_builder.rs
+++ b/nexus/db-queries/src/policy_test/resource_builder.rs
@@ -115,7 +115,7 @@ impl<'a> ResourceBuilder<'a> {
             let role_name = role.to_database_string();
             let username = format!("{}-{}", resource_name, role_name);
             let user_id = SiloUserUuid::new_v4();
-            println!("creating user: {}", &username);
+            println!("creating user: {}", username);
             self.users.push((username.clone(), user_id));
 
             let authz_silo = authz::Silo::new(

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -470,7 +470,7 @@ impl<'a> Collector<'a> {
         );
 
         let maybe_ident = client.inventory().await.with_context(|| {
-            format!("Sled Agent {:?}: inventory", &sled_agent_url)
+            format!("Sled Agent {:?}: inventory", sled_agent_url)
         });
         let inventory = match maybe_ident {
             Ok(inventory) => inventory.into_inner(),
@@ -545,7 +545,7 @@ impl<'a> Collector<'a> {
         );
 
         let maybe_ident = client.timesync().await.with_context(|| {
-            format!("Sled Agent {:?}: timesync", &sled_agent_url)
+            format!("Sled Agent {:?}: timesync", sled_agent_url)
         });
         let timesync = match maybe_ident {
             Ok(timesync) => nexus_types::inventory::TimeSync {
@@ -587,7 +587,7 @@ impl<'a> Collector<'a> {
         );
 
         let res = client.keeper_cluster_membership().await.with_context(|| {
-            format!("Clickhouse Keeper {:?}: inventory", &client.baseurl())
+            format!("Clickhouse Keeper {:?}: inventory", client.baseurl())
         });
 
         match res {

--- a/nexus/reconfigurator/cli-integration-tests/tests/integration/blueprint_edit.rs
+++ b/nexus/reconfigurator/cli-integration-tests/tests/integration/blueprint_edit.rs
@@ -165,7 +165,7 @@ async fn test_blueprint_edit(cptestctx: &ControlPlaneTestContext) {
     );
     swriteln!(s, "save {}", saved_state2_path);
     std::fs::write(&script1_path, &s)
-        .with_context(|| format!("write {}", &script1_path))
+        .with_context(|| format!("write {}", script1_path))
         .unwrap();
 
     // Run this reconfigurator-cli invocation.
@@ -208,7 +208,7 @@ async fn test_blueprint_edit(cptestctx: &ControlPlaneTestContext) {
     swriteln!(s, "load {} {}", saved_state2_path, collection.id);
     swriteln!(s, "blueprint-save {} {}", new_blueprint.id, new_blueprint_path);
     std::fs::write(&script2_path, &s)
-        .with_context(|| format!("write {}", &script2_path))
+        .with_context(|| format!("write {}", script2_path))
         .unwrap();
     let exec = Exec::cmd(path_to_cli()).arg(&script2_path);
     let (exit_status, _, stderr_text) = run_command(exec);

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -1829,7 +1829,7 @@ mod tests {
                     }
                 };
 
-                eprintln!("*** qorb lookup successful: {:?}", &**backends);
+                eprintln!("*** qorb lookup successful: {:?}", **backends);
             }
         }
 

--- a/nexus/src/app/background/tasks/read_only_region_replacement_start.rs
+++ b/nexus/src/app/background/tasks/read_only_region_replacement_start.rs
@@ -336,7 +336,7 @@ mod test {
         let result: ReadOnlyRegionReplacementStartStatus =
             serde_json::from_value(task.activate(&opctx).await).unwrap();
 
-        eprintln!("{:?}", &result);
+        eprintln!("{:?}", result);
 
         assert_eq!(result.requests_created_ok.len(), 1);
         assert!(result.errors.is_empty());

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
@@ -558,7 +558,7 @@ mod test {
         let result: RegionSnapshotReplacementStartStatus =
             serde_json::from_value(task.activate(&opctx).await).unwrap();
 
-        eprintln!("{:?}", &result);
+        eprintln!("{:?}", result);
 
         assert_eq!(result.requests_created_ok.len(), 1);
         assert_eq!(result.start_invoked_ok.len(), 1);

--- a/nexus/src/app/background/tasks/trust_quorum.rs
+++ b/nexus/src/app/background/tasks/trust_quorum.rs
@@ -274,7 +274,7 @@ async fn prepare(
             format!(
                 "failed to retrieve commissioned sled \
                     by baseboard_id {} and rack_id {}.",
-                &config.coordinator, &config.rack_id
+                config.coordinator, config.rack_id
             )
         })?
     else {
@@ -289,7 +289,7 @@ async fn prepare(
         .with_context(|| {
             format!(
                 "Failed to get coordinator status from {}.",
-                &config.coordinator
+                config.coordinator
             )
         })?
         .into_inner();

--- a/nexus/src/app/image.rs
+++ b/nexus/src/app/image.rs
@@ -133,7 +133,7 @@ impl super::Nexus {
 
         let created_image = saga_outputs
             .lookup_node_output::<db::model::Image>("created_image")
-            .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
+            .map_err(|e| Error::internal_error(&format!("{:#}", e)))
             .internal_context("looking up output from image create saga")?;
 
         Ok(created_image)

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -822,7 +822,7 @@ impl super::Nexus {
 
         let instance_id = saga_outputs
             .lookup_node_output::<Uuid>("instance_id")
-            .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
+            .map_err(|e| Error::internal_error(&format!("{:#}", e)))
             .internal_context("looking up output from instance create saga")?;
 
         // If the caller asked to start the instance, kick off that saga.
@@ -2566,7 +2566,7 @@ impl super::Nexus {
 
         let out = saga_outputs
             .lookup_node_output::<external_ip::ExternalIp>("output")
-            .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
+            .map_err(|e| Error::internal_error(&format!("{:#}", e)))
             .internal_context("looking up output from ip attach saga");
 
         // The VPC routing RPW currently has double-duty on ensuring that
@@ -2604,7 +2604,7 @@ impl super::Nexus {
 
         saga_outputs
             .lookup_node_output::<Option<external_ip::ExternalIp>>("output")
-            .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
+            .map_err(|e| Error::internal_error(&format!("{:#}", e)))
             .internal_context("looking up output from ip detach saga")
             .and_then(|eip| {
                 // Saga idempotency means we'll get Ok(None) on double detach

--- a/nexus/src/app/project.rs
+++ b/nexus/src/app/project.rs
@@ -68,7 +68,7 @@ impl super::Nexus {
             .lookup_node_output::<(authz::Project, db::model::Project)>(
                 "project",
             )
-            .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
+            .map_err(|e| Error::internal_error(&format!("{:#}", e)))
             .internal_context("looking up output from project create saga")?;
         Ok(db_project)
     }

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -1005,7 +1005,7 @@ impl super::Nexus {
                 "cannot create SAML identity provider for this Silo type \
                 (expected authentication mode {:?}, found {:?})",
                 nexus_db_model::AuthenticationMode::Saml,
-                &db_silo.authentication_mode,
+                db_silo.authentication_mode,
             )));
         }
 

--- a/nexus/src/app/vpc.rs
+++ b/nexus/src/app/vpc.rs
@@ -96,7 +96,7 @@ impl super::Nexus {
 
         let (_, db_vpc) = saga_outputs
             .lookup_node_output::<(authz::Vpc, db::model::Vpc)>("vpc")
-            .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
+            .map_err(|e| Error::internal_error(&format!("{:#}", e)))
             .internal_context("looking up output from VPC create saga")?;
 
         Ok(db_vpc)

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -161,7 +161,7 @@ impl super::Nexus {
 
         let out = saga_outputs
             .lookup_node_output::<VpcSubnet>("output")
-            .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
+            .map_err(|e| Error::internal_error(&format!("{:#}", e)))
             .internal_context("looking up output from vpc create saga")?;
 
         self.vpc_needed_notify_sleds();
@@ -213,7 +213,7 @@ impl super::Nexus {
 
         let out = saga_outputs
             .lookup_node_output::<VpcSubnet>("output")
-            .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
+            .map_err(|e| Error::internal_error(&format!("{:#}", e)))
             .internal_context("looking up output from vpc update saga")?;
 
         self.vpc_needed_notify_sleds();

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -999,7 +999,7 @@ pub async fn create_affinity_group(
 ) -> AffinityGroup {
     object_create(
         &client,
-        format!("/v1/affinity-groups?project={}", &project_name).as_str(),
+        format!("/v1/affinity-groups?project={}", project_name).as_str(),
         &affinity::AffinityGroupCreate {
             identity: IdentityMetadataCreateParams {
                 name: group_name.parse().unwrap(),
@@ -1019,7 +1019,7 @@ pub async fn create_anti_affinity_group(
 ) -> AntiAffinityGroup {
     object_create(
         &client,
-        format!("/v1/anti-affinity-groups?project={}", &project_name).as_str(),
+        format!("/v1/anti-affinity-groups?project={}", project_name).as_str(),
         &affinity::AntiAffinityGroupCreate {
             identity: IdentityMetadataCreateParams {
                 name: group_name.parse().unwrap(),
@@ -1039,7 +1039,7 @@ pub async fn create_vpc(
 ) -> Vpc {
     object_create(
         &client,
-        format!("/v1/vpcs?project={}", &project_name).as_str(),
+        format!("/v1/vpcs?project={}", project_name).as_str(),
         &vpc::VpcCreate {
             identity: IdentityMetadataCreateParams {
                 name: vpc_name.parse().unwrap(),
@@ -1064,7 +1064,7 @@ pub async fn create_vpc_with_error(
         RequestBuilder::new(
             client,
             Method::POST,
-            format!("/v1/vpcs?project={}", &project_name).as_str(),
+            format!("/v1/vpcs?project={}", project_name).as_str(),
         )
         .body(Some(&vpc::VpcCreate {
             identity: IdentityMetadataCreateParams {
@@ -1118,7 +1118,7 @@ pub async fn create_router(
 ) -> VpcRouter {
     NexusRequest::objects_post(
         &client,
-        format!("/v1/vpc-routers?project={}&vpc={}", &project_name, &vpc_name)
+        format!("/v1/vpc-routers?project={}&vpc={}", project_name, vpc_name)
             .as_str(),
         &vpc::VpcRouterCreate {
             identity: IdentityMetadataCreateParams {
@@ -1148,7 +1148,7 @@ pub async fn create_route(
         &client,
         format!(
             "/v1/vpc-router-routes?project={}&vpc={}&router={}",
-            &project_name, &vpc_name, &router_name
+            project_name, vpc_name, router_name
         )
         .as_str(),
         &vpc::RouterRouteCreate {
@@ -1185,7 +1185,7 @@ pub async fn create_route_with_error(
             Method::POST,
             format!(
                 "/v1/vpc-router-routes?project={}&vpc={}&router={}",
-                &project_name, &vpc_name, &router_name
+                project_name, vpc_name, router_name
             )
             .as_str(),
         )
@@ -1217,7 +1217,7 @@ pub async fn create_internet_gateway(
         &client,
         format!(
             "/v1/internet-gateways?project={}&vpc={}",
-            &project_name, &vpc_name
+            project_name, vpc_name
         )
         .as_str(),
         &vpc::VpcRouterCreate {
@@ -1246,7 +1246,7 @@ pub async fn delete_internet_gateway(
         &client,
         format!(
             "/v1/internet-gateways/{}?project={}&vpc={}&cascade={}",
-            &internet_gateway_name, &project_name, &vpc_name, cascade
+            internet_gateway_name, project_name, vpc_name, cascade
         )
         .as_str(),
     )

--- a/nexus/tests/integration_tests/audit_log.rs
+++ b/nexus/tests/integration_tests/audit_log.rs
@@ -77,7 +77,7 @@ async fn test_audit_log_list(ctx: &ControlPlaneTestContext) {
 
     // this this creates its own entry
     let session_token = create_console_session(ctx).await;
-    let session_cookie = format!("session={}", &session_token);
+    let session_cookie = format!("session={}", session_token);
 
     let t3 = Utc::now(); // after second entry
 

--- a/nexus/tests/integration_tests/certificates.rs
+++ b/nexus/tests/integration_tests/certificates.rs
@@ -679,15 +679,15 @@ impl SiloCert {
 
     /// Returns the base URL of the HTTPS endpoint for this Silo
     fn base_url(&self, port: u16) -> String {
-        format!("https://{}:{}", &self.dns_name, port)
+        format!("https://{}:{}", self.dns_name, port)
     }
 
     /// Returns the full URL to the login endpoint for this Silo
     fn login_url(&self, port: u16) -> String {
         format!(
             "{}/v1/login/{}/local",
-            &self.base_url(port),
-            &self.silo_name.as_str()
+            self.base_url(port),
+            self.silo_name.as_str()
         )
     }
 

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -626,7 +626,7 @@ async fn test_login_redirect_multiple_silos(
                     name: idp_name.parse().unwrap(),
                     description: format!(
                         "silo {:?} idp {:?}",
-                        &silo.identity.name, idp_name
+                        silo.identity.name, idp_name
                     ),
                 },
 
@@ -648,7 +648,7 @@ async fn test_login_redirect_multiple_silos(
             };
             let idp_create_url = format!(
                 "/v1/system/identity-providers/saml?silo={}",
-                &silo.identity.name
+                silo.identity.name
             );
             let _: identity_provider::SamlIdentityProvider =
                 object_create(client, &idp_create_url, &idp_params).await;
@@ -779,7 +779,7 @@ async fn test_login_redirect_multiple_silos(
     assert_eq!(
         make_request(&reqwest_client, cptestctx.silo_name.as_str(), port, None)
             .await,
-        Redirect::Location(format!("/login/{}/local", &cptestctx.silo_name,)),
+        Redirect::Location(format!("/login/{}/local", cptestctx.silo_name,)),
     );
 
     // same thing, but with state param in URL
@@ -793,7 +793,7 @@ async fn test_login_redirect_multiple_silos(
         .await,
         Redirect::Location(format!(
             "/login/{}/local?redirect_uri=%2Fabc%2Fdef",
-            &cptestctx.silo_name,
+            cptestctx.silo_name,
         )),
     );
 

--- a/nexus/tests/integration_tests/crucible_replacements.rs
+++ b/nexus/tests/integration_tests/crucible_replacements.rs
@@ -1083,7 +1083,7 @@ async fn test_racing_replacements_for_soft_deleted_disk_volume(
     let maybe_region =
         datastore.get_region_optional(region.id()).await.unwrap();
 
-    eprintln!("old_region_id: {:?}", &maybe_region);
+    eprintln!("old_region_id: {:?}", maybe_region);
     assert!(maybe_region.is_some());
 
     // But the new region id will be!
@@ -1092,7 +1092,7 @@ async fn test_racing_replacements_for_soft_deleted_disk_volume(
         .await
         .unwrap();
 
-    eprintln!("new region id: {:?}", &maybe_region);
+    eprintln!("new region id: {:?}", maybe_region);
     assert!(maybe_region.is_none());
 
     // The region_replacement drive task should invoke the drive saga now, which

--- a/nexus/tests/integration_tests/external_ips.rs
+++ b/nexus/tests/integration_tests/external_ips.rs
@@ -1957,7 +1957,7 @@ async fn can_list_instance_snat_ip(cptestctx: &ControlPlaneTestContext) {
         ..
     }) = &range.items[0].range
     else {
-        panic!("Expected IPv4 range, found {:?}", &range.items[0]);
+        panic!("Expected IPv4 range, found {:?}", range.items[0]);
     };
     let expected_v4_ip = IpAddr::V4(*first);
 
@@ -1977,7 +1977,7 @@ async fn can_list_instance_snat_ip(cptestctx: &ControlPlaneTestContext) {
         ..
     }) = &range.items[0].range
     else {
-        panic!("Expected IPv6 range, found {:?}", &range.items[0]);
+        panic!("Expected IPv6 range, found {:?}", range.items[0]);
     };
 
     // Create a running instance with only an SNAT IP address, for each IP
@@ -2074,7 +2074,7 @@ async fn can_create_instance_with_ephemeral_ipv6_address(
         ..
     }) = &range.items[0].range
     else {
-        panic!("Expected IPv6 range, found {:?}", &range.items[0]);
+        panic!("Expected IPv6 range, found {:?}", range.items[0]);
     };
 
     // Create a running instance with an Ephemeral IPv6 address.
@@ -2164,7 +2164,7 @@ async fn can_create_instance_with_floating_ipv6_address(
         ..
     }) = &range.items[0].range
     else {
-        panic!("Expected IPv6 range, found {:?}", &range.items[0]);
+        panic!("Expected IPv6 range, found {:?}", range.items[0]);
     };
     let expected_ip = IpAddr::V6(*first);
 
@@ -2238,7 +2238,7 @@ async fn can_create_instance_with_floating_ipv6_address(
         ..
     } = ip
     else {
-        panic!("Expected a Floating external IP, found {:?}", &ips[1]);
+        panic!("Expected a Floating external IP, found {:?}", ips[1]);
     };
     assert_eq!(id, &fip.identity.id);
     assert_eq!(instance_id, &Some(instance.identity.id));

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -375,7 +375,7 @@ async fn test_instances_create_reboot_halt(
                     name: instance.identity.name.clone(),
                     description: format!(
                         "instance {:?}",
-                        &instance.identity.name
+                        instance.identity.name
                     ),
                 },
                 ncpus: instance.ncpus,
@@ -721,7 +721,7 @@ async fn test_instance_start_creates_networking_state(
 
     assert_eq!(guest_nics.len(), 1);
     for agent in &sled_agents {
-        println!(">>> {:#?}", &nics[0]);
+        println!(">>> {:#?}", nics[0]);
         assert_sled_v2p_mappings(agent, &nics[0], guest_nics[0].vni).await;
     }
 
@@ -855,8 +855,7 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
         default_sled_id
     };
 
-    let migrate_url =
-        format!("/instances/{}/migrate", &instance_id.to_string());
+    let migrate_url = format!("/instances/{}/migrate", instance_id);
     let instance = NexusRequest::new(
         RequestBuilder::new(lockstep_client, Method::POST, &migrate_url)
             .body(Some(&InstanceMigrateRequest { dst_sled_id }))
@@ -1173,8 +1172,7 @@ async fn test_instance_migrate_target_finishes_first(
         default_sled_id
     };
 
-    let migrate_url =
-        format!("/instances/{}/migrate", &instance_id.to_string());
+    let migrate_url = format!("/instances/{}/migrate", instance_id);
     let instance = NexusRequest::new(
         RequestBuilder::new(lockstep_client, Method::POST, &migrate_url)
             .body(Some(&InstanceMigrateRequest { dst_sled_id }))
@@ -1531,8 +1529,7 @@ async fn test_instance_migrate_v2p_and_routes(
     };
 
     // Kick off migration and simulate its completion on the target.
-    let migrate_url =
-        format!("/instances/{}/migrate", &instance_id.to_string());
+    let migrate_url = format!("/instances/{}/migrate", instance_id);
     let _ = NexusRequest::new(
         RequestBuilder::new(lockstep_client, Method::POST, &migrate_url)
             .body(Some(&InstanceMigrateRequest { dst_sled_id }))
@@ -1716,8 +1713,7 @@ async fn test_instance_migration_compatible_cpu_platforms(
         first_sled_id
     };
 
-    let migrate_url =
-        format!("/instances/{}/migrate", &instance_id.to_string());
+    let migrate_url = format!("/instances/{}/migrate", instance_id);
     let instance = NexusRequest::new(
         RequestBuilder::new(lockstep_client, Method::POST, &migrate_url)
             .body(Some(&InstanceMigrateRequest { dst_sled_id }))
@@ -1902,8 +1898,7 @@ async fn test_instance_migration_incompatible_cpu_platforms(
     // wrong.
     assert_eq!(sled_info.sled_id, turin_sled_id);
 
-    let migrate_url =
-        format!("/instances/{}/migrate", &instance_id.to_string());
+    let migrate_url = format!("/instances/{}/migrate", instance_id);
     NexusRequest::new(
         RequestBuilder::new(lockstep_client, Method::POST, &migrate_url)
             .body(Some(&InstanceMigrateRequest { dst_sled_id: milan_sled_id }))
@@ -1990,8 +1985,7 @@ async fn test_instance_migration_unknown_sled_type(
         (first_sled_id, http::StatusCode::BAD_REQUEST)
     };
 
-    let migrate_url =
-        format!("/instances/{}/migrate", &instance_id.to_string());
+    let migrate_url = format!("/instances/{}/migrate", instance_id);
     NexusRequest::new(
         RequestBuilder::new(lockstep_client, Method::POST, &migrate_url)
             .body(Some(&InstanceMigrateRequest { dst_sled_id }))
@@ -2848,8 +2842,7 @@ async fn test_instance_metrics_with_migration(
     };
 
     // instance is already running on destination sled
-    let migrate_url =
-        format!("/instances/{}/migrate", &instance_id.to_string());
+    let migrate_url = format!("/instances/{}/migrate", instance_id);
     let _ = NexusRequest::new(
         RequestBuilder::new(lockstep_client, Method::POST, &migrate_url)
             .body(Some(&InstanceMigrateRequest { dst_sled_id }))
@@ -6797,7 +6790,7 @@ async fn test_instances_memory_rejected_less_than_min_memory_size(
     let instance = instance::InstanceCreate {
         identity: IdentityMetadataCreateParams {
             name: instance_name.parse().unwrap(),
-            description: format!("instance {:?}", &instance_name),
+            description: format!("instance {:?}", instance_name),
         },
         ncpus: InstanceCpuCount(1),
         memory: ByteCount::from(MIN_MEMORY_BYTES_PER_INSTANCE / 2),
@@ -6854,7 +6847,7 @@ async fn test_instances_memory_not_divisible_by_min_memory_size(
     let instance = instance::InstanceCreate {
         identity: IdentityMetadataCreateParams {
             name: instance_name.parse().unwrap(),
-            description: format!("instance {:?}", &instance_name),
+            description: format!("instance {:?}", instance_name),
         },
         ncpus: InstanceCpuCount(1),
         memory: ByteCount::from(1024 * 1024 * 1024 + 300),
@@ -6910,7 +6903,7 @@ async fn test_instances_memory_greater_than_max_size(
     let instance = instance::InstanceCreate {
         identity: IdentityMetadataCreateParams {
             name: instance_name.parse().unwrap(),
-            description: format!("instance {:?}", &instance_name),
+            description: format!("instance {:?}", instance_name),
         },
         ncpus: InstanceCpuCount(1),
         memory: ByteCount::try_from(MAX_MEMORY_BYTES_PER_INSTANCE + (1 << 30))

--- a/nexus/tests/integration_tests/utilization.rs
+++ b/nexus/tests/integration_tests/utilization.rs
@@ -110,7 +110,7 @@ async fn test_utilization_view(cptestctx: &ControlPlaneTestContext) {
 
     let instance_start_url = format!(
         "/v1/instances/{}/start?project={}",
-        &INSTANCE_NAME, &PROJECT_NAME
+        INSTANCE_NAME, PROJECT_NAME
     );
 
     // Start instance
@@ -140,7 +140,7 @@ async fn test_utilization_view(cptestctx: &ControlPlaneTestContext) {
     // Simulate space for disks
     DiskTest::new(&cptestctx).await;
 
-    let disk_url = format!("/v1/disks?project={}", &PROJECT_NAME);
+    let disk_url = format!("/v1/disks?project={}", PROJECT_NAME);
     // provision disk
     NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &disk_url)

--- a/nexus/tests/integration_tests/vpc_subnets.rs
+++ b/nexus/tests/integration_tests/vpc_subnets.rs
@@ -212,7 +212,7 @@ async fn test_vpc_subnets(cptestctx: &ControlPlaneTestContext) {
     subnets_eq(&subnet, &same_subnet);
 
     // get subnet by ID, should retrieve the same subnet
-    let subnet_by_id_url = format!("/v1/vpc-subnets/{}", &subnet.identity.id);
+    let subnet_by_id_url = format!("/v1/vpc-subnets/{}", subnet.identity.id);
     let same_subnet_again = NexusRequest::object_get(client, &subnet_by_id_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -1802,11 +1802,11 @@ impl<'a, 'b> BpDiffPendingMgsUpdates<'a, 'b> {
                 BpTableColumn::new(&u1.artifact_version, &u2.artifact_version);
             let details = if u1.details != u2.details {
                 BpTableColumn::diff(
-                    format!("{:?}", &u1.details),
-                    format!("{:?}", &u2.details),
+                    format!("{:?}", u1.details),
+                    format!("{:?}", u2.details),
                 )
             } else {
-                BpTableColumn::value(format!("{:?}", &u1.details))
+                BpTableColumn::value(format!("{:?}", u1.details))
             };
             rows.push(BpTableRow::new(
                 BpDiffState::Modified,

--- a/nexus/types/src/deployment/execution/dns.rs
+++ b/nexus/types/src/deployment/execution/dns.rs
@@ -230,7 +230,7 @@ pub fn blueprint_external_dns_config<'a>(
             let name = format!("ns{}", idx + 1);
             zone_records.push(DnsRecord::Ns(format!(
                 "{}.{}",
-                &name, external_dns_zone_name
+                name, external_dns_zone_name
             )));
             (name, vec![record])
         })

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -5037,7 +5037,7 @@ mod tests {
                 WHERE timeseries_name = '{}'",
                 crate::DATABASE_NAME,
                 table,
-                &to_delete[0].to_string(),
+                to_delete[0],
             );
             let count = client
                 .execute_with_block(&mut handle, &sql)

--- a/oximeter/db/src/model/from_block.rs
+++ b/oximeter/db/src/model/from_block.rs
@@ -160,7 +160,7 @@ impl FromBlock for TimeseriesSchema {
                     timeseries_names[row].clone().parse().map_err(|_| {
                         Error::Serde(format!(
                             "Failed to deserialize timeseries name from database: {:?}",
-                            &timeseries_names[row]
+                            timeseries_names[row]
                         ))
                     })?,
                 description: TimeseriesDescription::default(),
@@ -170,7 +170,7 @@ impl FromBlock for TimeseriesSchema {
                     .map_err(|_| {
                         Error::Serde(format!(
                             "Failed to deserialize datum type from database: {:?}",
-                            &datum_type_variants[&datum_types[row]]
+                            datum_type_variants[&datum_types[row]]
                         ))
                     })?,
                 version: unsafe { NonZeroU8::new_unchecked(1) },

--- a/oximeter/db/src/oxql/ast/table_ops/filter/visit.rs
+++ b/oximeter/db/src/oxql/ast/table_ops/filter/visit.rs
@@ -233,7 +233,7 @@ impl Visit for RemoveDatum<'_> {
                     "Start time can only be compared if the metric \
                     is cumulative, but table '{}' has metric type {}",
                     self.schema.name,
-                    &self.schema.metric_types[0],
+                    self.schema.metric_types[0],
                 ));
             }
             if matches!(filter.value, Literal::Timestamp(_)) {
@@ -351,7 +351,7 @@ impl Visit for RestrictToMeasurements<'_> {
                     "Start time can only be compared if the metric \
                     is cumulative, but table '{}' has metric type {}",
                     self.schema.name,
-                    &self.schema.metric_types[0],
+                    self.schema.metric_types[0],
                 ));
             }
             if matches!(filter.value, Literal::Timestamp(_)) {
@@ -472,7 +472,7 @@ impl Visit for RewriteForMeasurementTable<'_> {
                     "Start time can only be compared if the metric \
                     is cumulative, but table '{}' has metric type {}",
                     self.schema.name,
-                    &self.schema.metric_types[0],
+                    self.schema.metric_types[0],
                 ));
             }
             if matches!(filter.value, Literal::Timestamp(_)) {

--- a/oximeter/db/src/oxql/plan/plan.rs
+++ b/oximeter/db/src/oxql/plan/plan.rs
@@ -1263,7 +1263,7 @@ mod tests {
         let optimized_nodes = plan.optimized_nodes();
         assert_eq!(optimized_nodes.len(), 2);
         let Node::Get(get) = &optimized_nodes[0] else {
-            panic!("Expected a get node, found {:?}", &optimized_nodes[0]);
+            panic!("Expected a get node, found {:?}", optimized_nodes[0]);
         };
         assert_eq!(get.filters.len(), 1);
         assert!(matches!(&optimized_nodes[1], Node::Delta(_)));
@@ -1286,7 +1286,7 @@ mod tests {
         let optimized_nodes = plan.optimized_nodes();
         assert_eq!(optimized_nodes.len(), 4);
         let Node::Get(get) = &optimized_nodes[0] else {
-            panic!("Expected a get node, found {:?}", &optimized_nodes[0]);
+            panic!("Expected a get node, found {:?}", optimized_nodes[0]);
         };
         assert_eq!(get.filters.len(), 1);
         assert_eq!(
@@ -1311,13 +1311,13 @@ mod tests {
         let optimized_nodes = plan.optimized_nodes();
         assert_eq!(optimized_nodes.len(), 3);
         let Node::Subquery(subqueries) = &optimized_nodes[0] else {
-            panic!("Expected a subquery node, found {:?}", &optimized_nodes[0]);
+            panic!("Expected a subquery node, found {:?}", optimized_nodes[0]);
         };
         for subq in subqueries.iter() {
             let nodes = subq.optimized_nodes();
             assert_eq!(nodes.len(), 2);
             let Node::Get(get) = &nodes[0] else {
-                panic!("Expected a get node, found {:?}", &nodes[0]);
+                panic!("Expected a get node, found {:?}", nodes[0]);
             };
             assert_eq!(get.filters.len(), 1);
             assert!(matches!(&nodes[1], Node::Delta(_)));
@@ -1343,13 +1343,13 @@ mod tests {
         let optimized_nodes = plan.optimized_nodes();
         assert_eq!(optimized_nodes.len(), 1);
         let Node::Subquery(subqueries) = &optimized_nodes[0] else {
-            panic!("Expected a subquery node, found {:?}", &optimized_nodes[0]);
+            panic!("Expected a subquery node, found {:?}", optimized_nodes[0]);
         };
         for subq in subqueries.iter() {
             let nodes = subq.optimized_nodes();
             assert_eq!(nodes.len(), 2);
             let Node::Get(get) = &nodes[0] else {
-                panic!("Expected a get node, found {:?}", &nodes[0]);
+                panic!("Expected a get node, found {:?}", nodes[0]);
             };
             assert_eq!(get.filters.len(), 1);
             assert!(matches!(&nodes[1], Node::Delta(_)));

--- a/oximeter/db/src/oxql/query/mod.rs
+++ b/oximeter/db/src/oxql/query/mod.rs
@@ -281,13 +281,8 @@ impl Query {
                         // A filter can be pushed through a limiting table
                         // operation in a few cases, see `can_reorder_around`
                         // for details.
-                        maybe_filter.and_then(|filter| {
-                            if filter.can_reorder_around(limit) {
-                                Some(filter)
-                            } else {
-                                None
-                            }
-                        })
+                        maybe_filter
+                            .filter(|filter| filter.can_reorder_around(limit))
                     }
                     _ => maybe_filter,
                 }
@@ -314,13 +309,8 @@ impl Query {
                         // A limit can be pushed through a filter operation, in
                         // only a few cases, see `can_reorder_around` for
                         // details.
-                        maybe_limit.and_then(|limit| {
-                            if filter.can_reorder_around(&limit) {
-                                Some(limit)
-                            } else {
-                                None
-                            }
-                        })
+                        maybe_limit
+                            .filter(|&limit| filter.can_reorder_around(&limit))
                     }
                     BasicTableOp::Limit(limit) => {
                         // It is possible to "merge" limits if they're of the

--- a/oximeter/instruments/src/kstat/link.rs
+++ b/oximeter/instruments/src/kstat/link.rs
@@ -269,8 +269,8 @@ mod tests {
                 eprintln!(
                     "Failed to delete etherstub '{}'.\n\
                     Delete manually with `dladm delete-etherstub {}`:\n{}",
-                    &self.name,
-                    &self.name,
+                    self.name,
+                    self.name,
                     String::from_utf8_lossy(&output.stderr),
                 );
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
-channel = "1.96.1"
+channel = "1.97.1"
 profile = "default"

--- a/sled-agent/config-reconciler/src/debug_collector/file_archiver/planning.rs
+++ b/sled-agent/config-reconciler/src/debug_collector/file_archiver/planning.rs
@@ -362,7 +362,7 @@ impl ArchiveFile<'_> {
                 // gracefully.
                 anyhow!(
                     "file for archival has no filename: {:?}",
-                    &self.input_path
+                    self.input_path
                 )
             })?
             .to_owned()

--- a/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
@@ -1015,7 +1015,7 @@ async fn cleanup_former_zone_roots(
             &Mountpoint(Utf8PathBuf::from(&mountpoint)),
         )
         .await
-        .with_context(|| format!("mounting {:?}", &child_dataset_name))
+        .with_context(|| format!("mounting {:?}", child_dataset_name))
         .map_err(|error| {
             DiskManagementError::Other(
                 InlineErrorChain::new(&*error).to_string(),

--- a/sled-agent/rack-setup/src/service.rs
+++ b/sled-agent/rack-setup/src/service.rs
@@ -1817,7 +1817,7 @@ mod test {
             .join("../../smf/sled-agent/non-gimlet/config-rss.toml");
         let contents = std::fs::read_to_string(&path).unwrap();
         toml::from_str(&contents)
-            .unwrap_or_else(|e| panic!("failed to parse {:?}: {}", &path, e))
+            .unwrap_or_else(|e| panic!("failed to parse {:?}: {}", path, e))
     }
 
     fn make_sled_info(
@@ -2058,13 +2058,13 @@ mod test {
             manifest.join("../../smf/sled-agent/non-gimlet/config-rss.toml");
         let contents = std::fs::read_to_string(&path).unwrap();
         let _: RackInitializeRequest = toml::from_str(&contents)
-            .unwrap_or_else(|e| panic!("failed to parse {:?}: {}", &path, e));
+            .unwrap_or_else(|e| panic!("failed to parse {:?}: {}", path, e));
 
         let path = manifest
             .join("../../smf/sled-agent/gimlet-standalone/config-rss.toml");
         let contents = std::fs::read_to_string(&path).unwrap();
         let _: RackInitializeRequest = toml::from_str(&contents)
-            .unwrap_or_else(|e| panic!("failed to parse {:?}: {}", &path, e));
+            .unwrap_or_else(|e| panic!("failed to parse {:?}: {}", path, e));
     }
 
     #[test]
@@ -2189,7 +2189,7 @@ mod test {
             rack_initialize_request_from_file(&path).unwrap_or_else(|e| {
                 panic!(
                     "failed to parse {:?}: {}",
-                    &path,
+                    path,
                     InlineErrorChain::new(&e)
                 )
             });
@@ -2219,7 +2219,7 @@ mod test {
         let cfg_path = tempdir.path().join("config-rss.toml");
         let _ = std::fs::copy(&path, &cfg_path)
             .with_context(|| {
-                format!("failed to copy file {:?} to {:?}", &path, &cfg_path)
+                format!("failed to copy file {:?} to {:?}", path, cfg_path)
             })
             .unwrap();
 
@@ -2230,14 +2230,14 @@ mod test {
             .into_bytes();
         let cert_path = tempdir.path().join("initial-tls-cert.pem");
         std::fs::write(&cert_path, &cert_bytes)
-            .with_context(|| format!("failed to write to {:?}", &cert_path))
+            .with_context(|| format!("failed to write to {:?}", cert_path))
             .unwrap();
 
         // Write the private key.
         let key_path = tempdir.path().join("initial-tls-key.pem");
         let key_bytes = cert.serialize_private_key_pem().into_bytes();
         std::fs::write(&key_path, &key_bytes)
-            .with_context(|| format!("failed to write to {:?}", &key_path))
+            .with_context(|| format!("failed to write to {:?}", key_path))
             .unwrap();
 
         // Now try to load it all.

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -141,10 +141,10 @@ async fn do_run() -> Result<(), CmdError> {
         (None, None) => None,
         (Some(cert_path), Some(key_path)) => {
             let cert_bytes = std::fs::read_to_string(&cert_path)
-                .with_context(|| format!("read {:?}", &cert_path))
+                .with_context(|| format!("read {:?}", cert_path))
                 .map_err(CmdError::Failure)?;
             let key_bytes = std::fs::read_to_string(&key_path)
-                .with_context(|| format!("read {:?}", &key_path))
+                .with_context(|| format!("read {:?}", key_path))
                 .map_err(CmdError::Failure)?;
             Some(Certificate { cert: cert_bytes, key: key_bytes })
         }

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -2462,7 +2462,7 @@ impl InstanceRunner {
 
         let reqwest_client = reqwest::ClientBuilder::new().build().unwrap();
         let client = Arc::new(PropolisClient::new_with_client(
-            &format!("http://{}", &self.propolis_addr),
+            &format!("http://{}", self.propolis_addr),
             reqwest_client,
         ));
 

--- a/sled-agent/src/profile.rs
+++ b/sled-agent/src/profile.rs
@@ -237,7 +237,7 @@ impl Display for PropertyGroupBuilder {
                     r#"        <propval type="{ty}" name="{name}" value='{value}'/>
 "#,
                     name = property_name,
-                    value = &values[0],
+                    value = values[0],
                 )?;
             } else {
                 write!(

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -448,7 +448,7 @@ impl ClickHouseProcess {
             .envs(&env)
             .spawn()
             .with_context(|| {
-                format!("failed to spawn `clickhouse` (with args: {:?})", &args)
+                format!("failed to spawn `clickhouse` (with args: {:?})", args)
             })?;
         for (k, v) in std::env::vars_os() {
             env.insert(
@@ -548,7 +548,7 @@ impl ClickHouseProcess {
             .envs(&env)
             .spawn()
             .with_context(|| {
-                format!("failed to spawn `clickhouse` (with args: {:?})", &args)
+                format!("failed to spawn `clickhouse` (with args: {:?})", args)
             })?;
         for (k, v) in std::env::vars_os() {
             env.insert(
@@ -637,7 +637,7 @@ impl ClickHouseProcess {
             .with_context(|| {
                 format!(
                     "failed to spawn `clickhouse keeper` (with args: {:?})",
-                    &args
+                    args
                 )
             })?;
         for (k, v) in std::env::vars_os() {

--- a/test-utils/src/dev/dendrite.rs
+++ b/test-utils/src/dev/dendrite.rs
@@ -185,7 +185,7 @@ impl DendriteInstance {
             .kill_on_drop(true)
             .spawn()
             .with_context(|| {
-                format!("failed to spawn `dpd` (with args: {:?})", &args)
+                format!("failed to spawn `dpd` (with args: {:?})", args)
             })?;
         let stderr = child.stderr.take().unwrap();
 

--- a/test-utils/src/dev/maghemite.rs
+++ b/test-utils/src/dev/maghemite.rs
@@ -65,7 +65,7 @@ impl MgdInstance {
             .kill_on_drop(true)
             .spawn()
             .with_context(|| {
-                format!("failed to spawn `mgd` (with args: {:?})", &args)
+                format!("failed to spawn `mgd` (with args: {:?})", args)
             })?;
 
         let temp_dir = temp_dir.keep();
@@ -190,7 +190,7 @@ impl DdmInstance {
             .kill_on_drop(true)
             .spawn()
             .with_context(|| {
-                format!("failed to spawn `ddmd` (with args: {:?})", &args)
+                format!("failed to spawn `ddmd` (with args: {:?})", args)
             })?;
 
         let temp_dir = temp_dir.keep();


### PR DESCRIPTION
The goal here is to pick up a optimization miscompilation fix, but be aware that `-Csymbol-mangling-version=v0` is along for the ride too. I seem to remember some chatter in #oxide-rust that this is fine?

https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/
https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/

The bulk of the churn here is https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting. I would normally have disabled the lint to avoid the churn but:

> Detects format!-style macros (e.g. format!, println!, write!) where an argument is passed with an explicit & but the value is already a reference, resulting in a double reference (e.g. &&T).
>
> The extra & is redundant and can make the code less clear. Format macros take references to the arguments internally, so passing &x when x is already a reference produces a double reference. The compiler is currently unable to optimize double references, which results in about 6% degradation per call.

This will almost certainly result in "semantic merge conflicts" shortly after this PR lands. I will ask people to be vigilant but there is no real guard rail so it will happen anyway.

Note there is a new warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

proc-macro-error2 is unmaintained and is brought in through tabled_derive. tabled has [merged a change](https://github.com/zhiburt/tabled/pull/584) which removes the unmaintained dependency but this has not yet landed in a release.