### PR TITLE
[update-status] Exclude expected offline propolis zones from contact_support

### DIFF
--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -12,11 +12,13 @@ use chrono::TimeDelta;
 use chrono::Utc;
 use dropshot::HttpError;
 use futures::Stream;
+use illumos_utils::zone::PROPOLIS_ZONE_PREFIX;
 use nexus_auth::authz;
 use nexus_db_lookup::LookupPath;
 use nexus_db_model::Generation;
 use nexus_db_model::TufRepoUpload;
 use nexus_db_model::TufTrustRoot;
+use nexus_db_model::VmmState;
 use nexus_db_model::saga_types::Saga;
 use nexus_db_model::saga_types::SagaId;
 use nexus_db_queries::context::OpContext;
@@ -33,8 +35,11 @@ use nexus_types::inventory::Zpool;
 use omicron_common::api::external::InternalContext;
 use omicron_common::api::external::Nullable;
 use omicron_common::api::external::{DataPageParams, Error};
-use omicron_uuid_kinds::{GenericUuid, SledUuid, TufTrustRootUuid};
+use omicron_uuid_kinds::{
+    GenericUuid, PropolisUuid, SledUuid, TufTrustRootUuid,
+};
 use semver::Version;
+use sled_agent_types::inventory::SvcsEnabledNotOnline;
 use sled_agent_types::inventory::SvcsEnabledNotOnlineResult;
 use sled_hardware_types::BaseboardId;
 use slog::KV;
@@ -106,6 +111,10 @@ struct UpdateContactSupportChecksInput {
     // None when no target release has ever been set on the system.
     current_target_version: Option<Version>,
     internal_update_status: internal_views::UpdateStatus,
+    // Propolis IDs whose VMMs we expect to be offline (e.g. an instance that is
+    // being stopped). Enabled-but-not-online SMF services in these zones are
+    // filtered out.
+    expected_offline_propolis: BTreeSet<PropolisUuid>,
 }
 
 impl UpdateContactSupportChecksInput {
@@ -167,12 +176,51 @@ impl UpdateContactSupportChecksInput {
             .map(|(sled, zpools)| (sled, zpools.into_iter().cloned().collect()))
             .collect();
 
-        let enabled_smf_services_not_online_by_sled = self
-            .inventory
-            .enabled_smf_services_not_online()
-            .into_iter()
-            .map(|(sled, svcs)| (sled, svcs.clone()))
-            .collect();
+        // Drop propolis zones whose VMMs are expected to be offline from the
+        // per-sled lists.
+        let unexpected_enabled_smf_services_not_online_by_sled =
+            self.inventory
+                .enabled_smf_services_not_online()
+                .into_iter()
+                // TODO-K: Clean up. This is impossible to read
+                .filter_map(|(sled, svcs)| {
+                    let svcs = match svcs {
+                        SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
+                            not_online,
+                        ) => {
+                            let services: Vec<_> = not_online
+                                .services
+                                .iter()
+                                .filter(|svc| {
+                                    !propolis_id_from_zone(&svc.zone)
+                                        .is_some_and(|id| {
+                                            self.expected_offline_propolis
+                                                .contains(&id)
+                                        })
+                                })
+                                .cloned()
+                                .collect();
+
+                            if services.is_empty() {
+                                return None;
+                            }
+
+                            SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
+                                SvcsEnabledNotOnline {
+                                    services,
+                                    errors: not_online.errors.clone(),
+                                    time_of_status: not_online.time_of_status,
+                                },
+                            )
+                        }
+                        // Command errors and unavailable data aren't
+                        // propolis-specific, so they're always retained.
+                        other => other.clone(),
+                    };
+
+                    Some((sled, svcs))
+                })
+                .collect();
 
         UpdateStatusProblems {
             stuck_sagas,
@@ -180,7 +228,7 @@ impl UpdateContactSupportChecksInput {
             stuck_update_last_blueprint_created_time,
             stale_inventory_last_collection_time_done,
             unhealthy_zpools_by_sled,
-            enabled_smf_services_not_online_by_sled,
+            unexpected_enabled_smf_services_not_online_by_sled,
             missing_sleds,
         }
     }
@@ -209,8 +257,9 @@ struct UpdateStatusProblems {
     stale_inventory_last_collection_time_done: Option<DateTime<Utc>>,
     /// Zpools that are not in an `Online` state.
     unhealthy_zpools_by_sled: BTreeMap<SledUuid, Vec<Zpool>>,
-    /// Enabled SMF services that are not in an `online` state.
-    enabled_smf_services_not_online_by_sled:
+    /// Enabled SMF services that are not in an `online` state, excluding
+    /// propolis zones whose VMM is expected to be offline.
+    unexpected_enabled_smf_services_not_online_by_sled:
         BTreeMap<SledUuid, SvcsEnabledNotOnlineResult>,
     /// IDs of sleds that aren't present in inventory or haven't reported a
     /// reconciliation result yet.
@@ -225,7 +274,7 @@ impl UpdateStatusProblems {
             stuck_update_last_blueprint_created_time,
             stale_inventory_last_collection_time_done,
             unhealthy_zpools_by_sled,
-            enabled_smf_services_not_online_by_sled,
+            unexpected_enabled_smf_services_not_online_by_sled,
             missing_sleds,
         } = self;
         stuck_sagas.is_empty()
@@ -233,7 +282,7 @@ impl UpdateStatusProblems {
             && stuck_update_last_blueprint_created_time.is_none()
             && stale_inventory_last_collection_time_done.is_none()
             && unhealthy_zpools_by_sled.is_empty()
-            && enabled_smf_services_not_online_by_sled.is_empty()
+            && unexpected_enabled_smf_services_not_online_by_sled.is_empty()
             && missing_sleds.is_empty()
     }
 }
@@ -252,7 +301,7 @@ impl KV for UpdateStatusProblems {
             stuck_update_last_blueprint_created_time,
             stale_inventory_last_collection_time_done,
             unhealthy_zpools_by_sled,
-            enabled_smf_services_not_online_by_sled,
+            unexpected_enabled_smf_services_not_online_by_sled,
             missing_sleds,
         } = self;
 
@@ -290,10 +339,13 @@ impl KV for UpdateStatusProblems {
                 &format_args!("{:?}", unhealthy_zpools_by_sled),
             )?;
         }
-        if !enabled_smf_services_not_online_by_sled.is_empty() {
+        if !unexpected_enabled_smf_services_not_online_by_sled.is_empty() {
             serializer.emit_arguments(
-                "enabled_smf_services_not_online_by_sled".into(),
-                &format_args!("{:?}", enabled_smf_services_not_online_by_sled),
+                "unexpected_enabled_smf_services_not_online_by_sled".into(),
+                &format_args!(
+                    "{:?}",
+                    unexpected_enabled_smf_services_not_online_by_sled
+                ),
             )?;
         }
         if !missing_sleds.is_empty() {
@@ -304,6 +356,13 @@ impl KV for UpdateStatusProblems {
         }
         Ok(())
     }
+}
+
+// TODO-K: this recovers the Propolis ID by string-parsing the zone name.
+// It sucks, fix it. Maybe adding propolis ID somewhere else?
+fn propolis_id_from_zone(zone: &str) -> Option<PropolisUuid> {
+    zone.strip_prefix(PROPOLIS_ZONE_PREFIX)
+        .and_then(|id| id.parse::<PropolisUuid>().ok())
 }
 
 /// Returns true if the system appears to be mid-update.
@@ -629,6 +688,70 @@ impl super::Nexus {
             UpdateActivityState::Idle | UpdateActivityState::Stuck => {}
         };
 
+        // Propolis zones whose VMMs are expected to be offline (e.g. an
+        // instance that is being stopped) shouldn't count as unexpected
+        // enabled-not-online SMF services. They don't affect the update process
+        // and can confuse users thinking something may be wrong.
+        //
+        // Look up the state of each propolis zone that currently appears in
+        // the enabled-not-online lists and collect the ones we expect to be
+        // offline.
+        let mut expected_offline_propolis = BTreeSet::new();
+        for svcs_result in
+            inventory.enabled_smf_services_not_online().into_values()
+        {
+            let svcs = match svcs_result {
+                SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(svcs) => svcs,
+                // We're only retrieving information if there are any enabled
+                // services not online, we continue on to the next sled if there
+                // aren't any
+                SvcsEnabledNotOnlineResult::DataUnavailable
+                | SvcsEnabledNotOnlineResult::SvcsCmdError(_) => continue,
+            };
+
+            for svc in &svcs.services {
+                let Some(propolis_id) = propolis_id_from_zone(&svc.zone) else {
+                    // This isn't a propolis zone; move on.
+                    continue;
+                };
+
+                // TODO-K: Clean this up
+                let expected_offline_zone =
+                    // TODO-K: Probably don't use this endpoint? An option is to
+                    // write a new one that bulk fetches all the VMMs from a
+                    // given list of ids, so we don't have to do multiple API
+                    // calls. The downside of doing that would be knowing what
+                    // to do for an ObjectNotFound. Just omit it?
+                    match self.datastore().vmm_fetch(opctx, &propolis_id).await
+                    {
+                        Ok(vmm) => match vmm.state {
+                            VmmState::Stopping
+                            | VmmState::Stopped
+                            | VmmState::Destroyed
+                            | VmmState::SagaUnwound => true,
+                            VmmState::Creating
+                            | VmmState::Failed
+                            | VmmState::Migrating
+                            | VmmState::Rebooting
+                            | VmmState::Running
+                            | VmmState::Starting => false,
+                        },
+                        // This shouldn't happen, but the VMM record could already
+                        // have been reaped but its zone is still lingering for some
+                        // reason. Treat its offline propolis service as expected to
+                        // be offline.
+                        Err(Error::ObjectNotFound { .. }) => true,
+                        Err(e) => return Err(e),
+                    };
+
+                if expected_offline_zone {
+                    // This zone should be offline, include in list of propolis
+                    // zones to exclude from problems.
+                    expected_offline_propolis.insert(propolis_id);
+                }
+            }
+        }
+
         let checks = UpdateContactSupportChecksInput {
             inventory,
             // TODO-K: Temporarily disabling the retrieval of stuck sagas.
@@ -642,6 +765,7 @@ impl super::Nexus {
             blueprint,
             current_target_version: current_target_version.cloned(),
             internal_update_status,
+            expected_offline_propolis,
         };
 
         let problems = checks.problems();
@@ -1594,6 +1718,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::new(),
         };
         assert_eq!(checks.problems(), UpdateStatusProblems::default());
 
@@ -1623,6 +1748,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
@@ -1656,6 +1782,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
@@ -1689,6 +1816,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
@@ -1724,6 +1852,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::new(),
         };
         assert_eq!(checks.problems(), UpdateStatusProblems::default());
 
@@ -1754,6 +1883,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
@@ -1791,6 +1921,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::new(),
         };
 
         let expected_zpool = Zpool {
@@ -1834,12 +1965,125 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
-            enabled_smf_services_not_online_by_sled: BTreeMap::from([(
-                sled_id, services,
-            )]),
+            unexpected_enabled_smf_services_not_online_by_sled: BTreeMap::from(
+                [(sled_id, services)],
+            ),
+            ..Default::default()
+        };
+        assert_eq!(checks.problems(), expected);
+
+        logctx.cleanup_successful();
+    }
+
+    #[test]
+    fn test_problems_expected_offline_propolis_omits_sled() {
+        let logctx = test_setup_log(
+            "test_problems_expected_offline_propolis_omits_sled",
+        );
+        let blueprint = fake_blueprint(
+            &logctx.log,
+            &fake_target_version(),
+            Utc::now(),
+            false,
+        );
+        let sled_id = sled_id();
+
+        let propolis_id =
+            PropolisUuid::from_untyped_uuid(Uuid::from_u128(0xDDDD));
+        let services = SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
+            SvcsEnabledNotOnline {
+                services: vec![SvcEnabledNotOnline {
+                    fmri: "svc:/system/illumos/propolis-server:default"
+                        .to_string(),
+                    zone: format!("{PROPOLIS_ZONE_PREFIX}{propolis_id}"),
+                    state: SvcEnabledNotOnlineState::Offline,
+                }],
+                errors: vec![],
+                time_of_status: Utc::now(),
+            },
+        );
+        let collection =
+            fake_collection_with_ids(sled_id, healthy_zpools(), services);
+
+        let checks = UpdateContactSupportChecksInput {
+            inventory: Arc::new(collection),
+            stuck_sagas: Ok(vec![]),
+            blueprint,
+            current_target_version: Some(fake_target_version()),
+            internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::from([propolis_id]),
+        };
+
+        assert_eq!(checks.problems(), UpdateStatusProblems::default());
+
+        logctx.cleanup_successful();
+    }
+
+    #[test]
+    fn test_problems_expected_offline_propolis_retains_others() {
+        let logctx = test_setup_log(
+            "test_problems_expected_offline_propolis_retains_others",
+        );
+        let blueprint = fake_blueprint(
+            &logctx.log,
+            &fake_target_version(),
+            Utc::now(),
+            false,
+        );
+        let sled_id = sled_id();
+
+        let propolis_id =
+            PropolisUuid::from_untyped_uuid(Uuid::from_u128(0xDDDD));
+        let time_of_status = Utc::now();
+        let non_propolis_service = SvcEnabledNotOnline {
+            fmri: "svc:/system/test:default".to_string(),
+            zone: "global".to_string(),
+            state: SvcEnabledNotOnlineState::Maintenance,
+        };
+        let services = SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
+            SvcsEnabledNotOnline {
+                services: vec![
+                    SvcEnabledNotOnline {
+                        fmri: "svc:/system/illumos/propolis-server:default"
+                            .to_string(),
+                        zone: format!("{PROPOLIS_ZONE_PREFIX}{propolis_id}"),
+                        state: SvcEnabledNotOnlineState::Offline,
+                    },
+                    non_propolis_service.clone(),
+                ],
+                errors: vec![],
+                time_of_status,
+            },
+        );
+        let collection =
+            fake_collection_with_ids(sled_id, healthy_zpools(), services);
+
+        let checks = UpdateContactSupportChecksInput {
+            inventory: Arc::new(collection),
+            stuck_sagas: Ok(vec![]),
+            blueprint,
+            current_target_version: Some(fake_target_version()),
+            internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::from([propolis_id]),
+        };
+
+        let expected = UpdateStatusProblems {
+            unexpected_enabled_smf_services_not_online_by_sled: BTreeMap::from(
+                [(
+                    sled_id,
+                    SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
+                        SvcsEnabledNotOnline {
+                            services: vec![non_propolis_service],
+                            errors: vec![],
+                            time_of_status,
+                        },
+                    ),
+                )],
+            ),
             ..Default::default()
         };
         assert_eq!(checks.problems(), expected);
@@ -1876,6 +2120,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
+            expected_offline_propolis: BTreeSet::new(),
         };
 
         let expected_zpool = Zpool {
@@ -1937,6 +2182,7 @@ mod test {
                 [missing_sled_id],
                 [sled_id],
             ),
+            expected_offline_propolis: BTreeSet::new(),
         };
 
         let expected_zpool = Zpool {
@@ -1958,9 +2204,9 @@ mod test {
                 sled_id,
                 vec![expected_zpool],
             )]),
-            enabled_smf_services_not_online_by_sled: BTreeMap::from([(
-                sled_id, services,
-            )]),
+            unexpected_enabled_smf_services_not_online_by_sled: BTreeMap::from(
+                [(sled_id, services)],
+            ),
             missing_sleds: BTreeSet::from([missing_sled_id]),
         };
         assert_eq!(normalise_zpool_times(checks.problems()), expected);
@@ -1995,6 +2241,7 @@ mod test {
                 [missing_sled_id],
                 [healthy_sled_id],
             ),
+            expected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {

--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -688,69 +688,56 @@ impl super::Nexus {
             UpdateActivityState::Idle | UpdateActivityState::Stuck => {}
         };
 
+        // TODO-K: Extract all of this propolis-specific code into separate
+        // methods
+
         // Propolis zones whose VMMs are expected to be offline (e.g. an
         // instance that is being stopped) shouldn't count as unexpected
-        // enabled-not-online SMF services. They don't affect the update process
+        // enabled not online SMF services. They don't affect the update process
         // and can confuse users thinking something may be wrong.
         //
-        // Look up the state of each propolis zone that currently appears in
-        // the enabled-not-online lists and collect the ones we expect to be
-        // offline.
-        let mut expected_offline_propolis = BTreeSet::new();
-        for svcs_result in
-            inventory.enabled_smf_services_not_online().into_values()
-        {
-            let svcs = match svcs_result {
-                SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(svcs) => svcs,
+        // Gather the propolis zones that currently appear in the
+        // enabled-not-online lists, then look up each VMM's state concurrently
+        // and collect the ones we expect to be offline.
+        // TODO-K: Clean up. This is impossible to read
+        let candidate_propolis: Vec<PropolisUuid> = inventory
+            .enabled_smf_services_not_online()
+            .into_values()
+            .filter_map(|svcs_result| match svcs_result {
+                SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(svcs) => {
+                    Some(svcs)
+                }
                 // We're only retrieving information if there are any enabled
                 // services not online, we continue on to the next sled if there
                 // aren't any
                 SvcsEnabledNotOnlineResult::DataUnavailable
-                | SvcsEnabledNotOnlineResult::SvcsCmdError(_) => continue,
-            };
+                | SvcsEnabledNotOnlineResult::SvcsCmdError(_) => None,
+            })
+            .flat_map(|svcs| {
+                svcs.services
+                    .iter()
+                    .filter_map(|svc| propolis_id_from_zone(&svc.zone))
+            })
+            .collect();
 
-            for svc in &svcs.services {
-                let Some(propolis_id) = propolis_id_from_zone(&svc.zone) else {
-                    // This isn't a propolis zone; move on.
-                    continue;
-                };
-
-                // TODO-K: Clean this up
-                let expected_offline_zone =
-                    // TODO-K: Probably don't use this endpoint? An option is to
-                    // write a new one that bulk fetches all the VMMs from a
-                    // given list of ids, so we don't have to do multiple API
-                    // calls. The downside of doing that would be knowing what
-                    // to do for an ObjectNotFound. Just omit it?
-                    match self.datastore().vmm_fetch(opctx, &propolis_id).await
-                    {
-                        Ok(vmm) => match vmm.state {
-                            VmmState::Stopping
-                            | VmmState::Stopped
-                            | VmmState::Destroyed
-                            | VmmState::SagaUnwound => true,
-                            VmmState::Creating
-                            | VmmState::Failed
-                            | VmmState::Migrating
-                            | VmmState::Rebooting
-                            | VmmState::Running
-                            | VmmState::Starting => false,
-                        },
-                        // This shouldn't happen, but the VMM record could already
-                        // have been reaped but its zone is still lingering for some
-                        // reason. Treat its offline propolis service as expected to
-                        // be offline.
-                        Err(Error::ObjectNotFound { .. }) => true,
-                        Err(e) => return Err(e),
-                    };
-
-                if expected_offline_zone {
-                    // This zone should be offline, include in list of propolis
-                    // zones to exclude from problems.
-                    expected_offline_propolis.insert(propolis_id);
-                }
-            }
-        }
+        // TODO-K: Probably don't use this endpoint? An option is to
+        // write a new one that bulk fetches all the VMMs from a
+        // given list of ids, so we don't have to do multiple API
+        // calls. The downside of doing that would be knowing what
+        // to do for an ObjectNotFound. Just omit it?
+        //
+        // TODO-K: Clean this up
+        let expected_offline_propolis = futures::future::try_join_all(
+            candidate_propolis.into_iter().map(|propolis_id| async move {
+                self.is_propolis_expected_offline(opctx, propolis_id)
+                    .await
+                    .map(|expected| expected.then_some(propolis_id))
+            }),
+        )
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
 
         let checks = UpdateContactSupportChecksInput {
             inventory,
@@ -780,6 +767,34 @@ impl super::Nexus {
         }
 
         Ok(contact_support)
+    }
+
+    /// Determine whether the given VMM is expected to be offline.
+    async fn is_propolis_expected_offline(
+        &self,
+        opctx: &OpContext,
+        propolis_id: PropolisUuid,
+    ) -> Result<bool, Error> {
+        match self.datastore().vmm_fetch(opctx, &propolis_id).await {
+            // TODO-K: Ask ixi if this logic makes sense
+            Ok(vmm) => Ok(match vmm.state {
+                VmmState::Stopping
+                | VmmState::Stopped
+                | VmmState::Destroyed
+                | VmmState::SagaUnwound => true,
+                VmmState::Creating
+                | VmmState::Failed
+                | VmmState::Migrating
+                | VmmState::Rebooting
+                | VmmState::Running
+                | VmmState::Starting => false,
+            }),
+            // This shouldn't happen, but the VMM record could already have been
+            // reaped while its zone is still lingering for some reason. Treat
+            // its offline propolis service as expected to be offline.
+            Err(Error::ObjectNotFound { .. }) => Ok(true),
+            Err(e) => Err(e),
+        }
     }
 
     async fn get_internal_update_status(
@@ -1045,18 +1060,27 @@ mod test {
         })
     }
 
-    // A single enabled not online SMF service living in the propolis zone for
-    // the given propolis id.
-    fn offline_propolis_svc(
-        propolis_id: PropolisUuid,
+    // Enabled not online SMF services living in different propolis zones for
+    // the given propolis ids.
+    fn enabled_not_online_propolis_svcs(
+        propolis_id_1: PropolisUuid,
+        propolis_id_2: PropolisUuid,
     ) -> SvcsEnabledNotOnlineResult {
         SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(SvcsEnabledNotOnline {
-            services: vec![SvcEnabledNotOnline {
-                fmri: "svc:/system/illumos/propolis-server:default"
-                    .to_string(),
-                zone: format!("{PROPOLIS_ZONE_PREFIX}{propolis_id}"),
-                state: SvcEnabledNotOnlineState::Offline,
-            }],
+            services: vec![
+                SvcEnabledNotOnline {
+                    fmri: "svc:/system/illumos/propolis-server:default"
+                        .to_string(),
+                    zone: format!("{PROPOLIS_ZONE_PREFIX}{propolis_id_1}"),
+                    state: SvcEnabledNotOnlineState::Offline,
+                },
+                SvcEnabledNotOnline {
+                    fmri: "svc:/system/illumos/propolis-server:default"
+                        .to_string(),
+                    zone: format!("{PROPOLIS_ZONE_PREFIX}{propolis_id_2}"),
+                    state: SvcEnabledNotOnlineState::Maintenance,
+                },
+            ],
             errors: vec![],
             time_of_status: Utc::now(),
         })
@@ -1753,15 +1777,19 @@ mod test {
         let nexus = &cptestctx.server.server_context().nexus;
         let opctx = fake_opctx(cptestctx);
 
-        let propolis_id = PropolisUuid::new_v4();
+        let propolis_id_1 = PropolisUuid::new_v4();
+        let propolis_id_2 = PropolisUuid::new_v4();
         insert_fake_collection(
             cptestctx,
             &opctx,
             healthy_zpools(),
-            offline_propolis_svc(propolis_id),
+            enabled_not_online_propolis_svcs(propolis_id_1, propolis_id_2),
         )
         .await;
-        insert_vmm_in_db(cptestctx, &opctx, propolis_id, VmmState::Stopping)
+
+        insert_vmm_in_db(cptestctx, &opctx, propolis_id_1, VmmState::Stopping)
+            .await;
+        insert_vmm_in_db(cptestctx, &opctx, propolis_id_1, VmmState::Destroyed)
             .await;
 
         let inventory = Arc::new(
@@ -1775,10 +1803,11 @@ mod test {
         let version = fake_target_version();
         let blueprint =
             fake_blueprint(&cptestctx.logctx.log, &version, Utc::now(), false);
-        
-        // A propolis zone reports an enabled not online SMF service, but its
-        // VMM is in the `Stopping` state, so we expect it to be offline. It
-        // should be filtered out, and contact_support shoudl be false.
+
+        // Two propolis zones report an enabled not online SMF service, the
+        // VMM of one is in the `Stopping` state and the other `Destroyed`, so
+        // we expect them to be offline. They should both be filtered out, and
+        // contact_support should be false.
         assert!(
             !nexus
                 .contact_support(
@@ -1800,15 +1829,19 @@ mod test {
         let nexus = &cptestctx.server.server_context().nexus;
         let opctx = fake_opctx(cptestctx);
 
-        let propolis_id = PropolisUuid::new_v4();
+        let propolis_id_1 = PropolisUuid::new_v4();
+        let propolis_id_2 = PropolisUuid::new_v4();
         insert_fake_collection(
             cptestctx,
             &opctx,
             healthy_zpools(),
-            offline_propolis_svc(propolis_id),
+            enabled_not_online_propolis_svcs(propolis_id_1, propolis_id_2),
         )
         .await;
-        insert_vmm_in_db(cptestctx, &opctx, propolis_id, VmmState::Running)
+
+        insert_vmm_in_db(cptestctx, &opctx, propolis_id_1, VmmState::Running)
+            .await;
+        insert_vmm_in_db(cptestctx, &opctx, propolis_id_2, VmmState::Stopping)
             .await;
 
         let inventory = Arc::new(
@@ -1823,9 +1856,11 @@ mod test {
         let blueprint =
             fake_blueprint(&cptestctx.logctx.log, &version, Utc::now(), false);
 
-        // A propolis zone reports a enabled not-online SMF service while its
-        // VMM is in the `Running` state, so its being offline is unexpected.
-        // contact_support should be true.
+        // A propolis zone reports a enabled not online SMF service while its
+        // VMM is in the `Stopping` state, it is expected to be in this state,
+        // so it is filtered out. Another propolis zone also reports an enabled
+        // not online SMF service, but it's VMM is in the `Running` state, so
+        // its being offline is unexpected. contact_support should be true.
         assert!(
             nexus
                 .contact_support(

--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -928,6 +928,8 @@ async fn component_version_counts(
 mod test {
     use super::*;
     use chrono::Utc;
+    use nexus_db_model::Vmm;
+    use nexus_db_model::VmmCpuPlatform;
     use nexus_db_model::saga_types::Saga;
     use nexus_db_model::saga_types::SecId;
     use nexus_inventory::CollectionBuilder;
@@ -1043,6 +1045,23 @@ mod test {
         })
     }
 
+    // A single enabled not online SMF service living in the propolis zone for
+    // the given propolis id.
+    fn offline_propolis_svc(
+        propolis_id: PropolisUuid,
+    ) -> SvcsEnabledNotOnlineResult {
+        SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(SvcsEnabledNotOnline {
+            services: vec![SvcEnabledNotOnline {
+                fmri: "svc:/system/illumos/propolis-server:default"
+                    .to_string(),
+                zone: format!("{PROPOLIS_ZONE_PREFIX}{propolis_id}"),
+                state: SvcEnabledNotOnlineState::Offline,
+            }],
+            errors: vec![],
+            time_of_status: Utc::now(),
+        })
+    }
+
     fn fake_opctx(cptestctx: &ControlPlaneTestContext) -> OpContext {
         OpContext::for_tests(
             cptestctx.logctx.log.new(o!()),
@@ -1069,6 +1088,35 @@ mod test {
             .inventory_insert_collection(opctx, &collection)
             .await
             .expect("inserted inventory collection");
+    }
+
+    async fn insert_vmm_in_db(
+        cptestctx: &ControlPlaneTestContext,
+        opctx: &OpContext,
+        propolis_id: PropolisUuid,
+        state: VmmState,
+    ) {
+        let datastore = cptestctx.server.server_context().nexus.datastore();
+        datastore
+            .vmm_insert(
+                opctx,
+                Vmm {
+                    id: propolis_id.into_untyped_uuid(),
+                    time_created: Utc::now(),
+                    time_deleted: None,
+                    instance_id: Uuid::new_v4(),
+                    time_state_updated: Utc::now(),
+                    generation: Generation::new(),
+                    sled_id: sled_id().into(),
+                    propolis_ip: "10.1.9.42".parse().unwrap(),
+                    propolis_port: 12400.into(),
+                    state,
+                    cpu_platform: VmmCpuPlatform::SledDefault,
+                    failure_reason: None,
+                },
+            )
+            .await
+            .expect("inserted vmm");
     }
 
     // Insert a running saga whose `time_created` is older than
@@ -1691,6 +1739,100 @@ mod test {
                     inventory,
                     blueprint,
                     Some(&target_release),
+                    empty_internal_update_status(),
+                )
+                .await
+                .unwrap()
+        );
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_contact_support_expected_offline_propolis(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let nexus = &cptestctx.server.server_context().nexus;
+        let opctx = fake_opctx(cptestctx);
+
+        let propolis_id = PropolisUuid::new_v4();
+        insert_fake_collection(
+            cptestctx,
+            &opctx,
+            healthy_zpools(),
+            offline_propolis_svc(propolis_id),
+        )
+        .await;
+        insert_vmm_in_db(cptestctx, &opctx, propolis_id, VmmState::Stopping)
+            .await;
+
+        let inventory = Arc::new(
+            nexus
+                .datastore()
+                .inventory_get_latest_collection(&opctx)
+                .await
+                .unwrap()
+                .unwrap(),
+        );
+        let version = fake_target_version();
+        let blueprint =
+            fake_blueprint(&cptestctx.logctx.log, &version, Utc::now(), false);
+        
+        // A propolis zone reports an enabled not online SMF service, but its
+        // VMM is in the `Stopping` state, so we expect it to be offline. It
+        // should be filtered out, and contact_support shoudl be false.
+        assert!(
+            !nexus
+                .contact_support(
+                    &opctx,
+                    inventory,
+                    blueprint,
+                    Some(&version),
+                    empty_internal_update_status(),
+                )
+                .await
+                .unwrap()
+        );
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_contact_support_unexpected_offline_propolis(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let nexus = &cptestctx.server.server_context().nexus;
+        let opctx = fake_opctx(cptestctx);
+
+        let propolis_id = PropolisUuid::new_v4();
+        insert_fake_collection(
+            cptestctx,
+            &opctx,
+            healthy_zpools(),
+            offline_propolis_svc(propolis_id),
+        )
+        .await;
+        insert_vmm_in_db(cptestctx, &opctx, propolis_id, VmmState::Running)
+            .await;
+
+        let inventory = Arc::new(
+            nexus
+                .datastore()
+                .inventory_get_latest_collection(&opctx)
+                .await
+                .unwrap()
+                .unwrap(),
+        );
+        let version = fake_target_version();
+        let blueprint =
+            fake_blueprint(&cptestctx.logctx.log, &version, Utc::now(), false);
+
+        // A propolis zone reports a enabled not-online SMF service while its
+        // VMM is in the `Running` state, so its being offline is unexpected.
+        // contact_support should be true.
+        assert!(
+            nexus
+                .contact_support(
+                    &opctx,
+                    inventory,
+                    blueprint,
+                    Some(&version),
                     empty_internal_update_status(),
                 )
                 .await

--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -111,10 +111,11 @@ struct UpdateContactSupportChecksInput {
     // None when no target release has ever been set on the system.
     current_target_version: Option<Version>,
     internal_update_status: internal_views::UpdateStatus,
-    // Propolis IDs whose VMMs we expect to be offline (e.g. an instance that is
-    // being stopped). Enabled-but-not-online SMF services in these zones are
-    // filtered out.
-    expected_offline_propolis: BTreeSet<PropolisUuid>,
+    // Propolis IDs whose VMMs are NOT expected to be offline — i.e. their
+    // enabled-but-not-online SMF service is a genuine problem worth reporting.
+    // Any propolis zone not in this set is filtered out of the results (its VMM
+    // is expected to be offline, e.g. an instance that is being stopped).
+    unexpected_offline_propolis: BTreeSet<PropolisUuid>,
 }
 
 impl UpdateContactSupportChecksInput {
@@ -178,49 +179,19 @@ impl UpdateContactSupportChecksInput {
 
         // Drop propolis zones whose VMMs are expected to be offline from the
         // per-sled lists.
-        let unexpected_enabled_smf_services_not_online_by_sled =
-            self.inventory
-                .enabled_smf_services_not_online()
-                .into_iter()
-                // TODO-K: Clean up. This is impossible to read
-                .filter_map(|(sled, svcs)| {
-                    let svcs = match svcs {
-                        SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
-                            not_online,
-                        ) => {
-                            let services: Vec<_> = not_online
-                                .services
-                                .iter()
-                                .filter(|svc| {
-                                    !propolis_id_from_zone(&svc.zone)
-                                        .is_some_and(|id| {
-                                            self.expected_offline_propolis
-                                                .contains(&id)
-                                        })
-                                })
-                                .cloned()
-                                .collect();
-
-                            if services.is_empty() {
-                                return None;
-                            }
-
-                            SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
-                                SvcsEnabledNotOnline {
-                                    services,
-                                    errors: not_online.errors.clone(),
-                                    time_of_status: not_online.time_of_status,
-                                },
-                            )
-                        }
-                        // Command errors and unavailable data aren't
-                        // propolis-specific, so they're always retained.
-                        other => other.clone(),
-                    };
-
-                    Some((sled, svcs))
-                })
-                .collect();
+        let mut unexpected_enabled_smf_services_not_online_by_sled =
+            BTreeMap::new();
+        // TODO-K: This could be nicer
+        for (sled, svcs_result) in
+            self.inventory.enabled_smf_services_not_online()
+        {
+            if let Some(retained) =
+                self.retain_unexpected_enabled_not_online_svcs(svcs_result)
+            {
+                unexpected_enabled_smf_services_not_online_by_sled
+                    .insert(sled, retained);
+            }
+        }
 
         UpdateStatusProblems {
             stuck_sagas,
@@ -230,6 +201,60 @@ impl UpdateContactSupportChecksInput {
             unhealthy_zpools_by_sled,
             unexpected_enabled_smf_services_not_online_by_sled,
             missing_sleds,
+        }
+    }
+
+    /// Drop expected-offline propolis services from one sled's result,
+    /// returning `None` if nothing unexpected remains on that sled.
+    fn retain_unexpected_enabled_not_online_svcs(
+        &self,
+        // TODO-K: Can I avoid taking the result?
+        svcs_result: &SvcsEnabledNotOnlineResult,
+        // TODO-K: I think I can avoid this Option
+    ) -> Option<SvcsEnabledNotOnlineResult> {
+        let enabled_not_online = match svcs_result {
+            SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(svcs) => svcs,
+            // Command errors and unavailable data aren't propolis-specific, so
+            // they're always retained.
+            SvcsEnabledNotOnlineResult::DataUnavailable
+            | SvcsEnabledNotOnlineResult::SvcsCmdError(_) => {
+                return Some(svcs_result.clone());
+            }
+        };
+
+        let SvcsEnabledNotOnline { services, errors, time_of_status } =
+            enabled_not_online;
+
+        let services: Vec<_> = services
+            .iter()
+            .filter(|svc| {
+                // Whether the service in `zone` is an unexpected enabled not
+                // online service. It either doesn't live in a propolis zone,
+                // or lives in a propolis zone whose VMM we did not expect to be
+                // offline.
+                propolis_id_from_zone(&svc.zone).is_none_or(|id| {
+                    self.unexpected_offline_propolis.contains(&id)
+                })
+            })
+            .cloned()
+            .collect();
+
+        // TODO-K: Leave this for now to keep the test passing. Double check
+        // behaviour below based on notes on enabled_smf_services_not_online
+        // regarding how we report services
+        if services.is_empty() {
+            None
+        } else {
+            // We always return some because even if there are no services left,
+            // there may be errors, and we want to know the time the sample was
+            // taken.
+            Some(SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
+                SvcsEnabledNotOnline {
+                    services,
+                    errors: errors.to_vec(),
+                    time_of_status: *time_of_status,
+                },
+            ))
         }
     }
 }
@@ -698,7 +723,7 @@ impl super::Nexus {
         //
         // Gather the propolis zones that currently appear in the
         // enabled-not-online lists, then look up each VMM's state concurrently
-        // and collect the ones we expect to be offline.
+        // and collect the ones we did not expect to be offline.
         // TODO-K: Clean up. This is impossible to read
         let candidate_propolis: Vec<PropolisUuid> = inventory
             .enabled_smf_services_not_online()
@@ -727,11 +752,15 @@ impl super::Nexus {
         // to do for an ObjectNotFound. Just omit it?
         //
         // TODO-K: Clean this up
-        let expected_offline_propolis = futures::future::try_join_all(
+        let unexpected_offline_propolis = futures::future::try_join_all(
             candidate_propolis.into_iter().map(|propolis_id| async move {
-                self.is_propolis_expected_offline(opctx, propolis_id)
+                self.is_propolis_unexpected_offline(opctx, propolis_id)
                     .await
-                    .map(|expected| expected.then_some(propolis_id))
+                    .map(
+                        |unexpected| {
+                            if unexpected { Some(propolis_id) } else { None }
+                        },
+                    )
             }),
         )
         .await?
@@ -752,7 +781,7 @@ impl super::Nexus {
             blueprint,
             current_target_version: current_target_version.cloned(),
             internal_update_status,
-            expected_offline_propolis,
+            unexpected_offline_propolis,
         };
 
         let problems = checks.problems();
@@ -770,7 +799,7 @@ impl super::Nexus {
     }
 
     /// Determine whether the given VMM is expected to be offline.
-    async fn is_propolis_expected_offline(
+    async fn is_propolis_unexpected_offline(
         &self,
         opctx: &OpContext,
         propolis_id: PropolisUuid,
@@ -781,18 +810,18 @@ impl super::Nexus {
                 VmmState::Stopping
                 | VmmState::Stopped
                 | VmmState::Destroyed
-                | VmmState::SagaUnwound => true,
+                | VmmState::SagaUnwound => false,
                 VmmState::Creating
                 | VmmState::Failed
                 | VmmState::Migrating
                 | VmmState::Rebooting
                 | VmmState::Running
-                | VmmState::Starting => false,
+                | VmmState::Starting => true,
             }),
             // This shouldn't happen, but the VMM record could already have been
             // reaped while its zone is still lingering for some reason. Treat
             // its offline propolis service as expected to be offline.
-            Err(Error::ObjectNotFound { .. }) => Ok(true),
+            Err(Error::ObjectNotFound { .. }) => Ok(false),
             Err(e) => Err(e),
         }
     }
@@ -1895,7 +1924,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
         assert_eq!(checks.problems(), UpdateStatusProblems::default());
 
@@ -1925,7 +1954,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
@@ -1959,7 +1988,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
@@ -1993,7 +2022,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
@@ -2029,7 +2058,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
         assert_eq!(checks.problems(), UpdateStatusProblems::default());
 
@@ -2060,7 +2089,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
@@ -2098,7 +2127,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
 
         let expected_zpool = Zpool {
@@ -2142,7 +2171,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {
@@ -2157,54 +2186,9 @@ mod test {
     }
 
     #[test]
-    fn test_problems_expected_offline_propolis_omits_sled() {
-        let logctx = test_setup_log(
-            "test_problems_expected_offline_propolis_omits_sled",
-        );
-        let blueprint = fake_blueprint(
-            &logctx.log,
-            &fake_target_version(),
-            Utc::now(),
-            false,
-        );
-        let sled_id = sled_id();
-
-        let propolis_id =
-            PropolisUuid::from_untyped_uuid(Uuid::from_u128(0xDDDD));
-        let services = SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
-            SvcsEnabledNotOnline {
-                services: vec![SvcEnabledNotOnline {
-                    fmri: "svc:/system/illumos/propolis-server:default"
-                        .to_string(),
-                    zone: format!("{PROPOLIS_ZONE_PREFIX}{propolis_id}"),
-                    state: SvcEnabledNotOnlineState::Offline,
-                }],
-                errors: vec![],
-                time_of_status: Utc::now(),
-            },
-        );
-        let collection =
-            fake_collection_with_ids(sled_id, healthy_zpools(), services);
-
-        let checks = UpdateContactSupportChecksInput {
-            inventory: Arc::new(collection),
-            stuck_sagas: Ok(vec![]),
-            blueprint,
-            current_target_version: Some(fake_target_version()),
-            internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::from([propolis_id]),
-        };
-
-        assert_eq!(checks.problems(), UpdateStatusProblems::default());
-
-        logctx.cleanup_successful();
-    }
-
-    #[test]
-    fn test_problems_expected_offline_propolis_retains_others() {
-        let logctx = test_setup_log(
-            "test_problems_expected_offline_propolis_retains_others",
-        );
+    fn test_problems_unexpected_propolis_is_reported() {
+        let logctx =
+            test_setup_log("test_problems_unexpected_propolis_is_reported");
         let blueprint = fake_blueprint(
             &logctx.log,
             &fake_target_version(),
@@ -2216,11 +2200,6 @@ mod test {
         let propolis_id =
             PropolisUuid::from_untyped_uuid(Uuid::from_u128(0xDDDD));
         let time_of_status = Utc::now();
-        let non_propolis_service = SvcEnabledNotOnline {
-            fmri: "svc:/system/test:default".to_string(),
-            zone: "global".to_string(),
-            state: SvcEnabledNotOnlineState::Maintenance,
-        };
         let services = SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
             SvcsEnabledNotOnline {
                 services: vec![
@@ -2230,7 +2209,89 @@ mod test {
                         zone: format!("{PROPOLIS_ZONE_PREFIX}{propolis_id}"),
                         state: SvcEnabledNotOnlineState::Offline,
                     },
-                    non_propolis_service.clone(),
+                    // A non-propolis service, which is always reported.
+                    SvcEnabledNotOnline {
+                        fmri: "svc:/system/test:default".to_string(),
+                        zone: "global".to_string(),
+                        state: SvcEnabledNotOnlineState::Maintenance,
+                    },
+                ],
+                errors: vec![],
+                time_of_status,
+            },
+        );
+        let collection = fake_collection_with_ids(
+            sled_id,
+            healthy_zpools(),
+            services.clone(),
+        );
+
+        let checks = UpdateContactSupportChecksInput {
+            inventory: Arc::new(collection),
+            stuck_sagas: Ok(vec![]),
+            blueprint,
+            current_target_version: Some(fake_target_version()),
+            internal_update_status: empty_internal_update_status(),
+            // The propolis VMM was not expected to be offline, so its service
+            // is a genuine problem worth reporting.
+            unexpected_offline_propolis: BTreeSet::from([propolis_id]),
+        };
+
+        // Both services are kept, unchanged.
+        let expected = UpdateStatusProblems {
+            unexpected_enabled_smf_services_not_online_by_sled: BTreeMap::from(
+                [(sled_id, services)],
+            ),
+            ..Default::default()
+        };
+        assert_eq!(checks.problems(), expected);
+
+        logctx.cleanup_successful();
+    }
+
+    #[test]
+    fn test_problems_only_unexpected_propolis_retained() {
+        let logctx =
+            test_setup_log("test_problems_only_unexpected_propolis_retained");
+        let blueprint = fake_blueprint(
+            &logctx.log,
+            &fake_target_version(),
+            Utc::now(),
+            false,
+        );
+        let sled_id = sled_id();
+
+        let unexpected_propolis_id =
+            PropolisUuid::from_untyped_uuid(Uuid::from_u128(0xDDDD));
+        let expected_propolis_id =
+            PropolisUuid::from_untyped_uuid(Uuid::from_u128(0xEEEE));
+        let time_of_status = Utc::now();
+
+        let unexpected_propolis_svc = SvcEnabledNotOnline {
+            fmri: "svc:/system/illumos/propolis-server:default".to_string(),
+            zone: format!("{PROPOLIS_ZONE_PREFIX}{unexpected_propolis_id}"),
+            state: SvcEnabledNotOnlineState::Offline,
+        };
+        let non_propolis_svc = SvcEnabledNotOnline {
+            fmri: "svc:/system/test:default".to_string(),
+            zone: "global".to_string(),
+            state: SvcEnabledNotOnlineState::Maintenance,
+        };
+        let services = SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
+            SvcsEnabledNotOnline {
+                services: vec![
+                    unexpected_propolis_svc.clone(),
+                    // Expected to be offline, so this service will not count as a
+                    // problem
+                    SvcEnabledNotOnline {
+                        fmri: "svc:/system/illumos/propolis-server:default"
+                            .to_string(),
+                        zone: format!(
+                            "{PROPOLIS_ZONE_PREFIX}{expected_propolis_id}"
+                        ),
+                        state: SvcEnabledNotOnlineState::Offline,
+                    },
+                    non_propolis_svc.clone(),
                 ],
                 errors: vec![],
                 time_of_status,
@@ -2245,7 +2306,11 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::from([propolis_id]),
+            // Only the first propolis VMM was unexpected; the second is
+            // expected to be offline and should be dropped.
+            unexpected_offline_propolis: BTreeSet::from([
+                unexpected_propolis_id,
+            ]),
         };
 
         let expected = UpdateStatusProblems {
@@ -2254,7 +2319,12 @@ mod test {
                     sled_id,
                     SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(
                         SvcsEnabledNotOnline {
-                            services: vec![non_propolis_service],
+                            // Only the unexpected enabled-not-online propolis
+                            // service and the non-propolis service are kept
+                            services: vec![
+                                unexpected_propolis_svc,
+                                non_propolis_svc,
+                            ],
                             errors: vec![],
                             time_of_status,
                         },
@@ -2297,7 +2367,7 @@ mod test {
             blueprint,
             current_target_version: Some(fake_target_version()),
             internal_update_status: empty_internal_update_status(),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
 
         let expected_zpool = Zpool {
@@ -2359,7 +2429,7 @@ mod test {
                 [missing_sled_id],
                 [sled_id],
             ),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
 
         let expected_zpool = Zpool {
@@ -2418,7 +2488,7 @@ mod test {
                 [missing_sled_id],
                 [healthy_sled_id],
             ),
-            expected_offline_propolis: BTreeSet::new(),
+            unexpected_offline_propolis: BTreeSet::new(),
         };
 
         let expected = UpdateStatusProblems {

--- a/nexus/types/src/inventory.rs
+++ b/nexus/types/src/inventory.rs
@@ -324,6 +324,9 @@ impl Collection {
             .filter_map(|sled_agent| {
                 match &sled_agent.smf_services_enabled_not_online {
                     SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(svcs)
+                    // TODO-K: Double check if this is the behaviour we want.
+                    // Looks like we're not including sleds that return with errors
+                    // in the result (These would be parsing errors)
                         if svcs.services.is_empty() =>
                     {
                         None


### PR DESCRIPTION
This could be an option on how to handle https://github.com/oxidecomputer/omicron/issues/10779. We don't go the long winded way of plumbing VMM states all the way through, but we also don't blindly exclude all propolis zones.

We already query datastore to populate the response of this endpoint so it's not a big deal to add another call. I would also argue against implementing this logic to inventory, as we want to keep the information there unbiased aka we report the state, not our judgement of it.

Closes: https://github.com/oxidecomputer/omicron/issues/10779