### PR TITLE
[nexus] fix semantic merge conflict between #10787 and #10801

### DIFF
--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -2764,7 +2764,7 @@ mod tests {
             .instance_updater_inherit_lock(
                 &opctx,
                 &authz_instance,
-                parent_lock,
+                &parent_lock,
                 Uuid::new_v4(),
             )
             .await


### PR DESCRIPTION
PR #10801 changed one of the arguments to
`instance_updater_inherit_lock` to be passed as a reference, and #10787 added a new test that calls that function. I branched #10801 from `main` prior to #10787 merging, so the `&` was never added where it needed to be. Hilarity ensues. :(