### PR TITLE
Look up service IP Pools by assignment

### DIFF
--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -4481,15 +4481,21 @@ mod tests {
             // This looks up the pool again for each range; we only need at most
             // two (one V4, one V6), but our example system doesn't have many
             // ranges so this should be fine.
-            let (service_authz_ip_pool, service_ip_pool) = datastore
-                .ip_pools_service_lookup(&opctx, pool_range.version().into())
+            let service_pools = datastore
+                .ip_pools_service_lookup_by_version(
+                    &opctx,
+                    pool_range.version().into(),
+                    std::num::NonZeroU32::new(1).unwrap(),
+                )
                 .await
-                .expect("lookup service ip pool");
+                .expect("lookup service ip pools");
+            let service_pool =
+                service_pools.first().expect("service ip pool for version");
             datastore
                 .ip_pool_add_range(
                     &opctx,
-                    &service_authz_ip_pool,
-                    &service_ip_pool,
+                    &service_pool.authz_pool,
+                    &service_pool.db_pool,
                     &pool_range,
                 )
                 .await
@@ -4568,15 +4574,20 @@ mod tests {
                     .map(|(ip, _nic)| ip.ip())
             })
             .expect("found external IP");
-        let (service_authz_ip_pool, service_ip_pool) = datastore
-            .ip_pools_service_lookup(&opctx, IpVersion::V4)
+        let service_pools = datastore
+            .ip_pools_service_lookup_by_version(
+                &opctx,
+                IpVersion::V4,
+                std::num::NonZeroU32::new(1).unwrap(),
+            )
             .await
-            .expect("lookup service ip pool");
+            .expect("lookup service ip pools");
+        let service_pool = service_pools.first().expect("v4 service ip pool");
         datastore
             .ip_pool_add_range(
                 &opctx,
-                &service_authz_ip_pool,
-                &service_ip_pool,
+                &service_pool.authz_pool,
+                &service_pool.db_pool,
                 &IpRange::try_from((nexus_ip, nexus_ip))
                     .expect("valid IP range"),
             )

--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -220,7 +220,13 @@ impl DataStore {
                     conn,
                     external_ip.ip(),
                 )
-                .await?;
+                .await
+                .map_err(|e| {
+                    Self::map_external_ip_not_found_for_zone_error(
+                        e,
+                        external_ip.ip(),
+                    )
+                })?;
 
             // Actually ensure the IP address.
             let kind = z.zone_type.kind();

--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -199,10 +199,6 @@ impl DataStore {
         opctx: &OpContext,
         zones_to_allocate: impl Iterator<Item = &BlueprintZoneConfig>,
     ) -> Result<(), TransactionError<Error>> {
-        // Looking up the service pools requires an opctx; we'll do this at most
-        // once inside the loop below, when we first need it.
-        let mut service_pools = None;
-
         for z in zones_to_allocate {
             let Some((external_ip, nic)) = z.zone_type.external_networking()
             else {
@@ -217,31 +213,20 @@ impl DataStore {
                 "nic" => format!("{nic:?}"),
             ));
 
-            // Look up the system-service pools once, lazily, and cache them.
-            let version = external_ip.ip_version();
-            if service_pools.is_none() {
-                service_pools = Some(
-                    self.ip_pools_service_lookup_both_versions(opctx).await?,
-                );
-            }
-            let service_pools = service_pools.as_ref().unwrap();
-            // TODO(#8949): There could be multiple valid IP pools for a given
-            // service, even for a single IP version. For now, use the first
-            // such pool to match existing behavior.
-            let pool = service_pools
-                .pools_for_version(version.into())
-                .first()
-                .ok_or_else(|| {
-                    Error::internal_error(&format!(
-                        "no system services IP pool for IP version {version:?}"
-                    ))
-                })?;
+            // Look up the system-service pool containing this address, if any.
+            let (_authz_pool, db_pool) = self
+                .ip_pool_fetch_containing_address_for_services_on_connection(
+                    opctx,
+                    conn,
+                    external_ip.ip(),
+                )
+                .await?;
 
             // Actually ensure the IP address.
             let kind = z.zone_type.kind();
             self.ensure_external_service_ip(
                 conn,
-                &pool.db_pool,
+                &db_pool,
                 kind,
                 z.id,
                 external_ip,

--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -25,7 +25,6 @@ use nexus_types::deployment::UpstreamNtpConfig;
 use nexus_types::external_api::instance::PrivateIpStackCreate;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::IdentityMetadataCreateParams;
-use omicron_common::api::external::IpVersion;
 use omicron_common::api::internal::shared::PrivateIpConfig;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -200,11 +199,9 @@ impl DataStore {
         opctx: &OpContext,
         zones_to_allocate: impl Iterator<Item = &BlueprintZoneConfig>,
     ) -> Result<(), TransactionError<Error>> {
-        // Looking up the service pool IDs requires an opctx; we'll do this at
-        // most once inside the loop below, when we first encounter an address
-        // of the same IP version.
-        let mut v4_pool = None;
-        let mut v6_pool = None;
+        // Looking up the service pools requires an opctx; we'll do this at most
+        // once inside the loop below, when we first need it.
+        let mut service_pools = None;
 
         for z in zones_to_allocate {
             let Some((external_ip, nic)) = z.zone_type.external_networking()
@@ -220,29 +217,31 @@ impl DataStore {
                 "nic" => format!("{nic:?}"),
             ));
 
-            // Get existing pool or look it up and cache it.
+            // Look up the system-service pools once, lazily, and cache them.
             let version = external_ip.ip_version();
-            let pool_ref = match version {
-                IpVersion::V4 => &mut v4_pool,
-                IpVersion::V6 => &mut v6_pool,
-            };
-            let pool = match pool_ref {
-                Some(p) => p,
-                None => {
-                    let new = self
-                        .ip_pools_service_lookup(opctx, version.into())
-                        .await?
-                        .1;
-                    *pool_ref = Some(new);
-                    pool_ref.as_ref().unwrap()
-                }
-            };
+            if service_pools.is_none() {
+                service_pools = Some(
+                    self.ip_pools_service_lookup_both_versions(opctx).await?,
+                );
+            }
+            let service_pools = service_pools.as_ref().unwrap();
+            // TODO(#8949): There could be multiple valid IP pools for a given
+            // service, even for a single IP version. For now, use the first
+            // such pool to match existing behavior.
+            let pool = service_pools
+                .pools_for_version(version.into())
+                .first()
+                .ok_or_else(|| {
+                    Error::internal_error(&format!(
+                        "no system services IP pool for IP version {version:?}"
+                    ))
+                })?;
 
             // Actually ensure the IP address.
             let kind = z.zone_type.kind();
             self.ensure_external_service_ip(
                 conn,
-                pool,
+                &pool.db_pool,
                 kind,
                 z.id,
                 external_ip,
@@ -855,15 +854,21 @@ mod tests {
             opctx: &OpContext,
             datastore: &DataStore,
         ) {
-            let (ip_pool, db_pool) = datastore
-                .ip_pools_service_lookup(&opctx, IpVersion::V4.into())
+            let service_pools = datastore
+                .ip_pools_service_lookup_by_version(
+                    &opctx,
+                    omicron_common::api::external::IpVersion::V4.into(),
+                    std::num::NonZeroU32::new(1).unwrap(),
+                )
                 .await
-                .expect("failed to find service IP pool");
+                .expect("failed to find service IP pools");
+            let service_pool =
+                service_pools.first().expect("no v4 system services IP pool");
             datastore
                 .ip_pool_add_range(
                     &opctx,
-                    &ip_pool,
-                    &db_pool,
+                    &service_pool.authz_pool,
+                    &service_pool.db_pool,
                     &self.external_ips_range,
                 )
                 .await

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -304,7 +304,7 @@ impl DataStore {
         let (authz_pool, explicit_ip) = match &allocation {
             FloatingIpAllocation::Explicit { ip } => {
                 let pool = self
-                    .ip_pool_fetch_containing_address(
+                    .ip_pool_fetch_containing_address_in_current_silo(
                         opctx,
                         *ip,
                         IpPoolType::Unicast,

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -64,6 +64,7 @@ use ref_cast::RefCast;
 use sled_agent_types::inventory::ZoneKind;
 use slog::debug;
 use std::net::IpAddr;
+use std::num::NonZeroU32;
 use uuid::Uuid;
 
 /// Ephemeral IPs for an instance, with one slot per IP version.
@@ -482,17 +483,32 @@ impl DataStore {
         external_ip: OmicronZoneExternalIp,
     ) -> CreateResult<ExternalIp> {
         let version = IpVersion::from(external_ip.ip_version());
-        let (authz_pool, pool) =
-            self.ip_pools_service_lookup(opctx, version).await?;
-        opctx.authorize(authz::Action::CreateChild, &authz_pool).await?;
+        // TODO(#8949): There could be multiple valid IP pools for a given
+        // service, even for a single IP version. For now, use the first such
+        // pool to match existing behavior.
+        let service_pools = self
+            .ip_pools_service_lookup_by_version(
+                opctx,
+                version,
+                NonZeroU32::new(1).unwrap(),
+            )
+            .await?;
+        let service_pool = service_pools.first().ok_or_else(|| {
+            Error::internal_error(&format!(
+                "no system services IP pool for IP version {version}"
+            ))
+        })?;
+        opctx
+            .authorize(authz::Action::CreateChild, &service_pool.authz_pool)
+            .await?;
+        let pool_id = service_pool.db_pool.id();
         let data = IncompleteExternalIp::for_omicron_zone(
-            pool.id(),
+            pool_id,
             external_ip,
             zone_id,
             zone_kind,
         );
-        self.allocate_external_ip(opctx, data, LookupType::ById(pool.id()))
-            .await
+        self.allocate_external_ip(opctx, data, LookupType::ById(pool_id)).await
     }
 
     /// Variant of [Self::external_ip_allocate_omicron_zone] which may be called
@@ -527,13 +543,18 @@ impl DataStore {
     ) -> ListResultVec<ExternalIp> {
         use nexus_db_schema::schema::external_ip::dsl;
 
-        // Note the IP version used here isn't important. It's just for the
-        // authz check to list children, and not used for the actual database
-        // query below, which filters on is_service to get external IPs from
-        // either pool.
-        let (authz_pool, _pool) =
-            self.ip_pools_service_lookup(opctx, IpVersion::V4).await?;
-        opctx.authorize(authz::Action::ListChildren, &authz_pool).await?;
+        // We only need a system-service pool for the authz check; the IP
+        // version is irrelevant (both versions have the same permissions), and
+        // a v6-only rack may have no v4 pool.
+        let service_pools =
+            self.ip_pools_service_lookup_both_versions(opctx).await?;
+        let authz_pool = &service_pools
+            .any_pool()
+            .ok_or_else(|| {
+                Error::internal_error("no system services IP pool found")
+            })?
+            .authz_pool;
+        opctx.authorize(authz::Action::ListChildren, authz_pool).await?;
 
         paginated(dsl::external_ip, dsl::id, pagparams)
             .filter(dsl::is_service)
@@ -1432,12 +1453,22 @@ mod tests {
             Ipv4Addr::new(10, 0, 0, 10),
         ))
         .unwrap();
-        let (service_ip_pool, db_pool) = datastore
-            .ip_pools_service_lookup(opctx, IpVersion::V4)
+        let service_pools = datastore
+            .ip_pools_service_lookup_by_version(
+                opctx,
+                IpVersion::V4,
+                NonZeroU32::new(1).unwrap(),
+            )
             .await
-            .expect("lookup service ip pool");
+            .expect("lookup service ip pools");
+        let service_pool = service_pools.first().expect("v4 service ip pool");
         datastore
-            .ip_pool_add_range(opctx, &service_ip_pool, &db_pool, &ip_range)
+            .ip_pool_add_range(
+                opctx,
+                &service_pool.authz_pool,
+                &service_pool.db_pool,
+                &ip_range,
+            )
             .await
             .expect("add range to service ip pool");
 
@@ -1515,12 +1546,22 @@ mod tests {
         // Set up an service IP pool range with one IP in it.
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let ip_range = IpRange::try_from((ip, ip)).unwrap();
-        let (service_ip_pool, db_pool) = datastore
-            .ip_pools_service_lookup(opctx, IpVersion::V4)
+        let service_pools = datastore
+            .ip_pools_service_lookup_by_version(
+                opctx,
+                IpVersion::V4,
+                NonZeroU32::new(1).unwrap(),
+            )
             .await
-            .expect("lookup service ip pool");
+            .expect("lookup service ip pools");
+        let service_pool = service_pools.first().expect("v4 service ip pool");
         datastore
-            .ip_pool_add_range(opctx, &service_ip_pool, &db_pool, &ip_range)
+            .ip_pool_add_range(
+                opctx,
+                &service_pool.authz_pool,
+                &service_pool.db_pool,
+                &ip_range,
+            )
             .await
             .expect("add range to service ip pool");
 

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -64,7 +64,6 @@ use ref_cast::RefCast;
 use sled_agent_types::inventory::ZoneKind;
 use slog::debug;
 use std::net::IpAddr;
-use std::num::NonZeroU32;
 use uuid::Uuid;
 
 /// Ephemeral IPs for an instance, with one slot per IP version.
@@ -474,6 +473,21 @@ impl DataStore {
         })
     }
 
+    // Helper method to map an `Error` when looking up IP Pools for a specific
+    // IP for an _Omicron zone_, and no such pool contains the address at all.
+    pub(crate) fn map_external_ip_not_found_for_zone_error(
+        err: Error,
+        ip: IpAddr,
+    ) -> Error {
+        match err {
+            Error::ObjectNotFound { .. } => Error::invalid_request(format!(
+                "External IP address {ip} is not available in any \
+                pool assigned to system services",
+            )),
+            other => other,
+        }
+    }
+
     /// Allocates an explicit IP address for an Omicron zone.
     pub async fn external_ip_allocate_omicron_zone(
         &self,
@@ -482,26 +496,19 @@ impl DataStore {
         zone_kind: ZoneKind,
         external_ip: OmicronZoneExternalIp,
     ) -> CreateResult<ExternalIp> {
-        let version = IpVersion::from(external_ip.ip_version());
-        // TODO(#8949): There could be multiple valid IP pools for a given
-        // service, even for a single IP version. For now, use the first such
-        // pool to match existing behavior.
-        let service_pools = self
-            .ip_pools_service_lookup_by_version(
+        let (_authz_pool, db_pool) = self
+            .ip_pool_fetch_containing_address_for_services(
                 opctx,
-                version,
-                NonZeroU32::new(1).unwrap(),
+                external_ip.ip(),
             )
-            .await?;
-        let service_pool = service_pools.first().ok_or_else(|| {
-            Error::internal_error(&format!(
-                "no system services IP pool for IP version {version}"
-            ))
-        })?;
-        opctx
-            .authorize(authz::Action::CreateChild, &service_pool.authz_pool)
-            .await?;
-        let pool_id = service_pool.db_pool.id();
+            .await
+            .map_err(|e| {
+                Self::map_external_ip_not_found_for_zone_error(
+                    e,
+                    external_ip.ip(),
+                )
+            })?;
+        let pool_id = db_pool.id();
         let data = IncompleteExternalIp::for_omicron_zone(
             pool_id,
             external_ip,
@@ -1420,6 +1427,7 @@ mod tests {
     use sled_agent_types::inventory::SourceNatConfigGeneric;
     use std::collections::BTreeSet;
     use std::net::Ipv4Addr;
+    use std::num::NonZeroU32;
 
     async fn read_all_service_ips(
         datastore: &DataStore,

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -69,6 +69,7 @@ use omicron_common::api::external::http_pagination::PaginatedBy;
 use ref_cast::RefCast;
 use std::collections::HashSet;
 use std::net::IpAddr;
+use std::num::NonZeroU32;
 use uuid::Uuid;
 
 /// Helper type with both an authz IP Pool and the actual DB record.
@@ -97,6 +98,11 @@ impl ServiceIpPools {
             IpVersion::V4 => &self.ipv4,
             IpVersion::V6 => &self.ipv6,
         }
+    }
+
+    /// Return any one system-service pool, regardless of IP version.
+    pub fn any_pool(&self) -> Option<&ServiceIpPool> {
+        self.ipv4.first().or_else(|| self.ipv6.first())
     }
 }
 
@@ -485,6 +491,41 @@ impl DataStore {
         Ok(ServiceIpPools { ipv4, ipv6 })
     }
 
+    /// Look up the system-service IP pools of a single IP version.
+    ///
+    /// Returns every pool assigned to system services with the given IP
+    /// version, up to `limit`.
+    pub async fn ip_pools_service_lookup_by_version(
+        &self,
+        opctx: &OpContext,
+        ip_version: IpVersion,
+        limit: NonZeroU32,
+    ) -> LookupResult<Vec<ServiceIpPool>> {
+        let pagparams = PaginatedBy::Id(DataPageParams {
+            marker: None,
+            direction: dropshot::PaginationOrder::Ascending,
+            limit,
+        });
+        let pools = self
+            .ip_pools_list_paginated(
+                opctx,
+                Some(IpPoolAssignment::SystemServices),
+                Some(ip_version),
+                None,
+                &pagparams,
+            )
+            .await?;
+        Ok(pools
+            .into_iter()
+            .map(|db_pool| {
+                let id = db_pool.id();
+                let authz_pool =
+                    authz::IpPool::new(authz::FLEET, id, LookupType::ById(id));
+                ServiceIpPool { authz_pool, db_pool }
+            })
+            .collect())
+    }
+
     /// Fetch all default unicast IP pools for the current silo, one per IP
     /// version. Returns a [`DefaultIpPools`] where each version field is
     /// `Some` if a default pool of that version is linked to the silo, or
@@ -700,10 +741,11 @@ impl DataStore {
     ///
     /// This method may require an index by Availability Zone in the future.
     //
-    // TODO-remove: Use ip_pools_list_paginated with the right enum type
-    // instead.
-    //
-    // See https://github.com/oxidecomputer/omicron/issues/8947.
+    // The only remaining callers are the deprecated `ip-pools-service` API
+    // handlers. Everything else resolves system-service pools by assignment via
+    // `ip_pools_service_lookup_by_version` / `_both_versions`. This method and
+    // the well-known name constants are removed once those handlers move off
+    // the builtin names. See https://github.com/oxidecomputer/omicron/issues/8950.
     pub async fn ip_pools_service_lookup(
         &self,
         opctx: &OpContext,
@@ -2822,14 +2864,22 @@ mod test {
 
         for version in [IpVersion::V4, IpVersion::V6] {
             // confirm system services pools are identified correctly
-            let (authz_pool, pool) = datastore
-                .ip_pools_service_lookup(&opctx, version)
+            let service_pools = datastore
+                .ip_pools_service_lookup_by_version(
+                    &opctx,
+                    version,
+                    NonZeroU32::new(1).unwrap(),
+                )
                 .await
                 .unwrap();
-            assert_eq!(pool.ip_version, version);
+            let service_pool = service_pools.first().unwrap();
+            assert_eq!(service_pool.db_pool.ip_version, version);
 
             let is_internal = datastore
-                .ip_pool_is_assigned_to_system_services(&opctx, &authz_pool)
+                .ip_pool_is_assigned_to_system_services(
+                    &opctx,
+                    &service_pool.authz_pool,
+                )
                 .await;
             assert_eq!(is_internal, Ok(true));
 

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -683,42 +683,112 @@ impl DataStore {
     /// This searches all pools linked to the current silo for a range
     /// containing the given IP address. Since IP pool ranges cannot overlap,
     /// at most one pool can contain any given address.
-    pub async fn ip_pool_fetch_containing_address(
+    ///
+    /// NOTE: This also authorizes the CreateChild action on the pool.
+    pub async fn ip_pool_fetch_containing_address_in_current_silo(
         &self,
         opctx: &OpContext,
         ip: IpAddr,
         pool_type: IpPoolType,
     ) -> LookupResult<authz::IpPool> {
+        let silo_id = opctx.authn.silo_required()?.id();
+        self.lookup_ip_pool_containing_address_on_connection(
+            opctx,
+            &*self.pool_connection_authorized(opctx).await?,
+            ip,
+            pool_type,
+            Some(silo_id),
+        )
+        .await
+        .map(|(authz, _db)| authz)
+    }
+
+    /// Fetch the IP Pool assigned to services containing the provided address.
+    pub async fn ip_pool_fetch_containing_address_for_services(
+        &self,
+        opctx: &OpContext,
+        ip: IpAddr,
+    ) -> LookupResult<(authz::IpPool, IpPool)> {
+        self.ip_pool_fetch_containing_address_for_services_on_connection(
+            opctx,
+            &*self.pool_connection_authorized(opctx).await?,
+            ip,
+        )
+        .await
+    }
+
+    pub(crate) async fn ip_pool_fetch_containing_address_for_services_on_connection(
+        &self,
+        opctx: &OpContext,
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+        ip: IpAddr,
+    ) -> LookupResult<(authz::IpPool, IpPool)> {
+        self.lookup_ip_pool_containing_address_on_connection(
+            opctx,
+            conn,
+            ip,
+            // System services always use unicast addresses today.
+            IpPoolType::Unicast,
+            // And have no linked silo.
+            None,
+        )
+        .await
+    }
+
+    async fn lookup_ip_pool_containing_address_on_connection(
+        &self,
+        opctx: &OpContext,
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+        ip: IpAddr,
+        pool_type: IpPoolType,
+        silo_id: Option<Uuid>,
+    ) -> LookupResult<(authz::IpPool, IpPool)> {
         use nexus_db_schema::schema::ip_pool;
         use nexus_db_schema::schema::ip_pool_range;
         use nexus_db_schema::schema::ip_pool_resource;
-
         let ip_network: IpNetwork = ip.into();
-        let silo_id = opctx.authn.silo_required()?.id();
-
-        let pool = ip_pool_range::table
+        let ip_version =
+            if ip.is_ipv4() { IpVersion::V4 } else { IpVersion::V6 };
+        let mut query = ip_pool_range::table
             .inner_join(
                 ip_pool::table.on(ip_pool::id
                     .eq(ip_pool_range::ip_pool_id)
                     .and(ip_pool::time_deleted.is_null())),
             )
-            .inner_join(
-                ip_pool_resource::table.on(ip_pool_resource::ip_pool_id
-                    .eq(ip_pool::id)
-                    .and(
-                        ip_pool_resource::resource_type
-                            .eq(IpPoolResourceType::Silo),
-                    )
-                    .and(ip_pool_resource::resource_id.eq(silo_id))),
-            )
+            .into_boxed();
+
+        // We need to ensure the pool is linked to the provided silo, if it's
+        // Some(_). We can do that with an inner join, but that's difficult to
+        // express in Diesel. Instead, use a subquery that returns FALSE if
+        // there's no such link.
+        //
+        // NOTE: We don't do this at all for system services, and instead check
+        // that the pool itself is assigned for services.
+        if let Some(silo_id) = silo_id {
+            query = query.filter(diesel::dsl::exists(
+                ip_pool_resource::table.filter(
+                    ip_pool_resource::ip_pool_id
+                        .eq(ip_pool::id)
+                        .and(
+                            ip_pool_resource::resource_type
+                                .eq(IpPoolResourceType::Silo),
+                        )
+                        .and(ip_pool_resource::resource_id.eq(silo_id)),
+                ),
+            ));
+        } else {
+            query = query.filter(
+                ip_pool::assignment.eq(IpPoolAssignment::SystemServices),
+            );
+        }
+        let pool = query
             .filter(ip_pool_range::time_deleted.is_null())
             .filter(ip_pool_range::first_address.le(ip_network))
             .filter(ip_pool_range::last_address.ge(ip_network))
             .filter(ip_pool::pool_type.eq(pool_type))
+            .filter(ip_pool::ip_version.eq(ip_version))
             .select(IpPool::as_select())
-            .first_async::<IpPool>(
-                &*self.pool_connection_authorized(opctx).await?,
-            )
+            .first_async::<IpPool>(conn)
             .await
             .map_err(|e| {
                 public_error_from_diesel_lookup(
@@ -734,7 +804,7 @@ impl DataStore {
         let authz_pool =
             authz::IpPool::new(authz::FLEET, pool.id(), lookup_type);
         opctx.authorize(authz::Action::CreateChild, &authz_pool).await?;
-        Ok(authz_pool)
+        Ok((authz_pool, pool))
     }
 
     /// Look up system services IP pool by its well-known name.
@@ -6071,7 +6141,7 @@ mod test {
         // Case: IP within range should find the pool
         let ip_in_range = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 100));
         let result = datastore
-            .ip_pool_fetch_containing_address(
+            .ip_pool_fetch_containing_address_in_current_silo(
                 &opctx,
                 ip_in_range,
                 IpPoolType::Unicast,
@@ -6083,7 +6153,7 @@ mod test {
         // Case: IP at range boundaries should find the pool
         let ip_start = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0));
         let result = datastore
-            .ip_pool_fetch_containing_address(
+            .ip_pool_fetch_containing_address_in_current_silo(
                 &opctx,
                 ip_start,
                 IpPoolType::Unicast,
@@ -6094,7 +6164,7 @@ mod test {
 
         let ip_end = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 255));
         let result = datastore
-            .ip_pool_fetch_containing_address(
+            .ip_pool_fetch_containing_address_in_current_silo(
                 &opctx,
                 ip_end,
                 IpPoolType::Unicast,
@@ -6106,7 +6176,7 @@ mod test {
         // Case: IP outside range should return NotFound error
         let ip_outside = IpAddr::V4(Ipv4Addr::new(10, 1, 0, 1));
         let result = datastore
-            .ip_pool_fetch_containing_address(
+            .ip_pool_fetch_containing_address_in_current_silo(
                 &opctx,
                 ip_outside,
                 IpPoolType::Unicast,
@@ -6119,7 +6189,7 @@ mod test {
 
         // Case: Wrong pool type should return NotFound error
         let result = datastore
-            .ip_pool_fetch_containing_address(
+            .ip_pool_fetch_containing_address_in_current_silo(
                 &opctx,
                 ip_in_range,
                 IpPoolType::Multicast,
@@ -6186,7 +6256,7 @@ mod test {
         // Case: Multicast IP should find the multicast pool
         let mcast_ip = IpAddr::V4(Ipv4Addr::new(239, 0, 0, 50));
         let result = datastore
-            .ip_pool_fetch_containing_address(
+            .ip_pool_fetch_containing_address_in_current_silo(
                 &opctx,
                 mcast_ip,
                 IpPoolType::Multicast,
@@ -6197,7 +6267,7 @@ mod test {
 
         // Case: Multicast IP should not be found when asking for unicast
         let result = datastore
-            .ip_pool_fetch_containing_address(
+            .ip_pool_fetch_containing_address_in_current_silo(
                 &opctx,
                 mcast_ip,
                 IpPoolType::Unicast,
@@ -6206,6 +6276,76 @@ mod test {
         assert!(
             result.is_err(),
             "Should not find multicast pool when asking for unicast"
+        );
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn test_ip_pool_fetch_containing_address_for_services() {
+        let logctx = dev::test_setup_log(
+            "test_ip_pool_fetch_containing_address_for_services",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        // Create a pool assigned to system services. Note that we deliberately
+        // do not link it to a silo: system-services pools have no silo link,
+        // which is exactly the branch this method exercises.
+        let identity = IdentityMetadataCreateParams {
+            name: "service-pool".parse().unwrap(),
+            description: "Test system-services IP pool".to_string(),
+        };
+        let pool = datastore
+            .ip_pool_create(
+                &opctx,
+                IpPool::new(
+                    &identity,
+                    IpVersion::V4,
+                    IpPoolAssignment::SystemServices,
+                ),
+            )
+            .await
+            .expect("Should create system-services IP pool");
+
+        let authz_pool = authz::IpPool::new(
+            authz::FLEET,
+            pool.id(),
+            LookupType::ById(pool.id()),
+        );
+
+        // Add a range to the pool.
+        let range = IpRange::V4(
+            Ipv4Range::new(
+                Ipv4Addr::new(10, 0, 0, 0),
+                Ipv4Addr::new(10, 0, 0, 255),
+            )
+            .unwrap(),
+        );
+        datastore
+            .ip_pool_add_range(&opctx, &authz_pool, &pool, &range)
+            .await
+            .expect("Should add range to pool");
+
+        // Pick an address from that range and confirm the lookup finds our
+        // pool.
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 100));
+        let (found_authz, found_pool) = datastore
+            .ip_pool_fetch_containing_address_for_services(&opctx, ip)
+            .await
+            .expect("Should find system-services pool containing 10.0.0.100");
+        assert_eq!(found_authz.id(), pool.id());
+        assert_eq!(found_pool.id(), pool.id());
+
+        // An address outside the range should not be found.
+        let ip_outside = IpAddr::V4(Ipv4Addr::new(10, 1, 0, 1));
+        let result = datastore
+            .ip_pool_fetch_containing_address_for_services(&opctx, ip_outside)
+            .await;
+        assert!(
+            result.is_err(),
+            "Should not find a pool for an address outside all ranges"
         );
 
         db.terminate().await;

--- a/nexus/db-queries/src/db/datastore/multicast/groups.rs
+++ b/nexus/db-queries/src/db/datastore/multicast/groups.rs
@@ -577,7 +577,7 @@ impl DataStore {
         let (authz_pool, explicit_ip) = match &params.ip_allocation {
             MulticastIpAllocation::Explicit { ip } => {
                 let pool = self
-                    .ip_pool_fetch_containing_address(
+                    .ip_pool_fetch_containing_address_in_current_silo(
                         opctx,
                         *ip,
                         IpPoolType::Multicast,

--- a/nexus/db-queries/src/db/datastore/network_interface.rs
+++ b/nexus/db-queries/src/db/datastore/network_interface.rs
@@ -35,7 +35,6 @@ use nexus_db_errors::TransactionError;
 use nexus_db_errors::public_error_from_diesel;
 use nexus_db_errors::retryable;
 use nexus_db_lookup::DbConnection;
-use nexus_db_model::IpVersion;
 use nexus_db_model::Ipv4Addr;
 use nexus_db_model::Ipv6Addr;
 use nexus_db_model::ServiceNetworkInterface;
@@ -268,9 +267,15 @@ impl DataStore {
         //
         // Note that the IP version doesn't matter here, both pools have the
         // same permissions.
-        let (authz_pool, _pool) =
-            self.ip_pools_service_lookup(opctx, IpVersion::V4).await?;
-        opctx.authorize(authz::Action::ListChildren, &authz_pool).await?;
+        let service_pools =
+            self.ip_pools_service_lookup_both_versions(opctx).await?;
+        let authz_pool = &service_pools
+            .any_pool()
+            .ok_or_else(|| {
+                Error::internal_error("no system services IP pool found")
+            })?
+            .authz_pool;
+        opctx.authorize(authz::Action::ListChildren, authz_pool).await?;
 
         paginated(dsl::service_network_interface, dsl::id, pagparams)
             .filter(dsl::time_deleted.is_null())
@@ -332,12 +337,20 @@ impl DataStore {
         //
         // Note that the IP version here doesn't matter, both IPv4 and IPv6
         // service pools have the same permissions.
-        let (authz_service_ip_pool, _) = self
-            .ip_pools_service_lookup(opctx, IpVersion::V4)
+        let service_pools = self
+            .ip_pools_service_lookup_both_versions(opctx)
             .await
             .map_err(network_interface::InsertError::External)?;
+        let authz_service_ip_pool = &service_pools
+            .any_pool()
+            .ok_or_else(|| {
+                network_interface::InsertError::External(Error::internal_error(
+                    "no system services IP pool found",
+                ))
+            })?
+            .authz_pool;
         opctx
-            .authorize(authz::Action::CreateChild, &authz_service_ip_pool)
+            .authorize(authz::Action::CreateChild, authz_service_ip_pool)
             .await
             .map_err(network_interface::InsertError::External)?;
         self.service_create_network_interface_raw(opctx, interface).await
@@ -1034,9 +1047,15 @@ impl DataStore {
         //
         // But assuming this check is correct, both service pools have the same
         // permissions, so the actual IP version here doesn't matter.
-        let (authz_pool, _pool) =
-            self.ip_pools_service_lookup(opctx, IpVersion::V4).await?;
-        opctx.authorize(authz::Action::ListChildren, &authz_pool).await?;
+        let service_pools =
+            self.ip_pools_service_lookup_both_versions(opctx).await?;
+        let authz_pool = &service_pools
+            .any_pool()
+            .ok_or_else(|| {
+                Error::internal_error("no system services IP pool found")
+            })?
+            .authz_pool;
+        opctx.authorize(authz::Action::ListChildren, authz_pool).await?;
 
         paginated(dsl::instance_network_interface, dsl::id, pagparams)
             .filter(dsl::time_deleted.is_null())

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1647,10 +1647,15 @@ mod test {
 
         // Furthermore, we should be able to see that these IP addresses have
         // been allocated as a part of a service IP pool.
-        let (.., svc_pool) = datastore
-            .ip_pools_service_lookup(&opctx, IpVersion::V4)
+        let svc_pools = datastore
+            .ip_pools_service_lookup_by_version(
+                &opctx,
+                IpVersion::V4,
+                std::num::NonZeroU32::new(1).unwrap(),
+            )
             .await
             .unwrap();
+        let svc_pool = &svc_pools.first().expect("v4 service ip pool").db_pool;
         assert_eq!(svc_pool.name().as_str(), SERVICE_IPV4_POOL_NAME);
 
         let observed_ip_pool_ranges = get_all_ip_pool_ranges(&datastore).await;
@@ -1841,10 +1846,15 @@ mod test {
 
         // Furthermore, we should be able to see that this IP addresses have been
         // allocated as a part of a service IP pool.
-        let (.., svc_pool) = datastore
-            .ip_pools_service_lookup(&opctx, IpVersion::V4)
+        let svc_pools = datastore
+            .ip_pools_service_lookup_by_version(
+                &opctx,
+                IpVersion::V4,
+                std::num::NonZeroU32::new(1).unwrap(),
+            )
             .await
             .unwrap();
+        let svc_pool = &svc_pools.first().expect("v4 service ip pool").db_pool;
         assert_eq!(svc_pool.name().as_str(), SERVICE_IPV4_POOL_NAME);
 
         let observed_ip_pool_ranges = get_all_ip_pool_ranges(&datastore).await;
@@ -2025,10 +2035,15 @@ mod test {
 
         // Furthermore, we should be able to see that this IP address has been
         // allocated as a part of a service IPv6 IP pool.
-        let (.., svc_pool) = datastore
-            .ip_pools_service_lookup(&opctx, IpVersion::V6)
+        let svc_pools = datastore
+            .ip_pools_service_lookup_by_version(
+                &opctx,
+                IpVersion::V6,
+                std::num::NonZeroU32::new(1).unwrap(),
+            )
             .await
             .unwrap();
+        let svc_pool = &svc_pools.first().expect("v6 service ip pool").db_pool;
         assert_eq!(svc_pool.name().as_str(), SERVICE_IPV6_POOL_NAME);
 
         let observed_ip_pool_ranges = get_all_ip_pool_ranges(&datastore).await;

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -1755,7 +1755,8 @@ mod tests {
             .expect_err("Should have failed to allocate out-of-bounds IP");
         assert_eq!(
             err.to_string(),
-            "Invalid Request: Requested external IP address not available"
+            "Invalid Request: External IP address 10.0.0.5 is not \
+            available in any pool assigned to system services"
         );
 
         context.success().await;

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -2423,23 +2423,25 @@ mod tests {
             "fd01::ffff".parse::<Ipv6Addr>().unwrap(),
         ))
         .unwrap();
-        let (authz_pool, db_pool) = context
+        let service_pools = context
             .db
             .datastore()
-            .ip_pools_service_lookup(
+            .ip_pools_service_lookup_by_version(
                 context.db.opctx(),
                 nexus_db_model::IpVersion::V6,
+                std::num::NonZeroU32::new(1).unwrap(),
             )
             .await
-            .expect("should be able to lookup service IP Pool");
+            .expect("should be able to lookup service IP Pools");
+        let service_pool = service_pools.first().expect("v6 service ip pool");
         for range in [range1, range2] {
             let _ = context
                 .db
                 .datastore()
                 .ip_pool_add_range(
                     context.db.opctx(),
-                    &authz_pool,
-                    &db_pool,
+                    &service_pool.authz_pool,
+                    &service_pool.db_pool,
                     &range,
                 )
                 .await


### PR DESCRIPTION
Switch most callers from looking up service pools by hardcoded name to look them up by their assignment type. Also handle the possibility of many such pools, even for a single version. This is a layover to removing the hardcoded names entirely.