### PR TITLE
Oximeter: Cache `FieldSet` values.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10674,6 +10674,7 @@ dependencies = [
  "rstest",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
  "strum 0.27.2",
  "thiserror 2.0.18",
  "uuid",

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -13,6 +13,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 camino.workspace = true
 chrono.workspace = true
+serde_json.workspace = true
 clap.workspace = true
 dropshot.workspace = true
 futures.workspace = true

--- a/oximeter/collector/src/collection_task.rs
+++ b/oximeter/collector/src/collection_task.rs
@@ -10,14 +10,18 @@ use crate::self_stats;
 use chrono::DateTime;
 use chrono::Utc;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
+use oximeter::types::FieldSetCache;
 use oximeter::types::ProducerResults;
 use oximeter::types::ProducerResultsItem;
+use oximeter::types::RawProducerResults;
+use oximeter::types::RawProducerResultsItem;
 use oximeter_types::producer::FailedCollection;
 use oximeter_types::producer::ProducerDetails;
 use oximeter_types::producer::SuccessfulCollection;
 use slog::Logger;
 use slog::debug;
 use slog::error;
+use slog::info;
 use slog::o;
 use slog::trace;
 use slog::warn;
@@ -75,6 +79,8 @@ struct SingleCollectionResult {
     result: Result<ProducerResults, self_stats::FailureReason>,
     /// The duration the collection took.
     duration: Duration,
+
+    cache: FieldSetCache,
 }
 
 /// Run a single collection from the producer.
@@ -82,6 +88,7 @@ async fn perform_collection(
     log: Logger,
     client: reqwest::Client,
     producer: ProducerEndpoint,
+    mut cache: FieldSetCache,
 ) -> SingleCollectionResult {
     let start = Instant::now();
     debug!(log, "collecting from producer");
@@ -96,30 +103,25 @@ async fn perform_collection(
     let result = match res {
         Ok(res) => {
             if res.status().is_success() {
-                match res.json::<ProducerResults>().await {
-                    Ok(results) => {
-                        let n_samples: usize = results
-                            .iter()
-                            .map(|r| match r {
-                                ProducerResultsItem::Ok(samples) => {
-                                    samples.len()
-                                }
-                                ProducerResultsItem::Err(_) => 0,
-                            })
-                            .sum();
-                        debug!(
-                            log,
-                            "collected results from producer";
-                            "n_results" => results.len(),
-                            "n_samples" => n_samples,
-                        );
-                        Ok(results)
+                match res.bytes().await {
+                    Ok(body) => {
+                        match parse_producer_body(&body, &mut cache, &log) {
+                            Ok(results) => Ok(results),
+                            Err(err) => {
+                                warn!(
+                                    log,
+                                    "failed to collect results from producer";
+                                    InlineErrorChain::new(&err),
+                                );
+                                Err(self_stats::FailureReason::Deserialization)
+                            }
+                        }
                     }
-                    Err(e) => {
+                    Err(err) => {
                         warn!(
                             log,
                             "failed to collect results from producer";
-                            InlineErrorChain::new(&e),
+                            InlineErrorChain::new(&err),
                         );
                         Err(self_stats::FailureReason::Deserialization)
                     }
@@ -143,7 +145,40 @@ async fn perform_collection(
         }
     };
     emit_dtrace_probes(&producer.id, result.as_ref());
-    SingleCollectionResult { result, duration: start.elapsed() }
+    SingleCollectionResult { result, duration: start.elapsed(), cache }
+}
+
+fn parse_producer_body(
+    body: &[u8],
+    cache: &mut FieldSetCache,
+    log: &Logger,
+) -> Result<ProducerResults, serde_json::Error> {
+    let raw_results = serde_json::from_slice::<RawProducerResults>(&body)?;
+    let n_samples: usize = raw_results
+        .iter()
+        .map(|r| match r {
+            RawProducerResultsItem::Ok(samples) => samples.len(),
+            RawProducerResultsItem::Err(_) => 0,
+        })
+        .sum();
+    debug!(
+        log,
+        "collected results from producer";
+        "n_results" => raw_results.len(),
+        "n_samples" => n_samples,
+    );
+    let results = raw_results
+        .into_iter()
+        .map(|raw| raw.to_producer_result(cache))
+        .collect::<Result<Vec<_>, _>>()?;
+    let cache_stats = cache.purge();
+    let cache_gets = (cache_stats.hits + cache_stats.misses).max(1);
+    info!(log, "fieldset cache";
+        "hits" => cache_stats.hits,
+        "misses" => cache_stats.misses,
+        "hit_rate" => format!("{:.3}", cache_stats.hits as f64 / cache_gets as f64),
+    );
+    Ok(results)
 }
 
 // NOTE: We have some non-zero disabled-probe cost here, because we're deciding
@@ -237,6 +272,7 @@ async fn collection_loop(
         // Safety: `build()` only fails if TLS couldn't be initialized or the
         // system DNS configuration could not be loaded.
         .unwrap();
+    let mut cache = FieldSetCache::new();
     loop {
         // Wait for notification that we have a collection to perform, from
         // either the forced- or timer-collection queue.
@@ -282,12 +318,13 @@ async fn collection_loop(
             log.clone(),
             client.clone(),
             *producer_info_rx.borrow_and_update(),
+            cache,
         ));
 
         // Wait for that collection to complete or fail, or for an update to the
         // producer's information. In the latter case, recreate the future for
         // the collection itself with the new producer information.
-        let SingleCollectionResult { result, duration } = 'collection: loop {
+        let SingleCollectionResult { result, duration, cache: new_cache } = 'collection: loop {
             tokio::select! {
                 biased;
 
@@ -313,6 +350,7 @@ async fn collection_loop(
                                 log.new(o!("address" => update.address)),
                                 client.clone(),
                                 update,
+                                FieldSetCache::new(),
                             ));
                             continue 'collection;
                         }
@@ -333,6 +371,7 @@ async fn collection_loop(
                 }
             }
         };
+        cache = new_cache;
 
         // Now that the collection has completed, send on the results, along
         // with the timing information we got with the request.

--- a/oximeter/types/versions/Cargo.toml
+++ b/oximeter/types/versions/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 approx.workspace = true

--- a/oximeter/types/versions/src/impls/cache.rs
+++ b/oximeter/types/versions/src/impls/cache.rs
@@ -1,0 +1,134 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::v1::types::FieldSet;
+
+/// Cache mapping raw field JSON to parsed fieldsets.
+///
+/// Oximeter receives the full set of field labels and values for each
+/// sample. This fieldset metadata may repeat across samples, both within
+/// and between collections, for a given collection task. To avoid the work
+/// of re-parsing fieldsets that we've already encountered, we cache the
+/// mapping from raw JSON strings to parsed fieldsets, and only parse
+/// incoming fieldset strings on cache misses. To avoid the fieldset cache
+/// growing too large, we only retain cache entries that were accessed on
+/// the previous run of the collection task.
+///
+/// Note: the hit rate of the cache depends on producers serializing
+/// fieldsets in a consistent field order. Producers that use `FieldSet`
+/// to represent fields get this property for free, since fields are
+/// collected into a `BTreeMap`, which orders fields alphabetically.
+pub struct FieldSetCache {
+    fieldsets: HashMap<Box<str>, CachedFieldSet>,
+    stats: CacheStats,
+}
+
+struct CachedFieldSet {
+    fieldset: Arc<FieldSet>,
+    seen: bool,
+}
+
+#[derive(Default)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+}
+
+impl FieldSetCache {
+    pub fn new() -> Self {
+        Self { fieldsets: HashMap::new(), stats: CacheStats::default() }
+    }
+
+    pub(crate) fn get(
+        &mut self,
+        key: &str,
+    ) -> Result<Arc<FieldSet>, serde_json::Error> {
+        if let Some(cached_fieldset) = self.fieldsets.get_mut(key) {
+            self.stats.hits += 1;
+            cached_fieldset.seen = true;
+            Ok(Arc::clone(&cached_fieldset.fieldset))
+        } else {
+            self.stats.misses += 1;
+            let fieldset = Arc::new(serde_json::from_str::<FieldSet>(&key)?);
+            self.fieldsets.insert(
+                Box::from(key),
+                CachedFieldSet { fieldset: Arc::clone(&fieldset), seen: true },
+            );
+            Ok(fieldset)
+        }
+    }
+
+    /// Remove stale entries from the cache.
+    ///
+    /// To limit the growth of the cache as series churn, we mark each entry
+    /// as `seen` when it's fetched or created via `get()`. After each
+    /// collection, the collection task calls `purge()`, removing any entries
+    /// not `seen` since the previous call to `purge`. This limits the size of
+    /// the cache to the unique `FieldSet` values seen during a single
+    /// collection.
+    ///
+    /// Note: this is a simplified version of the scrape cache used in
+    /// Prometheus. Unlike the Prometheus implementation, we only retain
+    /// fieldsets accessed on the previous collection, rather than retaining for
+    /// multiple generations. If we find that a given fieldset may occur every
+    /// Nth collection, but not every collection, we'll consider adopting a
+    /// model like Prometheus's, which retains cached fieldsets for multiple
+    /// collections.
+    ///
+    /// Returns cache stats on purge.
+    pub fn purge(&mut self) -> CacheStats {
+        self.fieldsets.retain(|_, cached_fieldset| {
+            let seen = cached_fieldset.seen;
+            cached_fieldset.seen = false;
+            seen
+        });
+        std::mem::take(&mut self.stats)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::v1::types::{Field, FieldValue};
+
+    use super::*;
+
+    #[test]
+    fn get_miss() {
+        let mut cache = FieldSetCache::new();
+
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "field1".to_string(),
+            Field {
+                name: "field1".to_string(),
+                value: FieldValue::String("foo".into()),
+            },
+        );
+        fields.insert(
+            "field2".to_string(),
+            Field {
+                name: "field2".to_string(),
+                value: FieldValue::String("bar".into()),
+            },
+        );
+        let fs = FieldSet { name: "t".to_string(), fields };
+        let key = serde_json::to_string(&fs).unwrap();
+
+        // Cache miss: stats updated.
+        let value_miss = cache.get(key.as_str()).unwrap();
+        assert_eq!(cache.stats.hits, 0);
+        assert_eq!(cache.stats.misses, 1);
+
+        // Cache hit: pointer matches original Arc<FieldSet>, stats updated.
+        let value_hit = cache.get(key.as_str()).unwrap();
+        assert!(Arc::ptr_eq(&value_miss, &value_hit));
+        assert_eq!(cache.stats.hits, 1);
+        assert_eq!(cache.stats.misses, 1);
+    }
+}

--- a/oximeter/types/versions/src/impls/mod.rs
+++ b/oximeter/types/versions/src/impls/mod.rs
@@ -4,6 +4,7 @@
 
 //! Functional code for the latest versions of types.
 
+pub(crate) mod cache;
 pub(crate) mod histogram;
 mod producer;
 pub(crate) mod quantile;

--- a/oximeter/types/versions/src/impls/types.rs
+++ b/oximeter/types/versions/src/impls/types.rs
@@ -644,8 +644,8 @@ impl Sample {
         Ok(Self {
             timeseries_name,
             timeseries_version: target.version(),
-            target: target_fields,
-            metric: metric_fields,
+            target: target_fields.into(),
+            metric: metric_fields.into(),
             measurement: metric.measure(timestamp),
         })
     }
@@ -676,8 +676,8 @@ impl Sample {
         Ok(Self {
             timeseries_name,
             timeseries_version: target.version(),
-            target: target_fields,
-            metric: metric_fields,
+            target: target_fields.into(),
+            metric: metric_fields.into(),
             measurement: Measurement { timestamp, datum },
         })
     }

--- a/oximeter/types/versions/src/initial/types.rs
+++ b/oximeter/types/versions/src/initial/types.rs
@@ -6,6 +6,7 @@
 
 use super::histogram;
 use super::schema::TimeseriesName;
+use crate::impls::cache::FieldSetCache;
 use crate::impls::traits::Producer;
 use bytes::Bytes;
 use chrono::DateTime;
@@ -15,6 +16,7 @@ use parse_display::FromStr;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_json::value::RawValue;
 use std::borrow::Cow;
 use std::boxed::Box;
 use std::collections::BTreeMap;
@@ -282,10 +284,49 @@ pub struct Sample {
     pub timeseries_version: NonZeroU8,
 
     // Target name and fields
-    pub(crate) target: FieldSet,
+    pub(crate) target: Arc<FieldSet>,
 
     // Metric name and fields
-    pub(crate) metric: FieldSet,
+    pub(crate) metric: Arc<FieldSet>,
+}
+
+/// A concrete type representing a single, timestamped measurement from a timeseries.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RawSample<'a> {
+    /// The measured value of the metric at this sample
+    pub measurement: Measurement,
+
+    /// The name of the timeseries this sample belongs to
+    pub timeseries_name: TimeseriesName,
+
+    /// The version of the timeseries this sample belongs to
+    //
+    // TODO-cleanup: This should be removed once schema are tracked in CRDB.
+    #[serde(default = "super::schema::default_schema_version")]
+    pub timeseries_version: NonZeroU8,
+
+    // Target name and fields
+    #[serde(borrow)]
+    pub(crate) target: &'a RawValue,
+
+    // Metric name and fields
+    #[serde(borrow)]
+    pub(crate) metric: &'a RawValue,
+}
+
+impl<'a> RawSample<'a> {
+    pub fn to_sample(
+        self,
+        cache: &mut FieldSetCache,
+    ) -> Result<Sample, serde_json::Error> {
+        Ok(Sample {
+            measurement: self.measurement,
+            timeseries_name: self.timeseries_name,
+            timeseries_version: self.timeseries_version,
+            target: cache.get(self.target.get())?,
+            metric: cache.get(self.metric.get())?,
+        })
+    }
 }
 
 type ProducerList = Vec<Box<dyn Producer>>;
@@ -296,6 +337,34 @@ pub enum ProducerResultsItem {
     Err(MetricsError),
 }
 pub type ProducerResults = Vec<ProducerResultsItem>;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "status", content = "info", rename_all = "snake_case")]
+pub enum RawProducerResultsItem<'a> {
+    Ok(#[serde(borrow)] Vec<RawSample<'a>>),
+    Err(MetricsError),
+}
+
+impl<'a> RawProducerResultsItem<'a> {
+    pub fn to_producer_result(
+        self,
+        cache: &mut FieldSetCache,
+    ) -> Result<ProducerResultsItem, serde_json::Error> {
+        match self {
+            Self::Ok(raw_samples) => Ok(ProducerResultsItem::Ok(
+                raw_samples
+                    .into_iter()
+                    .map(|raw_sample| raw_sample.to_sample(cache))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            Self::Err(metrics_error) => {
+                Ok(ProducerResultsItem::Err(metrics_error))
+            }
+        }
+    }
+}
+
+pub type RawProducerResults<'a> = Vec<RawProducerResultsItem<'a>>;
 
 /// The `ProducerRegistry` is a centralized collection point for metrics in consumer code.
 #[derive(Debug, Clone)]

--- a/oximeter/types/versions/src/latest.rs
+++ b/oximeter/types/versions/src/latest.rs
@@ -64,6 +64,8 @@ pub mod traits {
 }
 
 pub mod types {
+    pub use crate::impls::cache::CacheStats;
+    pub use crate::impls::cache::FieldSetCache;
     pub use crate::v1::types::Cumulative;
     pub use crate::v1::types::Datum;
     pub use crate::v1::types::DatumType;
@@ -76,6 +78,8 @@ pub mod types {
     pub use crate::v1::types::ProducerRegistry;
     pub use crate::v1::types::ProducerResults;
     pub use crate::v1::types::ProducerResultsItem;
+    pub use crate::v1::types::RawProducerResults;
+    pub use crate::v1::types::RawProducerResultsItem;
     pub use crate::v1::types::Sample;
 
     // Use by both type definition and impls, but not pub.


### PR DESCRIPTION
Oximeter spends a meaningful chunk of cpu time, and a meaningful number of allocations, parsing `FieldSet` values from incoming json. Because we encounter the same `FieldSet` values many times each, we can avoid a measureable amount of work by caching parsed `FieldSet` values, keying on unparsed `RawValue` values.

Note: I'm marking this as a draft until I can also check in the benchmarking scripts I've been using to test this. So far, oximeter cpu/memory use look significantly better with this change, as does throughput, which should also help us #10552. But I want to be a bit more rigorous about the benchmarks before I call this change ready.