### PR TITLE
Oximeter: Wire up standalone collector.

### DIFF
--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -316,11 +316,6 @@ impl OximeterAgent {
             collector_port: address.port(),
         };
 
-        // We don't spawn the task to periodically refresh producers when run
-        // in standalone mode. We can just pretend we registered once, and
-        // that's it.
-        let last_refresh_time = Arc::new(Mutex::new(Some(Utc::now())));
-
         Ok(Self {
             id,
             log,
@@ -329,7 +324,7 @@ impl OximeterAgent {
             collection_tasks: Arc::new(Mutex::new(BTreeMap::new())),
             refresh_interval,
             refresh_task: Arc::new(Mutex::new(None)),
-            last_refresh_time,
+            last_refresh_time: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -982,7 +977,7 @@ mod tests {
         )
         .config(Default::default())
         .start()
-        .expect("failed to spawn empty dropshot server");
+        .expect("failed to spawn live producer server");
 
         // Register the dummy producer.
         let endpoint = ProducerEndpoint {
@@ -1357,6 +1352,102 @@ mod tests {
         assert_eq!(details.address, server.local_addr());
         assert!(details.n_collections > 0);
         assert!(collection_count.load(Ordering::SeqCst) > 0);
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn test_standalone_integration() {
+        usdt::register_probes().unwrap();
+        let logctx = test_setup_log("test_standalone_integration");
+        let log = &logctx.log;
+
+        // Start the standalone nexus to register and list producers.
+        let nexus = crate::standalone::Server::new(
+            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0)),
+            slog::Level::Error,
+        )
+        .expect("failed to start standalone nexus");
+
+        // Spawn the mock server that always reports dummy statistics.
+        let collection_count = Arc::new(AtomicUsize::new(0));
+        let producer = ServerBuilder::new(
+            producer_api_mod::api_description::<LiveProducer>().unwrap(),
+            collection_count.clone(),
+            log.new(slog::o!("component" => "producer")),
+        )
+        .config(Default::default())
+        .start()
+        .expect("failed to spawn live producer server");
+
+        // Spawn the standalone oximeter, using the standalone nexus to track producers.
+        let args = crate::OximeterArguments {
+            id: Uuid::new_v4(),
+            address: SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0),
+        };
+        let collector = crate::Oximeter::new_standalone(
+            log,
+            &args,
+            nexus.local_addr(),
+            None,
+            // Refresh often so the test doesn't wait the 15s production
+            // default for the collector to discover the producer.
+            Duration::from_millis(100),
+        )
+        .await
+        .expect("failed to start standalone collector");
+
+        // Register the producer with the standalone nexus.
+        let producer_id = Uuid::new_v4();
+        let endpoint = ProducerEndpoint {
+            id: producer_id,
+            kind: ProducerKind::Service,
+            address: producer.local_addr(),
+            interval: COLLECTION_INTERVAL,
+        };
+        reqwest::Client::new()
+            .post(format!("http://{}/metrics/producers", nexus.local_addr()))
+            .json(&endpoint)
+            .send()
+            .await
+            .expect("failed to register producer")
+            .error_for_status()
+            .expect("producer registration returned an error");
+
+        // Assert that the producer with the expected uuid was registered.
+        wait_for_condition(
+            || async {
+                if collector
+                    .list_producers(None, 10)
+                    .iter()
+                    .any(|p| p.id == producer_id)
+                {
+                    Ok(())
+                } else {
+                    Err(CondCheckError::<()>::NotYet { status: None })
+                }
+            },
+            &POLL_INTERVAL,
+            &COLLECTION_TIMEOUT,
+        )
+        .await
+        .expect("collector discovered the dummy producer");
+
+        // Assert that the collector collects at least one sample.
+        collector.try_force_collect().expect("forced collection enqueued");
+        wait_for_condition(
+            || async {
+                if collection_count.load(Ordering::SeqCst) >= 1 {
+                    Ok(())
+                } else {
+                    Err(CondCheckError::<()>::NotYet { status: None })
+                }
+            },
+            &POLL_INTERVAL,
+            &COLLECTION_TIMEOUT,
+        )
+        .await
+        .expect("collector collected >0 samples");
+
         logctx.cleanup_successful();
     }
 }

--- a/oximeter/collector/src/bin/oximeter.rs
+++ b/oximeter/collector/src/bin/oximeter.rs
@@ -139,6 +139,7 @@ async fn do_run() -> Result<(), CmdError> {
                 &args,
                 nexus_server.local_addr(),
                 clickhouse,
+                oximeter_collector::default_refresh_interval(),
             )
             .await
             .unwrap()

--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -364,24 +364,7 @@ impl Oximeter {
         .await
         .expect("Expected an infinite retry loop initializing the timeseries database");
 
-        let dropshot_log = log.new(o!("component" => "dropshot"));
-        let server = ServerBuilder::new(
-            oximeter_api(),
-            Arc::clone(&agent),
-            dropshot_log,
-        )
-        .config(ConfigDropshot {
-            bind_address: SocketAddr::V6(args.address),
-            ..Default::default()
-        })
-        .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
-            dropshot::ClientSpecifiesVersionInHeader::new(
-                omicron_common::api::VERSION_HEADER,
-                oximeter_api::latest_version(),
-            ),
-        )))
-        .start()
-        .map_err(|e| Error::Server(e.to_string()))?;
+        let server = build_server(agent.clone(), args, &log)?;
 
         // Notify Nexus that this oximeter instance is available.
         let our_info = nexus_client::types::OximeterInfo {
@@ -404,21 +387,7 @@ impl Oximeter {
                     ))
                 };
 
-            match qorb::pool::Pool::new(
-                "oximeter-to-nexus".to_string(),
-                nexus_resolver,
-                Arc::new(NexusConnector { log: log.clone() }),
-                qorb::policy::Policy::default(),
-            ) {
-                Ok(pool) => {
-                    debug!(log, "registered USDT probes");
-                    pool
-                }
-                Err(err) => {
-                    error!(log, "failed to register USDT probes");
-                    err.into_inner()
-                }
-            }
+            build_nexus_pool(nexus_resolver, &log)
         };
 
         let notify_nexus = || async {
@@ -469,37 +438,21 @@ impl Oximeter {
         args: &OximeterArguments,
         nexus: SocketAddr,
         clickhouse: Option<SocketAddr>,
+        refresh_interval: Duration,
     ) -> Result<Self, Error> {
         let db_config = clickhouse.map(DbConfig::with_address);
         let agent = Arc::new(
             OximeterAgent::new_standalone(
                 args.id,
                 args.address,
-                crate::default_refresh_interval(),
+                refresh_interval,
                 db_config,
                 &log,
             )
             .await?,
         );
 
-        let dropshot_log = log.new(o!("component" => "dropshot"));
-        let server = ServerBuilder::new(
-            oximeter_api(),
-            Arc::clone(&agent),
-            dropshot_log,
-        )
-        .config(ConfigDropshot {
-            bind_address: SocketAddr::V6(args.address),
-            ..Default::default()
-        })
-        .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
-            dropshot::ClientSpecifiesVersionInHeader::new(
-                omicron_common::api::VERSION_HEADER,
-                oximeter_api::latest_version(),
-            ),
-        )))
-        .start()
-        .map_err(|e| Error::Server(e.to_string()))?;
+        let server = build_server(agent.clone(), args, log)?;
         info!(log, "started oximeter standalone server");
 
         // Notify the standalone nexus.
@@ -540,6 +493,11 @@ impl Oximeter {
         )
         .await
         .expect("Expected an infinite retry loop contacting Nexus");
+
+        // Poll the standalone nexus for collectors.
+        let nexus_resolver = Box::new(FixedResolver::new([nexus]));
+        let nexus_pool = build_nexus_pool(nexus_resolver, &log);
+        agent.ensure_producer_refresh_task(nexus_pool);
 
         Ok(Self { agent, server })
     }
@@ -592,5 +550,47 @@ impl Oximeter {
     /// Return the address of the server.
     pub fn server_address(&self) -> SocketAddr {
         self.server.local_addr()
+    }
+}
+
+fn build_server(
+    agent: Arc<OximeterAgent>,
+    args: &OximeterArguments,
+    log: &Logger,
+) -> Result<HttpServer<Arc<OximeterAgent>>, Error> {
+    let dropshot_log = log.new(o!("component" => "dropshot"));
+    ServerBuilder::new(oximeter_api(), agent, dropshot_log)
+        .config(ConfigDropshot {
+            bind_address: SocketAddr::V6(args.address),
+            ..Default::default()
+        })
+        .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
+            dropshot::ClientSpecifiesVersionInHeader::new(
+                omicron_common::api::VERSION_HEADER,
+                oximeter_api::latest_version(),
+            ),
+        )))
+        .start()
+        .map_err(|e| Error::Server(e.to_string()))
+}
+
+fn build_nexus_pool(
+    nexus_resolver: BoxedResolver,
+    log: &Logger,
+) -> qorb::pool::Pool<nexus_client::Client> {
+    match qorb::pool::Pool::new(
+        "oximeter-to-nexus".to_string(),
+        nexus_resolver,
+        Arc::new(NexusConnector { log: log.clone() }),
+        qorb::policy::Policy::default(),
+    ) {
+        Ok(pool) => {
+            debug!(log, "registered USDT probes");
+            pool
+        }
+        Err(err) => {
+            error!(log, "failed to register USDT probes");
+            err.into_inner()
+        }
     }
 }

--- a/oximeter/collector/src/standalone.rs
+++ b/oximeter/collector/src/standalone.rs
@@ -10,17 +10,28 @@ use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::HttpError;
 use dropshot::HttpResponseCreated;
+use dropshot::HttpResponseOk;
 use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::HttpServer;
+use dropshot::Path;
+use dropshot::Query;
 use dropshot::RequestContext;
+use dropshot::ResultsPage;
 use dropshot::ServerBuilder;
 use dropshot::TypedBody;
 use dropshot::endpoint;
 use nexus_types::internal_api::params::OximeterInfo;
 use omicron_common::FileKv;
+use omicron_common::api::external::http_pagination::PaginatedById;
+use omicron_common::api::external::http_pagination::ScanById;
+use omicron_common::api::external::http_pagination::ScanParams;
+use omicron_common::api::external::http_pagination::data_page_params_for;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
 use omicron_common::api::internal::nexus::ProducerRegistrationResponse;
 use rand::seq::IteratorRandom;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
 use slog::Drain;
 use slog::Level;
 use slog::Logger;
@@ -149,6 +160,8 @@ pub fn standalone_nexus_api() -> ApiDescription<Arc<StandaloneNexus>> {
         .expect("Could not register cpapi_producers_post API handler");
     api.register(cpapi_collectors_post)
         .expect("Could not register cpapi_collectors_post API handler");
+    api.register(cpapi_assigned_producers_list)
+        .expect("Could not register cpapi_assigned_producers_list API handler");
     api
 }
 
@@ -168,6 +181,46 @@ async fn cpapi_producers_post(
         .await
         .map(HttpResponseCreated)
         .map_err(|e| HttpError::for_internal_error(e.to_string()))
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize)]
+pub struct CollectorIdPathParams {
+    /// The ID of the oximeter collector.
+    pub collector_id: Uuid,
+}
+
+/// List all metric producers assigned to an oximeter collector.
+#[endpoint {
+    method = GET,
+    path = "/metrics/collectors/{collector_id}/producers",
+}]
+async fn cpapi_assigned_producers_list(
+    request_context: RequestContext<Arc<StandaloneNexus>>,
+    path_params: Path<CollectorIdPathParams>,
+    query_params: Query<PaginatedById>,
+) -> Result<HttpResponseOk<ResultsPage<ProducerEndpoint>>, HttpError> {
+    let context = request_context.context();
+    let inner = context.inner.lock().await;
+    let query = query_params.into_inner();
+    let collector_id = path_params.into_inner().collector_id;
+
+    let mut producers = inner
+        .producers
+        .values()
+        .filter(|assignment| assignment.collector_id == collector_id)
+        .map(|assignment| assignment.producer)
+        .collect::<Vec<_>>();
+    producers.sort_by_key(|p| p.id);
+    let pagparams = data_page_params_for(&request_context, &query)?;
+    if let Some(&last_seen) = pagparams.marker {
+        producers.retain(|p| p.id > last_seen);
+    }
+
+    Ok(HttpResponseOk(ScanById::results_page(
+        &query,
+        producers,
+        &|_, producer: &ProducerEndpoint| producer.id,
+    )?))
 }
 
 /// Accept a notification of a new oximeter collection server.


### PR DESCRIPTION
We ship a "standalone" oximeter collector, along with a dummy nexus that only implements the parts of its api relevant for oximeter. However, the standalone oximeter and its nexus don't actually collect metrics: standalone nexus doesn't have an api endpoint listing its registered producers, and standalone oximeter doesn't poll the endpoint that doesn't exist.

This patch backfills the missing producers list endpoint to the standalone nexus, and updates the standalone oximeter to poll it.

For context, we'll use this for end-to-end load tests of oximeter, which we'll need in turn to understand oximeter performance, and any impacts of new oximeter features on performance.