### PR TITLE
[fm] add opt-in ANSI terminal colors to displayers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8230,6 +8230,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "openssl",
+ "owo-colors 4.3.0",
  "oximeter-db",
  "oxnet",
  "oxql-types",

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -1446,7 +1446,7 @@ impl DbArgs {
                         args.exec(&omdb, &opctx, &datastore).await
                     }
                     DbCommands::Sitrep(args) => {
-                        sitrep::cmd_db_sitrep(&opctx, &datastore, &fetch_opts, args).await
+                        sitrep::cmd_db_sitrep(&omdb, &opctx, &datastore, &fetch_opts, args).await
                     }
                     DbCommands::Sitreps(args) => {
                         sitrep::cmd_db_sitrep_history(&opctx, &datastore, &fetch_opts, args).await

--- a/dev-tools/omdb/src/bin/omdb/db/sitrep.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/sitrep.rs
@@ -4,10 +4,12 @@
 
 //! `omdb db sitrep` subcommands
 
+use crate::Omdb;
 use crate::db::DbFetchOptions;
 use crate::db::check_limit;
 use crate::helpers::const_max_len;
 use crate::helpers::datetime_opt_rfc3339_concise;
+use crate::helpers::should_colorize;
 use anyhow::Context;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use chrono::{DateTime, Utc};
@@ -239,17 +241,23 @@ impl SitrepSelector {
 }
 
 pub(super) async fn cmd_db_sitrep(
+    omdb: &Omdb,
     opctx: &OpContext,
     datastore: &DataStore,
     fetch_opts: &DbFetchOptions,
     args: &SitrepArgs,
 ) -> anyhow::Result<()> {
+    let colored =
+        should_colorize(omdb.output.color, supports_color::Stream::Stdout);
     match args.command {
         Commands::History(ref args) => {
             cmd_db_sitrep_history(opctx, datastore, fetch_opts, args).await
         }
         Commands::Info { sitrep, opts: ref args } => {
-            cmd_db_sitrep_show(opctx, datastore, fetch_opts, args, sitrep).await
+            cmd_db_sitrep_show(
+                opctx, datastore, fetch_opts, args, sitrep, colored,
+            )
+            .await
         }
         Commands::Current(ref args) => {
             cmd_db_sitrep_show(
@@ -258,12 +266,15 @@ pub(super) async fn cmd_db_sitrep(
                 fetch_opts,
                 args,
                 SitrepSelector::Current,
+                colored,
             )
             .await
         }
         Commands::AnalysisReport(ref args) => {
-            cmd_db_sitrep_analysis_report(opctx, datastore, fetch_opts, args)
-                .await
+            cmd_db_sitrep_analysis_report(
+                opctx, datastore, fetch_opts, args, colored,
+            )
+            .await
         }
     }
 }
@@ -347,6 +358,7 @@ async fn cmd_db_sitrep_show(
     _fetch_opts: &DbFetchOptions,
     opts: &ShowOptions,
     sitrep_selector: SitrepSelector,
+    colored: bool,
 ) -> anyhow::Result<()> {
     let current_version = datastore
         .fm_current_sitrep_version(&opctx)
@@ -499,7 +511,7 @@ async fn cmd_db_sitrep_show(
     if !cases.is_empty() {
         println!("\n{:=<80}\n", "== CASES ");
         for case in cases {
-            println!("{}", case.display_indented(4, Some(id)));
+            println!("{}", case.display_indented(4, Some(id)).colored(colored));
         }
     }
 
@@ -511,6 +523,7 @@ async fn cmd_db_sitrep_analysis_report(
     datastore: &DataStore,
     _fetch_opts: &DbFetchOptions,
     args: &AnalysisReportArgs,
+    colored: bool,
 ) -> anyhow::Result<()> {
     let &AnalysisReportArgs { sitrep, ref opts } = args;
     let (_, id) = sitrep.resolve(&datastore, &opctx).await?;
@@ -519,7 +532,7 @@ async fn cmd_db_sitrep_analysis_report(
         load_analysis_report(datastore, id).await.with_context(|| {
             format!("failed to load analysis report for {err_ctx}",)
         })?;
-    print_analysis_report(&report, opts.json)?;
+    print_analysis_report(&report, opts.json, colored)?;
 
     Ok(())
 }
@@ -527,6 +540,7 @@ async fn cmd_db_sitrep_analysis_report(
 fn print_analysis_report(
     report: &model::fm::SitrepAnalysisReport,
     json: bool,
+    colored: bool,
 ) -> anyhow::Result<()> {
     use nexus_types::fm::analysis_reports::{AnalysisReport, InputReport};
 
@@ -566,27 +580,33 @@ fn print_analysis_report(
 
     println!("\n{:=<80}", "== ANALYSIS INPUT REPORT ");
     match serde_json::from_value::<InputReport>(input_report.clone()) {
-        Ok(report) => println!("{}", report.display_multiline(0)),
+        Ok(report) => {
+            println!("{}", report.display_multiline(0).colored(colored))
+        }
         Err(e) => {
             eprintln!(
                 "WARNING: failed to parse input report; falling back to \
                 less structured output: {e}"
             );
-            let displayer = nexus_types::fm::display::Json::new(&input_report);
+            let displayer = nexus_types::fm::display::Json::new(&input_report)
+                .colored(colored);
             println!("{displayer}");
         }
     }
 
     println!("\n{:=<80}", "== ANALYSIS REPORT ");
     match serde_json::from_value::<AnalysisReport>(analysis_report.clone()) {
-        Ok(report) => println!("{}", report.display_multiline(0)),
+        Ok(report) => {
+            println!("{}", report.display_multiline(0).colored(colored))
+        }
         Err(e) => {
             eprintln!(
                 "WARNING: failed to parse analysis report; falling back to \
                 less structured output: {e}"
             );
             let displayer =
-                nexus_types::fm::display::Json::new(&analysis_report);
+                nexus_types::fm::display::Json::new(&analysis_report)
+                    .colored(colored);
             println!("{displayer}");
         }
     }

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -722,7 +722,14 @@ impl NexusArgs {
             }) => cmd_nexus_background_tasks_list(&client).await,
             NexusCommands::BackgroundTasks(BackgroundTasksArgs {
                 command: BackgroundTasksCommands::Show(args),
-            }) => cmd_nexus_background_tasks_show(&client, args).await,
+            }) => {
+                cmd_nexus_background_tasks_show(
+                    &client,
+                    args,
+                    omdb.output.color,
+                )
+                .await
+            }
             NexusCommands::BackgroundTasks(BackgroundTasksArgs {
                 command: BackgroundTasksCommands::PrintReport(args),
             }) => {
@@ -990,6 +997,7 @@ async fn cmd_nexus_background_tasks_list(
 async fn cmd_nexus_background_tasks_show(
     client: &nexus_lockstep_client::Client,
     args: &BackgroundTasksShowArgs,
+    color: ColorChoice,
 ) -> Result<(), anyhow::Error> {
     let response =
         client.bgtask_list().await.context("listing background tasks")?;
@@ -1039,6 +1047,7 @@ async fn cmd_nexus_background_tasks_show(
 
     let opts = BackgroundTasksPrintOpts {
         show_executing_info: !args.no_executing_info,
+        colored: should_colorize(color, supports_color::Stream::Stdout),
     };
 
     // Some tasks should be grouped and printed together in a certain order,
@@ -1137,6 +1146,8 @@ async fn cmd_nexus_background_tasks_activate(
 #[derive(Clone, Debug)]
 struct BackgroundTasksPrintOpts {
     show_executing_info: bool,
+    /// Whether to style output with ANSI terminal colors.
+    colored: bool,
 }
 
 fn print_task(bgtask: &BackgroundTask, opts: &BackgroundTasksPrintOpts) {
@@ -1185,7 +1196,7 @@ fn print_task(bgtask: &BackgroundTask, opts: &BackgroundTasksPrintOpts) {
     // unstable -- it gets exposed by background tasks as unstructured
     // (schemaless) data.  We make a best effort to interpret it.
     if let LastResult::Completed(completed) = &bgtask.last {
-        print_task_details(&bgtask, &completed.details);
+        print_task_details(&bgtask, &completed.details, opts.colored);
     }
 }
 
@@ -1229,7 +1240,11 @@ fn print_start_end_time(
 /// undocumented and unstable (subject to change).  That does make this code
 /// both ugly and brittle.  It's not a fatal error to fail to parse these, but
 /// we do warn the user if that happens.
-fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
+fn print_task_details(
+    bgtask: &BackgroundTask,
+    details: &serde_json::Value,
+    colored: bool,
+) {
     // All tasks might produce an "error" property.  If we find one, print that
     // out and stop.
     #[derive(Deserialize)]
@@ -1362,7 +1377,7 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
             print_task_webhook_deliverator(details);
         }
         "fm_analysis" => {
-            print_task_fm_analysis(details);
+            print_task_fm_analysis(details, colored);
         }
         "fm_sitrep_loader" => {
             print_task_fm_sitrep_loader(details);
@@ -3490,7 +3505,7 @@ mod ereporter_status_fields {
     pub const NUM_WIDTH: usize = 4;
 }
 
-fn print_task_fm_analysis(details: &serde_json::Value) {
+fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
     use nexus_types::internal_api::background::fm_analysis::{
         AnalysisOutcome, AnalysisStatus, Outcome, PreparationStatus,
     };
@@ -3629,7 +3644,7 @@ fn print_task_fm_analysis(details: &serde_json::Value) {
 
     let PreparationStatus { warnings, report: prep_report } = prep_status;
     println!("    preparation report:");
-    print!("{}", prep_report.display_multiline(6));
+    print!("{}", prep_report.display_multiline(6).colored(colored));
     if !warnings.is_empty() {
         println!("{ERRICON}   non-fatal errors preparing analysis inputs:");
         for error in warnings {
@@ -3639,7 +3654,7 @@ fn print_task_fm_analysis(details: &serde_json::Value) {
 
     println!();
     println!("    analysis report:");
-    print!("{}", analysis_report.display_multiline(6));
+    print!("{}", analysis_report.display_multiline(6).colored(colored));
     print_start_end_time(start_time, end_time, 4);
 }
 

--- a/nexus/types/Cargo.toml
+++ b/nexus/types/Cargo.toml
@@ -35,6 +35,7 @@ itertools.workspace = true
 newtype_derive.workspace = true
 omicron-uuid-kinds.workspace = true
 openssl.workspace = true
+owo-colors.workspace = true
 oximeter-db.workspace = true
 oxnet.workspace = true
 oxql-types.workspace = true

--- a/nexus/types/output/analysis_report_full.out
+++ b/nexus/types/output/analysis_report_full.out
@@ -1,0 +1,14 @@
+// an example analysis report
+sitrep ID: ea7affb0-36eb-4a9a-b9bd-22e00f1bcc04
+analysis log:
+  * began analysis
+cases (1 with activity):
+  * case b0d36461-e3e7-4a53-9162-82414fb30088
+    // PSU 0 faulted
+    diagnosis engine: power_shelf
+    opened in sitrep: ea7affb0-36eb-4a9a-b9bd-22e00f1bcc04 <-- this sitrep
+    activity in this analysis:
+      * opened case
+      * /!\ WARNING: something suspicious:
+        // hmmm...
+        * key: value

--- a/nexus/types/src/fm/analysis_reports.rs
+++ b/nexus/types/src/fm/analysis_reports.rs
@@ -124,45 +124,78 @@ impl iddqd::IdOrdItem for CaseReport {
 }
 
 impl AnalysisReport {
-    pub fn display_multiline(&self, indent: usize) -> impl fmt::Display + '_ {
-        struct AnalysisReportDisplayer<'a> {
-            report: &'a AnalysisReport,
-            indent: usize,
-        }
+    pub fn display_multiline(
+        &self,
+        indent: usize,
+    ) -> AnalysisReportDisplayer<'_> {
+        AnalysisReportDisplayer { report: self, indent, colored: false }
+    }
+}
 
-        impl<'a> fmt::Display for AnalysisReportDisplayer<'a> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let &Self {
-                    report: AnalysisReport { cases, sitrep_id, comment, log },
-                    indent,
-                } = self;
+/// Displays an [`AnalysisReport`], as returned by
+/// [`AnalysisReport::display_multiline`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct AnalysisReportDisplayer<'a> {
+    report: &'a AnalysisReport,
+    indent: usize,
+    colored: bool,
+}
 
-                display::Comment::from(comment).indent(indent).fmt(f)?;
-                writeln!(f, "{:indent$}sitrep ID: {sitrep_id}", "")?;
-                log.display_multiline(indent).titled("analysis log").fmt(f)?;
-                if cases.is_empty() {
-                    writeln!(
-                        f,
-                        "{:indent$}no cases changed in this analysis step",
-                        ""
-                    )?;
-                } else {
-                    writeln!(
-                        f,
-                        "{:indent$}cases ({} with activity):",
-                        "",
-                        cases.len()
-                    )?;
-                    for case in cases {
-                        case.display_multiline(indent + 2, Some(*sitrep_id))
-                            .fmt(f)?;
-                    }
-                }
-                Ok(())
+impl AnalysisReportDisplayer<'_> {
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    pub fn colored(mut self, colored: bool) -> Self {
+        self.colored = colored;
+        self
+    }
+}
+
+impl fmt::Display for AnalysisReportDisplayer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let &Self {
+            report: AnalysisReport { cases, sitrep_id, comment, log },
+            indent,
+            colored,
+        } = self;
+        let styles = display::Styles::new(colored);
+
+        display::Comment::from(comment)
+            .indent(indent)
+            .colored(colored)
+            .fmt(f)?;
+        writeln!(
+            f,
+            "{:indent$}{}: {sitrep_id}",
+            "",
+            styles.heading().style("sitrep ID")
+        )?;
+        log.display_multiline(indent)
+            .colored(colored)
+            .titled("analysis log")
+            .fmt(f)?;
+        if cases.is_empty() {
+            writeln!(
+                f,
+                "{:indent$}{}",
+                "",
+                styles
+                    .heading()
+                    .style("no cases changed in this analysis step")
+            )?;
+        } else {
+            writeln!(
+                f,
+                "{:indent$}{} ({} with activity):",
+                "",
+                styles.heading().style("cases"),
+                cases.len(),
+            )?;
+            for case in cases {
+                case.display_multiline(indent + 2, Some(*sitrep_id))
+                    .colored(colored)
+                    .fmt(f)?;
             }
         }
-
-        AnalysisReportDisplayer { report: self, indent }
+        Ok(())
     }
 }
 
@@ -171,32 +204,60 @@ impl CaseReport {
         &self,
         indent: usize,
         this_sitrep: Option<SitrepUuid>,
-    ) -> impl fmt::Display + '_ {
-        struct CaseReportDisplayer<'a> {
-            report: &'a CaseReport,
-            indent: usize,
-            this_sitrep: Option<SitrepUuid>,
+    ) -> CaseReportDisplayer<'_> {
+        CaseReportDisplayer {
+            report: self,
+            indent,
+            this_sitrep,
+            colored: false,
         }
+    }
+}
 
-        impl<'a> fmt::Display for CaseReportDisplayer<'a> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let &Self {
-                    report: CaseReport { id, metadata, log },
-                    indent,
-                    this_sitrep,
-                } = self;
-                let bullet = if indent > 0 { "* " } else { "" };
-                writeln!(f, "{:indent$}{bullet}case {id}", "")?;
-                let indent = indent + 2;
-                metadata.display_multiline(indent, this_sitrep).fmt(f)?;
-                log.display_multiline(indent)
-                    .titled("activity in this analysis")
-                    .fmt(f)?;
-                Ok(())
-            }
-        }
+/// Displays a [`CaseReport`], as returned by
+/// [`CaseReport::display_multiline`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct CaseReportDisplayer<'a> {
+    report: &'a CaseReport,
+    indent: usize,
+    this_sitrep: Option<SitrepUuid>,
+    colored: bool,
+}
 
-        CaseReportDisplayer { report: self, indent, this_sitrep }
+impl CaseReportDisplayer<'_> {
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    pub fn colored(mut self, colored: bool) -> Self {
+        self.colored = colored;
+        self
+    }
+}
+
+impl fmt::Display for CaseReportDisplayer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let &Self {
+            report: CaseReport { id, metadata, log },
+            indent,
+            this_sitrep,
+            colored,
+        } = self;
+        let styles = display::Styles::new(colored);
+        let bullet = if indent > 0 { "* " } else { "" };
+        writeln!(
+            f,
+            "{:indent$}{bullet}{}",
+            "",
+            styles.heading().style(format_args!("case {id}"))
+        )?;
+        let indent = indent + 2;
+        metadata
+            .display_multiline(indent, this_sitrep)
+            .colored(colored)
+            .fmt(f)?;
+        log.display_multiline(indent)
+            .colored(colored)
+            .titled("activity in this analysis")
+            .fmt(f)?;
+        Ok(())
     }
 }
 
@@ -236,7 +297,7 @@ impl DebugLog {
     }
 
     fn display_multiline(&self, indent: usize) -> DebugLogDisplayer<'_> {
-        DebugLogDisplayer { log: self, indent, title: None }
+        DebugLogDisplayer { log: self, indent, title: None, colored: false }
     }
 }
 
@@ -244,33 +305,55 @@ struct DebugLogDisplayer<'a> {
     log: &'a DebugLog,
     indent: usize,
     title: Option<&'a str>,
+    colored: bool,
 }
 
 impl<'a> DebugLogDisplayer<'a> {
     fn titled(self, title: &'a str) -> Self {
         Self { title: Some(title), ..self }
     }
+
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    fn colored(self, colored: bool) -> Self {
+        Self { colored, ..self }
+    }
 }
 
 impl fmt::Display for DebugLogDisplayer<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let &Self { log, indent, title } = self;
+        let &Self { log, indent, title, colored } = self;
+        let styles = display::Styles::new(colored);
         let mut indent = indent;
         if let Some(title) = title {
             if log.is_empty() {
-                return writeln!(f, "{:<indent$}no {title}", "");
+                return writeln!(
+                    f,
+                    "{:<indent$}{}",
+                    "",
+                    styles.heading().style(format_args!("no {title}"))
+                );
             } else {
-                writeln!(f, "{:<indent$}{title}:", "")?;
+                writeln!(
+                    f,
+                    "{:<indent$}{}:",
+                    "",
+                    styles.heading().style(format_args!("{title}"))
+                )?;
                 // log entries will be indented under the title
                 indent += 2;
             }
         }
         if log.is_empty() {
-            return writeln!(f, "{:<indent$}(no log entries)", "");
+            return writeln!(
+                f,
+                "{:<indent$}{}",
+                "",
+                styles.heading().style("(no log entries)")
+            );
         }
 
         for entry in &log.0 {
-            entry.display_indented(indent).fmt(f)?;
+            entry.display_indented(indent).colored(colored).fmt(f)?;
         }
 
         Ok(())
@@ -360,34 +443,60 @@ impl LogEntry {
         self
     }
 
-    pub fn display_indented(&self, indent: usize) -> impl fmt::Display + '_ {
-        struct LogEntryDisplayer<'a> {
-            entry: &'a LogEntry,
-            indent: usize,
-        }
+    pub fn display_indented(&self, indent: usize) -> LogEntryDisplayer<'_> {
+        LogEntryDisplayer { entry: self, indent, colored: false }
+    }
+}
 
-        impl<'a> fmt::Display for LogEntryDisplayer<'a> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let &Self {
-                    entry: LogEntry { event, comment, kvs, level },
-                    indent,
-                } = self;
-                let bullet = if indent > 0 { "* " } else { "" };
-                let colon = if kvs.is_empty() { "" } else { ":" };
-                let lvl = match level {
-                    LogLevel::Info => "",
-                    LogLevel::Warn => "/!\\ WARNING: ",
-                };
+/// Displays a [`LogEntry`], as returned by [`LogEntry::display_indented`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct LogEntryDisplayer<'a> {
+    entry: &'a LogEntry,
+    indent: usize,
+    colored: bool,
+}
 
-                writeln!(f, "{:indent$}{bullet}{lvl}{event}{colon}", "")?;
-                display::Comment::from(comment).indent(indent + 2).fmt(f)?;
-                for (k, v) in kvs {
-                    display::fmt_json_value(f, k, v, indent + 2)?;
-                }
-                Ok(())
+impl LogEntryDisplayer<'_> {
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    pub fn colored(mut self, colored: bool) -> Self {
+        self.colored = colored;
+        self
+    }
+}
+
+impl fmt::Display for LogEntryDisplayer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let &Self {
+            entry: LogEntry { event, comment, kvs, level },
+            indent,
+            colored,
+        } = self;
+        let styles = display::Styles::new(colored);
+        let bullet = if indent > 0 { "* " } else { "" };
+        let colon = if kvs.is_empty() { "" } else { ":" };
+
+        match level {
+            LogLevel::Info => {
+                writeln!(f, "{:indent$}{bullet}{event}{colon}", "")?;
+            }
+            LogLevel::Warn => {
+                writeln!(
+                    f,
+                    "{:indent$}{bullet}{}{}{colon}",
+                    "",
+                    styles.warning().style("/!\\ WARNING: "),
+                    styles.warning_text().style(event),
+                )?;
             }
         }
-        LogEntryDisplayer { entry: self, indent }
+        display::Comment::from(comment)
+            .indent(indent + 2)
+            .colored(colored)
+            .fmt(f)?;
+        for (k, v) in kvs {
+            display::fmt_json_value(f, k, v, indent + 2, styles)?;
+        }
+        Ok(())
     }
 }
 
@@ -419,14 +528,29 @@ pub struct ClosedCaseReport {
 }
 
 impl InputReport {
-    pub fn display_multiline(&self, indent: usize) -> impl fmt::Display + '_ {
-        InputReportMultilineDisplay { report: self, indent }
+    pub fn display_multiline(
+        &self,
+        indent: usize,
+    ) -> InputReportMultilineDisplay<'_> {
+        InputReportMultilineDisplay { report: self, indent, colored: false }
     }
 }
 
-struct InputReportMultilineDisplay<'report> {
+/// Displays an [`InputReport`], as returned by
+/// [`InputReport::display_multiline`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct InputReportMultilineDisplay<'report> {
     report: &'report InputReport,
     indent: usize,
+    colored: bool,
+}
+
+impl InputReportMultilineDisplay<'_> {
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    pub fn colored(mut self, colored: bool) -> Self {
+        self.colored = colored;
+        self
+    }
 }
 
 impl fmt::Display for InputReportMultilineDisplay<'_> {
@@ -444,38 +568,68 @@ impl fmt::Display for InputReportMultilineDisplay<'_> {
                     in_service_disks,
                 },
             indent,
+            colored,
         } = self;
+        let styles = display::Styles::new(*colored);
+        let heading = styles.heading();
 
         if let Some(id) = parent_sitrep_id {
-            writeln!(f, "{:indent$}parent sitrep:        {id}", "",)?;
-        } else {
-            writeln!(f, "{:indent$}parent sitrep:        <none>", "")?;
-        }
-
-        writeln!(f, "{:indent$}inventory collection: {inv_id}", "",)?;
-        if Some(inv_id) == parent_inv_id.as_ref() {
-            writeln!(f, "{:indent$} --> same collection as parent sitrep", "",)?;
-        } else if let Some(parent_inv_id) = parent_inv_id {
             writeln!(
                 f,
-                "{:indent$} --> different from parent sitrep \
-                 (collection {parent_inv_id})",
+                "{:indent$}{}:        {id}",
                 "",
+                heading.style("parent sitrep")
+            )?;
+        } else {
+            writeln!(
+                f,
+                "{:indent$}{}:        {}",
+                "",
+                heading.style("parent sitrep"),
+                styles.missing().style("<none>")
             )?;
         }
 
         writeln!(
             f,
-            "{:indent$}total known ereport restart IDs: \
-                {num_ereporter_restarts}",
+            "{:indent$}{}: {inv_id}",
             "",
+            heading.style("inventory collection")
+        )?;
+        if Some(inv_id) == parent_inv_id.as_ref() {
+            writeln!(
+                f,
+                "{:indent$} {}",
+                "",
+                styles
+                    .annotation()
+                    .style("--> same collection as parent sitrep"),
+            )?;
+        } else if let Some(parent_inv_id) = parent_inv_id {
+            writeln!(
+                f,
+                "{:indent$} {}",
+                "",
+                styles.annotation().style(format_args!(
+                    "--> different from parent sitrep \
+                     (collection {parent_inv_id})"
+                )),
+            )?;
+        }
+
+        writeln!(
+            f,
+            "{:indent$}{}: {num_ereporter_restarts}",
+            "",
+            heading.style("total known ereport restart IDs"),
         )?;
 
         if !new_ereport_ids.is_empty() {
             writeln!(
                 f,
-                "\n{:indent$}new ereports ({} total):",
+                "\n{:indent$}{} ({} total):",
                 "",
+                heading.style("new ereports"),
                 new_ereport_ids.len()
             )?;
             let indent = indent + 2;
@@ -485,42 +639,68 @@ impl fmt::Display for InputReportMultilineDisplay<'_> {
         } else {
             writeln!(
                 f,
-                "{:indent$}no new ereports since the parent sitrep",
+                "{:indent$}{}",
                 "",
+                styles
+                    .heading()
+                    .style("no new ereports since the parent sitrep"),
             )?;
         }
 
         let total_cases = open_cases.len() + closed_cases_copied_forward.len();
         if total_cases > 0 {
-            writeln!(f, "\n{:indent$}cases ({} total):", "", total_cases)?;
+            writeln!(
+                f,
+                "\n{:indent$}{} ({total_cases} total):",
+                "",
+                heading.style("cases")
+            )?;
             let indent = indent + 2;
             if open_cases.is_empty() {
-                writeln!(f, "{:indent$}no open cases", "",)?;
+                writeln!(
+                    f,
+                    "{:indent$}{}",
+                    "",
+                    styles.heading().style("no open cases"),
+                )?;
             } else {
                 writeln!(
                     f,
-                    "{:indent$}open cases ({} total):",
+                    "{:indent$}{} ({} total):",
                     "",
+                    heading.style("open cases"),
                     open_cases.len()
                 )?;
                 let indent = indent + 2;
                 for (case_id, metadata) in open_cases {
-                    writeln!(f, "{:indent$}* case {case_id}", "")?;
-                    metadata.display_multiline(indent + 2, None).fmt(f)?;
+                    writeln!(
+                        f,
+                        "{:indent$}* {}",
+                        "",
+                        heading.style(format_args!("case {case_id}"))
+                    )?;
+                    metadata
+                        .display_multiline(indent + 2, None)
+                        .colored(*colored)
+                        .fmt(f)?;
                 }
             }
 
             if closed_cases_copied_forward.is_empty() {
                 writeln!(
                     f,
-                    "{:indent$}no closed cases must be copied forwards",
+                    "{:indent$}{}",
                     "",
+                    styles
+                        .heading()
+                        .style("no closed cases must be copied forwards"),
                 )?;
             } else {
                 writeln!(
                     f,
-                    "{:indent$}closed cases copied forwards ({} total):",
+                    "{:indent$}{} ({} total):",
                     "",
+                    heading.style("closed cases copied forwards"),
                     closed_cases_copied_forward.len()
                 )?;
                 let indent = indent + 2;
@@ -534,9 +714,17 @@ impl fmt::Display for InputReportMultilineDisplay<'_> {
                     },
                 ) in closed_cases_copied_forward
                 {
-                    writeln!(f, "{:indent$}* case {case_id}", "")?;
+                    writeln!(
+                        f,
+                        "{:indent$}* {}",
+                        "",
+                        heading.style(format_args!("case {case_id}"))
+                    )?;
                     let indent = indent + 2;
-                    metadata.display_multiline(indent, None).fmt(f)?;
+                    metadata
+                        .display_multiline(indent, None)
+                        .colored(*colored)
+                        .fmt(f)?;
                     // A closed case is only carried forward when it has
                     // outstanding work, so spell out why. If we don't seem to
                     // have any outstanding work but the closed case was carried
@@ -547,19 +735,29 @@ impl fmt::Display for InputReportMultilineDisplay<'_> {
                     {
                         writeln!(
                             f,
-                            "{:indent$}/!\\ WEIRD: this case has no recorded \
-                             reason for being copied forwards!",
-                            ""
+                            "{:indent$}{} {}",
+                            "",
+                            styles.warning().style("/!\\ WEIRD:"),
+                            styles.warning_text().style(
+                                "this case has no recorded \
+                                 reason for being copied forwards!"
+                            )
                         )?;
                         continue;
                     }
-                    writeln!(f, "{:indent$}copied forwards due to:", "")?;
+                    writeln!(
+                        f,
+                        "{:indent$}{}:",
+                        "",
+                        heading.style("copied forwards due to")
+                    )?;
                     let indent = indent + 2;
                     if !unmarked_ereports.is_empty() {
                         writeln!(
                             f,
-                            "{:indent$}ereports not yet marked seen:",
-                            ""
+                            "{:indent$}{}:",
+                            "",
+                            heading.style("ereports not yet marked seen")
                         )?;
                         let indent = indent + 2;
                         for ereport_id in unmarked_ereports {
@@ -573,8 +771,9 @@ impl fmt::Display for InputReportMultilineDisplay<'_> {
                     if !unmarked_alert_requests.is_empty() {
                         writeln!(
                             f,
-                            "{:indent$}alert requests not yet satisfied:",
-                            ""
+                            "{:indent$}{}:",
+                            "",
+                            heading.style("alert requests not yet satisfied")
                         )?;
                         let indent = indent + 2;
                         for alert_id in unmarked_alert_requests {
@@ -584,9 +783,11 @@ impl fmt::Display for InputReportMultilineDisplay<'_> {
                     if !unmarked_support_bundle_requests.is_empty() {
                         writeln!(
                             f,
-                            "{:indent$}support bundle requests not yet \
-                             satisfied:",
-                            ""
+                            "{:indent$}{}:",
+                            "",
+                            heading.style(
+                                "support bundle requests not yet satisfied"
+                            )
                         )?;
                         let indent = indent + 2;
                         for bundle_id in unmarked_support_bundle_requests {
@@ -600,16 +801,27 @@ impl fmt::Display for InputReportMultilineDisplay<'_> {
                 }
             }
         } else {
-            writeln!(f, "{:indent$}no cases copied forward", "")?;
+            writeln!(
+                f,
+                "{:indent$}{}",
+                "",
+                styles.heading().style("no cases copied forward"),
+            )?;
         }
 
         if in_service_disks.is_empty() {
-            writeln!(f, "\n{:indent$}no in-service control plane disks", "")?;
+            writeln!(
+                f,
+                "\n{:indent$}{}",
+                "",
+                styles.heading().style("no in-service control plane disks"),
+            )?;
         } else {
             writeln!(
                 f,
-                "\n{:indent$}in-service control plane disks ({} total):",
+                "\n{:indent$}{} ({} total):",
                 "",
+                heading.style("in-service control plane disks"),
                 in_service_disks.len()
             )?;
             let indent = indent + 2;
@@ -787,10 +999,14 @@ mod tests {
         }
     }
 
+    // Note: the example report includes the `/!\ WEIRD` warning, so
+    // the colored-display check here also covers warning styling.
     #[test]
     fn test_analysis_input_report_display_with_cases() {
         let report = example_report_with_cases();
-        let output = format!("{}", report.display_multiline(0));
+        let output = display::test_utils::check_colored_display(|colored| {
+            report.display_multiline(0).colored(colored)
+        });
         expectorate::assert_contents(
             "output/analysis_input_report_with_cases.out",
             &output,
@@ -800,7 +1016,9 @@ mod tests {
     #[test]
     fn test_analysis_input_report_display_empty() {
         let report = example_report_empty();
-        let output = format!("{}", report.display_multiline(0));
+        let output = display::test_utils::check_colored_display(|colored| {
+            report.display_multiline(0).colored(colored)
+        });
         expectorate::assert_contents(
             "output/analysis_input_report_empty.out",
             &output,
@@ -810,11 +1028,69 @@ mod tests {
     #[test]
     fn test_analysis_input_report_display_same_inv() {
         let report = example_report_same_inv();
-        let output = format!("{}", report.display_multiline(0));
+        let output = display::test_utils::check_colored_display(|colored| {
+            report.display_multiline(0).colored(colored)
+        });
         expectorate::assert_contents(
             "output/analysis_input_report_same_inv.out",
             &output,
         );
+    }
+
+    /// Golden-file test for the full `AnalysisReport` displayer tree, which
+    /// composes the case report, debug log, and case metadata displayers.
+    /// The example includes a warning-level log entry, so the colored
+    /// check also covers `/!\ WARNING:` styling.
+    #[test]
+    fn test_analysis_report_display_full() {
+        let report: AnalysisReport =
+            serde_json::from_value(serde_json::json!({
+                "sitrep_id": "ea7affb0-36eb-4a9a-b9bd-22e00f1bcc04",
+                "comment": "an example analysis report",
+                "cases": [{
+                    "id": "b0d36461-e3e7-4a53-9162-82414fb30088",
+                    "created_sitrep_id": "ea7affb0-36eb-4a9a-b9bd-22e00f1bcc04",
+                    "closed_sitrep_id": null,
+                    "de": "power_shelf",
+                    "comment": "PSU 0 faulted",
+                    "log": [
+                        { "event": "opened case" },
+                        {
+                            "event": "something suspicious",
+                            "level": "Warn",
+                            "comment": "hmmm...",
+                            "key": "value",
+                        },
+                    ],
+                }],
+                "log": [{ "event": "began analysis" }],
+            }))
+            .expect("example analysis report should deserialize");
+
+        let output = display::test_utils::check_colored_display(|colored| {
+            report.display_multiline(0).colored(colored)
+        });
+        expectorate::assert_contents(
+            "output/analysis_report_full.out",
+            &output,
+        );
+    }
+
+    /// As above, for a warning-level `LogEntry`, covering the
+    /// `/!\ WARNING:` styling.
+    #[test]
+    fn test_log_entry_display_colored() {
+        let json = serde_json::json!({
+            "event": "something suspicious happened",
+            "comment": "hmmm...",
+            "level": "Warn",
+            "key": "value",
+            "missing": null,
+        });
+        let entry: LogEntry = serde_json::from_value(json).unwrap();
+        display::test_utils::check_colored_display(|colored| {
+            entry.display_indented(2).colored(colored)
+        });
     }
 
     /// A JSON object containing only the required `event` field should
@@ -909,7 +1185,9 @@ mod tests {
             "arr": [10, 20]
         });
         let entry: LogEntry = serde_json::from_value(json).unwrap();
-        let output = format!("{}", entry.display_indented(0));
+        let output = display::test_utils::check_colored_display(|colored| {
+            entry.display_indented(0).colored(colored)
+        });
         expectorate::assert_contents(
             "output/log_entry_display_nested_values.out",
             &output,
@@ -926,7 +1204,9 @@ mod tests {
             "flat_key": "flat_value",
         });
         let entry: LogEntry = serde_json::from_value(json).unwrap();
-        let output = format!("{}", entry.display_indented(0));
+        let output = display::test_utils::check_colored_display(|colored| {
+            entry.display_indented(0).colored(colored)
+        });
         expectorate::assert_contents(
             "output/log_entry_display_multiline_comment.out",
             &output,

--- a/nexus/types/src/fm/case.rs
+++ b/nexus/types/src/fm/case.rs
@@ -45,8 +45,8 @@ impl Case {
         &self,
         indent: usize,
         sitrep_id: Option<SitrepUuid>,
-    ) -> impl fmt::Display + '_ {
-        DisplayCase { case: self, indent, sitrep_id }
+    ) -> DisplayCase<'_> {
+        DisplayCase { case: self, indent, sitrep_id, colored: false }
     }
 }
 
@@ -85,58 +85,76 @@ impl Metadata {
         &self,
         indent: usize,
         sitrep: Option<SitrepUuid>,
-    ) -> impl fmt::Display + '_ {
-        struct DisplayMetadata<'a> {
-            meta: &'a Metadata,
-            indent: usize,
-            sitrep_id: Option<SitrepUuid>,
+    ) -> DisplayMetadata<'_> {
+        DisplayMetadata {
+            meta: self,
+            indent,
+            sitrep_id: sitrep,
+            colored: false,
+        }
+    }
+}
+
+/// Displays a case's [`Metadata`], as returned by
+/// [`Metadata::display_multiline`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct DisplayMetadata<'a> {
+    meta: &'a Metadata,
+    indent: usize,
+    sitrep_id: Option<SitrepUuid>,
+    colored: bool,
+}
+
+impl DisplayMetadata<'_> {
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    pub fn colored(mut self, colored: bool) -> Self {
+        self.colored = colored;
+        self
+    }
+}
+
+impl fmt::Display for DisplayMetadata<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let DisplayMetadata {
+            meta: Metadata { de, created_sitrep_id, closed_sitrep_id, comment },
+            indent,
+            sitrep_id,
+            colored,
+        } = self;
+        let styles = display::Styles::new(*colored);
+        let sitrep_id = sitrep_id.as_ref();
+        let this_sitrep = move |s| {
+            styles.annotation_if(Some(s) == sitrep_id, " <-- this sitrep")
+        };
+
+        const DE: &str = "diagnosis engine:";
+        const OPENED_IN: &str = "opened in sitrep:";
+        const CLOSED_IN: &str = "closed in sitrep:";
+        const WIDTH: usize = const_max_len(&[DE, OPENED_IN, CLOSED_IN]);
+
+        display::Comment::from(comment)
+            .indent(*indent)
+            .colored(*colored)
+            .fmt(f)?;
+        writeln!(f, "{:>indent$}{} {de}", "", styles.label(DE, WIDTH))?;
+        writeln!(
+            f,
+            "{:>indent$}{} {created_sitrep_id}{}",
+            "",
+            styles.label(OPENED_IN, WIDTH),
+            this_sitrep(created_sitrep_id)
+        )?;
+        if let Some(closed_id) = closed_sitrep_id {
+            writeln!(
+                f,
+                "{:>indent$}{} {closed_id}{}",
+                "",
+                styles.label(CLOSED_IN, WIDTH),
+                this_sitrep(closed_id)
+            )?;
         }
 
-        impl fmt::Display for DisplayMetadata<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let DisplayMetadata {
-                    meta:
-                        Metadata {
-                            de,
-                            created_sitrep_id,
-                            closed_sitrep_id,
-                            comment,
-                        },
-                    indent,
-                    sitrep_id,
-                } = self;
-                let sitrep_id = sitrep_id.as_ref();
-                let this_sitrep = move |s| {
-                    if Some(s) == sitrep_id { " <-- this sitrep" } else { "" }
-                };
-
-                const DE: &str = "diagnosis engine:";
-                const OPENED_IN: &str = "opened in sitrep:";
-                const CLOSED_IN: &str = "closed in sitrep:";
-                const WIDTH: usize = const_max_len(&[DE, OPENED_IN, CLOSED_IN]);
-
-                display::Comment::from(comment).indent(*indent).fmt(f)?;
-                writeln!(f, "{:>indent$}{DE:<WIDTH$} {de}", "")?;
-                writeln!(
-                    f,
-                    "{:>indent$}{OPENED_IN:<WIDTH$} {created_sitrep_id}{}",
-                    "",
-                    this_sitrep(created_sitrep_id)
-                )?;
-                if let Some(closed_id) = closed_sitrep_id {
-                    writeln!(
-                        f,
-                        "{:>indent$}{CLOSED_IN:<WIDTH$} {closed_id}{}",
-                        "",
-                        this_sitrep(closed_id)
-                    )?;
-                }
-
-                Ok(())
-            }
-        }
-
-        DisplayMetadata { meta: self, indent, sitrep_id: sitrep }
+        Ok(())
     }
 }
 
@@ -205,47 +223,66 @@ impl Fact {
         &self,
         indent: usize,
         sitrep_id: Option<SitrepUuid>,
-    ) -> impl fmt::Display + '_ {
-        struct DisplayFact<'a> {
-            fact: &'a Fact,
-            indent: usize,
-            sitrep_id: Option<SitrepUuid>,
-        }
+    ) -> DisplayFact<'_> {
+        DisplayFact { fact: self, indent, sitrep_id, colored: false }
+    }
+}
 
-        impl fmt::Display for DisplayFact<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                const BULLET: &str = "* ";
+/// Displays a [`Fact`], as returned by [`Fact::display_multiline`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct DisplayFact<'a> {
+    fact: &'a Fact,
+    indent: usize,
+    sitrep_id: Option<SitrepUuid>,
+    colored: bool,
+}
 
-                let &Self {
-                    fact:
-                        Fact {
-                            metadata:
-                                FactMetadata { id, created_sitrep_id, comment },
-                            payload,
-                        },
-                    indent,
-                    sitrep_id,
-                } = self;
-                let this_sitrep = |s| {
-                    if Some(s) == sitrep_id { " <-- this sitrep" } else { "" }
-                };
+impl DisplayFact<'_> {
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    pub fn colored(mut self, colored: bool) -> Self {
+        self.colored = colored;
+        self
+    }
+}
 
-                writeln!(f, "{BULLET:>indent$}fact {id}")?;
-                display::Comment::from(comment).indent(indent).fmt(f)?;
-                writeln!(
-                    f,
-                    "{:>indent$}added in: {created_sitrep_id}{}",
-                    "",
-                    this_sitrep(*created_sitrep_id),
-                )?;
-                let payload = serde_json::to_value(payload)
-                    .unwrap_or(serde_json::Value::Null);
-                display::fmt_json_value(f, "payload", &payload, indent)?;
-                writeln!(f)
-            }
-        }
+impl fmt::Display for DisplayFact<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const BULLET: &str = "* ";
 
-        DisplayFact { fact: self, indent, sitrep_id }
+        let &Self {
+            fact:
+                Fact {
+                    metadata: FactMetadata { id, created_sitrep_id, comment },
+                    payload,
+                },
+            indent,
+            sitrep_id,
+            colored,
+        } = self;
+        let styles = display::Styles::new(colored);
+        let this_sitrep =
+            |s| styles.annotation_if(Some(s) == sitrep_id, " <-- this sitrep");
+
+        writeln!(
+            f,
+            "{BULLET:>indent$}{}",
+            styles.heading().style(format_args!("fact {id}"))
+        )?;
+        display::Comment::from(comment)
+            .indent(indent)
+            .colored(colored)
+            .fmt(f)?;
+        writeln!(
+            f,
+            "{:>indent$}{}: {created_sitrep_id}{}",
+            "",
+            styles.heading().style("added in"),
+            this_sitrep(*created_sitrep_id),
+        )?;
+        let payload =
+            serde_json::to_value(payload).unwrap_or(serde_json::Value::Null);
+        display::fmt_json_value(f, "payload", &payload, indent, styles)?;
+        writeln!(f)
     }
 }
 
@@ -290,10 +327,21 @@ impl iddqd::IdOrdItem for SupportBundleRequest {
     iddqd::id_upcast!();
 }
 
-struct DisplayCase<'a> {
+/// Displays a [`Case`], as returned by [`Case::display_indented`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct DisplayCase<'a> {
     case: &'a Case,
     indent: usize,
     sitrep_id: Option<SitrepUuid>,
+    colored: bool,
+}
+
+impl DisplayCase<'_> {
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    pub fn colored(mut self, colored: bool) -> Self {
+        self.colored = colored;
+        self
+    }
 }
 
 impl fmt::Display for DisplayCase<'_> {
@@ -312,27 +360,35 @@ impl fmt::Display for DisplayCase<'_> {
                 },
             indent,
             sitrep_id,
+            colored,
         } = self;
 
+        let styles = display::Styles::new(colored);
+        let heading = styles.heading();
         let this_sitrep = move |s| {
-            if Some(s) == sitrep_id { " <-- this sitrep" } else { "" }
+            styles.annotation_if(Some(s) == sitrep_id, " <-- this sitrep")
         };
 
         writeln!(
             f,
-            "{:>indent$}case {id}",
+            "{:>indent$}{}",
             if indent > 0 { BULLET } else { "" },
+            heading.style(format_args!("case {id}")),
         )?;
         writeln!(
             f,
-            "{:>indent$}=========================================",
-            ""
+            "{:>indent$}{}",
+            "",
+            heading.style("=========================================")
         )?;
-        metadata.display_multiline(indent, sitrep_id).fmt(f)?;
+        metadata
+            .display_multiline(indent, sitrep_id)
+            .colored(colored)
+            .fmt(f)?;
 
         if !ereports.is_empty() {
-            writeln!(f, "\n{:>indent$}ereports:", "")?;
-            writeln!(f, "{:>indent$}---------", "")?;
+            writeln!(f, "\n{:>indent$}{}:", "", heading.style("ereports"))?;
+            writeln!(f, "{:>indent$}{}", "", heading.style("---------"))?;
 
             let indent = indent + 2;
             for CaseEreport { id, ereport, assigned_sitrep_id, comment } in
@@ -350,46 +406,75 @@ impl fmt::Display for DisplayCase<'_> {
                     ASSIGNMENT_ID,
                 ]);
 
-                let pn = ereport.part_number.as_deref().unwrap_or("<UNKNOWN>");
-                let sn =
-                    ereport.serial_number.as_deref().unwrap_or("<UNKNOWN>");
-                writeln!(f, "{BULLET:>indent$}ereport {}", ereport.id)?;
-                display::Comment::from(comment).indent(indent).fmt(f)?;
+                let pn = styles
+                    .or_missing(ereport.part_number.as_deref(), "<UNKNOWN>");
+                let sn = styles
+                    .or_missing(ereport.serial_number.as_deref(), "<UNKNOWN>");
                 writeln!(
                     f,
-                    "{:>indent$}{CLASS:<WIDTH$} {}",
+                    "{BULLET:>indent$}{}",
+                    heading.style(format_args!("ereport {}", ereport.id))
+                )?;
+                display::Comment::from(comment)
+                    .indent(indent)
+                    .colored(colored)
+                    .fmt(f)?;
+                writeln!(
+                    f,
+                    "{:>indent$}{} {}",
                     "",
-                    ereport.class.as_deref().unwrap_or("<NONE>")
+                    styles.label(CLASS, WIDTH),
+                    styles.or_missing(ereport.class.as_deref(), "<NONE>")
                 )?;
                 writeln!(
                     f,
-                    "{:>indent$}{REPORTED_BY:<WIDTH$} {pn:>11}:{sn:<11} ({})",
-                    "", ereport.reporter
+                    "{:>indent$}{} {pn:>11}:{sn:<11} ({})",
+                    "",
+                    styles.label(REPORTED_BY, WIDTH),
+                    ereport.reporter
                 )?;
                 writeln!(
                     f,
-                    "{:>indent$}{ADDED_IN:<WIDTH$} {assigned_sitrep_id}{}",
+                    "{:>indent$}{} {assigned_sitrep_id}{}",
                     "",
+                    styles.label(ADDED_IN, WIDTH),
                     this_sitrep(*assigned_sitrep_id)
                 )?;
-                writeln!(f, "{:>indent$}{ASSIGNMENT_ID:<WIDTH$} {id}", "")?;
+                writeln!(
+                    f,
+                    "{:>indent$}{} {id}",
+                    "",
+                    styles.label(ASSIGNMENT_ID, WIDTH)
+                )?;
                 writeln!(f)?;
             }
         }
 
         if !facts.is_empty() {
-            writeln!(f, "\n{:>indent$}facts:", "")?;
-            writeln!(f, "{:>indent$}------", "")?;
+            writeln!(f, "\n{:>indent$}{}:", "", heading.style("facts"))?;
+            writeln!(f, "{:>indent$}{}", "", heading.style("------"))?;
 
             let indent = indent + 2;
             for fact in facts.iter() {
-                fact.display_multiline(indent, sitrep_id).fmt(f)?;
+                fact.display_multiline(indent, sitrep_id)
+                    .colored(colored)
+                    .fmt(f)?;
             }
         }
 
         if !alerts_requested.is_empty() {
-            writeln!(f, "\n{:>indent$}alerts requested:", "")?;
-            writeln!(f, "{:>indent$}-----------------", "")?;
+            writeln!(
+                f,
+                "\n{:>indent$}{}:",
+                "",
+                heading.style("alerts requested")
+            )?;
+            writeln!(
+                f,
+                "{:>indent$}{}",
+                "",
+                heading.style("-----------------")
+            )?;
 
             let indent = indent + 2;
             for AlertRequest {
@@ -406,17 +491,26 @@ impl fmt::Display for DisplayCase<'_> {
 
                 const WIDTH: usize = const_max_len(&[CLASS, REQUESTED_IN]);
 
-                writeln!(f, "{BULLET:>indent$}alert {id}",)?;
-                display::Comment::from(comment).indent(indent).fmt(f)?;
                 writeln!(
                     f,
-                    "{:>indent$}{CLASS:<WIDTH$} {class}, v{version}",
+                    "{BULLET:>indent$}{}",
+                    heading.style(format_args!("alert {id}"))
+                )?;
+                display::Comment::from(comment)
+                    .indent(indent)
+                    .colored(colored)
+                    .fmt(f)?;
+                writeln!(
+                    f,
+                    "{:>indent$}{} {class}, v{version}",
                     "",
+                    styles.label(CLASS, WIDTH),
                 )?;
                 writeln!(
                     f,
-                    "{:>indent$}{REQUESTED_IN:<WIDTH$} {requested_sitrep_id}{}",
+                    "{:>indent$}{} {requested_sitrep_id}{}",
                     "",
+                    styles.label(REQUESTED_IN, WIDTH),
                     this_sitrep(*requested_sitrep_id)
                 )?;
                 writeln!(f)?;
@@ -424,8 +518,18 @@ impl fmt::Display for DisplayCase<'_> {
         }
 
         if !support_bundles_requested.is_empty() {
-            writeln!(f, "\n{:>indent$}support bundles requested:", "")?;
-            writeln!(f, "{:>indent$}-------------------------", "")?;
+            writeln!(
+                f,
+                "\n{:>indent$}{}:",
+                "",
+                heading.style("support bundles requested")
+            )?;
+            writeln!(
+                f,
+                "{:>indent$}{}",
+                "",
+                heading.style("-------------------------")
+            )?;
 
             let indent = indent + 2;
             for SupportBundleRequest {
@@ -439,15 +543,23 @@ impl fmt::Display for DisplayCase<'_> {
                 const DATA: &str = "data:";
                 const WIDTH: usize = const_max_len(&[REQUESTED_IN, DATA]);
 
-                writeln!(f, "{BULLET:>indent$}bundle {id}",)?;
-                display::Comment::from(comment).indent(indent).fmt(f)?;
                 writeln!(
                     f,
-                    "{:>indent$}{REQUESTED_IN:<WIDTH$} {requested_sitrep_id}{}",
+                    "{BULLET:>indent$}{}",
+                    heading.style(format_args!("bundle {id}"))
+                )?;
+                display::Comment::from(comment)
+                    .indent(indent)
+                    .colored(colored)
+                    .fmt(f)?;
+                writeln!(
+                    f,
+                    "{:>indent$}{} {requested_sitrep_id}{}",
                     "",
+                    styles.label(REQUESTED_IN, WIDTH),
                     this_sitrep(*requested_sitrep_id)
                 )?;
-                writeln!(f, "{:>indent$}{DATA}", "")?;
+                writeln!(f, "{:>indent$}{}", "", styles.label(DATA, 0))?;
                 writeln!(f, "{}", data_selection.display(indent + 2))?;
                 writeln!(f)?;
             }
@@ -489,8 +601,7 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
 
-    #[test]
-    fn test_case_display() {
+    fn example_case() -> (Case, SitrepUuid) {
         // Create UUIDs for the case
         let case_id =
             CaseUuid::from_str("b0d36461-e3e7-4a53-9162-82414fb30088").unwrap();
@@ -670,6 +781,13 @@ mod tests {
             facts,
         };
 
+        (case, closed_sitrep_id)
+    }
+
+    #[test]
+    fn test_case_display() {
+        let (case, closed_sitrep_id) = example_case();
+
         eprintln!("example case display:");
         eprintln!("=====================\n");
         eprintln!("{case}");
@@ -677,5 +795,17 @@ mod tests {
         eprintln!("example case display (indented by 4):");
         eprintln!("=====================================\n");
         eprintln!("{}", case.display_indented(4, Some(closed_sitrep_id)));
+    }
+
+    /// Checks that the colored and non-colored display outputs are the same
+    /// string, see: [`display::test_utils::check_colored_display`].
+    #[test]
+    fn test_case_display_colored() {
+        let (case, closed_sitrep_id) = example_case();
+        eprintln!("example case display (colored):");
+        eprintln!("===============================\n");
+        display::test_utils::check_colored_display(|colored| {
+            case.display_indented(4, Some(closed_sitrep_id)).colored(colored)
+        });
     }
 }

--- a/nexus/types/src/fm/display.rs
+++ b/nexus/types/src/fm/display.rs
@@ -44,8 +44,8 @@ impl Styles {
         if self.colored { f(Style::new()) } else { Style::new() }
     }
 
-    /// Headings: field labels (e.g. "sitrep ID:"), section titles, item
-    /// headers (e.g. "case <uuid>"), and the keys of key-value pairs.
+    /// Headings: field labels (e.g. `sitrep ID:`), section titles, item
+    /// headers (e.g. `case <uuid>`), and the keys of key-value pairs.
     pub(crate) fn heading(self) -> Style {
         self.style(|s| s.bold())
     }
@@ -65,12 +65,12 @@ impl Styles {
         self.style(|s| s)
     }
 
-    /// Annotations pointing at a value of note (e.g. "<-- this sitrep").
+    /// Annotations pointing at a value of note (e.g. `<!-- this sitrep`).
     pub(crate) fn annotation(self) -> Style {
         self.style(|s| s.cyan())
     }
 
-    /// Placeholders for missing values ("<none>", "<UNKNOWN>") appearing on
+    /// Placeholders for missing values (`<none>`, `<UNKNOWN>`) appearing on
     /// the value side of a key-value pair. Not for standalone notes that a
     /// section is empty; those are [headings](Self::heading).
     pub(crate) fn missing(self) -> Style {

--- a/nexus/types/src/fm/display.rs
+++ b/nexus/types/src/fm/display.rs
@@ -3,24 +3,157 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Shared helpers for rendering `serde_json::Value`s as bulleted lists in
-//! `Display` impls.
+//! `Display` impls, and for optionally styling FM displayer output with
+//! ANSI terminal colors.
 
+use owo_colors::{Style, Styled};
 use std::fmt;
+
+/// The palette of terminal styles used by the FM displayers.
+///
+/// When terminal colors are not enabled, all styles are no-ops, and styling a
+/// value does nothing. When colors are enabled, each method on `Styles` may be
+/// used to decorate a particular value in the style for the semantic meaning of
+/// that value, such as [`Self::warning`] for warning lines or
+/// [`Self::annotation`] for annotations.
+///
+/// ## Styling conventions:
+///
+/// Follow these if you want to make Eliza happy. Chosen completely based on my
+/// personal preference. :)
+///
+/// * Punctuation that is not part of the text itself stays *outside* the
+///   styled span: the `:` after a field label or section title is not
+///   bolded, and neither are parenthesized counts like `(2 total)` in
+///   section titles.
+/// * The [missing style](Self::missing) is only for placeholders appearing
+///   on the value side of a key-value pair (`foo: <none>`). A standalone
+///   line whose body says a section is empty ("no open cases") is a
+///   heading, not a missing value.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct Styles {
+    colored: bool,
+}
+
+impl Styles {
+    pub(crate) fn new(colored: bool) -> Self {
+        Self { colored }
+    }
+
+    fn style(self, f: impl FnOnce(Style) -> Style) -> Style {
+        if self.colored { f(Style::new()) } else { Style::new() }
+    }
+
+    /// Headings: field labels (e.g. "sitrep ID:"), section titles, item
+    /// headers (e.g. "case <uuid>"), and the keys of key-value pairs.
+    pub(crate) fn heading(self) -> Style {
+        self.style(|s| s.bold())
+    }
+
+    /// `// comments`.
+    pub(crate) fn comment(self) -> Style {
+        self.style(|s| s.dimmed())
+    }
+
+    /// The `/!\ WARNING:` marker (and similar) prefixing warning lines.
+    pub(crate) fn warning(self) -> Style {
+        self.style(|s| s.red().bold())
+    }
+
+    /// The message text of a warning line.
+    pub(crate) fn warning_text(self) -> Style {
+        self.style(|s| s)
+    }
+
+    /// Annotations pointing at a value of note (e.g. "<-- this sitrep").
+    pub(crate) fn annotation(self) -> Style {
+        self.style(|s| s.cyan())
+    }
+
+    /// Placeholders for missing values ("<none>", "<UNKNOWN>") appearing on
+    /// the value side of a key-value pair. Not for standalone notes that a
+    /// section is empty; those are [headings](Self::heading).
+    pub(crate) fn missing(self) -> Style {
+        self.style(|s| s.dimmed())
+    }
+
+    /// Returns a displayer for a field label ending in `:`, styling
+    /// everything before the colon as a [heading](Self::heading) and
+    /// left-aligning the whole label (colon included, per `{text:<width$}`)
+    /// to `width` visible columns. The colon and padding stay unstyled, per
+    /// the conventions above.
+    pub(crate) fn label<'s>(self, text: &'s str, width: usize) -> Label<'s> {
+        Label { text, style: self.heading(), width }
+    }
+
+    /// Returns `value` unstyled if present, or `placeholder` in the
+    /// [missing-value style](Self::missing) if not.
+    pub(crate) fn or_missing<'s>(
+        self,
+        value: Option<&'s str>,
+        placeholder: &'s str,
+    ) -> Styled<&'s str> {
+        match value {
+            Some(value) => Style::new().style(value),
+            None => self.missing().style(placeholder),
+        }
+    }
+
+    /// Returns `text` in the [annotation style](Self::annotation) if `cond`
+    /// holds, or the empty string (with no escape sequences) if it doesn't.
+    pub(crate) fn annotation_if(self, cond: bool, text: &str) -> Styled<&str> {
+        if cond {
+            self.annotation().style(text)
+        } else {
+            Style::new().style("")
+        }
+    }
+}
+
+/// Displays a field label such as `diagnosis engine:`, as returned by
+/// [`Styles::label`]: the label text bold, the trailing `:` and alignment
+/// padding unstyled.
+pub(crate) struct Label<'s> {
+    text: &'s str,
+    style: Style,
+    width: usize,
+}
+
+impl fmt::Display for Label<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let &Self { text, style, width } = self;
+        match text.strip_suffix(':') {
+            Some(label) => write!(f, "{}:", style.style(label))?,
+            None => write!(f, "{}", style.style(text))?,
+        }
+        // Pad outside the styled span, so that alignment whitespace does
+        // not carry the style.
+        let pad = width.saturating_sub(text.len());
+        write!(f, "{:pad$}", "")
+    }
+}
 
 /// Recursively format a JSON value as a bulleted list entry, nesting any
 /// object or array children as indented sub-bullets.
 pub struct Json<'json> {
     json: &'json serde_json::Value,
     indent: usize,
+    colored: bool,
 }
 
 impl<'json> Json<'json> {
     pub fn new(json: &'json serde_json::Value) -> Self {
-        Self { json, indent: 0 }
+        Self { json, indent: 0, colored: false }
     }
 
     pub fn with_indent(mut self, indent: usize) -> Self {
         self.indent = indent;
+        self
+    }
+
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    pub fn colored(mut self, colored: bool) -> Self {
+        self.colored = colored;
         self
     }
 }
@@ -28,22 +161,28 @@ impl<'json> Json<'json> {
 impl fmt::Display for Json<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let indent = self.indent;
+        let styles = Styles::new(self.colored);
         match self.json {
             serde_json::Value::Object(map) => {
                 for (k, v) in map {
-                    fmt_json_value(f, k, v, indent)?;
+                    fmt_json_value(f, k, v, indent, styles)?;
                 }
             }
             serde_json::Value::Array(arr) => {
                 for (i, v) in arr.iter().enumerate() {
-                    fmt_json_array_item(f, i + 1, v, indent)?;
+                    fmt_json_array_item(f, i + 1, v, indent, styles)?;
                 }
             }
             serde_json::Value::String(s) => {
                 writeln!(f, "{:indent$}{s}", "")?;
             }
             serde_json::Value::Null => {
-                writeln!(f, "{:indent$}<none>", "")?;
+                writeln!(
+                    f,
+                    "{:indent$}{}",
+                    "",
+                    styles.missing().style("<none>")
+                )?;
             }
             serde_json::Value::Bool(val) => {
                 writeln!(f, "{:indent$}{val}", "")?;
@@ -63,12 +202,16 @@ pub(crate) fn fmt_json_value(
     key: &str,
     value: &serde_json::Value,
     indent: usize,
+    styles: Styles,
 ) -> fmt::Result {
+    // Style the key like other headings; the `:` stays unstyled, which is
+    // indistinguishable in practice and avoids formatting the key twice.
+    let key = styles.heading().style(key);
     match value {
         serde_json::Value::Object(map) => {
             writeln!(f, "{:indent$}* {key}:", "")?;
             for (k, v) in map {
-                fmt_json_value(f, k, v, indent + 2)?;
+                fmt_json_value(f, k, v, indent + 2, styles)?;
             }
             Ok(())
         }
@@ -76,7 +219,7 @@ pub(crate) fn fmt_json_value(
             writeln!(f, "{:indent$}* {key}:", "")?;
             let indent = indent + 2;
             for (i, v) in arr.iter().enumerate() {
-                fmt_json_array_item(f, i + 1, v, indent)?;
+                fmt_json_array_item(f, i + 1, v, indent, styles)?;
             }
             Ok(())
         }
@@ -84,7 +227,12 @@ pub(crate) fn fmt_json_value(
             writeln!(f, "{:indent$}* {key}: {s}", "")
         }
         serde_json::Value::Null => {
-            writeln!(f, "{:indent$}* {key}: <none>", "")
+            writeln!(
+                f,
+                "{:indent$}* {key}: {}",
+                "",
+                styles.missing().style("<none>")
+            )
         }
         serde_json::Value::Bool(b) => {
             writeln!(f, "{:indent$}* {key}: {b}", "")
@@ -103,12 +251,13 @@ pub(crate) fn fmt_json_array_item(
     n: usize,
     value: &serde_json::Value,
     indent: usize,
+    styles: Styles,
 ) -> fmt::Result {
     match value {
         serde_json::Value::Object(map) => {
             writeln!(f, "{:indent$}{n}.", "")?;
             for (k, v) in map {
-                fmt_json_value(f, k, v, indent + 2)?;
+                fmt_json_value(f, k, v, indent + 2, styles)?;
             }
             Ok(())
         }
@@ -116,7 +265,7 @@ pub(crate) fn fmt_json_array_item(
             writeln!(f, "{:indent$}{n}.", "")?;
             let indent = indent + 2;
             for (i, v) in arr.iter().enumerate() {
-                fmt_json_array_item(f, i + 1, v, indent)?;
+                fmt_json_array_item(f, i + 1, v, indent, styles)?;
             }
             Ok(())
         }
@@ -124,7 +273,12 @@ pub(crate) fn fmt_json_array_item(
             writeln!(f, "{:indent$}{n}. {s}", "")
         }
         serde_json::Value::Null => {
-            writeln!(f, "{:indent$}{n}. <none>", "")
+            writeln!(
+                f,
+                "{:indent$}{n}. {}",
+                "",
+                styles.missing().style("<none>")
+            )
         }
         serde_json::Value::Bool(b) => {
             writeln!(f, "{:indent$}{n}. {b}", "")
@@ -141,11 +295,12 @@ pub struct Comment<'c> {
     comment: &'c str,
     indent: usize,
     leading_newline: bool,
+    colored: bool,
 }
 
 impl<'c> Comment<'c> {
     pub fn new(comment: &'c str, indent: usize) -> Self {
-        Self { comment, indent, leading_newline: false }
+        Self { comment, indent, leading_newline: false, colored: false }
     }
 
     pub fn indent(self, indent: usize) -> Self {
@@ -154,6 +309,11 @@ impl<'c> Comment<'c> {
 
     pub fn with_leading_newline(self) -> Self {
         Self { leading_newline: true, ..self }
+    }
+
+    /// If `colored` is true, dim the comment text.
+    pub fn colored(self, colored: bool) -> Self {
+        Self { colored, ..self }
     }
 }
 
@@ -183,16 +343,113 @@ impl<'c> From<Option<&'c str>> for Comment<'c> {
 
 impl std::fmt::Display for Comment<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let &Self { comment, indent, leading_newline } = self;
+        let &Self { comment, indent, leading_newline, colored } = self;
         if comment.is_empty() {
             return Ok(());
         }
         if leading_newline {
             writeln!(f, "")?;
         }
+        let style = Styles::new(colored).comment();
         for line in comment.lines() {
-            writeln!(f, "{:indent$}// {line}", "",)?;
+            writeln!(
+                f,
+                "{:indent$}{}",
+                "",
+                style.style(format_args!("// {line}"))
+            )?;
         }
         Ok(())
+    }
+}
+
+/// Test helpers for asserting that colored displayer output differs from
+/// uncolored output only in ANSI escape sequences.
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use std::fmt;
+
+    /// Renders the `fmt::Display` output of the value constructed by
+    /// `mk_displayer` with colors off and on, prints the colored output to
+    /// stderr for manual inspection, and asserts that:
+    ///
+    /// * the plain (non-colored) `Display` output contains no ANSI escapes
+    /// * the colored output, with SGR sequences stripped, is identical
+    ///   to the plain one. Enabling colors should add styling but should not
+    ///   change the underlying text.
+    ///
+    /// It also asserts that the colored output contains at least one escape
+    /// (but deliberately not any *particular* escape, since updating assertions
+    /// if we change how things are formatted is annoying). This only guards
+    /// against the `colored` flag silently not being passed through.
+    ///
+    /// Taking a constructor closure rather than two pre-rendered strings
+    /// guarantees the two formatted outputs come from the same displayer,
+    /// differing only in the `colored` flag.
+    ///
+    /// Returns the plain output, for golden-file comparison.
+    #[track_caller]
+    pub(crate) fn check_colored_display<D: fmt::Display>(
+        mk_displayer: impl Fn(bool) -> D,
+    ) -> String {
+        let plain = mk_displayer(false).to_string();
+        let colored = mk_displayer(true).to_string();
+        eprintln!("{colored}");
+        assert!(
+            !plain.contains('\x1b'),
+            "uncolored output must not contain ANSI escapes:\n{}",
+            ShowEscapes(&plain)
+        );
+        assert!(
+            colored.contains('\x1b'),
+            "colored output should contain at least one ANSI escape; \
+             is the `colored` flag being passed through?\n{}",
+            ShowEscapes(&colored)
+        );
+        assert_eq!(
+            strip_sgr(&colored),
+            plain,
+            "colored output must differ from uncolored output only in \
+             ANSI escape sequences"
+        );
+        plain
+    }
+
+    /// Displays a string with control characters *other than newlines*
+    /// escaped, so that ANSI escape sequences in assertion failure messages
+    /// are visible as text rather than interpreted by the terminal, while
+    /// multi-line output doesn't get dumped out on one giant line.
+    struct ShowEscapes<'a>(&'a str);
+
+    impl fmt::Display for ShowEscapes<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            for c in self.0.chars() {
+                if c == '\n' || !c.is_control() {
+                    write!(f, "{c}")?;
+                } else {
+                    write!(f, "{}", c.escape_debug())?;
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Strip ANSI SGR sequences (`ESC [ ... m`), the only kind of escape
+    /// the `Display` implementations here emit.
+    fn strip_sgr(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                for c in chars.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
     }
 }

--- a/nexus/types/src/fm/ereport.rs
+++ b/nexus/types/src/fm/ereport.rs
@@ -319,6 +319,15 @@ impl TryFrom<EreportFiltersParams> for EreportFilters {
 #[must_use = "this struct does nothing unless displayed"]
 pub struct DisplayEreportFilters<'a> {
     filters: &'a EreportFilters,
+    colored: bool,
+}
+
+impl DisplayEreportFilters<'_> {
+    /// If `colored` is true, style the output with ANSI terminal colors.
+    pub fn colored(mut self, colored: bool) -> Self {
+        self.colored = colored;
+        self
+    }
 }
 
 impl EreportFilters {
@@ -405,7 +414,7 @@ impl EreportFilters {
     }
 
     pub fn display(&self) -> DisplayEreportFilters<'_> {
-        DisplayEreportFilters { filters: self }
+        DisplayEreportFilters { filters: self, colored: false }
     }
 }
 
@@ -414,6 +423,8 @@ impl fmt::Display for DisplayEreportFilters<'_> {
         use itertools::Itertools;
 
         let filters = self.filters;
+        let styles = super::display::Styles::new(self.colored);
+        let heading = styles.heading();
 
         // Writes a semicolon-separated part to the formatter, tracking whether
         // we've written anything yet.
@@ -428,16 +439,17 @@ impl fmt::Display for DisplayEreportFilters<'_> {
             };
 
         if let Some(start) = filters.start_time() {
-            fmt_part(f, format_args!("start: {start}"))?;
+            fmt_part(f, format_args!("{}: {start}", heading.style("start")))?;
         }
         if let Some(end) = filters.end_time() {
-            fmt_part(f, format_args!("end: {end}"))?;
+            fmt_part(f, format_args!("{}: {end}", heading.style("end")))?;
         }
         if !filters.only_serials().is_empty() {
             fmt_part(
                 f,
                 format_args!(
-                    "serials: {}",
+                    "{}: {}",
+                    heading.style("serials"),
                     filters.only_serials().iter().format(", ")
                 ),
             )?;
@@ -446,7 +458,8 @@ impl fmt::Display for DisplayEreportFilters<'_> {
             fmt_part(
                 f,
                 format_args!(
-                    "classes: {}",
+                    "{}: {}",
+                    heading.style("classes"),
                     filters.only_classes().iter().format(", ")
                 ),
             )?;
@@ -454,7 +467,7 @@ impl fmt::Display for DisplayEreportFilters<'_> {
 
         // If no filters are set, display "none" rather than empty output.
         if empty {
-            write!(f, "none")?;
+            write!(f, "{}", styles.missing().style("none"))?;
         }
         Ok(())
     }


### PR DESCRIPTION
The FM `Display` implementations for things like sitreps and analysis reports output a lot of text, which, in my opinion, is a bit easier to read with some (tasteful) use of ANSI formatting escape codes. This branch adds that. ANSI formatting is opt-in, and right now, it is only displayed when OMDB is told that it's allowed to use colors.

I didn't feature flag the `owo-colors` dep, because it's really not adding very much code, and it's probably not worth having to build `nexus-types` twice if only `omdb` enables it.