### PR TITLE
[common] be less confusing about what a "prefix" is

### DIFF
--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -19,10 +19,10 @@ use std::{
     sync::LazyLock,
 };
 
-pub const BOOTSTRAP_SUBNET_PREFIX: u8 = 40;
-pub const AZ_PREFIX: u8 = 48;
-pub const RACK_PREFIX: u8 = 56;
-pub const SLED_PREFIX: u8 = 64;
+pub const BOOTSTRAP_SUBNET_PREFIX_LENGTH: u8 = 40;
+pub const AZ_PREFIX_LENGTH: u8 = 48;
+pub const RACK_PREFIX_LENGTH: u8 = 56;
+pub const SLED_PREFIX_LENGTH: u8 = 64;
 
 /// Effective MTU for external-facing OPTE ports when jumbo frames have been
 /// opted into. 500 bytes of headroom under the 9000 byte underlay MTU leaves
@@ -276,7 +276,7 @@ pub const VPC_SUBNET_IPV6_PREFIX_LENGTH: u8 = 64;
 /// Minimum prefix size supported in IPv4 VPC Subnets.
 ///
 /// NOTE: This is the minimum _prefix_, which sets the maximum subnet size.
-pub const MIN_VPC_IPV4_SUBNET_PREFIX: u8 = 8;
+pub const MIN_VPC_IPV4_SUBNET_PREFIX_LENGTH: u8 = 8;
 
 /// The number of reserved addresses at the beginning of a subnet range.
 pub const NUM_INITIAL_RESERVED_IP_ADDRESSES: usize = 5;
@@ -287,7 +287,7 @@ pub const NUM_INITIAL_RESERVED_IP_ADDRESSES: usize = 5;
 /// like, and the broadcast address at the end of the subnet. This size provides
 /// room for 2 ** 6 - 6 = 58 IP addresses, which seems like a reasonable size
 /// for the smallest subnet that's still useful in many contexts.
-pub const MAX_VPC_IPV4_SUBNET_PREFIX: u8 = 26;
+pub const MAX_VPC_IPV4_SUBNET_PREFIX_LENGTH: u8 = 26;
 
 // The number of ports available to an SNAT IP.
 // Note that for static NAT, this value isn't used, and all ports are available.
@@ -478,11 +478,11 @@ impl<'de, const N: u8> Deserialize<'de> for Ipv6Subnet<N> {
     Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord,
 )]
 pub struct DnsSubnet {
-    subnet: Ipv6Subnet<SLED_PREFIX>,
+    subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 }
 
 impl DnsSubnet {
-    pub fn new(subnet: Ipv6Subnet<SLED_PREFIX>) -> Self {
+    pub fn new(subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>) -> Self {
         Self { subnet }
     }
 
@@ -492,7 +492,7 @@ impl DnsSubnet {
     }
 
     /// Returns the DNS subnet.
-    pub fn subnet(&self) -> Ipv6Subnet<SLED_PREFIX> {
+    pub fn subnet(&self) -> Ipv6Subnet<SLED_PREFIX_LENGTH> {
         self.subnet
     }
 
@@ -520,17 +520,19 @@ impl DnsSubnet {
 /// A wrapper around an IPv6 network, indicating it is a "reserved" rack
 /// subnet which can be used for AZ-wide services.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ReservedRackSubnet(pub Ipv6Subnet<RACK_PREFIX>);
+pub struct ReservedRackSubnet(pub Ipv6Subnet<RACK_PREFIX_LENGTH>);
 
 impl ReservedRackSubnet {
     /// Returns the subnet for the reserved rack subnet.
-    pub fn new(subnet: Ipv6Subnet<AZ_PREFIX>) -> Self {
-        ReservedRackSubnet(Ipv6Subnet::<RACK_PREFIX>::new(subnet.net().addr()))
+    pub fn new(subnet: Ipv6Subnet<AZ_PREFIX_LENGTH>) -> Self {
+        ReservedRackSubnet(Ipv6Subnet::<RACK_PREFIX_LENGTH>::new(
+            subnet.net().addr(),
+        ))
     }
 
     /// Infer the reserved rack subnet from a sled/AZ/DNS subnet.
     pub fn from_subnet<const N: u8>(subnet: Ipv6Subnet<N>) -> Self {
-        Self::new(Ipv6Subnet::<AZ_PREFIX>::new(subnet.net().addr()))
+        Self::new(Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(subnet.net().addr()))
     }
 
     /// Returns the `index`th DNS subnet from this reserved rack subnet.
@@ -552,7 +554,7 @@ impl ReservedRackSubnet {
 /// Return the list of DNS servers for the rack, given any address in the AZ
 /// subnet
 pub fn get_internal_dns_server_addresses(addr: Ipv6Addr) -> Vec<IpAddr> {
-    let az_subnet = Ipv6Subnet::<AZ_PREFIX>::new(addr);
+    let az_subnet = Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(addr);
     ReservedRackSubnet::new(az_subnet)
         .get_dns_subnets()
         .iter()
@@ -566,7 +568,9 @@ const SWITCH_ZONE_ADDRESS_INDEX: usize = 2;
 /// Return the sled agent address for a subnet.
 ///
 /// This address will come from the first address of the [`SLED_PREFIX`] subnet.
-pub fn get_sled_address(sled_subnet: Ipv6Subnet<SLED_PREFIX>) -> SocketAddrV6 {
+pub fn get_sled_address(
+    sled_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
+) -> SocketAddrV6 {
     let sled_agent_ip =
         sled_subnet.net().nth(SLED_AGENT_ADDRESS_INDEX as u128).unwrap();
     SocketAddrV6::new(sled_agent_ip, SLED_AGENT_PORT, 0, 0)
@@ -576,7 +580,7 @@ pub fn get_sled_address(sled_subnet: Ipv6Subnet<SLED_PREFIX>) -> SocketAddrV6 {
 ///
 /// This address will come from the second address of the [`SLED_PREFIX`] subnet.
 pub fn get_switch_zone_address(
-    sled_subnet: Ipv6Subnet<SLED_PREFIX>,
+    sled_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 ) -> Ipv6Addr {
     sled_subnet.net().nth(SWITCH_ZONE_ADDRESS_INDEX as u128).unwrap()
 }
@@ -585,14 +589,14 @@ pub fn get_switch_zone_address(
 ///
 /// The subnet at index == 0 is used for rack-local services.
 pub fn get_64_subnet(
-    rack_subnet: Ipv6Subnet<RACK_PREFIX>,
+    rack_subnet: Ipv6Subnet<RACK_PREFIX_LENGTH>,
     index: u8,
-) -> Ipv6Subnet<SLED_PREFIX> {
+) -> Ipv6Subnet<SLED_PREFIX_LENGTH> {
     let mut rack_network = rack_subnet.net().addr().octets();
 
     // To set bits distinguishing the /64 from the /56, we modify the 7th octet.
     rack_network[7] = index;
-    Ipv6Subnet::<SLED_PREFIX>::new(Ipv6Addr::from(rack_network))
+    Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(Ipv6Addr::from(rack_network))
 }
 
 /// The IP address version.
@@ -1046,7 +1050,7 @@ mod test {
 
     #[test]
     fn test_dns_subnets() {
-        let subnet = Ipv6Subnet::<AZ_PREFIX>::new(
+        let subnet = Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(
             "fd00:1122:3344:0100::".parse::<Ipv6Addr>().unwrap(),
         );
         let rack_subnet = ReservedRackSubnet::new(subnet);
@@ -1075,7 +1079,7 @@ mod test {
 
     #[test]
     fn test_sled_address() {
-        let subnet = Ipv6Subnet::<SLED_PREFIX>::new(
+        let subnet = Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(
             "fd00:1122:3344:0101::".parse::<Ipv6Addr>().unwrap(),
         );
         assert_eq!(
@@ -1083,7 +1087,7 @@ mod test {
             get_sled_address(subnet)
         );
 
-        let subnet = Ipv6Subnet::<SLED_PREFIX>::new(
+        let subnet = Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(
             "fd00:1122:3344:0308::".parse::<Ipv6Addr>().unwrap(),
         );
         assert_eq!(

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -322,7 +322,7 @@ pub const NUM_SOURCE_NAT_PORTS: u16 = 1 << 14;
 // prefix range (`fd00::/48`). See `random_vpc_ipv6_prefix`.
 // Furthermore, all the below *_OPTE_IPV6_SUBNET constants are
 // /64's within this prefix.
-pub static SERVICE_VPC_IPV6_PREFIX: LazyLock<Ipv6Net> = LazyLock::new(|| {
+pub static SERVICE_VPC_IPV6_SUBNET: LazyLock<Ipv6Net> = LazyLock::new(|| {
     Ipv6Net::new(
         Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 0, 0, 0, 0, 0),
         VPC_IPV6_PREFIX_LENGTH,

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -109,8 +109,10 @@ pub const IPV4_LINK_LOCAL_MULTICAST_SUBNET: Ipv4Net =
 /// See [RFC 4291] for IPv6 addressing architecture.
 ///
 /// [RFC 4291]: https://www.rfc-editor.org/rfc/rfc4291
-pub const IPV6_MULTICAST_RANGE: Ipv6Net =
-    Ipv6Net::new_unchecked(Ipv6Addr::new(IPV6_MULTICAST_PREFIX, 0, 0, 0, 0, 0, 0, 0), 8);
+pub const IPV6_MULTICAST_RANGE: Ipv6Net = Ipv6Net::new_unchecked(
+    Ipv6Addr::new(IPV6_MULTICAST_PREFIX, 0, 0, 0, 0, 0, 0, 0),
+    8,
+);
 
 /// IPv6 multicast prefix (ff00::/8) mask/value for scope checking.
 ///

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -545,7 +545,7 @@ impl ReservedRackSubnet {
     /// Returns the DNS addresses from this reserved rack subnet.
     ///
     /// These addresses will come from the first [`INTERNAL_DNS_REDUNDANCY`]
-    /// `/64s` of the [`RACK_PREFIX`] subnet.
+    /// `/64s` of this reserved rack subnet.
     pub fn get_dns_subnets(&self) -> Vec<DnsSubnet> {
         (0..INTERNAL_DNS_REDUNDANCY)
             .map(|idx| self.get_dns_subnet(u8::try_from(idx + 1).unwrap()))
@@ -569,7 +569,7 @@ const SWITCH_ZONE_ADDRESS_INDEX: usize = 2;
 
 /// Return the sled agent address for a subnet.
 ///
-/// This address will come from the first address of the [`SLED_PREFIX`] subnet.
+/// This address will come from the first address of the provided `sled_subnet`.
 pub fn get_sled_address(
     sled_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 ) -> SocketAddrV6 {
@@ -580,7 +580,8 @@ pub fn get_sled_address(
 
 /// Return the switch zone address for a subnet.
 ///
-/// This address will come from the second address of the [`SLED_PREFIX`] subnet.
+/// This address will come from the second address of the provided
+/// `sled_subnet`.
 pub fn get_switch_zone_address(
     sled_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 ) -> Ipv6Addr {

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -110,7 +110,7 @@ pub const IPV4_LINK_LOCAL_MULTICAST_SUBNET: Ipv4Net =
 ///
 /// [RFC 4291]: https://www.rfc-editor.org/rfc/rfc4291
 pub const IPV6_MULTICAST_RANGE: Ipv6Net =
-    Ipv6Net::new_unchecked(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0), 8);
+    Ipv6Net::new_unchecked(Ipv6Addr::new(IPV6_MULTICAST_PREFIX, 0, 0, 0, 0, 0, 0, 0), 8);
 
 /// IPv6 multicast prefix (ff00::/8) mask/value for scope checking.
 ///

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -317,6 +317,24 @@ pub const NUM_SOURCE_NAT_PORTS: u16 = 1 << 14;
 // The specific values aren't deployment-specific as they are virtualized
 // within OPTE.
 
+// VPC IPv6 prefixes are three octet-pairs, so we need three `u16` constants to
+// represent the service VPC subnet prefix of `fd77:e9d2:9cd9::/48`.
+//
+// These are used to construct the `SERVICE_VPC_IPV6_SUBNET` constant below,
+// which represents the entire /48, and the various constants for the individual
+// service /64s within this subnet.
+//
+// XXX(eliza): it would be nice to have a way to construct these subnets from
+// the shared prefix octet-pairs that is a bit less gross than having to scream
+// `SERVICE_VPC_IPV6_PREFIX_n` three times for each one, such as by taking the
+// `SERVICE_VPC_IPV6_SUBNET` value and just setting the value of the 4th
+// octet-pair for each service subnet, but I couldn't figure out a way to do
+// that with the current `oxnet` API. At least this way, we aren't hard-coding
+// the `u16` literals for each subnet...
+const SERVICE_VPC_IPV6_PREFIX_1: u16 = 0xfd77;
+const SERVICE_VPC_IPV6_PREFIX_2: u16 = 0xe9d2;
+const SERVICE_VPC_IPV6_PREFIX_3: u16 = 0x9cd9;
+
 /// The IPv6 prefix assigned to the built-in services VPC.
 // The specific prefix here was randomly chosen from the expected VPC
 // prefix range (`fd00::/48`). See `random_vpc_ipv6_prefix`.
@@ -324,7 +342,16 @@ pub const NUM_SOURCE_NAT_PORTS: u16 = 1 << 14;
 // /64's within this prefix.
 pub static SERVICE_VPC_IPV6_SUBNET: LazyLock<Ipv6Net> = LazyLock::new(|| {
     Ipv6Net::new(
-        Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 0, 0, 0, 0, 0),
+        Ipv6Addr::new(
+            SERVICE_VPC_IPV6_PREFIX_1,
+            SERVICE_VPC_IPV6_PREFIX_2,
+            SERVICE_VPC_IPV6_PREFIX_3,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ),
         VPC_IPV6_PREFIX_LENGTH,
     )
     .unwrap()
@@ -337,7 +364,16 @@ pub static DNS_OPTE_IPV4_SUBNET: LazyLock<Ipv4Net> =
 /// The IPv6 subnet for External DNS OPTE ports.
 pub static DNS_OPTE_IPV6_SUBNET: LazyLock<Ipv6Net> = LazyLock::new(|| {
     Ipv6Net::new(
-        Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 1, 0, 0, 0, 0),
+        Ipv6Addr::new(
+            SERVICE_VPC_IPV6_PREFIX_1,
+            SERVICE_VPC_IPV6_PREFIX_2,
+            SERVICE_VPC_IPV6_PREFIX_3,
+            1,
+            0,
+            0,
+            0,
+            0,
+        ),
         VPC_SUBNET_IPV6_PREFIX_LENGTH,
     )
     .unwrap()
@@ -350,7 +386,16 @@ pub static NEXUS_OPTE_IPV4_SUBNET: LazyLock<Ipv4Net> =
 /// The IPv6 subnet for Nexus OPTE ports.
 pub static NEXUS_OPTE_IPV6_SUBNET: LazyLock<Ipv6Net> = LazyLock::new(|| {
     Ipv6Net::new(
-        Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 2, 0, 0, 0, 0),
+        Ipv6Addr::new(
+            SERVICE_VPC_IPV6_PREFIX_1,
+            SERVICE_VPC_IPV6_PREFIX_2,
+            SERVICE_VPC_IPV6_PREFIX_3,
+            2,
+            0,
+            0,
+            0,
+            0,
+        ),
         VPC_SUBNET_IPV6_PREFIX_LENGTH,
     )
     .unwrap()
@@ -363,7 +408,16 @@ pub static NTP_OPTE_IPV4_SUBNET: LazyLock<Ipv4Net> =
 /// The IPv6 subnet for Boundary NTP OPTE ports.
 pub static NTP_OPTE_IPV6_SUBNET: LazyLock<Ipv6Net> = LazyLock::new(|| {
     Ipv6Net::new(
-        Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 3, 0, 0, 0, 0),
+        Ipv6Addr::new(
+            SERVICE_VPC_IPV6_PREFIX_1,
+            SERVICE_VPC_IPV6_PREFIX_2,
+            SERVICE_VPC_IPV6_PREFIX_3,
+            3,
+            0,
+            0,
+            0,
+            0,
+        ),
         VPC_SUBNET_IPV6_PREFIX_LENGTH,
     )
     .unwrap()

--- a/common/src/api/internal/shared/private_ip_config/mod.rs
+++ b/common/src/api/internal/shared/private_ip_config/mod.rs
@@ -8,8 +8,8 @@
 
 //! Shared private IP config types.
 
-use crate::address::MAX_VPC_IPV4_SUBNET_PREFIX;
-use crate::address::MIN_VPC_IPV4_SUBNET_PREFIX;
+use crate::address::MAX_VPC_IPV4_SUBNET_PREFIX_LENGTH;
+use crate::address::MIN_VPC_IPV4_SUBNET_PREFIX_LENGTH;
 use crate::address::VPC_SUBNET_IPV6_PREFIX_LENGTH;
 use crate::api::external;
 use daft::Diffable;
@@ -29,7 +29,8 @@ pub enum PrivateIpConfigError {
     IpNotInSubnet { subnet: IpNet, ip: IpAddr },
     #[error(
         "IPv4 subnet prefix /{prefix} must be between \
-        /{MIN_VPC_IPV4_SUBNET_PREFIX} and /{MAX_VPC_IPV4_SUBNET_PREFIX}"
+        /{MIN_VPC_IPV4_SUBNET_PREFIX_LENGTH} and \
+        /{MAX_VPC_IPV4_SUBNET_PREFIX_LENGTH}"
     )]
     InvalidIpv4NetworkPrefix { prefix: u8 },
     #[error(
@@ -263,8 +264,8 @@ impl PrivateIpv4Config {
         subnet: Ipv4Net,
         transit_ips: Vec<Ipv4Net>,
     ) -> Result<Self, PrivateIpConfigError> {
-        if subnet.width() < MIN_VPC_IPV4_SUBNET_PREFIX
-            || subnet.width() > MAX_VPC_IPV4_SUBNET_PREFIX
+        if subnet.width() < MIN_VPC_IPV4_SUBNET_PREFIX_LENGTH
+            || subnet.width() > MAX_VPC_IPV4_SUBNET_PREFIX_LENGTH
         {
             return Err(PrivateIpConfigError::InvalidIpv4NetworkPrefix {
                 prefix: subnet.width(),

--- a/illumos-utils/src/route.rs
+++ b/illumos-utils/src/route.rs
@@ -10,7 +10,9 @@ use crate::{
     output_to_exec_error,
 };
 use libc::ESRCH;
-use omicron_common::address::{AZ_PREFIX, BOOTSTRAP_SUBNET_PREFIX, Ipv6Subnet};
+use omicron_common::address::{
+    AZ_PREFIX_LENGTH, BOOTSTRAP_SUBNET_PREFIX_LENGTH, Ipv6Subnet,
+};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use tokio::process::Command;
 
@@ -35,7 +37,8 @@ impl Route {
         datalink: &str,
     ) -> Result<(), ExecutionError> {
         // Route to the underlay AZ's /48 by deriving it from the gateway IP.
-        let underlay_az: Ipv6Subnet<AZ_PREFIX> = Ipv6Subnet::new(gateway);
+        let underlay_az: Ipv6Subnet<AZ_PREFIX_LENGTH> =
+            Ipv6Subnet::new(gateway);
         let gateway = Gateway::Ipv6(gateway);
         Self::ensure_route_with_gateway(
             &underlay_az.to_string(),
@@ -149,7 +152,7 @@ impl Route {
     }
 
     pub async fn add_bootstrap_route(
-        bootstrap_prefix: Ipv6Subnet<BOOTSTRAP_SUBNET_PREFIX>,
+        bootstrap_prefix: Ipv6Subnet<BOOTSTRAP_SUBNET_PREFIX_LENGTH>,
         gz_bootstrap_addr: Ipv6Addr,
         zone_vnic_name: &str,
     ) -> Result<(), ExecutionError> {

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -20,7 +20,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::Utf8TempDir;
 use debug_ignore::DebugIgnore;
 use ipnetwork::IpNetwork;
-use omicron_common::address::{AZ_PREFIX, Ipv6Subnet};
+use omicron_common::address::{AZ_PREFIX_LENGTH, Ipv6Subnet};
 use omicron_common::backoff;
 use omicron_common::resolvable_files::ResolvableFileSource;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -476,7 +476,8 @@ impl RunningZone {
         gateway: Ipv6Addr,
     ) -> Result<(), RunCommandError> {
         // Route to the underlay AZ's /48 by deriving it from the gateway IP.
-        let underlay_az: Ipv6Subnet<AZ_PREFIX> = Ipv6Subnet::new(gateway);
+        let underlay_az: Ipv6Subnet<AZ_PREFIX_LENGTH> =
+            Ipv6Subnet::new(gateway);
         self.run_cmd([
             ROUTE,
             "add",

--- a/illumos-utils/src/zone.rs
+++ b/illumos-utils/src/zone.rs
@@ -19,7 +19,7 @@ use crate::addrobj::AddrObject;
 use crate::dladm::{EtherstubVnic, VNIC_PREFIX_BOOTSTRAP, VNIC_PREFIX_CONTROL};
 use crate::zpool::PathInPool;
 use crate::{PFEXEC, execute_async};
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_uuid_kinds::OmicronZoneUuid;
 
 const DLADM: &str = "/usr/sbin/dladm";
@@ -230,7 +230,7 @@ impl AddressRequest {
     pub fn new_static(ip: IpAddr, prefix: Option<u8>) -> Self {
         let prefix = prefix.unwrap_or_else(|| match ip {
             IpAddr::V4(_) => 24,
-            IpAddr::V6(_) => SLED_PREFIX,
+            IpAddr::V6(_) => SLED_PREFIX_LENGTH,
         });
         let addr = IpNetwork::new(ip, prefix).unwrap();
         AddressRequest::Static(addr)
@@ -894,7 +894,7 @@ impl Zones {
                     .map_err(|err| anyhow!(err))?,
                 AddressRequest::new_static(
                     IpAddr::V6(address),
-                    Some(omicron_common::address::SLED_PREFIX),
+                    Some(omicron_common::address::SLED_PREFIX_LENGTH),
                 ),
             )
             .await

--- a/installinator/src/bootstrap.rs
+++ b/installinator/src/bootstrap.rs
@@ -12,7 +12,7 @@ use illumos_utils::dladm;
 use illumos_utils::dladm::Dladm;
 use illumos_utils::zone::Zones;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::backoff::retry_notify;
 use omicron_common::backoff::retry_policy_internal_service_aggressive;
 use omicron_ddm_admin_client::Client as DdmAdminClient;
@@ -87,7 +87,7 @@ pub(crate) async fn bootstrap_sled(
     // so it can advertise it to other sleds.
     let ddmd_client = DdmAdminClient::localhost(&log)?;
     tokio::spawn({
-        let prefix = Ipv6Subnet::<SLED_PREFIX>::new(ip).net();
+        let prefix = Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(ip).net();
         async move {
             retry_notify(
                 retry_policy_internal_service_aggressive(),

--- a/internal-dns/resolver/src/resolver.rs
+++ b/internal-dns/resolver/src/resolver.rs
@@ -11,7 +11,7 @@ use hickory_resolver::lookup::SrvLookup;
 use hickory_resolver::name_server::TokioConnectionProvider;
 use internal_dns_types::names::ServiceName;
 use omicron_common::address::{
-    AZ_PREFIX, DNS_PORT, Ipv6Subnet, get_internal_dns_server_addresses,
+    AZ_PREFIX_LENGTH, DNS_PORT, Ipv6Subnet, get_internal_dns_server_addresses,
 };
 use slog::{debug, error, info, trace};
 use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
@@ -186,7 +186,7 @@ impl Resolver {
         log: slog::Logger,
         address: Ipv6Addr,
     ) -> Result<Self, ResolveError> {
-        let subnet = Ipv6Subnet::<AZ_PREFIX>::new(address);
+        let subnet = Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(address);
         Self::new_from_subnet(log, subnet)
     }
 
@@ -209,7 +209,7 @@ impl Resolver {
     // re-resolve this.  That's how we'd learn about dynamic changes to the set
     // of DNS servers.
     pub fn servers_from_subnet(
-        subnet: Ipv6Subnet<AZ_PREFIX>,
+        subnet: Ipv6Subnet<AZ_PREFIX_LENGTH>,
     ) -> Vec<SocketAddr> {
         get_internal_dns_server_addresses(subnet.net().addr())
             .into_iter()
@@ -227,7 +227,7 @@ impl Resolver {
     /// [omicron_common::address::ReservedRackSubnet].
     pub fn new_from_subnet(
         log: slog::Logger,
-        subnet: Ipv6Subnet<AZ_PREFIX>,
+        subnet: Ipv6Subnet<AZ_PREFIX_LENGTH>,
     ) -> Result<Self, ResolveError> {
         let dns_ips = Self::servers_from_subnet(subnet);
         Resolver::new_from_addrs(log, &dns_ips)

--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -11,11 +11,11 @@ use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
 use nexus_types::deployment::ReconfiguratorConfig;
 use omicron_common::address::Ipv6Subnet;
-pub use omicron_common::address::MAX_VPC_IPV4_SUBNET_PREFIX;
-pub use omicron_common::address::MIN_VPC_IPV4_SUBNET_PREFIX;
+pub use omicron_common::address::MAX_VPC_IPV4_SUBNET_PREFIX_LENGTH;
+pub use omicron_common::address::MIN_VPC_IPV4_SUBNET_PREFIX_LENGTH;
 use omicron_common::address::NEXUS_TECHPORT_EXTERNAL_PORT;
 pub use omicron_common::address::NUM_INITIAL_RESERVED_IP_ADDRESSES;
-use omicron_common::address::RACK_PREFIX;
+use omicron_common::address::RACK_PREFIX_LENGTH;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::RackUuid;
 use schemars::JsonSchema;
@@ -142,7 +142,7 @@ pub enum InternalDns {
     /// Nexus should infer the DNS server addresses from this subnet.
     ///
     /// This is a more common usage for production.
-    FromSubnet { subnet: Ipv6Subnet<RACK_PREFIX> },
+    FromSubnet { subnet: Ipv6Subnet<RACK_PREFIX_LENGTH> },
     /// Nexus should use precisely the following address.
     ///
     /// This is less desirable in production, but can give value
@@ -329,7 +329,8 @@ impl Tunables {
                 as u8,
             )
             .expect("Invalid absolute maximum IPv4 subnet prefix");
-        if prefix >= MIN_VPC_IPV4_SUBNET_PREFIX && prefix <= absolute_max {
+        if prefix >= MIN_VPC_IPV4_SUBNET_PREFIX_LENGTH && prefix <= absolute_max
+        {
             Ok(())
         } else {
             Err(InvalidTunable {
@@ -346,7 +347,7 @@ impl Tunables {
 impl Default for Tunables {
     fn default() -> Self {
         Tunables {
-            max_vpc_ipv4_subnet_prefix: MAX_VPC_IPV4_SUBNET_PREFIX,
+            max_vpc_ipv4_subnet_prefix: MAX_VPC_IPV4_SUBNET_PREFIX_LENGTH,
             load_timeout: None,
         }
     }
@@ -1138,7 +1139,7 @@ mod test {
     use nexus_types::deployment::PlannerConfig;
     use nexus_types::deployment::ReconfiguratorDisruptionPolicy;
     use omicron_common::address::{
-        CLICKHOUSE_TCP_PORT, Ipv6Subnet, RACK_PREFIX,
+        CLICKHOUSE_TCP_PORT, Ipv6Subnet, RACK_PREFIX_LENGTH,
     };
 
     use camino::{Utf8Path, Utf8PathBuf};
@@ -1392,7 +1393,7 @@ mod test {
                         ..Default::default()
                     },
                     internal_dns: InternalDns::FromSubnet {
-                        subnet: Ipv6Subnet::<RACK_PREFIX>::new(
+                        subnet: Ipv6Subnet::<RACK_PREFIX_LENGTH>::new(
                             Ipv6Addr::LOCALHOST
                         )
                     },

--- a/nexus/db-fixed-data/src/vpc.rs
+++ b/nexus/db-fixed-data/src/vpc.rs
@@ -5,7 +5,7 @@
 use crate::project::SERVICES_DB_NAME;
 use nexus_db_model as model;
 use nexus_types::external_api::vpc;
-use omicron_common::address::SERVICE_VPC_IPV6_PREFIX;
+use omicron_common::address::SERVICE_VPC_IPV6_SUBNET;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use std::sync::LazyLock;
 
@@ -58,7 +58,7 @@ pub static SERVICES_VPC: LazyLock<model::IncompleteVpc> = LazyLock::new(|| {
                 name: SERVICES_DB_NAME.parse().unwrap(),
                 description: "Built-in VPC for Oxide Services".to_string(),
             },
-            ipv6_prefix: Some(*SERVICE_VPC_IPV6_PREFIX),
+            ipv6_prefix: Some(*SERVICE_VPC_IPV6_SUBNET),
             dns_name: SERVICES_DB_NAME.parse().unwrap(),
         },
     )

--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -60,7 +60,7 @@ use nexus_types::deployment::{
     OmicronZoneExternalSnatIp,
 };
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::disk::DiskIdentity;
 use omicron_common::zpool_name::ZpoolName;
 use omicron_uuid_kinds::{
@@ -259,7 +259,7 @@ pub struct BpSledMetadata {
 }
 
 impl BpSledMetadata {
-    pub fn subnet(&self) -> anyhow::Result<Ipv6Subnet<SLED_PREFIX>> {
+    pub fn subnet(&self) -> anyhow::Result<Ipv6Subnet<SLED_PREFIX_LENGTH>> {
         let subnet = match self.subnet {
             IpNetwork::V4(subnet) => bail!(
                 "invalid subnet for sled {}: {subnet} (should be Ipv6)",

--- a/nexus/reconfigurator/blippy/src/blippy.rs
+++ b/nexus/reconfigurator/blippy/src/blippy.rs
@@ -16,7 +16,7 @@ use nexus_types::deployment::PlanningInput;
 use nexus_types::inventory::ZpoolName;
 use omicron_common::address::DnsSubnet;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::api::external::Generation;
 use omicron_common::api::external::MacAddr;
 use omicron_common::disk::DatasetKind;
@@ -138,7 +138,7 @@ pub enum SledKind {
     /// A sled has a zone with an IP that isn't a member of its subnet.
     UnderlayIpOnWrongSubnet {
         zone: BlueprintZoneConfig,
-        subnet: Ipv6Subnet<SLED_PREFIX>,
+        subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     },
     /// A sled has a zone with an IP that is above the sled's overall "last
     /// allocated IP" value.
@@ -149,7 +149,7 @@ pub enum SledKind {
     /// Two sleds are using the same sled subnet.
     ConflictingSledSubnets {
         other_sled: SledUuid,
-        subnet: Ipv6Subnet<SLED_PREFIX>,
+        subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     },
     /// An internal DNS zone has an IP that is not one of the expected rack DNS
     /// subnets.

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -23,7 +23,7 @@ use nexus_types::deployment::SledFilter;
 use nexus_types::deployment::blueprint_zone_type;
 use omicron_common::address::DnsSubnet;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::api::external::Generation;
 use omicron_common::disk::DatasetKind;
 use omicron_common::disk::M2Slot;
@@ -60,7 +60,7 @@ fn check_underlay_ips(blippy: &mut Blippy<'_>) {
     let mut underlay_ips: BTreeMap<Ipv6Addr, &BlueprintZoneConfig> =
         BTreeMap::new();
     let mut sled_subnets_by_subnet: BTreeMap<
-        Ipv6Subnet<SLED_PREFIX>,
+        Ipv6Subnet<SLED_PREFIX_LENGTH>,
         SledUuid,
     > = BTreeMap::new();
     let mut rack_dns_subnets: BTreeSet<DnsSubnet> = BTreeSet::new();

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -349,9 +349,9 @@ mod test {
     use nexus_types::silo::silo_dns_name;
     use omicron_common::address::IpRange;
     use omicron_common::address::Ipv6Subnet;
-    use omicron_common::address::RACK_PREFIX;
+    use omicron_common::address::RACK_PREFIX_LENGTH;
     use omicron_common::address::REPO_DEPOT_PORT;
-    use omicron_common::address::SLED_PREFIX;
+    use omicron_common::address::SLED_PREFIX_LENGTH;
     use omicron_common::address::get_sled_address;
     use omicron_common::address::get_switch_zone_address;
     use omicron_common::api::external::Generation;
@@ -646,8 +646,9 @@ mod test {
         let rack_subnet_base: Ipv6Addr =
             "fd00:1122:3344:0100::".parse().unwrap();
         let rack_subnet =
-            ipnet::Ipv6Net::new(rack_subnet_base, RACK_PREFIX).unwrap();
-        let possible_sled_subnets = rack_subnet.subnets(SLED_PREFIX).unwrap();
+            ipnet::Ipv6Net::new(rack_subnet_base, RACK_PREFIX_LENGTH).unwrap();
+        let possible_sled_subnets =
+            rack_subnet.subnets(SLED_PREFIX_LENGTH).unwrap();
 
         let mut blueprint_sleds = BTreeMap::new();
 

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -62,7 +62,7 @@ use omicron_common::address::DnsSubnet;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::NTP_PORT;
 use omicron_common::address::ReservedRackSubnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::api::external::Generation;
 use omicron_common::api::external::Vni;
 use omicron_common::disk::M2Slot;
@@ -675,7 +675,7 @@ impl<'a> BlueprintBuilder<'a> {
     pub fn ensure_sled_exists(
         &mut self,
         sled_id: SledUuid,
-        sled_subnet: Ipv6Subnet<SLED_PREFIX>,
+        sled_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     ) {
         if let Entry::Vacant(slot) = self.sled_editors.entry(sled_id) {
             slot.insert(SledEditor::for_new_active(sled_subnet));

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -39,7 +39,7 @@ use nexus_types::deployment::PendingMgsUpdate;
 use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::external_api::sled::SledState;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::api::external::Generation;
 use omicron_common::disk::DatasetKind;
 use omicron_common::disk::M2Slot;
@@ -225,7 +225,7 @@ impl SledEditor {
         })
     }
 
-    pub fn for_new_active(subnet: Ipv6Subnet<SLED_PREFIX>) -> Self {
+    pub fn for_new_active(subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>) -> Self {
         Self {
             underlay_ip_allocator: SledUnderlayIpAllocator::new(
                 subnet,
@@ -332,7 +332,7 @@ impl SledEditor {
         }
     }
 
-    pub fn subnet(&self) -> Ipv6Subnet<SLED_PREFIX> {
+    pub fn subnet(&self) -> Ipv6Subnet<SLED_PREFIX_LENGTH> {
         self.underlay_ip_allocator.subnet()
     }
 

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/underlay_ip_allocator.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/underlay_ip_allocator.rs
@@ -9,7 +9,7 @@ use ipnet::IpSub;
 use nexus_types::deployment::LastAllocatedSubnetIpOffset;
 use omicron_common::address::CP_SERVICES_RESERVED_ADDRESSES;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::address::SLED_RESERVED_ADDRESSES;
 use omicron_common::address::get_sled_address;
 use omicron_common::address::get_switch_zone_address;
@@ -25,7 +25,7 @@ use std::net::Ipv6Addr;
 // general enough to use here, though this one could potentially be used there.
 #[derive(Debug)]
 pub(crate) struct SledUnderlayIpAllocator {
-    subnet: Ipv6Subnet<SLED_PREFIX>,
+    subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     last: Ipv6Addr,
     maximum: Ipv6Addr,
 }
@@ -35,7 +35,7 @@ impl SledUnderlayIpAllocator {
     /// IPs from the "reserved for control plane usage" block up through
     /// `last_allocated_ip_subnet_offset`.
     pub fn new(
-        sled_subnet: Ipv6Subnet<SLED_PREFIX>,
+        sled_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
         last_allocated_ip_subnet_offset: LastAllocatedSubnetIpOffset,
     ) -> Self {
         let sled_subnet_addr = sled_subnet.net().prefix();
@@ -71,7 +71,7 @@ impl SledUnderlayIpAllocator {
     }
 
     /// Get the subnet used to create this allocator.
-    pub fn subnet(&self) -> Ipv6Subnet<SLED_PREFIX> {
+    pub fn subnet(&self) -> Ipv6Subnet<SLED_PREFIX_LENGTH> {
         self.subnet
     }
 

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -44,8 +44,8 @@ use nexus_types::inventory::RotSlot;
 use nexus_types::inventory::SpType;
 use omicron_common::address::Ipv4Range;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::RACK_PREFIX;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::RACK_PREFIX_LENGTH;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::address::get_sled_address;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Generation;
@@ -169,7 +169,7 @@ impl SystemDescription {
         let rack_subnet_base: Ipv6Addr =
             "fd00:1122:3344:0100::".parse().unwrap();
         let rack_subnet =
-            ipnet::Ipv6Net::new(rack_subnet_base, RACK_PREFIX).unwrap();
+            ipnet::Ipv6Net::new(rack_subnet_base, RACK_PREFIX_LENGTH).unwrap();
         // Skip the initial DNS subnet.
         // (The same behavior is replicated in RSS in `SledPlan::create()` in
         // sled-agent/rack-setup/src/plan/sled.rs.)
@@ -1399,7 +1399,7 @@ impl Sled {
     #[allow(clippy::too_many_arguments)]
     fn new_simulated(
         sled_id: SledUuid,
-        sled_subnet: Ipv6Subnet<SLED_PREFIX>,
+        sled_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
         sled_role: SledRole,
         unique: Option<String>,
         hardware: SledHardware,
@@ -2168,7 +2168,7 @@ struct SubnetIterator {
 
 impl SubnetIterator {
     fn new(rack_subnet: Ipv6Net) -> Self {
-        let mut subnets = rack_subnet.subnets(SLED_PREFIX).unwrap();
+        let mut subnets = rack_subnet.subnets(SLED_PREFIX_LENGTH).unwrap();
         // Skip the initial DNS subnet.
         // (The same behavior is replicated in RSS in `SledPlan::create()` in
         // sled-agent/rack-setup/src/plan/sled.rs.)
@@ -2178,7 +2178,7 @@ impl SubnetIterator {
 }
 
 impl Iterator for SubnetIterator {
-    type Item = Ipv6Subnet<SLED_PREFIX>;
+    type Item = Ipv6Subnet<SLED_PREFIX_LENGTH>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.subnets.next().map(|s| Ipv6Subnet::new(s.network()))

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -42,7 +42,7 @@ use nexus_types::identity::Resource;
 use nexus_types::inventory::Collection;
 use omicron_common::address::IpRange;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::InternalContext;
 use omicron_common::api::external::LookupType;
@@ -409,7 +409,7 @@ impl PlanningInputFromDb<'_> {
 
         for sled_row in self.sled_rows {
             let sled_id = sled_row.id();
-            let subnet = Ipv6Subnet::<SLED_PREFIX>::new(sled_row.ip());
+            let subnet = Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(sled_row.ip());
             let zpools = zpools_by_sled_id
                 .remove(&sled_id)
                 .unwrap_or_else(BTreeMap::new);

--- a/nexus/src/app/background/tasks/trust_quorum.rs
+++ b/nexus/src/app/background/tasks/trust_quorum.rs
@@ -22,7 +22,7 @@ use nexus_types::trust_quorum::{
     TrustQuorumConfig as NexusTrustQuorumConfig, TrustQuorumConfigState,
     TrustQuorumMemberState,
 };
-use omicron_common::address::{Ipv6Subnet, RACK_PREFIX, get_64_subnet};
+use omicron_common::address::{Ipv6Subnet, RACK_PREFIX_LENGTH, get_64_subnet};
 use omicron_uuid_kinds::{RackUuid, SledUuid};
 use parallel_task_set::ParallelTaskSet;
 use rand::seq::SliceRandom;
@@ -563,7 +563,7 @@ async fn start_sled_agents(
     info!(log, "Looking up subnet for rack: {}", rack_id);
     let subnet = datastore.rack_subnet(&opctx, rack_id).await?;
     let rack_subnet =
-        Ipv6Subnet::<RACK_PREFIX>::from(rack_subnet(Some(subnet))?);
+        Ipv6Subnet::<RACK_PREFIX_LENGTH>::from(rack_subnet(Some(subnet))?);
 
     // Get a set of random sled agent clients for concurrent calls to
     // `start_sled_agent`.
@@ -616,7 +616,7 @@ async fn send_start_sled_agent_requests(
     log: &Logger,
     client_dest: BaseboardId,
     client: sled_agent_client::Client,
-    rack_subnet: Ipv6Subnet<RACK_PREFIX>,
+    rack_subnet: Ipv6Subnet<RACK_PREFIX_LENGTH>,
     allocations_by_baseboard_id: BTreeMap<
         BaseboardId,
         SledUnderlaySubnetAllocation,

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -28,7 +28,7 @@ use nexus_types::external_api::silo;
 use nexus_types::external_api::sled as sled_types;
 use nexus_types::inventory::SpType;
 use nexus_types::silo::silo_dns_name;
-use omicron_common::address::{Ipv6Subnet, RACK_PREFIX, get_64_subnet};
+use omicron_common::address::{Ipv6Subnet, RACK_PREFIX_LENGTH, get_64_subnet};
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::IdentityMetadataCreateParams;
@@ -793,7 +793,7 @@ impl super::Nexus {
 
         let subnet = self.db_datastore.rack_subnet(opctx, self.rack_id).await?;
         let rack_subnet =
-            Ipv6Subnet::<RACK_PREFIX>::from(rack_subnet(Some(subnet))?);
+            Ipv6Subnet::<RACK_PREFIX_LENGTH>::from(rack_subnet(Some(subnet))?);
 
         let allocation = match self
             .db_datastore

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -6,7 +6,7 @@
 
 use super::sagas;
 use nexus_auth::authn;
-use nexus_config::MIN_VPC_IPV4_SUBNET_PREFIX;
+use nexus_config::MIN_VPC_IPV4_SUBNET_PREFIX_LENGTH;
 use nexus_db_lookup::LookupPath;
 use nexus_db_lookup::lookup;
 use nexus_db_queries::authz;
@@ -90,14 +90,14 @@ impl super::Nexus {
                 "VPC Subnet IPv4 address ranges must be from a private range",
             ));
         }
-        if params.ipv4_block.width() < MIN_VPC_IPV4_SUBNET_PREFIX
+        if params.ipv4_block.width() < MIN_VPC_IPV4_SUBNET_PREFIX_LENGTH
             || params.ipv4_block.width()
                 > self.tunables.max_vpc_ipv4_subnet_prefix
         {
             return Err(external::Error::invalid_request(&format!(
                 "VPC Subnet IPv4 address ranges must have prefix \
                 length between {} and {}, inclusive",
-                MIN_VPC_IPV4_SUBNET_PREFIX,
+                MIN_VPC_IPV4_SUBNET_PREFIX_LENGTH,
                 self.tunables.max_vpc_ipv4_subnet_prefix,
             )));
         }

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -21,7 +21,7 @@ use nexus_db_queries::authn::ConsoleSessionWithSiloId;
 use nexus_db_queries::authn::external::session_cookie::SessionStore;
 use nexus_db_queries::context::{OpContext, OpKind};
 use nexus_db_queries::{authn, authz, db};
-use omicron_common::address::{AZ_PREFIX, Ipv6Subnet};
+use omicron_common::address::{AZ_PREFIX_LENGTH, Ipv6Subnet};
 use omicron_uuid_kinds::ConsoleSessionUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::RackUuid;
@@ -231,7 +231,7 @@ impl ServerContext {
         let (resolver, qorb_resolver) = match config.deployment.internal_dns {
             nexus_config::InternalDns::FromSubnet { subnet } => {
                 let az_subnet =
-                    Ipv6Subnet::<AZ_PREFIX>::new(subnet.net().addr());
+                    Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(subnet.net().addr());
                 info!(
                     log,
                     "Setting up resolver using DNS servers for subnet: {:?}",

--- a/nexus/tests/integration_tests/data_migrations/blueprint_sled_config_subnet.rs
+++ b/nexus/tests/integration_tests/data_migrations/blueprint_sled_config_subnet.rs
@@ -5,7 +5,7 @@
 use super::super::schema::{DataMigrationFns, MigrationContext};
 use futures::future::BoxFuture;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use pretty_assertions::assert_eq;
 use std::collections::BTreeSet;
 use uuid::Uuid;
@@ -68,17 +68,17 @@ async fn after_impl(ctx: &MigrationContext<'_>) {
     let expected = [
         (
             sled_id_1,
-            Ipv6Subnet::<SLED_PREFIX>::new(SLED_IP_1.parse().unwrap())
+            Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(SLED_IP_1.parse().unwrap())
                 .to_string(),
         ),
         (
             sled_id_2,
-            Ipv6Subnet::<SLED_PREFIX>::new(SLED_IP_2.parse().unwrap())
+            Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(SLED_IP_2.parse().unwrap())
                 .to_string(),
         ),
         (
             sled_id_3,
-            Ipv6Subnet::<SLED_PREFIX>::new(SLED_IP_3.parse().unwrap())
+            Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(SLED_IP_3.parse().unwrap())
                 .to_string(),
         ),
     ]

--- a/nexus/tests/integration_tests/data_migrations/vpc_firewall_icmp.rs
+++ b/nexus/tests/integration_tests/data_migrations/vpc_firewall_icmp.rs
@@ -20,7 +20,7 @@ fn before<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
     Box::pin(async {
         use nexus_db_queries::db::fixed_data::project::*;
         use nexus_db_queries::db::fixed_data::vpc::*;
-        use omicron_common::address::SERVICE_VPC_IPV6_PREFIX;
+        use omicron_common::address::SERVICE_VPC_IPV6_SUBNET;
 
         // First, create the oxide-services vpc. The migration will only add
         // a new rule if it detects the presence of *this* VPC entry (i.e.,
@@ -41,7 +41,7 @@ fn before<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
                     '{svc_proj}', '{svc_router}', '{svc_vpc_name}',
                     100, '{}', 0, 0
                 );",
-                *SERVICE_VPC_IPV6_PREFIX
+                *SERVICE_VPC_IPV6_SUBNET
             ))
             .await
             .expect("failed to create services vpc record");

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -30,7 +30,7 @@ use iddqd::id_ord_map::RefMut;
 use iddqd::id_upcast;
 use ipnet::IpAdd;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::address::SLED_RESERVED_ADDRESSES;
 use omicron_common::address::get_sled_address;
 use omicron_common::api::external::ByteCount;
@@ -1583,7 +1583,7 @@ impl fmt::Display for BlueprintDisplay<'_> {
 )]
 pub struct BlueprintSledConfig {
     pub state: SledState,
-    pub subnet: Ipv6Subnet<SLED_PREFIX>,
+    pub subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 
     /// Each sled is assigned an IPv6 /64 `subnet` (above). Currently, the
     /// lowest /112 subnet within the sled subnet is reserved for control plane
@@ -1722,7 +1722,7 @@ impl LastAllocatedSubnetIpOffset {
     }
 
     /// Convert this offset into the `offset`'th IP in `subnet`.
-    pub fn to_ip(self, subnet: Ipv6Subnet<SLED_PREFIX>) -> Ipv6Addr {
+    pub fn to_ip(self, subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>) -> Ipv6Addr {
         subnet.net().prefix().saturating_add(u128::from(self.0))
     }
 

--- a/nexus/types/src/deployment/execution/overridables.rs
+++ b/nexus/types/src/deployment/execution/overridables.rs
@@ -8,7 +8,7 @@ use omicron_common::address::DENDRITE_PORT;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::MGD_PORT;
 use omicron_common::address::MGS_PORT;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::address::get_switch_zone_address;
 use omicron_uuid_kinds::SledUuid;
 use std::collections::BTreeMap;
@@ -110,7 +110,7 @@ impl Overridables {
     pub fn switch_zone_ip(
         &self,
         sled_id: SledUuid,
-        sled_subnet: Ipv6Subnet<SLED_PREFIX>,
+        sled_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     ) -> Ipv6Addr {
         self.switch_zone_ips
             .get(&sled_id)

--- a/nexus/types/src/deployment/execution/utils.rs
+++ b/nexus/types/src/deployment/execution/utils.rs
@@ -6,7 +6,7 @@ use std::net::{IpAddr, SocketAddrV6};
 
 use iddqd::{IdOrdItem, id_upcast};
 use omicron_common::{
-    address::{Ipv6Subnet, SLED_PREFIX},
+    address::{Ipv6Subnet, SLED_PREFIX_LENGTH},
     api::external::Generation,
 };
 use omicron_uuid_kinds::SledUuid;
@@ -60,8 +60,8 @@ impl Sled {
         )
     }
 
-    pub fn subnet(&self) -> Ipv6Subnet<SLED_PREFIX> {
-        Ipv6Subnet::<SLED_PREFIX>::new(*self.sled_agent_address.ip())
+    pub fn subnet(&self) -> Ipv6Subnet<SLED_PREFIX_LENGTH> {
+        Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(*self.sled_agent_address.ip())
     }
 
     pub fn role(&self) -> SledRole {

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -34,7 +34,7 @@ use omicron_common::address::IpRange;
 use omicron_common::address::Ipv4Range;
 use omicron_common::address::Ipv6Range;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::api::external::Generation;
 use omicron_common::api::external::TufRepoDescription;
 use omicron_common::disk::DiskIdentity;
@@ -857,7 +857,7 @@ pub struct SledResources {
     ///
     /// (implicitly specifies the whole range of addresses that the planner can
     /// use for control plane components)
-    pub subnet: Ipv6Subnet<SLED_PREFIX>,
+    pub subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 }
 
 impl SledResources {

--- a/sled-agent/bootstrap-agent-lockstep-types/src/lib.rs
+++ b/sled-agent/bootstrap-agent-lockstep-types/src/lib.rs
@@ -9,11 +9,11 @@
 //! out of this crate and into the relevant `*-types-versions` / `*-types` crate
 //! pairs.
 
-use omicron_common::address::AZ_PREFIX;
+use omicron_common::address::AZ_PREFIX_LENGTH;
 use omicron_common::address::IpRange;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::RACK_PREFIX;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::RACK_PREFIX_LENGTH;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::address::get_64_subnet;
 use omicron_common::api::external::AllowedSourceIps;
 use omicron_common::api::external::Name;
@@ -131,21 +131,21 @@ impl std::fmt::Debug for RackInitializeRequest {
 }
 
 impl RackInitializeRequest {
-    pub fn az_subnet(&self) -> Ipv6Subnet<AZ_PREFIX> {
-        Ipv6Subnet::<AZ_PREFIX>::new(
+    pub fn az_subnet(&self) -> Ipv6Subnet<AZ_PREFIX_LENGTH> {
+        Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(
             self.rack_network_config.rack_subnet.addr(),
         )
     }
 
     /// Returns the subnet for our rack.
-    pub fn rack_subnet(&self) -> Ipv6Subnet<RACK_PREFIX> {
-        Ipv6Subnet::<RACK_PREFIX>::new(
+    pub fn rack_subnet(&self) -> Ipv6Subnet<RACK_PREFIX_LENGTH> {
+        Ipv6Subnet::<RACK_PREFIX_LENGTH>::new(
             self.rack_network_config.rack_subnet.addr(),
         )
     }
 
     /// Returns the subnet for the `index`-th sled in the rack.
-    pub fn sled_subnet(&self, index: u8) -> Ipv6Subnet<SLED_PREFIX> {
+    pub fn sled_subnet(&self, index: u8) -> Ipv6Subnet<SLED_PREFIX_LENGTH> {
         get_64_subnet(self.rack_subnet(), index)
     }
 }

--- a/sled-agent/config-reconciler/src/reconciler_task/zones.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/zones.rs
@@ -1301,7 +1301,7 @@ mod tests {
     use illumos_utils::zpool::PathInPool;
     use illumos_utils::zpool::ZpoolName;
     use illumos_utils::zpool::ZpoolOrRamdisk;
-    use omicron_common::address::SLED_PREFIX;
+    use omicron_common::address::SLED_PREFIX_LENGTH;
     use omicron_common::disk::DatasetConfig;
     use omicron_common::disk::DatasetKind;
     use omicron_common::disk::DatasetName;
@@ -1511,7 +1511,7 @@ mod tests {
     #[derive(Debug)]
     struct FakeSledAgentFacilitiesInner {
         start_responses: VecDeque<anyhow::Result<RunningZone>>,
-        removed_ddm_prefixes: BTreeSet<Ipv6Subnet<SLED_PREFIX>>,
+        removed_ddm_prefixes: BTreeSet<Ipv6Subnet<SLED_PREFIX_LENGTH>>,
         resolver_status: ResolverStatus,
     }
 
@@ -1630,7 +1630,7 @@ mod tests {
 
         fn ddm_remove_internal_dns_prefix(
             &self,
-            prefix: Ipv6Subnet<SLED_PREFIX>,
+            prefix: Ipv6Subnet<SLED_PREFIX_LENGTH>,
         ) {
             self.inner.lock().unwrap().removed_ddm_prefixes.insert(prefix);
         }

--- a/sled-agent/config-reconciler/src/sled_agent_facilities.rs
+++ b/sled-agent/config-reconciler/src/sled_agent_facilities.rs
@@ -9,7 +9,7 @@ use illumos_utils::dladm::EtherstubVnic;
 use illumos_utils::running_zone::RunningZone;
 use illumos_utils::zpool::PathInPool;
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_uuid_kinds::MupdateOverrideUuid;
 use sled_agent_types::resolvable_files::PreparedOmicronZone;
 use sled_agent_types::resolvable_files::RemoveMupdateOverrideResult;
@@ -60,7 +60,7 @@ pub trait SledAgentFacilities: Send + Sync + 'static {
     ) -> anyhow::Result<()>;
 
     /// Instruct DDM to stop advertising a prefix.
-    fn ddm_remove_internal_dns_prefix(&self, prefix: Ipv6Subnet<SLED_PREFIX>);
+    fn ddm_remove_internal_dns_prefix(&self, prefix: Ipv6Subnet<SLED_PREFIX_LENGTH>);
 }
 
 pub trait SledAgentArtifactStore: Send + Sync + 'static {

--- a/sled-agent/config-reconciler/src/sled_agent_facilities.rs
+++ b/sled-agent/config-reconciler/src/sled_agent_facilities.rs
@@ -60,7 +60,10 @@ pub trait SledAgentFacilities: Send + Sync + 'static {
     ) -> anyhow::Result<()>;
 
     /// Instruct DDM to stop advertising a prefix.
-    fn ddm_remove_internal_dns_prefix(&self, prefix: Ipv6Subnet<SLED_PREFIX_LENGTH>);
+    fn ddm_remove_internal_dns_prefix(
+        &self,
+        prefix: Ipv6Subnet<SLED_PREFIX_LENGTH>,
+    );
 }
 
 pub trait SledAgentArtifactStore: Send + Sync + 'static {

--- a/sled-agent/rack-setup/src/plan/service.rs
+++ b/sled-agent/rack-setup/src/plan/service.rs
@@ -32,8 +32,8 @@ use omicron_common::address::{
     CP_SERVICES_RESERVED_ADDRESSES, DDMD_PORT, DENDRITE_PORT, DNS_HTTP_PORT,
     DNS_PORT, Ipv6Subnet, MGD_PORT, MGS_PORT, NEXUS_INTERNAL_PORT,
     NEXUS_LOCKSTEP_PORT, NTP_PORT, NUM_SOURCE_NAT_PORTS, REPO_DEPOT_PORT,
-    ReservedRackSubnet, SLED_PREFIX_LENGTH, SLED_RESERVED_ADDRESSES, get_sled_address,
-    get_switch_zone_address,
+    ReservedRackSubnet, SLED_PREFIX_LENGTH, SLED_RESERVED_ADDRESSES,
+    get_sled_address, get_switch_zone_address,
 };
 use omicron_common::api::external::{Generation, MacAddr, Vni};
 use omicron_common::api::internal::shared::{

--- a/sled-agent/rack-setup/src/plan/service.rs
+++ b/sled-agent/rack-setup/src/plan/service.rs
@@ -32,7 +32,7 @@ use omicron_common::address::{
     CP_SERVICES_RESERVED_ADDRESSES, DDMD_PORT, DENDRITE_PORT, DNS_HTTP_PORT,
     DNS_PORT, Ipv6Subnet, MGD_PORT, MGS_PORT, NEXUS_INTERNAL_PORT,
     NEXUS_LOCKSTEP_PORT, NTP_PORT, NUM_SOURCE_NAT_PORTS, REPO_DEPOT_PORT,
-    ReservedRackSubnet, SLED_PREFIX, SLED_RESERVED_ADDRESSES, get_sled_address,
+    ReservedRackSubnet, SLED_PREFIX_LENGTH, SLED_RESERVED_ADDRESSES, get_sled_address,
     get_switch_zone_address,
 };
 use omicron_common::api::external::{Generation, MacAddr, Vni};
@@ -178,7 +178,7 @@ impl SledConfig {
 pub struct PlannedSledDescription {
     pub underlay_address: SocketAddrV6,
     pub sled_id: SledUuid,
-    pub subnet: Ipv6Subnet<SLED_PREFIX>,
+    pub subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     pub config: SledConfig,
     pub last_allocated_ip_subnet_offset: LastAllocatedSubnetIpOffset,
 }
@@ -995,12 +995,12 @@ impl ServicePlan {
 
 struct AddressBumpAllocator {
     sled_id: SledUuid,
-    subnet: Ipv6Subnet<SLED_PREFIX>,
+    subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     last_addr_offset: u16,
 }
 
 impl AddressBumpAllocator {
-    fn new(sled_id: SledUuid, subnet: Ipv6Subnet<SLED_PREFIX>) -> Self {
+    fn new(sled_id: SledUuid, subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>) -> Self {
         Self { sled_id, subnet, last_addr_offset: SLED_RESERVED_ADDRESSES }
     }
 
@@ -1038,7 +1038,7 @@ pub struct SledInfo {
     /// unique id for the sled agent
     pub sled_id: SledUuid,
     /// the sled's unique IPv6 subnet
-    subnet: Ipv6Subnet<SLED_PREFIX>,
+    subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     /// the address of the Sled Agent on the sled's subnet
     pub sled_address: SocketAddrV6,
     /// the inventory returned by the Sled
@@ -1059,7 +1059,7 @@ pub struct SledInfo {
 impl SledInfo {
     pub fn new(
         sled_id: SledUuid,
-        subnet: Ipv6Subnet<SLED_PREFIX>,
+        subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
         sled_address: SocketAddrV6,
         inventory: Inventory,
         is_scrimlet: bool,
@@ -1380,7 +1380,7 @@ mod tests {
         let logctx = test_setup_log("bump_allocator_basics");
 
         let address = Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0);
-        let subnet = Ipv6Subnet::<SLED_PREFIX>::new(address);
+        let subnet = Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(address);
 
         let mut allocator =
             AddressBumpAllocator::new(SledUuid::new_v4(), subnet);
@@ -1419,7 +1419,7 @@ mod tests {
         let logctx = test_setup_log("bump_allocator_exhaustion");
 
         let address = Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0);
-        let subnet = Ipv6Subnet::<SLED_PREFIX>::new(address);
+        let subnet = Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(address);
 
         let mut allocator =
             AddressBumpAllocator::new(SledUuid::new_v4(), subnet);
@@ -1501,7 +1501,7 @@ mod tests {
     fn test_sled_info() -> SledInfo {
         let sled_id = SledUuid::new_v4();
         let address = Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0);
-        let subnet = Ipv6Subnet::<SLED_PREFIX>::new(address);
+        let subnet = Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(address);
         let sled_address = get_sled_address(subnet);
         let is_scrimlet = true;
 

--- a/sled-agent/rack-setup/src/service.rs
+++ b/sled-agent/rack-setup/src/service.rs
@@ -1790,8 +1790,8 @@ mod test {
     use nexus_reconfigurator_blippy::{Blippy, BlippyReportSortKey};
     use omicron_common::{
         address::{
-            AZ_PREFIX, IpRange, Ipv6Subnet, RACK_PREFIX, SLED_PREFIX,
-            get_sled_address,
+            AZ_PREFIX_LENGTH, IpRange, Ipv6Subnet, RACK_PREFIX_LENGTH,
+            SLED_PREFIX_LENGTH, get_sled_address,
         },
         api::external::{AllowedSourceIps, ByteCount, Generation},
         disk::{DiskIdentity, DiskVariant},
@@ -1822,7 +1822,7 @@ mod test {
 
     fn make_sled_info(
         sled_id: SledUuid,
-        subnet: Ipv6Subnet<SLED_PREFIX>,
+        subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
         u2_count: usize,
     ) -> SledInfo {
         let sled_agent_address = get_sled_address(subnet);
@@ -1875,21 +1875,21 @@ mod test {
         vec![
             make_sled_info(
                 SledUuid::new_v4(),
-                Ipv6Subnet::<SLED_PREFIX>::new(
+                Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(
                     "fd00:1122:3344:101::1".parse().unwrap(),
                 ),
                 5,
             ),
             make_sled_info(
                 SledUuid::new_v4(),
-                Ipv6Subnet::<SLED_PREFIX>::new(
+                Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(
                     "fd00:1122:3344:102::1".parse().unwrap(),
                 ),
                 5,
             ),
             make_sled_info(
                 SledUuid::new_v4(),
-                Ipv6Subnet::<SLED_PREFIX>::new(
+                Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(
                     "fd00:1122:3344:103::1".parse().unwrap(),
                 ),
                 5,
@@ -2120,7 +2120,7 @@ mod test {
             rack_network_config: RackNetworkConfig {
                 rack_subnet: Ipv6Net::new(
                     "fd00:1122:3344:0100::".parse().unwrap(),
-                    RACK_PREFIX,
+                    RACK_PREFIX_LENGTH,
                 )
                 .unwrap(),
                 infra_ip_first: IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -2139,7 +2139,7 @@ mod test {
         };
 
         assert_eq!(
-            omicron_common::address::Ipv6Subnet::<AZ_PREFIX>::new(
+            omicron_common::address::Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(
                 //              Masked out in AZ Subnet
                 //              vv
                 "fd00:1122:3344:0000::".parse::<Ipv6Addr>().unwrap(),
@@ -2147,7 +2147,7 @@ mod test {
             cfg.az_subnet()
         );
         assert_eq!(
-            omicron_common::address::Ipv6Subnet::<RACK_PREFIX>::new(
+            omicron_common::address::Ipv6Subnet::<RACK_PREFIX_LENGTH>::new(
                 //              Shows up from Rack Subnet
                 //              vv
                 "fd00:1122:3344:0100::".parse::<Ipv6Addr>().unwrap(),
@@ -2155,7 +2155,7 @@ mod test {
             cfg.rack_subnet()
         );
         assert_eq!(
-            omicron_common::address::Ipv6Subnet::<SLED_PREFIX>::new(
+            omicron_common::address::Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(
                 //                0th Sled Subnet
                 //                vv
                 "fd00:1122:3344:0100::".parse::<Ipv6Addr>().unwrap(),
@@ -2163,7 +2163,7 @@ mod test {
             cfg.sled_subnet(0)
         );
         assert_eq!(
-            omicron_common::address::Ipv6Subnet::<SLED_PREFIX>::new(
+            omicron_common::address::Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(
                 //                1st Sled Subnet
                 //                vv
                 "fd00:1122:3344:0101::".parse::<Ipv6Addr>().unwrap(),
@@ -2171,7 +2171,7 @@ mod test {
             cfg.sled_subnet(1)
         );
         assert_eq!(
-            omicron_common::address::Ipv6Subnet::<SLED_PREFIX>::new(
+            omicron_common::address::Ipv6Subnet::<SLED_PREFIX_LENGTH>::new(
                 //                Last Sled Subnet
                 //                vv
                 "fd00:1122:3344:01ff::".parse::<Ipv6Addr>().unwrap(),

--- a/sled-agent/src/ddm_reconciler.rs
+++ b/sled-agent/src/ddm_reconciler.rs
@@ -13,7 +13,7 @@
 //! * Updating either of these immediately when changes are requested
 
 use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_ddm_admin_client::Client;
 use omicron_ddm_admin_client::DdmError;
 use omicron_ddm_admin_client::types::EnableStatsRequest;
@@ -50,7 +50,7 @@ pub(crate) struct DdmReconciler {
 
 impl DdmReconciler {
     pub fn new(
-        bootstrap_subnet: Ipv6Subnet<SLED_PREFIX>,
+        bootstrap_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
         base_log: &Logger,
     ) -> Result<Self, DdmError> {
         let client = Client::localhost(base_log)?;
@@ -77,7 +77,7 @@ impl DdmReconciler {
 
     pub fn set_underlay_subnet(
         &self,
-        underlay_subnet: Ipv6Subnet<SLED_PREFIX>,
+        underlay_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     ) {
         self.prefixes.send_if_modified(|prefixes| {
             let modified = prefixes.underlay != Some(underlay_subnet);
@@ -91,7 +91,7 @@ impl DdmReconciler {
     /// This method is idempotent.
     pub fn add_internal_dns_subnet(
         &self,
-        internal_dns_subnet: Ipv6Subnet<SLED_PREFIX>,
+        internal_dns_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     ) {
         self.prefixes.send_if_modified(|prefixes| {
             prefixes.internal_dns.insert(internal_dns_subnet)
@@ -103,7 +103,7 @@ impl DdmReconciler {
     /// This method is idempotent.
     pub fn remove_internal_dns_subnet(
         &self,
-        internal_dns_subnet: Ipv6Subnet<SLED_PREFIX>,
+        internal_dns_subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
     ) {
         self.prefixes.send_if_modified(|prefixes| {
             prefixes.internal_dns.remove(&internal_dns_subnet)
@@ -113,13 +113,13 @@ impl DdmReconciler {
 
 #[derive(Debug)]
 struct PrefixesToAdvertise {
-    bootstrap: Ipv6Subnet<SLED_PREFIX>,
-    underlay: Option<Ipv6Subnet<SLED_PREFIX>>,
-    internal_dns: BTreeSet<Ipv6Subnet<SLED_PREFIX>>,
+    bootstrap: Ipv6Subnet<SLED_PREFIX_LENGTH>,
+    underlay: Option<Ipv6Subnet<SLED_PREFIX_LENGTH>>,
+    internal_dns: BTreeSet<Ipv6Subnet<SLED_PREFIX_LENGTH>>,
 }
 
 impl PrefixesToAdvertise {
-    fn new(bootstrap: Ipv6Subnet<SLED_PREFIX>) -> Self {
+    fn new(bootstrap: Ipv6Subnet<SLED_PREFIX_LENGTH>) -> Self {
         Self { bootstrap, underlay: None, internal_dns: BTreeSet::new() }
     }
 

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -58,15 +58,15 @@ use internal_dns_resolver::Resolver;
 use internal_dns_types::names::BOUNDARY_NTP_DNS_NAME;
 use internal_dns_types::names::DNS_ZONE;
 use nexus_config::{ConfigDropshotWithTls, DeploymentConfig};
-use omicron_common::address::AZ_PREFIX;
+use omicron_common::address::AZ_PREFIX_LENGTH;
 use omicron_common::address::ConcreteIp;
 use omicron_common::address::DENDRITE_PORT;
 use omicron_common::address::LLDP_PORT;
 use omicron_common::address::MAX_PORT;
 use omicron_common::address::MGS_PORT;
 use omicron_common::address::NTP_ADMIN_PORT;
-use omicron_common::address::RACK_PREFIX;
-use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::RACK_PREFIX_LENGTH;
+use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::address::TFPORTD_PORT;
 use omicron_common::address::WICKETD_NEXUS_PROXY_PORT;
 use omicron_common::address::WICKETD_PORT;
@@ -950,7 +950,7 @@ impl ServiceManager {
     // Derive two unique techport /64 prefixes from the bootstrap address.
     fn bootstrap_addr_to_techport_prefixes(
         addr: &Ipv6Addr,
-    ) -> [Ipv6Subnet<SLED_PREFIX>; 2] {
+    ) -> [Ipv6Subnet<SLED_PREFIX_LENGTH>; 2] {
         // Generate two unique prefixes from the bootstrap address, by
         // incrementing the second octet. This assumes that the bootstrap
         // address starts with `fdb0`, and so we end up with `fdb1` and `fdb2`.
@@ -2095,10 +2095,11 @@ impl ServiceManager {
                     &[*address.ip()],
                 )?;
 
-                let rack_net =
-                    Ipv6Subnet::<RACK_PREFIX>::new(info.underlay_address)
-                        .net()
-                        .to_string();
+                let rack_net = Ipv6Subnet::<RACK_PREFIX_LENGTH>::new(
+                    info.underlay_address,
+                )
+                .net()
+                .to_string();
 
                 let dns_install_service = Self::dns_install(
                     info,
@@ -2191,10 +2192,11 @@ impl ServiceManager {
                     &[*address.ip()],
                 )?;
 
-                let rack_net =
-                    Ipv6Subnet::<RACK_PREFIX>::new(info.underlay_address)
-                        .net()
-                        .to_string();
+                let rack_net = Ipv6Subnet::<RACK_PREFIX_LENGTH>::new(
+                    info.underlay_address,
+                )
+                .net()
+                .to_string();
 
                 let dns_install_service = Self::dns_install(info, None, None)?;
 
@@ -2435,7 +2437,7 @@ impl ServiceManager {
                         compression: dropshot::CompressionConfig::None,
                     },
                     internal_dns: nexus_config::InternalDns::FromSubnet {
-                        subnet: Ipv6Subnet::<RACK_PREFIX>::new(
+                        subnet: Ipv6Subnet::<RACK_PREFIX_LENGTH>::new(
                             info.underlay_address,
                         ),
                     },
@@ -2704,8 +2706,9 @@ impl ServiceManager {
                     );
 
                     if let Some(i) = info {
-                        let rack_subnet =
-                            Ipv6Subnet::<AZ_PREFIX>::new(i.underlay_address);
+                        let rack_subnet = Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(
+                            i.underlay_address,
+                        );
 
                         wicketd_config = wicketd_config.add_property(
                             "rack-subnet",
@@ -2746,7 +2749,7 @@ impl ServiceManager {
                         );
                         if *address != Ipv6Addr::LOCALHOST {
                             let az_prefix =
-                                Ipv6Subnet::<AZ_PREFIX>::new(*address);
+                                Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(*address);
                             for addr in Resolver::servers_from_subnet(az_prefix)
                             {
                                 dendrite_config = dendrite_config.add_property(
@@ -3019,7 +3022,7 @@ impl ServiceManager {
                     for address in addresses {
                         if *address != Ipv6Addr::LOCALHOST {
                             let az_prefix =
-                                Ipv6Subnet::<AZ_PREFIX>::new(*address);
+                                Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(*address);
                             for addr in Resolver::servers_from_subnet(az_prefix)
                             {
                                 mgd_config = mgd_config.add_property(
@@ -3061,7 +3064,7 @@ impl ServiceManager {
                     for address in addresses {
                         if *address != Ipv6Addr::LOCALHOST {
                             let az_prefix =
-                                Ipv6Subnet::<AZ_PREFIX>::new(*address);
+                                Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(*address);
                             for addr in Resolver::servers_from_subnet(az_prefix)
                             {
                                 mg_ddm_config = mg_ddm_config.add_property(
@@ -3786,7 +3789,9 @@ impl ServiceManager {
                                 )?;
                                 if *address != Ipv6Addr::LOCALHOST {
                                     let az_prefix =
-                                        Ipv6Subnet::<AZ_PREFIX>::new(*address);
+                                        Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(
+                                            *address,
+                                        );
                                     for addr in
                                         Resolver::servers_from_subnet(az_prefix)
                                     {
@@ -3807,7 +3812,9 @@ impl ServiceManager {
                         SwitchService::Wicketd { .. } => {
                             if let Some(&address) = first_address {
                                 let rack_subnet =
-                                    Ipv6Subnet::<AZ_PREFIX>::new(address);
+                                    Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(
+                                        address,
+                                    );
 
                                 info!(
                                     self.inner.log, "configuring wicketd";
@@ -3920,7 +3927,9 @@ impl ServiceManager {
                             for address in &request.addresses {
                                 if *address != Ipv6Addr::LOCALHOST {
                                     let az_prefix =
-                                        Ipv6Subnet::<AZ_PREFIX>::new(*address);
+                                        Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(
+                                            *address,
+                                        );
                                     for addr in
                                         Resolver::servers_from_subnet(az_prefix)
                                     {
@@ -3967,7 +3976,9 @@ impl ServiceManager {
                             for address in &request.addresses {
                                 if *address != Ipv6Addr::LOCALHOST {
                                     let az_prefix =
-                                        Ipv6Subnet::<AZ_PREFIX>::new(*address);
+                                        Ipv6Subnet::<AZ_PREFIX_LENGTH>::new(
+                                            *address,
+                                        );
                                     for addr in
                                         Resolver::servers_from_subnet(az_prefix)
                                     {

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -46,7 +46,7 @@ use illumos_utils::zpool::ZpoolOrRamdisk;
 use internal_dns_resolver::Resolver;
 use itertools::Itertools as _;
 use omicron_common::address::BOOTSTRAP_AGENT_RACK_INIT_PORT;
-use omicron_common::address::{Ipv6Subnet, SLED_PREFIX, get_sled_address};
+use omicron_common::address::{Ipv6Subnet, SLED_PREFIX_LENGTH, get_sled_address};
 use omicron_common::api::external::{ByteCount, ByteCountRangeError, Vni};
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::shared::DelegatedZvol;
@@ -380,7 +380,7 @@ struct SledAgentInner {
     // Subnet of the Sled's underlay.
     //
     // The Sled Agent's address can be derived from this value.
-    subnet: Ipv6Subnet<SLED_PREFIX>,
+    subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 
     // The request that was used to start the sled-agent
     // This is used for idempotence checks during RSS/Add-Sled internal APIs
@@ -1875,7 +1875,7 @@ impl SledAgentFacilities for ReconcilerFacilities {
         }
     }
 
-    fn ddm_remove_internal_dns_prefix(&self, prefix: Ipv6Subnet<SLED_PREFIX>) {
+    fn ddm_remove_internal_dns_prefix(&self, prefix: Ipv6Subnet<SLED_PREFIX_LENGTH>) {
         self.service_manager
             .ddm_reconciler()
             .remove_internal_dns_subnet(prefix);

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -46,7 +46,9 @@ use illumos_utils::zpool::ZpoolOrRamdisk;
 use internal_dns_resolver::Resolver;
 use itertools::Itertools as _;
 use omicron_common::address::BOOTSTRAP_AGENT_RACK_INIT_PORT;
-use omicron_common::address::{Ipv6Subnet, SLED_PREFIX_LENGTH, get_sled_address};
+use omicron_common::address::{
+    Ipv6Subnet, SLED_PREFIX_LENGTH, get_sled_address,
+};
 use omicron_common::api::external::{ByteCount, ByteCountRangeError, Vni};
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::shared::DelegatedZvol;
@@ -1875,7 +1877,10 @@ impl SledAgentFacilities for ReconcilerFacilities {
         }
     }
 
-    fn ddm_remove_internal_dns_prefix(&self, prefix: Ipv6Subnet<SLED_PREFIX_LENGTH>) {
+    fn ddm_remove_internal_dns_prefix(
+        &self,
+        prefix: Ipv6Subnet<SLED_PREFIX_LENGTH>,
+    ) {
         self.service_manager
             .ddm_reconciler()
             .remove_internal_dns_subnet(prefix);

--- a/sled-agent/types/versions/src/impls/sled.rs
+++ b/sled-agent/types/versions/src/impls/sled.rs
@@ -7,7 +7,7 @@
 use std::net::{Ipv6Addr, SocketAddrV6};
 
 use async_trait::async_trait;
-use omicron_common::address::{self, Ipv6Subnet, SLED_PREFIX};
+use omicron_common::address::{self, Ipv6Subnet, SLED_PREFIX_LENGTH};
 use omicron_ledger::Ledgerable;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::RackUuid;
@@ -95,7 +95,7 @@ pub struct StartSledAgentRequestV0 {
     // `SledAgentRequest`s as toml. `subnet` serializes as a TOML table, so it
     // must come after non-table fields.
     /// Portion of the IP space to be managed by the Sled Agent.
-    pub subnet: Ipv6Subnet<SLED_PREFIX>,
+    pub subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 }
 
 impl From<StartSledAgentRequestV0> for StartSledAgentRequest {

--- a/sled-agent/types/versions/src/initial/sled.rs
+++ b/sled-agent/types/versions/src/initial/sled.rs
@@ -4,7 +4,7 @@
 
 //! Sled-related types for the Sled Agent API.
 
-use omicron_common::address::{Ipv6Subnet, SLED_PREFIX};
+use omicron_common::address::{Ipv6Subnet, SLED_PREFIX_LENGTH};
 use omicron_uuid_kinds::SledUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -61,5 +61,5 @@ pub struct StartSledAgentRequestBody {
     pub is_lrtq_learner: bool,
 
     /// Portion of the IP space to be managed by the Sled Agent.
-    pub subnet: Ipv6Subnet<SLED_PREFIX>,
+    pub subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 }

--- a/sled-agent/types/versions/src/non_empty_uplink_ports/sled.rs
+++ b/sled-agent/types/versions/src/non_empty_uplink_ports/sled.rs
@@ -8,7 +8,7 @@
 //! `RackUuid` rather than an untyped `Uuid`.
 
 use crate::v1;
-use omicron_common::address::{Ipv6Subnet, SLED_PREFIX};
+use omicron_common::address::{Ipv6Subnet, SLED_PREFIX_LENGTH};
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::RackUuid;
 use omicron_uuid_kinds::SledUuid;
@@ -66,7 +66,7 @@ pub struct StartSledAgentRequestBody {
     pub is_lrtq_learner: bool,
 
     /// Portion of the IP space to be managed by the Sled Agent.
-    pub subnet: Ipv6Subnet<SLED_PREFIX>,
+    pub subnet: Ipv6Subnet<SLED_PREFIX_LENGTH>,
 }
 
 impl From<v1::sled::AddSledRequest> for AddSledRequest {

--- a/wicketd/src/lib.rs
+++ b/wicketd/src/lib.rs
@@ -36,7 +36,7 @@ use mgs::make_mgs_client;
 pub(crate) use mgs::{MgsHandle, MgsManager};
 use nexus_proxy::NexusTcpProxy;
 use omicron_common::FileKv;
-use omicron_common::address::{AZ_PREFIX, Ipv6Subnet};
+use omicron_common::address::{AZ_PREFIX_LENGTH, Ipv6Subnet};
 use preflight_check::PreflightCheckerHandler;
 use sled_hardware_types::Baseboard;
 use slog::{Drain, debug, error, o};
@@ -58,12 +58,12 @@ pub struct Args {
     pub mgs_address: SocketAddrV6,
     pub nexus_proxy_address: SocketAddrV6,
     pub baseboard: Option<Baseboard>,
-    pub rack_subnet: Option<Ipv6Subnet<AZ_PREFIX>>,
+    pub rack_subnet: Option<Ipv6Subnet<AZ_PREFIX_LENGTH>>,
 }
 
 pub struct SmfConfigValues {
     pub address: SocketAddrV6,
-    pub rack_subnet: Option<Ipv6Subnet<AZ_PREFIX>>,
+    pub rack_subnet: Option<Ipv6Subnet<AZ_PREFIX_LENGTH>>,
 }
 
 impl SmfConfigValues {


### PR DESCRIPTION
The `omicron_common::address` module contains a whole bunch of constants whose names end with or otherwise contain the word "prefix" (or, in this case, the word "PREFIX"). Unfortunately, this word is used somewhat inconsistently. In some cases, "prefix" means "the _length_ of a prefix of a subnet", such as [`BOOTSTRAP_SUBNET_PREFIX`], which describes a /40 network, and therefore unsurprisingly is the number 40, or [`RACK_PREFIX`] and [`AZ_PREFIX`], which are 56 and 48, respectively. These constants are typically used as const generic parameters to the `Ipv6Subnet` type, which is generic over the length of a prefix. In other cases, we use the word "prefix" to refer to the "first octets in a subnet", such as [`IPV6_MULTICAST_PREFIX`] and
[`IPV6_ADMIN_SCOPED_MULTICAST_PREFIX`], which are `ff00` and `ff04`, and respectivefly describe the first octet or first two octets in subnets which are /8 and /16, respectively.

This was a bit confusing for me to discover that sometimes ending with "_PREFIX" means a constant contains one thing, and sometimes it means another thing. If one were to use one kind of `_PREFIX` constant in a place where the other kind is expected, I can imagine things going quite wrong, although this is helped a bit by the ones that represent prefix lengths typically being `u8`s and the ones that represent IPv6 octet pairs being, naturally, octet _pairs_, i.e. `u16`s. Luckily, one cannot accidentally insert a `u16` into a `u8`-shaped hole, or vice versa, so we haven't messed this up _yet_, at least as far as I can tell.

However, there is another annoying issue here, which is that I would quite like to move the constant [`BOOTSTRAP_PREFIX`], which represents the first two octets of the bootstrap network, from `sled_hardware_types::underlay` to `omicron_common::address`.[^1] I'd like to be able to reference it in Nexus in #10835. Sadly, as I mentioned above, there is already a `BOOTSTRAP_SUBNET_PREFIX` here, which represents the _length_ of a prefix, rather than the actual octets. Having both `BOOTSTRAP_PREFIX` and `BOOTSTRAP_SUBNET_PREFIX`, with different meanings, seems bad and unfortunate.

Therefore, this branch adopts a more consistent naming scheme, where constants that represent the length of a prefix are always named `FOO_PREFIX_LENGTH`, while constants which represent the first octet(s) of a subnet, often beginning with the letter `f`, are named `FOO_PREFIX`. Doing this touches a lot of files, but reviewers should really only need to look closely at `common/src/address.rs`, as the rest are just places where these various constants are referenced. I would love to have a network guy or two fact-check whether I am using these terms correctly. Thanks!

**AI Usage Disclosure**: This was a large, mechanical change, so I used an AI tool called "the rust-analyzer `Rename Symbol` button" to assist in making this change.

[^1]: Which it's only currently referenced in `sled-hardware`, which depends on `omicron-common` as well as on `sled-hardware-types`.

[`BOOTSTRAP_SUBNET_PREFIX`]: https://github.com/oxidecomputer/omicron/blob/720bec205869c24ca34cc9c8d4b46345c8fcbafd/common/src/address.rs#L22
[`RACK_PREFIX`]: https://github.com/oxidecomputer/omicron/blob/720bec205869c24ca34cc9c8d4b46345c8fcbafd/common/src/address.rs#L24
[`AZ_PREFIX`]: https://github.com/oxidecomputer/omicron/blob/720bec205869c24ca34cc9c8d4b46345c8fcbafd/common/src/address.rs#L23
[`IPV6_MULTICAST_PREFIX`]: https://github.com/oxidecomputer/omicron/blob/720bec205869c24ca34cc9c8d4b46345c8fcbafd/common/src/address.rs#L120
[`IPV6_ADMIN_SCOPED_MULTICAST_PREFIX`]: https://github.com/oxidecomputer/omicron/blob/720bec205869c24ca34cc9c8d4b46345c8fcbafd/common/src/address.rs#L130
[`BOOTSTRAP_PREFIX`]: https://github.com/oxidecomputer/omicron/blob/720bec205869c24ca34cc9c8d4b46345c8fcbafd/sled-hardware/types/src/underlay.rs#L6