### PR TITLE
[integration-tests] fix test_disk_attach_limit flake

### DIFF
--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -5213,17 +5213,44 @@ async fn test_disk_attach_limit(cptestctx: &ControlPlaneTestContext) {
 
     let project_name = "bit-barrel";
 
-    // Each 1 GB Crucible disk requires 1.25 GB overhead. With the default size
-    // for DiskTest of 16 GB disks, this means 12 regions can be allocated on
-    // each zpool. This means 4 disks per pool.
+    // Each 1 GiB Crucible disk reserves 1.25 GiB (a 25% overhead). With the
+    // default DiskTest zpool size of 16 GiB, 12 regions fit on each zpool.
+    // This test creates 13 1 GiB disks, or 39 regions. Allocation needs 3
+    // distinct zpools per disk, so it fails once fewer than 3 zpools have room
+    // -- no matter how much space is left on the ones that aren't full. The
+    // allocator picks those 3 zpools uniformly at random, with no capacity
+    // weighting, so it does not pack evenly.
     //
-    // This test creates 13 1 GB disks, so we need 4 pools.
+    // So why create 6 zpools here? We do that to avoid test flakes with a
+    // smaller number of zpools. It's illustrative to walk through what happens
+    // when we choose to create a smaller number of zpools.
+    //
+    // Let's say we create 4 zpools. Then, each disk is a uniform "4 choose 3"
+    // selection, or equivalently "4 choose 1" to skip. A zpool gains at most
+    // one region per disk, so it cannot reach 12 before the 12th disk: for the
+    // first 12 disks, all 4 zpools always have room. But consider what happens
+    // with the 13th disk.
+    //
+    // Disk 13 will fail to allocate when at least two zpools are full, i.e.
+    // regions allocated per zpool is of the form {12, 12, m, n}, where the
+    // order of zpools is arbitrary and m + n = 12 (the first 12 disks having
+    // placed 36 regions). A zpool is full exactly when it was never skipped,
+    // so a given pair is both-full exactly when all 12 skips landed on the
+    // other two: a probability of (2/4)^12, or 1/4096. There are C(4,2) = 6
+    // such pairs, which leads to a 6/4096 - ε flake rate, where ε is a small
+    // error factor due to inclusion-exclusion (selections of the form
+    // {12, 12, 12, 0}). That's approximately 0.15%, or 1 run in 700.
+    //
+    // What about 5 zpools? It is possible to end up in the state
+    // {12, 12, 12, 0, 0}, but that requires all 12 disks to have picked the
+    // same 3 zpools out of C(5,3) = 10, i.e. (1/10)^11. The flake is much
+    // rarer, but still possible.
+    //
+    // With 6 zpools, 36 regions can saturate at most 3 of them, so the worst
+    // case is {12, 12, 12, 0, 0, 0} -- the 13th disk will bring this up to
+    // {12, 12, 12, 1, 1, 1}. As a result, the flake becomes impossible.
 
-    DiskTestBuilder::new(&cptestctx)
-        .on_all_sleds()
-        .with_zpool_count(4)
-        .build()
-        .await;
+    DiskTestBuilder::new(&cptestctx).with_zpool_count(6).build().await;
 
     create_project(client, project_name).await;
 


### PR DESCRIPTION
Fix [this flake](https://buildomat.eng.oxide.computer/wg/0/details/01KYB7G2ZKGFG7VFK919CPMP7G/d311Bqeq2AmgeY07idmCRkV1mwecfAyfFKV5cShb7gkDAqUS/01KYB7GG5FR8JAVTA77VGME47J) that occurs around 1 time in 700.

Fixes #10300.