### PR TITLE
[14/n] [wicketd] add UpdateTargets and adopt it in the unstable update API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17570,14 +17570,17 @@ dependencies = [
 name = "wicketd-commission-types-versions"
 version = "0.1.0"
 dependencies = [
+ "gateway-types-versions",
  "omicron-common",
  "omicron-workspace-hack",
  "oxnet",
+ "proptest",
  "schemars 0.8.22",
  "serde",
  "serde_json",
  "sled-agent-types-versions",
  "slog-error-chain",
+ "test-strategy",
  "toml 0.8.23",
 ]
 

--- a/clients/wicketd-client/src/lib.rs
+++ b/clients/wicketd-client/src/lib.rs
@@ -88,6 +88,7 @@ progenitor::generate_api!(
         StepEventForWicketdEngineSpec = wicket_common::update_events::StepEvent,
         SwitchSlot = sled_agent_types::early_networking::SwitchSlot,
         UpdateSimulatedResult = wicket_common::rack_update::UpdateSimulatedResult,
+        UpdateTargets = wicketd_commission_types_versions::latest::update::UpdateTargets,
         UpdateTestError = wicket_common::rack_update::UpdateTestError,
         UplinkPreflightStepId = wicket_common::preflight_check::UplinkPreflightStepId,
         UserSpecifiedBgpPeerConfig = wicketd_commission_types_versions::latest::rack_setup::UserSpecifiedBgpPeerConfig,

--- a/gateway-types/versions/src/initial/component.rs
+++ b/gateway-types/versions/src/initial/component.rs
@@ -43,6 +43,7 @@ pub enum SpType {
     Deserialize,
     JsonSchema,
 )]
+#[cfg_attr(any(test, feature = "testing"), derive(test_strategy::Arbitrary))]
 pub struct SpIdentifier {
     #[serde(rename = "type")]
     pub typ: SpType,

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -1469,12 +1469,12 @@
             ]
           },
           "targets": {
-            "description": "The SP identifiers to clear the update state for. Must be non-empty.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SpIdentifier"
-            },
-            "uniqueItems": true
+            "description": "The SP identifiers to clear the update state for.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UpdateTargets"
+              }
+            ]
           }
         },
         "required": [
@@ -5037,12 +5037,12 @@
             ]
           },
           "targets": {
-            "description": "The SP identifiers to start the update with. Must be non-empty.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SpIdentifier"
-            },
-            "uniqueItems": true
+            "description": "The SP identifiers to start the update with.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UpdateTargets"
+              }
+            ]
           }
         },
         "required": [
@@ -7694,6 +7694,15 @@
             ]
           }
         ]
+      },
+      "UpdateTargets": {
+        "description": "A non-empty set of service processors to act on.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SpIdentifier"
+        },
+        "minItems": 1,
+        "uniqueItems": true
       },
       "UpdateTestError": {
         "oneOf": [

--- a/wicket/src/cli/rack_update.rs
+++ b/wicket/src/cli/rack_update.rs
@@ -45,6 +45,7 @@ use wicketd_client::types::{
     ClearUpdateStateParams, GetArtifactsAndEventReportsResponse,
     StartUpdateParams,
 };
+use wicketd_commission_types::update::UpdateTargets;
 
 use super::command::CommandOutput;
 
@@ -153,10 +154,11 @@ impl StartRackUpdateArgs {
 
         let num_update_ids = update_ids.len();
 
-        let params = StartUpdateParams {
-            targets: update_ids.iter().copied().map(Into::into).collect(),
-            options,
-        };
+        let targets = UpdateTargets::new(
+            update_ids.iter().copied().map(Into::into).collect(),
+        )
+        .context("error starting update")?;
+        let params = StartUpdateParams { targets, options };
 
         slog::debug!(log, "Sending post_start_update"; "num_update_ids" => num_update_ids);
         match client.post_start_update(&params).await {
@@ -724,10 +726,11 @@ async fn do_clear_update_state(
 ) -> Result<ClearUpdateStateResponse> {
     let options =
         CreateClearUpdateStateOptions {}.to_clear_update_state_options()?;
-    let params = ClearUpdateStateParams {
-        targets: update_ids.iter().copied().map(Into::into).collect(),
-        options,
-    };
+    let targets = UpdateTargets::new(
+        update_ids.iter().copied().map(Into::into).collect(),
+    )
+    .context("error clearing update state")?;
+    let params = ClearUpdateStateParams { targets, options };
 
     let result = client
         .post_clear_update_state(&params)

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -18,6 +18,7 @@ use wicketd_client::types::{
     ClearUpdateStateParams, GetInventoryParams, GetInventoryResponse,
     GetLocationResponse, IgnitionCommand, StartUpdateParams,
 };
+use wicketd_commission_types::update::UpdateTargets;
 
 use crate::events::{ArtifactData, EventReportMap};
 use crate::keymap::ShowPopupCmd;
@@ -165,7 +166,7 @@ impl WicketdManager {
             let update_client =
                 create_wicketd_client(&log, addr, WICKETD_TIMEOUT);
             let params = StartUpdateParams {
-                targets: vec![component_id.into()],
+                targets: UpdateTargets::single(component_id.into()),
                 options,
             };
             let response = match update_client.post_start_update(&params).await
@@ -230,7 +231,7 @@ impl WicketdManager {
             let update_client =
                 create_wicketd_client(&log, addr, WICKETD_TIMEOUT);
             let params = ClearUpdateStateParams {
-                targets: vec![component_id.into()],
+                targets: UpdateTargets::single(component_id.into()),
                 options,
             };
             let response =

--- a/wicketd-api/src/lib.rs
+++ b/wicketd-api/src/lib.rs
@@ -40,6 +40,7 @@ use wicket_common::update_events::EventReport;
 use wicketd_commission_types::rack_setup::BgpAuthKeyId;
 use wicketd_commission_types::rack_setup::CertificateUploadResponse;
 use wicketd_commission_types::rack_setup::PutRssUserConfigInsensitive;
+use wicketd_commission_types::update::UpdateTargets;
 
 /// Full release repositories are currently (Dec 2024) 1.8 GiB and are likely to
 /// continue growing.
@@ -502,8 +503,8 @@ pub struct GetArtifactsAndEventReportsResponse {
 
 #[derive(Clone, Debug, JsonSchema, Deserialize)]
 pub struct StartUpdateParams {
-    /// The SP identifiers to start the update with. Must be non-empty.
-    pub targets: BTreeSet<SpIdentifier>,
+    /// The SP identifiers to start the update with.
+    pub targets: UpdateTargets,
 
     /// Options for the update.
     pub options: StartUpdateOptions,
@@ -511,8 +512,8 @@ pub struct StartUpdateParams {
 
 #[derive(Clone, Debug, JsonSchema, Deserialize)]
 pub struct ClearUpdateStateParams {
-    /// The SP identifiers to clear the update state for. Must be non-empty.
-    pub targets: BTreeSet<SpIdentifier>,
+    /// The SP identifiers to clear the update state for.
+    pub targets: UpdateTargets,
 
     /// Options for clearing update state
     pub options: ClearUpdateStateOptions,

--- a/wicketd-commission-types/src/lib.rs
+++ b/wicketd-commission-types/src/lib.rs
@@ -8,3 +8,4 @@
 //! have to depend on `wicketd-commission-types-versions` directly. See RFD 619.
 
 pub mod rack_setup;
+pub mod update;

--- a/wicketd-commission-types/src/update.rs
+++ b/wicketd-commission-types/src/update.rs
@@ -2,7 +2,4 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Functional code for the latest versions of types.
-
-mod rack_setup;
-mod update;
+pub use wicketd_commission_types_versions::latest::update::*;

--- a/wicketd-commission-types/versions/Cargo.toml
+++ b/wicketd-commission-types/versions/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 workspace = true
 
 [dependencies]
+gateway-types-versions.workspace = true
 omicron-common.workspace = true
 omicron-workspace-hack.workspace = true
 oxnet.workspace = true
@@ -17,5 +18,8 @@ sled-agent-types-versions.workspace = true
 slog-error-chain.workspace = true
 
 [dev-dependencies]
+gateway-types-versions = { workspace = true, features = ["testing"] }
+proptest.workspace = true
 serde_json.workspace = true
+test-strategy.workspace = true
 toml.workspace = true

--- a/wicketd-commission-types/versions/src/impls/update.rs
+++ b/wicketd-commission-types/versions/src/impls/update.rs
@@ -1,0 +1,132 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeSet;
+
+use gateway_types_versions::v1::component::SpIdentifier;
+
+use crate::latest::update::UpdateTargets;
+
+impl UpdateTargets {
+    /// Create a new `UpdateTargets` set containing a single target.
+    pub fn single(target: SpIdentifier) -> Self {
+        Self(std::iter::once(target).collect())
+    }
+
+    /// Return an iterator over the targets in this set.
+    pub fn iter(&self) -> std::collections::btree_set::Iter<'_, SpIdentifier> {
+        self.0.iter()
+    }
+
+    /// Return true if the set contains the given target.
+    pub fn contains(&self, target: &SpIdentifier) -> bool {
+        self.0.contains(target)
+    }
+
+    /// Convert this set into the inner `BTreeSet<SpIdentifier>`, losing the
+    /// non-empty guarantee.
+    pub fn into_inner(self) -> BTreeSet<SpIdentifier> {
+        self.0
+    }
+}
+
+impl IntoIterator for UpdateTargets {
+    type Item = SpIdentifier;
+    type IntoIter = std::collections::btree_set::IntoIter<SpIdentifier>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a UpdateTargets {
+    type Item = &'a SpIdentifier;
+    type IntoIter = std::collections::btree_set::Iter<'a, SpIdentifier>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::latest::update::EmptyUpdateTargets;
+    use gateway_types_versions::v1::component::SpType;
+    use proptest::prelude::*;
+    use test_strategy::proptest;
+
+    fn target(slot: u16) -> SpIdentifier {
+        SpIdentifier { typ: SpType::Sled, slot }
+    }
+
+    #[test]
+    fn new_rejects_empty() {
+        assert_eq!(
+            UpdateTargets::new(BTreeSet::new()),
+            Err(EmptyUpdateTargets)
+        );
+    }
+
+    #[test]
+    fn new_accepts_single() {
+        let set: BTreeSet<_> = std::iter::once(target(0)).collect();
+        let targets =
+            UpdateTargets::new(set.clone()).expect("a singleton is non-empty");
+        assert_eq!(targets.into_inner(), set);
+    }
+
+    #[test]
+    fn deserialize_rejects_empty() {
+        let err = serde_json::from_str::<UpdateTargets>("[]")
+            .expect_err("an empty array is not a valid UpdateTargets");
+        assert!(
+            err.to_string().contains("at least one target"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn deserialize_accepts_single() {
+        let targets: UpdateTargets =
+            serde_json::from_value(serde_json::json!([target(1)]))
+                .expect("a singleton array deserializes");
+        let expected: BTreeSet<_> = std::iter::once(target(1)).collect();
+        assert_eq!(targets.into_inner(), expected);
+    }
+
+    #[proptest]
+    fn serde_roundtrip(
+        #[strategy(prop::collection::btree_set(any::<SpIdentifier>(), 1..=8))]
+        set: BTreeSet<SpIdentifier>,
+    ) {
+        let targets =
+            UpdateTargets::new(set).expect("generated set is non-empty");
+        let json = serde_json::to_value(&targets).expect("serializes");
+        let round_tripped: UpdateTargets =
+            serde_json::from_value(json).expect("deserializes");
+        prop_assert_eq!(round_tripped, targets);
+    }
+
+    // Test that duplicate items are accepted, even though the schema specifies
+    // uniqueItems.
+    //
+    // This is because we delegate to serde's `BTreeSet` deserializer which
+    // accepts duplicates. There's an argument to be made that our deserializer
+    // should not accept duplicates, but it doesn't matter too much and is
+    // easier this way.
+    #[proptest]
+    fn deserialize_dedups_duplicates(
+        #[strategy(prop::collection::vec(any::<SpIdentifier>(), 1..=8))]
+        entries: Vec<SpIdentifier>,
+    ) {
+        let mut doubled = entries.clone();
+        doubled.extend(entries.iter().copied());
+        let json = serde_json::to_value(&doubled).expect("serializes");
+        let targets: UpdateTargets =
+            serde_json::from_value(json).expect("deserializes");
+        let expected: BTreeSet<_> = entries.into_iter().collect();
+        prop_assert_eq!(targets.into_inner(), expected);
+    }
+}

--- a/wicketd-commission-types/versions/src/initial/mod.rs
+++ b/wicketd-commission-types/versions/src/initial/mod.rs
@@ -5,3 +5,4 @@
 //! Version `INITIAL` of the wicketd commissioning API.
 
 pub mod rack_setup;
+pub mod update;

--- a/wicketd-commission-types/versions/src/initial/update.rs
+++ b/wicketd-commission-types/versions/src/initial/update.rs
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Update types shared across wicketd's update APIs.
+
+use std::collections::BTreeSet;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use gateway_types_versions::v1::component::SpIdentifier;
+
+/// A non-empty set of service processors to act on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UpdateTargets(pub(crate) BTreeSet<SpIdentifier>);
+
+impl UpdateTargets {
+    pub fn new(
+        targets: BTreeSet<SpIdentifier>,
+    ) -> Result<Self, EmptyUpdateTargets> {
+        if targets.is_empty() {
+            Err(EmptyUpdateTargets)
+        } else {
+            Ok(Self(targets))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UpdateTargets {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let targets = BTreeSet::<SpIdentifier>::deserialize(deserializer)?;
+        UpdateTargets::new(targets).map_err(|EmptyUpdateTargets| {
+            serde::de::Error::invalid_length(0, &"at least one target")
+        })
+    }
+}
+
+impl JsonSchema for UpdateTargets {
+    fn schema_name() -> String {
+        "UpdateTargets".to_string()
+    }
+
+    fn json_schema(
+        generator: &mut schemars::r#gen::SchemaGenerator,
+    ) -> schemars::schema::Schema {
+        use schemars::schema::{
+            ArrayValidation, InstanceType, Metadata, Schema, SchemaObject,
+        };
+
+        Schema::Object(SchemaObject {
+            metadata: Some(Box::new(Metadata {
+                description: Some(
+                    "A non-empty set of service processors to act on."
+                        .to_string(),
+                ),
+                ..Default::default()
+            })),
+            instance_type: Some(InstanceType::Array.into()),
+            array: Some(Box::new(ArrayValidation {
+                items: Some(generator.subschema_for::<SpIdentifier>().into()),
+                min_items: Some(1),
+                unique_items: Some(true),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+/// Error returned when UpdateTargets is constructed from an empty set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmptyUpdateTargets;
+
+impl std::fmt::Display for EmptyUpdateTargets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("at least one target must be specified")
+    }
+}
+
+impl std::error::Error for EmptyUpdateTargets {}

--- a/wicketd-commission-types/versions/src/latest.rs
+++ b/wicketd-commission-types/versions/src/latest.rs
@@ -33,3 +33,8 @@ pub mod rack_setup {
     pub use crate::v1::rack_setup::UserSpecifiedRouterPeerAddr;
     pub use crate::v1::rack_setup::UserSpecifiedUplinkAddressConfig;
 }
+
+pub mod update {
+    pub use crate::v1::update::EmptyUpdateTargets;
+    pub use crate::v1::update::UpdateTargets;
+}

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -556,13 +556,6 @@ impl WicketdApi for WicketdApiImpl {
         let rqctx = rqctx.context();
         let params = params.into_inner();
 
-        if params.targets.is_empty() {
-            return Err(HttpError::for_bad_request(
-                None,
-                "No targets specified".into(),
-            ));
-        }
-
         if let Some(test_error) = params.options.test_error {
             return Err(test_error
                 .into_http_error(log, "clearing update state")

--- a/wicketd/src/http_helpers.rs
+++ b/wicketd/src/http_helpers.rs
@@ -17,9 +17,9 @@ use slog::Logger;
 use slog_error_chain::InlineErrorChain;
 use wicket_common::WICKETD_TIMEOUT;
 use wicket_common::inventory::MgsV1Inventory;
-use wicket_common::inventory::SpIdentifier;
 use wicket_common::inventory::SpType;
 use wicket_common::rack_update::StartUpdateOptions;
+use wicketd_commission_types::update::UpdateTargets;
 
 use crate::ServerContext;
 use crate::helpers::SpIdentifierDisplay;
@@ -180,16 +180,9 @@ fn http_error_with_message(
 pub(crate) async fn start_update(
     ctx: &ServerContext,
     log: &Logger,
-    targets: BTreeSet<SpIdentifier>,
+    targets: UpdateTargets,
     options: StartUpdateOptions,
 ) -> Result<(), HttpError> {
-    if targets.is_empty() {
-        return Err(HttpError::for_bad_request(
-            None,
-            "No update targets specified".into(),
-        ));
-    }
-
     // Can we update the target SPs? We refuse to update if, for any target SP:
     //
     // 1. We haven't pulled its state in our inventory (most likely cause: the

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -99,6 +99,7 @@ use wicket_common::update_events::UpdateEngine;
 use wicket_common::update_events::UpdateStepId;
 use wicket_common::update_events::UpdateTerminalError;
 use wicketd_api::GetArtifactsAndEventReportsResponse;
+use wicketd_commission_types::update::UpdateTargets;
 
 #[derive(Debug)]
 struct SpUpdateData {
@@ -197,7 +198,7 @@ impl UpdateTracker {
 
     pub(crate) async fn start(
         &self,
-        sps: BTreeSet<SpIdentifier>,
+        sps: UpdateTargets,
         opts: StartUpdateOptions,
     ) -> Result<(), Vec<StartUpdateError>> {
         let imp = RealSpawnUpdateDriver { update_tracker: self, opts };
@@ -211,7 +212,7 @@ impl UpdateTracker {
     #[doc(hidden)]
     pub async fn start_fake_update(
         &self,
-        sps: BTreeSet<SpIdentifier>,
+        sps: UpdateTargets,
         fake_step_receiver: oneshot::Receiver<oneshot::Sender<()>>,
     ) -> Result<(), Vec<StartUpdateError>> {
         let imp = FakeUpdateDriver {
@@ -223,10 +224,10 @@ impl UpdateTracker {
 
     pub(crate) async fn clear_update_state(
         &self,
-        sps: BTreeSet<SpIdentifier>,
+        targets: UpdateTargets,
     ) -> Result<ClearUpdateStateResponse, ClearUpdateStateError> {
         let mut update_data = self.sp_update_data.lock().await;
-        update_data.clear_update_state(&sps)
+        update_data.clear_update_state(&targets)
     }
 
     pub(crate) async fn abort_update(
@@ -248,14 +249,14 @@ impl UpdateTracker {
     /// performs the same checks.
     pub(crate) async fn update_pre_checks(
         &self,
-        sps: BTreeSet<SpIdentifier>,
+        sps: UpdateTargets,
     ) -> Result<(), Vec<StartUpdateError>> {
         self.start_impl::<NeverUpdateDriver>(sps, None).await
     }
 
     async fn start_impl<Spawn>(
         &self,
-        sps: BTreeSet<SpIdentifier>,
+        sps: UpdateTargets,
         spawn_update_driver: Option<Spawn>,
     ) -> Result<(), Vec<StartUpdateError>>
     where
@@ -679,7 +680,7 @@ impl UpdateTrackerData {
 
     fn clear_update_state(
         &mut self,
-        sps: &BTreeSet<SpIdentifier>,
+        sps: &UpdateTargets,
     ) -> Result<ClearUpdateStateResponse, ClearUpdateStateError> {
         // Are any updates currently running? If so, then reject the request.
         let in_progress_updates = sps

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -45,6 +45,7 @@ use wicketd::{RunningUpdateState, StartUpdateError};
 use wicketd_client::types::{
     GetInventoryParams, GetInventoryResponse, StartUpdateParams,
 };
+use wicketd_commission_types::update::UpdateTargets;
 
 /// The list of zone file names defined in fake-non-semver.toml.
 static FAKE_NON_SEMVER_ZONE_FILE_NAMES: &[&str] = &[
@@ -210,7 +211,10 @@ async fn test_updates() {
 
     // Now, try starting the update on SP 0.
     let options = StartUpdateOptions::default();
-    let params = StartUpdateParams { targets: vec![target_sp], options };
+    let params = StartUpdateParams {
+        targets: UpdateTargets::single(target_sp),
+        options,
+    };
     wicketd_testctx
         .wicketd_client
         .post_start_update(&params)
@@ -783,7 +787,7 @@ async fn test_update_races() {
 
     // Now start an update.
     let sp = SpIdentifier { slot: 0, typ: SpType::Sled };
-    let sps: BTreeSet<_> = vec![sp].into_iter().collect();
+    let sps = UpdateTargets::single(sp);
 
     let (sender, receiver) = oneshot::channel();
     wicketd_testctx


### PR DESCRIPTION
Add a newtype wrapper which ensures that the set of update targets is non-empty.

This can be landed without breaking rkdeploy because we used to reject empty lists here anyway, so there are no new restrictions involved.
