### PR TITLE
Add static assertion for latest `WriteNetworkConfigRequest` alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13986,6 +13986,7 @@ dependencies = [
  "sled-diagnostics",
  "sled-hardware-types",
  "slog-error-chain",
+ "static_assertions",
  "trust-quorum-types",
  "tufaceous-artifact 0.1.0",
  "uuid",

--- a/sled-agent/api/Cargo.toml
+++ b/sled-agent/api/Cargo.toml
@@ -25,6 +25,7 @@ sled-agent-types.workspace = true
 sled-diagnostics.workspace = true
 sled-hardware-types.workspace = true
 slog-error-chain.workspace = true
+static_assertions.workspace = true
 tufaceous-artifact.workspace = true
 trust-quorum-types.workspace = true
 uuid.workspace = true

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -948,7 +948,25 @@ pub trait SledAgentApi {
     // (i.e., faithfully serialize the _old_ format into the bootstore). The
     // latest version does _not_ use the `latest::*` type alias to be a gentle
     // stumbling block toward this comment.
+    //
+    // This pattern opens the door for the opposite problem, too: what if we
+    // forget to add a new `write_network_bootstore_config_v*` endpoint when
+    // adding a new `WriteNetworkConfigRequest` type? `sled-agent-client` uses a
+    // `replace` directive pointed to `latest`, which will silently do the wrong
+    // thing: it will allow calling the most recent
+    // `write_network_bootstore_config_v*` endpoint defined here even though
+    // these types explicitly do not use the `latest` alias. To guard against
+    // this, the `static_assert_latest_write_network_config_type()` function
+    // below contains a compile-time check that the `latest` alias matches a
+    // specific version: when adding a new `write_network_bootstore_config_v*`
+    // endpoint, also update this assertion.
     // -------------------------------------------------------------------------
+    fn static_assert_latest_write_network_config_type() {
+        static_assertions::assert_type_eq_all!(
+            v42::system_networking::WriteNetworkConfigRequest,
+            latest::system_networking::WriteNetworkConfigRequest
+        );
+    }
 
     // As described above, this must not forward to newer versions; sled-agent
     // must implement this by faithfully serializing the requested version.


### PR DESCRIPTION
This is followup from https://github.com/oxidecomputer/omicron/pull/10572#discussion_r3658799347: on that PR, we added a new `WriteNetworkConfigRequest` type for a bootstore bump, but didn't add a corresponding new sled-agent API to handle it, and there were no compile time or test time failures to point out the oversight.

The sled-agent API intentionally and explicitly does not use the `latest` alias for reasons explained in a long block comment; this PR extends that block comment and adds a static assertion checking that `latest` points to a specific version. This will have to be kept in sync manually when adding new bootstore type versions; I _think_ that's acceptable overhead, is better than silently allowing the wrong thing, and I'm not sure how to make this easier without introducing similar footguns as those we're trying to avoid.

If I patch this onto #10572 in its current state, I get this compilation error:

```
error: could not compile `sled-agent-api` (lib) due to 1 previous error
error[E0271]: type mismatch resolving `<WriteNetworkConfigRequest as TypeEq>::This == WriteNetworkConfigRequest`
   --> sled-agent/api/src/lib.rs:965:13
    |
965 |             v42::system_networking::WriteNetworkConfigRequest,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<WriteNetworkConfigRequest as TypeEq>::This == WriteNetworkConfigRequest`
    |
note: expected this to be `sled_agent_types_versions::latest::system_networking::WriteNetworkConfigRequest`
   --> sled-agent/api/src/lib.rs:964:9
    |
964 | /         static_assertions::assert_type_eq_all!(
965 | |             v42::system_networking::WriteNetworkConfigRequest,
966 | |             latest::system_networking::WriteNetworkConfigRequest
967 | |         );
    | |_________^
note: required by a bound in `assert_type_eq_all`
   --> sled-agent/api/src/lib.rs:964:9
    |
964 | /         static_assertions::assert_type_eq_all!(
965 | |             v42::system_networking::WriteNetworkConfigRequest,
966 | |             latest::system_networking::WriteNetworkConfigRequest
967 | |         );
    | |         ^
    | |         |
    | |_________required by a bound in this function
    |           required by this bound in `assert_type_eq_all`
    = note: this error originates in the macro `static_assertions::assert_type_eq_all` (in Nightly builds, run with -Z macro-backtrace for more info)
```

which hopefully sticks out enough that we know to (a) bump that v42 to v43 and (b) read the attached comment and add a `write_network_bootstore_config_v43()` endpoint.