### PR TITLE
[28/n] [wicketd] extract the baseboard/SP-state match into a helper

### DIFF
--- a/wicketd/src/helpers.rs
+++ b/wicketd/src/helpers.rs
@@ -7,7 +7,23 @@
 use std::fmt;
 
 use itertools::Itertools;
-use wicket_common::inventory::{SpIdentifier, SpType};
+use sled_hardware_types::Baseboard;
+use wicket_common::inventory::{SpIdentifier, SpState, SpType};
+
+/// Return true if the provided baseboard matches the provided `SpState`.
+///
+/// This currently checks for equality on all of part number (model), serial
+/// number, and revision. In the future, following the definition of
+/// `BaseboardId`, we may change this to only match on the part number and
+/// serial number.
+pub(crate) fn baseboard_matches_sp_state(
+    baseboard: &Baseboard,
+    state: &SpState,
+) -> bool {
+    baseboard.model() == state.model
+        && baseboard.identifier() == state.serial_number
+        && baseboard.revision() == state.revision
+}
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub(crate) struct SpIdentifierDisplay(pub(crate) SpIdentifier);
@@ -38,4 +54,77 @@ pub(crate) fn sps_to_string<S: Into<SpIdentifierDisplay>>(
     sps: impl IntoIterator<Item = S>,
 ) -> String {
     sps.into_iter().map_into().join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use gateway_types::component::PowerState;
+    use wicket_common::inventory::RotState;
+
+    fn sp_state(model: &str, serial_number: &str, revision: u32) -> SpState {
+        SpState {
+            model: model.to_string(),
+            serial_number: serial_number.to_string(),
+            revision,
+            hubris_archive_id: "archive".to_string(),
+            base_mac_address: [0; 6],
+            power_state: PowerState::A0,
+            rot: RotState::CommunicationFailed {
+                message: "rot down".to_string(),
+            },
+        }
+    }
+
+    const MODEL: &str = "gimlet";
+    const SERIAL: &str = "BRM123";
+    const REVISION: u32 = 4;
+
+    fn baseboard() -> Baseboard {
+        // Note that Baseboard::new_gimlet takes the serial number first, which
+        // is the opposite of BaseboardId's order (model/part number first).
+        Baseboard::new_gimlet(SERIAL.to_string(), MODEL.to_string(), REVISION)
+    }
+
+    #[test]
+    fn baseboard_matches_only_when_all_three_fields_agree() {
+        assert!(
+            baseboard_matches_sp_state(
+                &baseboard(),
+                &sp_state(MODEL, SERIAL, REVISION)
+            ),
+            "the same model, serial number, and revision is a match",
+        );
+
+        // Any of the three fields being different is a reason to say no.
+        for (model, serial, revision, what) in [
+            ("cosmo", SERIAL, REVISION, "a different model"),
+            (MODEL, "BRM999", REVISION, "a different serial number"),
+            (MODEL, SERIAL, 5, "a different revision"),
+        ] {
+            assert!(
+                !baseboard_matches_sp_state(
+                    &baseboard(),
+                    &sp_state(model, serial, revision)
+                ),
+                "{what} is not a match",
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_baseboard_matches_its_own_placeholder_identity() {
+        // This shows that `Baseboard::Unknown` reports "unknown"/"unknown"/0
+        // rather than nothing. This is probably wrong and should be replaced
+        // with BaseboardId in the future.
+        assert!(baseboard_matches_sp_state(
+            &Baseboard::unknown(),
+            &sp_state("unknown", "unknown", 0)
+        ));
+        assert!(!baseboard_matches_sp_state(
+            &Baseboard::unknown(),
+            &sp_state(MODEL, SERIAL, REVISION)
+        ));
+    }
 }

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -7,6 +7,7 @@
 use crate::SmfConfigValues;
 use crate::context::CommonConfigContainer;
 use crate::context::RssOrMultirackJoinConfig;
+use crate::helpers::baseboard_matches_sp_state;
 use crate::http_helpers::ba_lockstep_client;
 use crate::http_helpers::ba_lockstep_error_to_http;
 use crate::http_helpers::mgs_inventory_or_unavail;
@@ -512,10 +513,7 @@ impl WicketdApi for WicketdApiImpl {
             } else if let (Some(sled_baseboard), Some(state)) =
                 (sled_baseboard.as_ref(), sp.state.as_ref())
             {
-                if sled_baseboard.identifier() == state.serial_number
-                    && sled_baseboard.model() == state.model
-                    && sled_baseboard.revision() == state.revision
-                {
+                if baseboard_matches_sp_state(sled_baseboard, state) {
                     sled_id = Some(sp.id);
                 }
             }

--- a/wicketd/src/http_helpers.rs
+++ b/wicketd/src/http_helpers.rs
@@ -23,6 +23,7 @@ use wicketd_commission_types::update::UpdateTargets;
 
 use crate::ServerContext;
 use crate::helpers::SpIdentifierDisplay;
+use crate::helpers::baseboard_matches_sp_state;
 use crate::helpers::sps_to_string;
 use crate::mgs::GetInventoryResponse;
 use crate::mgs::MgsHandle;
@@ -235,10 +236,7 @@ pub(crate) async fn start_update(
         // refuse to try to update our own sled.
         match &ctx.baseboard {
             Some(baseboard) => {
-                if baseboard.identifier() == sp_state.serial_number
-                    && baseboard.model() == sp_state.model
-                    && baseboard.revision() == sp_state.revision
-                {
+                if baseboard_matches_sp_state(baseboard, sp_state) {
                     self_update = Some(*target);
                     continue;
                 }


### PR DESCRIPTION
This determination is used in a couple of spots, and we're going to add a third one soon.

This is a pure refactor with no functional changes (other than swapping the model/part number and serial number order for consistency with `BaseboardId`), though it raises a few questions that need to be answered in the future.
