### PR TITLE
[nix] make using the flake less...flaky

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,20 +1,30 @@
 # For use with direnv: https://direnv.net
 # See also: ./env.sh
 
-PATH_add out/cockroachdb/bin
-PATH_add out/clickhouse
-PATH_add out/dendrite-stub/bin
-PATH_add out/mgd/root/opt/oxide/mgd/bin
-PATH_add out/mg-ddm/root/opt/oxide/mg-ddm/bin
-
 if [ "$OMICRON_USE_FLAKE" = 1 ] && nix flake show &> /dev/null
 then
-    # watch version files which should cause the nix-direnv cache to be
-    # invalidated, as they are inputs to the Nix flake.
-    watch_file tools/maghemite_mg_openapi_version
-    watch_file tools/dendrite_version
-    watch_file tools/clickhouse_version
-    watch_file tools/cocroachdb_version
+    # watch the files that the Nix flake takes as inputs, so that changing them
+    # invalidates the nix-direnv cache. note that the version and checksum files
+    # should always be updated together, but we will watch both nonetheless.
     watch_file rust-toolchain.toml
-    use flake;
+    watch_file tools/maghemite_mg_openapi_version
+    watch_file tools/maghemite_ddm_openapi_version
+    watch_file tools/maghemite_mgd_checksums
+    watch_file tools/dendrite_version
+    watch_file tools/dendrite_stub_checksums
+    watch_file tools/clickhouse_version
+    watch_file tools/clickhouse_checksums
+    watch_file tools/cockroachdb_version
+    watch_file tools/cockroachdb_checksums
+    use flake
+else
+    # only add `out/` paths to the PATH if we're not using the Nix flake. for
+    # Nix users, the PATH is instead directly munged to contain the
+    # `/nix/store/` paths at which we've downloaded all the test dependencies,
+    # and adding `out/` paths would fight with that.
+    PATH_add out/cockroachdb/bin
+    PATH_add out/clickhouse
+    PATH_add out/dendrite-stub/bin
+    PATH_add out/mgd/root/opt/oxide/mgd/bin
+    PATH_add out/mg-ddm/root/opt/oxide/mg-ddm/bin
 fi

--- a/flake.nix
+++ b/flake.nix
@@ -422,10 +422,16 @@
           }
           {
             inherit buildInputs;
+
+            # The test suite finds all of these on the PATH (see
+            # `test-utils/src/dev/{db,clickhouse,dendrite,maghemite}.rs`, which
+            # spawn them by bare name). Placing them in `nativeBuildInputs`
+            # ensures that the versions we just stuck in the Nix store are
+            # always on the PATH.
             nativeBuildInputs = nativeBuildInputs ++ [
-              # Dendrite and maghemite, for running tests.
               dendrite-stub
               mgd
+              mgDdmd
               clickhouse
               cockroachdb
             ];
@@ -439,23 +445,6 @@
             # Needed by rustfmt-wrapper, see:
             # https://github.com/oxidecomputer/rustfmt-wrapper/blob/main/src/lib.rs
             RUSTFMT = "${rustToolchain}/bin/rustfmt";
-
-            shellHook = ''
-              rm out/mgd
-              rm out/dendrite-stub
-              rm -r out/clickhouse
-              rm -r out/cockroachdb
-
-              mkdir -p out/clickhouse
-              mkdir -p out/cockroachdb/
-
-              ln -s ${mgd.out} -T out/mgd
-              ln -s ${mgDdmd.out} -T out/mg-ddm
-              ln -s ${dendrite-stub.out} -T out/dendrite-stub
-              ln -s ${clickhouse.out}/bin/clickhouse out/clickhouse/clickhouse
-              ln -s ${clickhouse.out}/etc/config.xml out/clickhouse
-              ln -s ${cockroachdb.out}/bin out/cockroachdb/bin
-            '';
           };
     };
 }


### PR DESCRIPTION
The current Nix flake dev environment downloads all of the repo's test dependencies (such as dendrite, maghemite, and CockroachDB), and (in addition to putting them on the PATH) also symlinks them into the `out/` directory in the repo. This is basically because two years ago, when I first added the Nix dev environment, I cargo-culted it from what the old bash download scripts did. At the time, I had assumed that the test suite was specifically looking for stuff to be in `out/`. It turns out that it does not, and instead runs them from the `PATH`...which is much nicer, and much friendlier to the way Nix actually wants to work.

This commit gets rid of all the symlinking nonsense and instead just has the Nix flake put everything we need on the PATH directly. This is much closer to how Nix generally does things, and also happens to fix a bunch of bugs in my symlinking script, such as the fact that I had forgotten to make it `rm` an older version of the `mg-ddm` symlink when the pinned version changes. I also changed the `.envrc` so that the `out/` dir paths are only added to the PATH if you're *not* using the Nix dev setup, so that any users of the Nix flake who have stale symlinks in the out directory don't have them fight with the ones the flake is actually putting on the path.

This should all be a lot less janky for any anyone developing Omicron on NixOS...which, as far as I know, seems to only be me at this point? So...it's less janky for me. Thanks for reviewing this PR that only matters to me!