### PR TITLE
[fm] enforce an upper bound on sitreps, abandon old history

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+./.claude/skills

--- a/.agents/skills
+++ b/.agents/skills
@@ -1,1 +1,0 @@
-./.claude/skills

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -3599,6 +3599,7 @@ fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
         end_time,
         report: analysis_report,
         outcome,
+        capacity,
     } = analysis_status;
     match outcome {
         AnalysisOutcome::Error(error) => {
@@ -3609,6 +3610,13 @@ fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
                 "    no changes from the current situation report ({:?})",
                 parent_sitrep_id
             );
+        }
+        AnalysisOutcome::LimitReached { limit } => {
+            println!(
+                "{ERRICON}   analysis succeeded, but the database sitrep \
+                 limit ({limit} sitreps) has been reached!"
+            );
+            println!("    no new sitrep was written.");
         }
         AnalysisOutcome::NotCommitted { sitrep_id } => {
             println!(
@@ -3640,6 +3648,13 @@ fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
         for error in warnings {
             println!("      > {error}")
         }
+    }
+
+    if let Some(capacity) = capacity {
+        let usage_percent = capacity.usage_percent();
+        println!("    sitrep storage capacity: {usage_percent}% used");
+        println!("      limit: {}", capacity.limit);
+        println!("      count: {}", capacity.count);
     }
 
     let PreparationStatus { warnings, report: prep_report } = prep_status;

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -3653,8 +3653,8 @@ fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
     if let Some(capacity) = capacity {
         let usage_percent = capacity.usage_percent();
         println!("    sitrep storage capacity: {usage_percent}% used");
-        println!("      limit: {}", capacity.limit);
-        println!("      count: {}", capacity.count);
+        println!("      limit: {:>6}", capacity.limit);
+        println!("      count: {:>6}", capacity.count);
     }
 
     let PreparationStatus { warnings, report: prep_report } = prep_status;
@@ -3701,7 +3701,11 @@ fn print_task_fm_sitrep_loader(details: &serde_json::Value) {
 }
 
 fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
+    use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningStatus;
+
     let SitrepGcStatus {
+        history_pruning_status,
+        history_limit,
         orphaned_sitreps_deleted,
         sitrep_metadata_batches,
         batch_size,
@@ -3718,6 +3722,41 @@ fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
         Ok(status) => status,
     };
 
+    println!("    pruning sitrep history table:");
+    const HISTORY_LIMIT: &str = "max sitreps to keep:";
+    const STATUS: &str = "status:";
+    const SITREP_COUNT: &str = "current count:";
+    const PRUNED: &str = "sitreps pruned:";
+    const LATEST_VERSION_PRUNED: &str = "latest version pruned:";
+    const P_WIDTH: usize = const_max_len(&[
+        HISTORY_LIMIT,
+        SITREP_COUNT,
+        PRUNED,
+        LATEST_VERSION_PRUNED,
+    ]) + 1;
+    println!("      {HISTORY_LIMIT:<P_WIDTH$}{history_limit:>NUM_WIDTH$}");
+    match history_pruning_status {
+        Err(error) => {
+            println!("{ERRICON}   {STATUS}: failed!");
+            println!("        > {error}")
+        }
+        Ok(HistoryPruningStatus::BelowLimit { count }) => {
+            println!("      {STATUS}: below limit (no sitreps pruned)");
+            println!("      {SITREP_COUNT:<P_WIDTH$}{count:>NUM_WIDTH$}");
+        }
+        Ok(HistoryPruningStatus::Pruned {
+            n_pruned,
+            newest_version_pruned,
+        }) => {
+            println!("      {STATUS}: limit reached");
+            println!("      {PRUNED:<P_WIDTH$}{n_pruned:>NUM_WIDTH$}");
+            println!(
+                "      {LATEST_VERSION_PRUNED:<P_WIDTH$}v{newest_version_pruned}"
+            );
+        }
+    }
+
+    println!("    garbage collecting orphaned sitreps:");
     const BASE_WIDTH: usize = 40;
     const NUM_WIDTH: usize = 4;
 
@@ -3741,27 +3780,27 @@ fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
         }
     }
 
-    println!("    {:<width$}{batch_size:>NUM_WIDTH$}", "batch size:");
+    println!("      {:<width$}{batch_size:>NUM_WIDTH$}", "batch size:");
     println!(
-        "    {:<width$}{orphaned_sitreps_deleted:>NUM_WIDTH$}",
+        "      {:<width$}{orphaned_sitreps_deleted:>NUM_WIDTH$}",
         "orphaned sitreps deleted:"
     );
     println!(
-        "    {:<width$}{sitrep_metadata_batches:>NUM_WIDTH$}",
+        "      {:<width$}{sitrep_metadata_batches:>NUM_WIDTH$}",
         "  batches:"
     );
 
     if child_tables.is_empty() {
-        eprintln!("(!)   warning: no child tables reported (likely a bug)");
+        eprintln!("(!)     warning: no child tables reported (likely a bug)");
     }
 
     for (table_name, stats) in &child_tables {
         println!(
-            "    {:<width$}{:>NUM_WIDTH$}",
+            "      {:<width$}{:>NUM_WIDTH$}",
             format!("orphaned {table_name} rows deleted:"),
             stats.rows_deleted,
         );
-        println!("    {:<width$}{:>NUM_WIDTH$}", "  batches:", stats.batches,);
+        println!("      {:<width$}{:>NUM_WIDTH$}", "  batches:", stats.batches);
     }
 }
 

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -3740,15 +3740,15 @@ fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
             println!("{ERRICON}   {STATUS} failed!");
             println!("        > {error}")
         }
-        Ok(HistoryPruningStatus::BelowLimit { count }) => {
-            println!("      {STATUS} below limit (no sitreps pruned)");
+        Ok(HistoryPruningStatus::NotPruned { count }) => {
+            println!("      {STATUS} no sitreps pruned");
             println!("      {SITREP_COUNT:<P_WIDTH$}{count:>NUM_WIDTH$}");
         }
         Ok(HistoryPruningStatus::Pruned {
             n_pruned,
             newest_version_pruned,
         }) => {
-            println!("      {STATUS} limit reached");
+            println!("      {STATUS} history limit reached");
             println!("      {PRUNED:<P_WIDTH$}{n_pruned:>NUM_WIDTH$}");
             println!(
                 "      {LATEST_VERSION_PRUNED:<P_WIDTH$}v{newest_version_pruned}"

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -3701,11 +3701,18 @@ fn print_task_fm_sitrep_loader(details: &serde_json::Value) {
 }
 
 fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
+    use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningOutcome;
     use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningStatus;
 
     let SitrepGcStatus {
-        history_pruning_status,
         history_limit,
+        history_pruning_status:
+            HistoryPruningStatus {
+                batches: pruning_batches,
+                sitreps_pruned,
+                versions_pruned,
+            },
+        history_pruning_outcome,
         orphaned_sitreps_deleted,
         sitrep_metadata_batches,
         batch_size,
@@ -3727,33 +3734,44 @@ fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
     const STATUS: &str = "status:";
     const SITREP_COUNT: &str = "current count:";
     const PRUNED: &str = "sitreps pruned:";
-    const LATEST_VERSION_PRUNED: &str = "latest version pruned:";
+    const VERSIONS_PRUNED: &str = "versions pruned:";
+    const PRUNE_BATCHES: &str = "batches:";
+    const BATCH_SIZE: &str = "batch size:";
     const P_WIDTH: usize = const_max_len(&[
         HISTORY_LIMIT,
         SITREP_COUNT,
         PRUNED,
-        LATEST_VERSION_PRUNED,
+        VERSIONS_PRUNED,
+        PRUNE_BATCHES,
+        BATCH_SIZE,
     ]) + 1;
     println!("      {HISTORY_LIMIT:<P_WIDTH$}{history_limit:>NUM_WIDTH$}");
-    match history_pruning_status {
-        Err(error) => {
+    match history_pruning_outcome {
+        HistoryPruningOutcome::Error(error) => {
             println!("{ERRICON}   {STATUS} failed!");
             println!("        > {error}")
         }
-        Ok(HistoryPruningStatus::NotPruned { count }) => {
-            println!("      {STATUS} no sitreps pruned");
+        HistoryPruningOutcome::NotPruned { count } => {
+            println!("      {STATUS} within limit (nothing was deleted)");
             println!("      {SITREP_COUNT:<P_WIDTH$}{count:>NUM_WIDTH$}");
         }
-        Ok(HistoryPruningStatus::Pruned {
-            n_pruned,
-            newest_version_pruned,
-        }) => {
-            println!("      {STATUS} history limit reached");
-            println!("      {PRUNED:<P_WIDTH$}{n_pruned:>NUM_WIDTH$}");
-            println!(
-                "      {LATEST_VERSION_PRUNED:<P_WIDTH$}v{newest_version_pruned}"
-            );
+        HistoryPruningOutcome::Pruned { count } => {
+            println!("      {STATUS} limit reached (old sitreps were deleted)");
+            println!("      {SITREP_COUNT:<P_WIDTH$}{count:>NUM_WIDTH$}");
         }
+    }
+
+    // If anything was deleted, including partial progress made before a
+    // query failed, display the details of what was pruned.
+    if sitreps_pruned > 0 {
+        println!("      {PRUNED:<P_WIDTH$}{sitreps_pruned:>NUM_WIDTH$}");
+        if let Some(versions) = versions_pruned {
+            println!("      {VERSIONS_PRUNED:<P_WIDTH$}v{versions:?}");
+        }
+        println!(
+            "      {PRUNE_BATCHES:<P_WIDTH$}{pruning_batches:>NUM_WIDTH$}"
+        );
+        println!("      {BATCH_SIZE:<P_WIDTH$}{batch_size:>NUM_WIDTH$}");
     }
 
     println!("    garbage collecting orphaned sitreps:");
@@ -3780,7 +3798,7 @@ fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
         }
     }
 
-    println!("      {:<width$}{batch_size:>NUM_WIDTH$}", "batch size:");
+    println!("      {BATCH_SIZE:<width$}{batch_size:>NUM_WIDTH$}");
     println!(
         "      {:<width$}{orphaned_sitreps_deleted:>NUM_WIDTH$}",
         "orphaned sitreps deleted:"

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -3737,18 +3737,18 @@ fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
     println!("      {HISTORY_LIMIT:<P_WIDTH$}{history_limit:>NUM_WIDTH$}");
     match history_pruning_status {
         Err(error) => {
-            println!("{ERRICON}   {STATUS}: failed!");
+            println!("{ERRICON}   {STATUS} failed!");
             println!("        > {error}")
         }
         Ok(HistoryPruningStatus::BelowLimit { count }) => {
-            println!("      {STATUS}: below limit (no sitreps pruned)");
+            println!("      {STATUS} below limit (no sitreps pruned)");
             println!("      {SITREP_COUNT:<P_WIDTH$}{count:>NUM_WIDTH$}");
         }
         Ok(HistoryPruningStatus::Pruned {
             n_pruned,
             newest_version_pruned,
         }) => {
-            println!("      {STATUS}: limit reached");
+            println!("      {STATUS} limit reached");
             println!("      {PRUNED:<P_WIDTH$}{n_pruned:>NUM_WIDTH$}");
             println!(
                 "      {LATEST_VERSION_PRUNED:<P_WIDTH$}v{newest_version_pruned}"

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -1385,6 +1385,9 @@ fn print_task_details(
         "fm_sitrep_gc" => {
             print_task_fm_sitrep_gc(details);
         }
+        "fm_sitrep_history_pruner" => {
+            print_task_fm_sitrep_history_pruner(details);
+        }
         "fm_rendezvous" => {
             print_task_fm_rendezvous(details);
         }
@@ -3700,19 +3703,76 @@ fn print_task_fm_sitrep_loader(details: &serde_json::Value) {
     };
 }
 
-fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
-    use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningOutcome;
-    use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningStatus;
+fn print_task_fm_sitrep_history_pruner(details: &serde_json::Value) {
+    use nexus_types::internal_api::background::SitrepHistoryPrunerStatus;
+    use nexus_types::internal_api::background::fm_sitrep_history_pruner::{
+        Outcome, SitrepsPruned,
+    };
 
-    let SitrepGcStatus {
+    let SitrepHistoryPrunerStatus {
         history_limit,
-        history_pruning_status:
-            HistoryPruningStatus {
-                batches: pruning_batches,
-                sitreps_pruned,
-                versions_pruned,
-            },
-        history_pruning_outcome,
+        batch_size,
+        pruned: SitrepsPruned { batches, total, versions },
+        outcome,
+    } = match serde_json::from_value::<SitrepHistoryPrunerStatus>(
+        details.clone(),
+    ) {
+        Err(error) => {
+            eprintln!(
+                "warning: failed to interpret task details: {:?}: {:?}",
+                error, details
+            );
+            return;
+        }
+        Ok(status) => status,
+    };
+
+    const HISTORY_LIMIT: &str = "max sitreps to keep:";
+    const STATUS: &str = "status:";
+    const SITREP_COUNT: &str = "  current count:";
+    const PRUNED_COUNT: &str = "  sitreps pruned:";
+    const PRUNED_VERSIONS: &str = "  versions pruned:";
+    const BATCHES: &str = "  batches:";
+    const BATCH_SIZE: &str = "deletion batch size:";
+    const P_WIDTH: usize = const_max_len(&[
+        HISTORY_LIMIT,
+        SITREP_COUNT,
+        PRUNED_COUNT,
+        PRUNED_VERSIONS,
+        BATCHES,
+        BATCH_SIZE,
+    ]) + 1;
+    const NUM_WIDTH: usize = 4;
+    println!("    {HISTORY_LIMIT:<P_WIDTH$}{history_limit:>NUM_WIDTH$}");
+    println!("    {BATCH_SIZE:<P_WIDTH$}{batch_size:>NUM_WIDTH$}");
+    match outcome {
+        Outcome::Error(error) => {
+            println!("{ERRICON} {STATUS} failed!");
+            println!("      > {error}")
+        }
+        Outcome::NotPruned { count } => {
+            println!("    {STATUS} within limit (nothing was deleted)");
+            println!("    {SITREP_COUNT:<P_WIDTH$}{count:>NUM_WIDTH$}");
+        }
+        Outcome::Pruned { count } => {
+            println!("    {STATUS} limit reached (old sitreps were deleted)");
+            println!("    {SITREP_COUNT:<P_WIDTH$}{count:>NUM_WIDTH$}");
+        }
+    }
+
+    // If anything was deleted, including partial progress made before a
+    // query failed, display the details of what was pruned.
+    if total > 0 {
+        println!("    {PRUNED_COUNT:<P_WIDTH$}{total:>NUM_WIDTH$}");
+        if let Some(versions) = versions {
+            println!("    {PRUNED_VERSIONS:<P_WIDTH$}v{versions:?}");
+        }
+        println!("    {BATCHES:<P_WIDTH$}{batches:>NUM_WIDTH$}");
+    }
+}
+
+fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
+    let SitrepGcStatus {
         orphaned_sitreps_deleted,
         sitrep_metadata_batches,
         batch_size,
@@ -3729,52 +3789,6 @@ fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
         Ok(status) => status,
     };
 
-    println!("    pruning sitrep history table:");
-    const HISTORY_LIMIT: &str = "max sitreps to keep:";
-    const STATUS: &str = "status:";
-    const SITREP_COUNT: &str = "current count:";
-    const PRUNED: &str = "sitreps pruned:";
-    const VERSIONS_PRUNED: &str = "versions pruned:";
-    const PRUNE_BATCHES: &str = "batches:";
-    const BATCH_SIZE: &str = "batch size:";
-    const P_WIDTH: usize = const_max_len(&[
-        HISTORY_LIMIT,
-        SITREP_COUNT,
-        PRUNED,
-        VERSIONS_PRUNED,
-        PRUNE_BATCHES,
-        BATCH_SIZE,
-    ]) + 1;
-    println!("      {HISTORY_LIMIT:<P_WIDTH$}{history_limit:>NUM_WIDTH$}");
-    match history_pruning_outcome {
-        HistoryPruningOutcome::Error(error) => {
-            println!("{ERRICON}   {STATUS} failed!");
-            println!("        > {error}")
-        }
-        HistoryPruningOutcome::NotPruned { count } => {
-            println!("      {STATUS} within limit (nothing was deleted)");
-            println!("      {SITREP_COUNT:<P_WIDTH$}{count:>NUM_WIDTH$}");
-        }
-        HistoryPruningOutcome::Pruned { count } => {
-            println!("      {STATUS} limit reached (old sitreps were deleted)");
-            println!("      {SITREP_COUNT:<P_WIDTH$}{count:>NUM_WIDTH$}");
-        }
-    }
-
-    // If anything was deleted, including partial progress made before a
-    // query failed, display the details of what was pruned.
-    if sitreps_pruned > 0 {
-        println!("      {PRUNED:<P_WIDTH$}{sitreps_pruned:>NUM_WIDTH$}");
-        if let Some(versions) = versions_pruned {
-            println!("      {VERSIONS_PRUNED:<P_WIDTH$}v{versions:?}");
-        }
-        println!(
-            "      {PRUNE_BATCHES:<P_WIDTH$}{pruning_batches:>NUM_WIDTH$}"
-        );
-        println!("      {BATCH_SIZE:<P_WIDTH$}{batch_size:>NUM_WIDTH$}");
-    }
-
-    println!("    garbage collecting orphaned sitreps:");
     const BASE_WIDTH: usize = 40;
     const NUM_WIDTH: usize = 4;
 
@@ -3788,37 +3802,33 @@ fn print_task_fm_sitrep_gc(details: &serde_json::Value) {
         .fold(BASE_WIDTH, |w, l| w.max(l));
 
     if !errors.is_empty() {
-        println!(
-            "{ERRICON}   {:<width$}{:>NUM_WIDTH$}",
-            "errors:",
-            errors.len()
-        );
+        println!("{ERRICON} {:<width$}{:>NUM_WIDTH$}", "errors:", errors.len());
         for error in errors {
-            println!("      > {error}")
+            println!("    > {error}")
         }
     }
 
-    println!("      {BATCH_SIZE:<width$}{batch_size:>NUM_WIDTH$}");
+    println!("    {:<width$}{batch_size:>NUM_WIDTH$}", "batch size:");
     println!(
-        "      {:<width$}{orphaned_sitreps_deleted:>NUM_WIDTH$}",
+        "    {:<width$}{orphaned_sitreps_deleted:>NUM_WIDTH$}",
         "orphaned sitreps deleted:"
     );
     println!(
-        "      {:<width$}{sitrep_metadata_batches:>NUM_WIDTH$}",
+        "    {:<width$}{sitrep_metadata_batches:>NUM_WIDTH$}",
         "  batches:"
     );
 
     if child_tables.is_empty() {
-        eprintln!("(!)     warning: no child tables reported (likely a bug)");
+        eprintln!("(!)   warning: no child tables reported (likely a bug)");
     }
 
     for (table_name, stats) in &child_tables {
         println!(
-            "      {:<width$}{:>NUM_WIDTH$}",
+            "    {:<width$}{:>NUM_WIDTH$}",
             format!("orphaned {table_name} rows deleted:"),
             stats.rows_deleted,
         );
-        println!("      {:<width$}{:>NUM_WIDTH$}", "  batches:", stats.batches);
+        println!("    {:<width$}{:>NUM_WIDTH$}", "  batches:", stats.batches);
     }
 }
 

--- a/dev-tools/omdb/tests/env.out
+++ b/dev-tools/omdb/tests/env.out
@@ -125,6 +125,11 @@ task: "fm_sitrep_gc"
     garbage collects fault management situation reports
 
 
+task: "fm_sitrep_history_pruner"
+    maintains the configured limit on the fault management sitrep history table
+    by deleting the oldest entries
+
+
 task: "fm_sitrep_loader"
     loads the current fault management situation report from the database
 
@@ -393,6 +398,11 @@ task: "fm_sitrep_gc"
     garbage collects fault management situation reports
 
 
+task: "fm_sitrep_history_pruner"
+    maintains the configured limit on the fault management sitrep history table
+    by deleting the oldest entries
+
+
 task: "fm_sitrep_loader"
     loads the current fault management situation report from the database
 
@@ -646,6 +656,11 @@ task: "fm_rendezvous"
 
 task: "fm_sitrep_gc"
     garbage collects fault management situation reports
+
+
+task: "fm_sitrep_history_pruner"
+    maintains the configured limit on the fault management sitrep history table
+    by deleting the oldest entries
 
 
 task: "fm_sitrep_loader"

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -772,9 +772,9 @@ task: "fm_sitrep_gc"
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     pruning sitrep history table:
-      max sitreps to keep:   2000
-      status: no sitreps pruned
-      current count:            1
+      max sitreps to keep: 2000
+      status: within limit (nothing was pruned)
+      current count:          1
     garbage collecting orphaned sitreps:
       batch size:                                                               1000
       orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>
@@ -1493,9 +1493,9 @@ task: "fm_sitrep_gc"
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     pruning sitrep history table:
-      max sitreps to keep:   2000
-      status: no sitreps pruned
-      current count:            1
+      max sitreps to keep: 2000
+      status: within limit (nothing was pruned)
+      current count:          1
     garbage collecting orphaned sitreps:
       batch size:                                                               1000
       orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -773,7 +773,7 @@ task: "fm_sitrep_gc"
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     pruning sitrep history table:
       max sitreps to keep: 2000
-      status: within limit (nothing was pruned)
+      status: within limit (nothing was deleted)
       current count:          1
     garbage collecting orphaned sitreps:
       batch size:                                                               1000
@@ -1494,7 +1494,7 @@ task: "fm_sitrep_gc"
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     pruning sitrep history table:
       max sitreps to keep: 2000
-      status: within limit (nothing was pruned)
+      status: within limit (nothing was deleted)
       current count:          1
     garbage collecting orphaned sitreps:
       batch size:                                                               1000

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -773,7 +773,7 @@ task: "fm_sitrep_gc"
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     pruning sitrep history table:
       max sitreps to keep:   2000
-      status:: below limit (no sitreps pruned)
+      status: below limit (no sitreps pruned)
       current count:            1
     garbage collecting orphaned sitreps:
       batch size:                                                               1000
@@ -1494,7 +1494,7 @@ task: "fm_sitrep_gc"
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     pruning sitrep history table:
       max sitreps to keep:   2000
-      status:: below limit (no sitreps pruned)
+      status: below limit (no sitreps pruned)
       current count:            1
     garbage collecting orphaned sitreps:
       batch size:                                                               1000

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -773,7 +773,7 @@ task: "fm_sitrep_gc"
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     pruning sitrep history table:
       max sitreps to keep:   2000
-      status: below limit (no sitreps pruned)
+      status: no sitreps pruned
       current count:            1
     garbage collecting orphaned sitreps:
       batch size:                                                               1000
@@ -1494,7 +1494,7 @@ task: "fm_sitrep_gc"
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     pruning sitrep history table:
       max sitreps to keep:   2000
-      status: below limit (no sitreps pruned)
+      status: no sitreps pruned
       current count:            1
     garbage collecting orphaned sitreps:
       batch size:                                                               1000

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -709,6 +709,9 @@ task: "fm_analysis"
     =================================
     no changes from the current situation report (Some(..........<REDACTED_UUID>........... (sitrep)))
 
+    sitrep storage capacity: 0% used
+      limit:   2500
+      count:      1
     preparation report:
       parent sitrep:        ..........<REDACTED_UUID>...........
       inventory collection: ..........<REDACTED_UUID>...........
@@ -768,27 +771,32 @@ task: "fm_sitrep_gc"
   configured period: every <REDACTED_DURATION>s
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    batch size:                                                               1000
-    orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>
-      batches:                                                                   1
-    orphaned fm_alert_request rows deleted:                                      0
-      batches:                                                                   1
-    orphaned fm_case rows deleted:                                               0
-      batches:                                                                   1
-    orphaned fm_ereport_in_case rows deleted:                                    0
-      batches:                                                                   1
-    orphaned fm_fact_physical_disk rows deleted:                                 0
-      batches:                                                                   1
-    orphaned fm_sitrep_analysis_report rows deleted:                             <ORPHANED_FMSITREPANALYSISREPORT_ROWS_DELETED_REDACTED>
-      batches:                                                                   1
-    orphaned fm_support_bundle_request rows deleted:                             0
-      batches:                                                                   1
-    orphaned fm_support_bundle_request_data_selection_ereports rows deleted:     0
-      batches:                                                                   1
-    orphaned fm_support_bundle_request_data_selection_flags rows deleted:        0
-      batches:                                                                   1
-    orphaned fm_support_bundle_request_data_selection_host_info rows deleted:    0
-      batches:                                                                   1
+    pruning sitrep history table:
+      max sitreps to keep:   2000
+      status:: below limit (no sitreps pruned)
+      current count:            1
+    garbage collecting orphaned sitreps:
+      batch size:                                                               1000
+      orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>
+        batches:                                                                   1
+      orphaned fm_alert_request rows deleted:                                      0
+        batches:                                                                   1
+      orphaned fm_case rows deleted:                                               0
+        batches:                                                                   1
+      orphaned fm_ereport_in_case rows deleted:                                    0
+        batches:                                                                   1
+      orphaned fm_fact_physical_disk rows deleted:                                 0
+        batches:                                                                   1
+      orphaned fm_sitrep_analysis_report rows deleted:                             <ORPHANED_FMSITREPANALYSISREPORT_ROWS_DELETED_REDACTED>
+        batches:                                                                   1
+      orphaned fm_support_bundle_request rows deleted:                             0
+        batches:                                                                   1
+      orphaned fm_support_bundle_request_data_selection_ereports rows deleted:     0
+        batches:                                                                   1
+      orphaned fm_support_bundle_request_data_selection_flags rows deleted:        0
+        batches:                                                                   1
+      orphaned fm_support_bundle_request_data_selection_host_info rows deleted:    0
+        batches:                                                                   1
 
 task: "fm_sitrep_loader"
   configured period: every <REDACTED_DURATION>s
@@ -1422,6 +1430,9 @@ task: "fm_analysis"
     =================================
     no changes from the current situation report (Some(..........<REDACTED_UUID>........... (sitrep)))
 
+    sitrep storage capacity: 0% used
+      limit:   2500
+      count:      1
     preparation report:
       parent sitrep:        ..........<REDACTED_UUID>...........
       inventory collection: ..........<REDACTED_UUID>...........
@@ -1481,27 +1492,32 @@ task: "fm_sitrep_gc"
   configured period: every <REDACTED_DURATION>s
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    batch size:                                                               1000
-    orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>
-      batches:                                                                   1
-    orphaned fm_alert_request rows deleted:                                      0
-      batches:                                                                   1
-    orphaned fm_case rows deleted:                                               0
-      batches:                                                                   1
-    orphaned fm_ereport_in_case rows deleted:                                    0
-      batches:                                                                   1
-    orphaned fm_fact_physical_disk rows deleted:                                 0
-      batches:                                                                   1
-    orphaned fm_sitrep_analysis_report rows deleted:                             <ORPHANED_FMSITREPANALYSISREPORT_ROWS_DELETED_REDACTED>
-      batches:                                                                   1
-    orphaned fm_support_bundle_request rows deleted:                             0
-      batches:                                                                   1
-    orphaned fm_support_bundle_request_data_selection_ereports rows deleted:     0
-      batches:                                                                   1
-    orphaned fm_support_bundle_request_data_selection_flags rows deleted:        0
-      batches:                                                                   1
-    orphaned fm_support_bundle_request_data_selection_host_info rows deleted:    0
-      batches:                                                                   1
+    pruning sitrep history table:
+      max sitreps to keep:   2000
+      status:: below limit (no sitreps pruned)
+      current count:            1
+    garbage collecting orphaned sitreps:
+      batch size:                                                               1000
+      orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>
+        batches:                                                                   1
+      orphaned fm_alert_request rows deleted:                                      0
+        batches:                                                                   1
+      orphaned fm_case rows deleted:                                               0
+        batches:                                                                   1
+      orphaned fm_ereport_in_case rows deleted:                                    0
+        batches:                                                                   1
+      orphaned fm_fact_physical_disk rows deleted:                                 0
+        batches:                                                                   1
+      orphaned fm_sitrep_analysis_report rows deleted:                             <ORPHANED_FMSITREPANALYSISREPORT_ROWS_DELETED_REDACTED>
+        batches:                                                                   1
+      orphaned fm_support_bundle_request rows deleted:                             0
+        batches:                                                                   1
+      orphaned fm_support_bundle_request_data_selection_ereports rows deleted:     0
+        batches:                                                                   1
+      orphaned fm_support_bundle_request_data_selection_flags rows deleted:        0
+        batches:                                                                   1
+      orphaned fm_support_bundle_request_data_selection_host_info rows deleted:    0
+        batches:                                                                   1
 
 task: "fm_sitrep_loader"
   configured period: every <REDACTED_DURATION>s

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -360,6 +360,11 @@ task: "fm_sitrep_gc"
     garbage collects fault management situation reports
 
 
+task: "fm_sitrep_history_pruner"
+    maintains the configured limit on the fault management sitrep history table
+    by deleting the oldest entries
+
+
 task: "fm_sitrep_loader"
     loads the current fault management situation report from the database
 
@@ -768,35 +773,39 @@ task: "fm_rendezvous"
       errors:          0
 
 task: "fm_sitrep_gc"
-  configured period: every <REDACTED_DURATION>s
+  configured period: every <REDACTED_DURATION>m
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    pruning sitrep history table:
-      max sitreps to keep: 2000
-      status: within limit (nothing was deleted)
-      current count:          1
-    garbage collecting orphaned sitreps:
-      batch size:                                                               1000
-      orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>
-        batches:                                                                   1
-      orphaned fm_alert_request rows deleted:                                      0
-        batches:                                                                   1
-      orphaned fm_case rows deleted:                                               0
-        batches:                                                                   1
-      orphaned fm_ereport_in_case rows deleted:                                    0
-        batches:                                                                   1
-      orphaned fm_fact_physical_disk rows deleted:                                 0
-        batches:                                                                   1
-      orphaned fm_sitrep_analysis_report rows deleted:                             <ORPHANED_FMSITREPANALYSISREPORT_ROWS_DELETED_REDACTED>
-        batches:                                                                   1
-      orphaned fm_support_bundle_request rows deleted:                             0
-        batches:                                                                   1
-      orphaned fm_support_bundle_request_data_selection_ereports rows deleted:     0
-        batches:                                                                   1
-      orphaned fm_support_bundle_request_data_selection_flags rows deleted:        0
-        batches:                                                                   1
-      orphaned fm_support_bundle_request_data_selection_host_info rows deleted:    0
-        batches:                                                                   1
+    batch size:                                                               1000
+    orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>
+      batches:                                                                   1
+    orphaned fm_alert_request rows deleted:                                      0
+      batches:                                                                   1
+    orphaned fm_case rows deleted:                                               0
+      batches:                                                                   1
+    orphaned fm_ereport_in_case rows deleted:                                    0
+      batches:                                                                   1
+    orphaned fm_fact_physical_disk rows deleted:                                 0
+      batches:                                                                   1
+    orphaned fm_sitrep_analysis_report rows deleted:                             <ORPHANED_FMSITREPANALYSISREPORT_ROWS_DELETED_REDACTED>
+      batches:                                                                   1
+    orphaned fm_support_bundle_request rows deleted:                             0
+      batches:                                                                   1
+    orphaned fm_support_bundle_request_data_selection_ereports rows deleted:     0
+      batches:                                                                   1
+    orphaned fm_support_bundle_request_data_selection_flags rows deleted:        0
+      batches:                                                                   1
+    orphaned fm_support_bundle_request_data_selection_host_info rows deleted:    0
+      batches:                                                                   1
+
+task: "fm_sitrep_history_pruner"
+  configured period: every <REDACTED_DURATION>m
+  last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+    started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
+    max sitreps to keep: 2000
+    deletion batch size: 1000
+    status: within limit (nothing was deleted)
+      current count:        1
 
 task: "fm_sitrep_loader"
   configured period: every <REDACTED_DURATION>s
@@ -1489,35 +1498,39 @@ task: "fm_rendezvous"
       errors:          0
 
 task: "fm_sitrep_gc"
-  configured period: every <REDACTED_DURATION>s
+  configured period: every <REDACTED_DURATION>m
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    pruning sitrep history table:
-      max sitreps to keep: 2000
-      status: within limit (nothing was deleted)
-      current count:          1
-    garbage collecting orphaned sitreps:
-      batch size:                                                               1000
-      orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>
-        batches:                                                                   1
-      orphaned fm_alert_request rows deleted:                                      0
-        batches:                                                                   1
-      orphaned fm_case rows deleted:                                               0
-        batches:                                                                   1
-      orphaned fm_ereport_in_case rows deleted:                                    0
-        batches:                                                                   1
-      orphaned fm_fact_physical_disk rows deleted:                                 0
-        batches:                                                                   1
-      orphaned fm_sitrep_analysis_report rows deleted:                             <ORPHANED_FMSITREPANALYSISREPORT_ROWS_DELETED_REDACTED>
-        batches:                                                                   1
-      orphaned fm_support_bundle_request rows deleted:                             0
-        batches:                                                                   1
-      orphaned fm_support_bundle_request_data_selection_ereports rows deleted:     0
-        batches:                                                                   1
-      orphaned fm_support_bundle_request_data_selection_flags rows deleted:        0
-        batches:                                                                   1
-      orphaned fm_support_bundle_request_data_selection_host_info rows deleted:    0
-        batches:                                                                   1
+    batch size:                                                               1000
+    orphaned sitreps deleted:                                                    <ORPHANED_SITREPS_DELETED_REDACTED>
+      batches:                                                                   1
+    orphaned fm_alert_request rows deleted:                                      0
+      batches:                                                                   1
+    orphaned fm_case rows deleted:                                               0
+      batches:                                                                   1
+    orphaned fm_ereport_in_case rows deleted:                                    0
+      batches:                                                                   1
+    orphaned fm_fact_physical_disk rows deleted:                                 0
+      batches:                                                                   1
+    orphaned fm_sitrep_analysis_report rows deleted:                             <ORPHANED_FMSITREPANALYSISREPORT_ROWS_DELETED_REDACTED>
+      batches:                                                                   1
+    orphaned fm_support_bundle_request rows deleted:                             0
+      batches:                                                                   1
+    orphaned fm_support_bundle_request_data_selection_ereports rows deleted:     0
+      batches:                                                                   1
+    orphaned fm_support_bundle_request_data_selection_flags rows deleted:        0
+      batches:                                                                   1
+    orphaned fm_support_bundle_request_data_selection_host_info rows deleted:    0
+      batches:                                                                   1
+
+task: "fm_sitrep_history_pruner"
+  configured period: every <REDACTED_DURATION>m
+  last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+    started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
+    max sitreps to keep: 2000
+    deletion batch size: 1000
+    status: within limit (nothing was deleted)
+      current count:        1
 
 task: "fm_sitrep_loader"
   configured period: every <REDACTED_DURATION>s

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -714,9 +714,6 @@ task: "fm_analysis"
     =================================
     no changes from the current situation report (Some(..........<REDACTED_UUID>........... (sitrep)))
 
-    sitrep storage capacity: 0% used
-      limit:   2500
-      count:      1
     preparation report:
       parent sitrep:        ..........<REDACTED_UUID>...........
       inventory collection: ..........<REDACTED_UUID>...........
@@ -1439,9 +1436,6 @@ task: "fm_analysis"
     =================================
     no changes from the current situation report (Some(..........<REDACTED_UUID>........... (sitrep)))
 
-    sitrep storage capacity: 0% used
-      limit:   2500
-      count:      1
     preparation report:
       parent sitrep:        ..........<REDACTED_UUID>...........
       inventory collection: ..........<REDACTED_UUID>...........

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -217,11 +217,19 @@ async fn test_omdb_success_cases() {
     //    consumable ereports, so every post-load analysis is a no-op.)
     // 4. `fm_rendezvous` runs against the loaded sitrep, so its status shows
     //    the executed operations rather than "no FM situation report loaded".
+    // 5. `fm_sitrep_history_pruner` runs, determines we have not reached the
+    //    sitrep history limit, and does nothing. However, this task's status
+    //    will print the count of sitrep history entries currently in the
+    //    database, so activating it explicitly *after* analysis has committed
+    //    the first sitrep ensures that its most recent status always says
+    //    there's 1 sitrep, rather than depending on whether it ran before or
+    //    after the analysis task.
     let lockstep_client = &cptestctx.lockstep_client;
     activate_background_task(lockstep_client, "fm_analysis").await;
     activate_background_task(lockstep_client, "fm_sitrep_loader").await;
     activate_background_task(lockstep_client, "fm_analysis").await;
     activate_background_task(lockstep_client, "fm_rendezvous").await;
+    activate_background_task(lockstep_client, "fm_sitrep_history_pruner").await;
 
     let mut output = String::new();
 

--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -1004,6 +1004,10 @@ pub struct FmTasksConfig {
     #[serde_as(as = "DurationSeconds<u64>")]
     pub sitrep_gc_period_secs: Duration,
     /// period (in seconds) for periodic activations of the background task that
+    /// prunes the oldest entries from the fault management sitrep history
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub sitrep_history_prune_period_secs: Duration,
+    /// period (in seconds) for periodic activations of the background task that
     /// updates externally-visible database tables to match the current situation
     /// report.
     #[serde_as(as = "DurationSeconds<u64>")]
@@ -1023,6 +1027,11 @@ impl Default for FmTasksConfig {
             // time the current sitrep changes, and activating it more
             // frequently won't make things more responsive.
             sitrep_gc_period_secs: Duration::from_secs(600),
+            // This need not be activated very frequently, as it's triggered
+            // whenever a new sitrep is committed and by the analysis task when
+            // nearing capacity limits, so periodic activation is only a
+            // backstop.
+            sitrep_history_prune_period_secs: Duration::from_secs(600),
             // This, too, is activated whenever a new sitrep is loaded, so we
             // need not set the periodic activation interval too high.
             rendezvous_period_secs: Duration::from_secs(300),
@@ -1337,6 +1346,7 @@ mod test {
             sp_ereport_ingester.period_secs = 47
             fm.sitrep_load_period_secs = 48
             fm.sitrep_gc_period_secs = 49
+            fm.sitrep_history_prune_period_secs = 53
             probe_distributor.period_secs = 50
             multicast_reconciler.period_secs = 60
             fm.rendezvous_period_secs = 51
@@ -1601,6 +1611,8 @@ mod test {
                             analysis_period_secs: Duration::from_secs(52),
                             sitrep_load_period_secs: Duration::from_secs(48),
                             sitrep_gc_period_secs: Duration::from_secs(49),
+                            sitrep_history_prune_period_secs:
+                                Duration::from_secs(53),
                             rendezvous_period_secs: Duration::from_secs(51),
                         },
                         probe_distributor: ProbeDistributorConfig {
@@ -1736,6 +1748,7 @@ mod test {
             sp_ereport_ingester.period_secs = 44
             fm.sitrep_load_period_secs = 45
             fm.sitrep_gc_period_secs = 46
+            fm.sitrep_history_prune_period_secs = 50
             probe_distributor.period_secs = 47
             fm.rendezvous_period_secs = 48
             fm.analysis_period_secs = 49

--- a/nexus/background-task-interface/src/init.rs
+++ b/nexus/background-task-interface/src/init.rs
@@ -57,6 +57,7 @@ pub struct BackgroundTasks {
     pub task_fm_rendezvous: Activator,
     pub task_fm_sitrep_loader: Activator,
     pub task_fm_sitrep_gc: Activator,
+    pub task_fm_sitrep_history_pruner: Activator,
     pub task_probe_distributor: Activator,
     pub task_multicast_reconciler: Activator,
     pub task_trust_quorum_manager: Activator,

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -1772,12 +1772,177 @@ pub enum InsertSitrepError {
     ParentNotCurrent(SitrepUuid),
 }
 
+// This is a `pub(crate)` module enabled by either compiling tests or the
+// "testing" featuer flag, so that some of the code in this module can be used
+// by this crate's `pub_test_utils` module.
+#[cfg(any(feature = "testing", test))]
+pub(crate) mod test_utils {
+    use super::*;
+    use crate::db::raw_query_builder::QueryBuilder;
+    use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
+
+    // ---------------------------------------------------------------
+    // SitrepChildTableCounts: queries each table listed in
+    // `SitrepChildTable::ALL` to count the number of rows matching a
+    // given `sitrep_id`. Used by tests to verify that orphan GC
+    // actually cleaned up the expected rows.
+    //
+    // Mirrors `BlueprintTableCounts` from deployment.rs; the
+    // completeness test below ensures every `fm_*` child table with
+    // a `sitrep_id` column is covered by `SitrepChildTable`.
+    // ---------------------------------------------------------------
+
+    pub(super) struct SitrepChildTableCounts {
+        counts: BTreeMap<String, i64>,
+    }
+
+    impl SitrepChildTableCounts {
+        /// Query row counts for each child table tracked by
+        /// `SitrepChildTable`, for the given `sitrep_id`.
+        pub(super) async fn new(
+            datastore: &DataStore,
+            sitrep_id: SitrepUuid,
+        ) -> SitrepChildTableCounts {
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+            let mut counts = BTreeMap::new();
+
+            for &table in SitrepChildTable::ALL {
+                let mut query = QueryBuilder::new();
+                query.sql("SELECT COUNT(*) FROM ");
+                query.sql(table.table_name());
+                query.sql(" WHERE ");
+                query.sql(table.sitrep_id_column());
+                query.sql(" = ");
+                query.param().bind::<diesel::sql_types::Uuid, _>(
+                    sitrep_id.into_untyped_uuid(),
+                );
+
+                let count: i64 = query
+                    .query::<diesel::sql_types::BigInt>()
+                    .get_result_async(&*conn)
+                    .await
+                    .unwrap_or_else(|e| {
+                        panic!(
+                            "failed to count rows in {}: {e}",
+                            table.table_name()
+                        )
+                    });
+                counts.insert(table.table_name().to_string(), count);
+            }
+
+            let table_counts = SitrepChildTableCounts { counts };
+
+            // Verify no new fm_* child tables were added without
+            // updating SitrepChildTable.
+            if let Err(msg) =
+                table_counts.verify_all_tables_covered(datastore).await
+            {
+                panic!("{msg}");
+            }
+
+            table_counts
+        }
+
+        pub(super) fn all_empty(&self) -> bool {
+            self.counts.values().all(|&count| count == 0)
+        }
+
+        pub(super) fn empty_tables(&self) -> Vec<String> {
+            self.counts
+                .iter()
+                .filter_map(
+                    |(table, &count)| {
+                        if count == 0 { Some(table.clone()) } else { None }
+                    },
+                )
+                .collect()
+        }
+
+        pub(super) fn non_empty_tables(&self) -> Vec<String> {
+            self.counts
+                .iter()
+                .filter_map(
+                    |(table, &count)| {
+                        if count > 0 { Some(table.clone()) } else { None }
+                    },
+                )
+                .collect()
+        }
+
+        pub(super) fn tables_checked(&self) -> BTreeSet<&str> {
+            self.counts.keys().map(|s| s.as_str()).collect()
+        }
+
+        /// Verify no new fm_* tables were added without updating
+        /// `SitrepChildTable`.
+        pub(super) async fn verify_all_tables_covered(
+            &self,
+            datastore: &DataStore,
+        ) -> Result<(), String> {
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            // fm_* tables that are NOT children of fm_sitrep and are
+            // intentionally ignored.
+            let tables_ignored: BTreeSet<&str> =
+                ["fm_sitrep", "fm_sitrep_history"].into_iter().collect();
+            let tables_checked = self.tables_checked();
+
+            let mut query = QueryBuilder::new();
+            query.sql(
+                "SELECT table_name FROM information_schema.tables \
+                 WHERE table_name LIKE 'fm\\_%'",
+            );
+            let tables_unchecked: Vec<String> = query
+                .query::<diesel::sql_types::Text>()
+                .load_async(&*conn)
+                .await
+                .expect("failed to query information_schema for fm_* tables")
+                .into_iter()
+                .filter(|f: &String| {
+                    let t = f.as_str();
+                    !tables_ignored.contains(t) && !tables_checked.contains(t)
+                })
+                .collect();
+
+            if !tables_unchecked.is_empty() {
+                Err(format!(
+                    "found fm_* child table(s) not covered by \
+                     `SitrepChildTable`: {}\n\n\
+                     If you added a new fm_* child table, add a variant \
+                     to `SitrepChildTable` and update the orphan GC code \
+                     in `fm_sitrep_gc_orphans`.\n\n\
+                     If your new table should NOT be covered by orphan GC, \
+                     either drop the `fm_` prefix or add it to \
+                     `tables_ignored` in this test.",
+                    tables_unchecked.join(", ")
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) async fn ensure_sitrep_children_fully_deleted(
+        datastore: &DataStore,
+        sitrep_id: SitrepUuid,
+    ) {
+        let counts = SitrepChildTableCounts::new(datastore, sitrep_id).await;
+
+        assert!(
+            counts.all_empty(),
+            "sitrep {sitrep_id} not fully deleted. Non-empty tables: {:?}",
+            counts.non_empty_tables()
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::test_utils::*;
     use super::*;
     use crate::db::explain::ExplainableAsync;
     use crate::db::pub_test_utils::TestDatabase;
-    use crate::db::raw_query_builder::QueryBuilder;
     use crate::db::raw_query_builder::expectorate_query_contents;
     use chrono::Utc;
     use diesel::pg::Pg;
@@ -1794,8 +1959,6 @@ mod tests {
     use omicron_uuid_kinds::OmicronZoneUuid;
     use omicron_uuid_kinds::RackUuid;
     use omicron_uuid_kinds::SupportBundleUuid;
-    use std::collections::BTreeMap;
-    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -3686,147 +3849,6 @@ mod tests {
         logctx.cleanup_successful();
     }
 
-    // ---------------------------------------------------------------
-    // SitrepChildTableCounts: queries each table listed in
-    // `SitrepChildTable::ALL` to count the number of rows matching a
-    // given `sitrep_id`. Used by tests to verify that orphan GC
-    // actually cleaned up the expected rows.
-    //
-    // Mirrors `BlueprintTableCounts` from deployment.rs; the
-    // completeness test below ensures every `fm_*` child table with
-    // a `sitrep_id` column is covered by `SitrepChildTable`.
-    // ---------------------------------------------------------------
-
-    struct SitrepChildTableCounts {
-        counts: BTreeMap<String, i64>,
-    }
-
-    impl SitrepChildTableCounts {
-        /// Query row counts for each child table tracked by
-        /// `SitrepChildTable`, for the given `sitrep_id`.
-        async fn new(
-            datastore: &DataStore,
-            sitrep_id: SitrepUuid,
-        ) -> SitrepChildTableCounts {
-            let conn = datastore.pool_connection_for_tests().await.unwrap();
-            let mut counts = BTreeMap::new();
-
-            for &table in SitrepChildTable::ALL {
-                let mut query = QueryBuilder::new();
-                query.sql("SELECT COUNT(*) FROM ");
-                query.sql(table.table_name());
-                query.sql(" WHERE ");
-                query.sql(table.sitrep_id_column());
-                query.sql(" = ");
-                query.param().bind::<diesel::sql_types::Uuid, _>(
-                    sitrep_id.into_untyped_uuid(),
-                );
-
-                let count: i64 = query
-                    .query::<diesel::sql_types::BigInt>()
-                    .get_result_async(&*conn)
-                    .await
-                    .unwrap_or_else(|e| {
-                        panic!(
-                            "failed to count rows in {}: {e}",
-                            table.table_name()
-                        )
-                    });
-                counts.insert(table.table_name().to_string(), count);
-            }
-
-            let table_counts = SitrepChildTableCounts { counts };
-
-            // Verify no new fm_* child tables were added without
-            // updating SitrepChildTable.
-            if let Err(msg) =
-                table_counts.verify_all_tables_covered(datastore).await
-            {
-                panic!("{msg}");
-            }
-
-            table_counts
-        }
-
-        fn all_empty(&self) -> bool {
-            self.counts.values().all(|&count| count == 0)
-        }
-
-        fn empty_tables(&self) -> Vec<String> {
-            self.counts
-                .iter()
-                .filter_map(
-                    |(table, &count)| {
-                        if count == 0 { Some(table.clone()) } else { None }
-                    },
-                )
-                .collect()
-        }
-
-        fn non_empty_tables(&self) -> Vec<String> {
-            self.counts
-                .iter()
-                .filter_map(
-                    |(table, &count)| {
-                        if count > 0 { Some(table.clone()) } else { None }
-                    },
-                )
-                .collect()
-        }
-
-        fn tables_checked(&self) -> BTreeSet<&str> {
-            self.counts.keys().map(|s| s.as_str()).collect()
-        }
-
-        /// Verify no new fm_* tables were added without updating
-        /// `SitrepChildTable`.
-        async fn verify_all_tables_covered(
-            &self,
-            datastore: &DataStore,
-        ) -> Result<(), String> {
-            let conn = datastore.pool_connection_for_tests().await.unwrap();
-
-            // fm_* tables that are NOT children of fm_sitrep and are
-            // intentionally ignored.
-            let tables_ignored: BTreeSet<&str> =
-                ["fm_sitrep", "fm_sitrep_history"].into_iter().collect();
-            let tables_checked = self.tables_checked();
-
-            let mut query = QueryBuilder::new();
-            query.sql(
-                "SELECT table_name FROM information_schema.tables \
-                 WHERE table_name LIKE 'fm\\_%'",
-            );
-            let tables_unchecked: Vec<String> = query
-                .query::<diesel::sql_types::Text>()
-                .load_async(&*conn)
-                .await
-                .expect("failed to query information_schema for fm_* tables")
-                .into_iter()
-                .filter(|f: &String| {
-                    let t = f.as_str();
-                    !tables_ignored.contains(t) && !tables_checked.contains(t)
-                })
-                .collect();
-
-            if !tables_unchecked.is_empty() {
-                Err(format!(
-                    "found fm_* child table(s) not covered by \
-                     `SitrepChildTable`: {}\n\n\
-                     If you added a new fm_* child table, add a variant \
-                     to `SitrepChildTable` and update the orphan GC code \
-                     in `fm_sitrep_gc_orphans`.\n\n\
-                     If your new table should NOT be covered by orphan GC, \
-                     either drop the `fm_` prefix or add it to \
-                     `tables_ignored` in this test.",
-                    tables_unchecked.join(", ")
-                ))
-            } else {
-                Ok(())
-            }
-        }
-    }
-
     async fn ensure_sitrep_fully_populated(
         datastore: &DataStore,
         sitrep_id: SitrepUuid,
@@ -3843,19 +3865,6 @@ mod tests {
                  exception to ensure_sitrep_fully_populated()."
             );
         }
-    }
-
-    async fn ensure_sitrep_children_fully_deleted(
-        datastore: &DataStore,
-        sitrep_id: SitrepUuid,
-    ) {
-        let counts = SitrepChildTableCounts::new(datastore, sitrep_id).await;
-
-        assert!(
-            counts.all_empty(),
-            "sitrep {sitrep_id} not fully deleted. Non-empty tables: {:?}",
-            counts.non_empty_tables()
-        );
     }
 
     #[tokio::test]

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -1759,7 +1759,7 @@ impl DataStore {
                     // activation. Because there are no gaps in the version
                     // numbers assigned to sitreps as they are committed, this
                     // means we are exactly at the limit. This is the expected
-                    // steady state if everything is more or less in sync.So,
+                    // steady state if everything is more or less in sync. So,
                     // don't say that we pruned something if we didn't actually
                     // delete anything.
                     if n_pruned == 0 {
@@ -1768,7 +1768,10 @@ impl DataStore {
                         });
                     }
 
-                    Ok(HistoryPruningStatus::Pruned { n_pruned, newest_version_pruned })
+                    Ok(HistoryPruningStatus::Pruned {
+                        n_pruned,
+                        newest_version_pruned,
+                    })
                 }
             })
             .await

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -1712,7 +1712,7 @@ impl DataStore {
 
                     // If the history table is below the limit, we're done here.
                     if let db::IsLimitReached::No { count } = limit_reached {
-                        return Ok(HistoryPruningStatus::BelowLimit {
+                        return Ok(HistoryPruningStatus::NotPruned {
                             count,
                         });
                     }
@@ -1753,6 +1753,20 @@ impl DataStore {
                         .filter(history_dsl::version.le(SqlU32(newest_version_pruned)))
                         .execute_async(&conn)
                         .await?;
+
+                    // If the delete removed no rows, every version at or below
+                    // `newest_version_pruned` was already pruned by a previous
+                    // activation. Because there are no gaps in the version
+                    // numbers assigned to sitreps as they are committed, this
+                    // means we are exactly at the limit. This is the expected
+                    // steady state if everything is more or less in sync.So,
+                    // don't say that we pruned something if we didn't actually
+                    // delete anything.
+                    if n_pruned == 0 {
+                        return Ok(HistoryPruningStatus::NotPruned {
+                            count: u64::from(limit),
+                        });
+                    }
 
                     Ok(HistoryPruningStatus::Pruned { n_pruned, newest_version_pruned })
                 }

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -1749,7 +1749,11 @@ impl DataStore {
                             err.bail(TransactionError::CustomError(e))
                         })?;
 
-                    let n_pruned = diesel::delete(history_dsl::fm_sitrep_history).filter(history_dsl::version.le(SqlU32(newest_version_pruned))).execute_async(&conn).await.map_err(|e| err.bail(TransactionError::Database(e)))?;
+                    let n_pruned = diesel::delete(history_dsl::fm_sitrep_history)
+                        .filter(history_dsl::version.le(SqlU32(newest_version_pruned)))
+                        .execute_async(&conn)
+                        .await
+                        .map_err(|e| err.bail(TransactionError::Database(e)))?;
 
                     Ok(HistoryPruningStatus::Pruned { n_pruned, newest_version_pruned })
                 }

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -1794,7 +1794,7 @@ pub(crate) mod test_utils {
     // ---------------------------------------------------------------
 
     pub(super) struct SitrepChildTableCounts {
-        counts: BTreeMap<String, i64>,
+        pub(super) counts: BTreeMap<String, i64>,
     }
 
     impl SitrepChildTableCounts {
@@ -1846,17 +1846,6 @@ pub(crate) mod test_utils {
 
         pub(super) fn all_empty(&self) -> bool {
             self.counts.values().all(|&count| count == 0)
-        }
-
-        pub(super) fn empty_tables(&self) -> Vec<String> {
-            self.counts
-                .iter()
-                .filter_map(
-                    |(table, &count)| {
-                        if count == 0 { Some(table.clone()) } else { None }
-                    },
-                )
-                .collect()
         }
 
         pub(super) fn non_empty_tables(&self) -> Vec<String> {
@@ -3847,6 +3836,21 @@ mod tests {
 
         db.terminate().await;
         logctx.cleanup_successful();
+    }
+
+    // This one lives here because the pub test utils don't need it, and rustc
+    // warns it's unused if it lives there.
+    impl SitrepChildTableCounts {
+        fn empty_tables(&self) -> Vec<String> {
+            self.counts
+                .iter()
+                .filter_map(
+                    |(table, &count)| {
+                        if count == 0 { Some(table.clone()) } else { None }
+                    },
+                )
+                .collect()
+        }
     }
 
     async fn ensure_sitrep_fully_populated(

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -1752,8 +1752,7 @@ impl DataStore {
                     let n_pruned = diesel::delete(history_dsl::fm_sitrep_history)
                         .filter(history_dsl::version.le(SqlU32(newest_version_pruned)))
                         .execute_async(&conn)
-                        .await
-                        .map_err(|e| err.bail(TransactionError::Database(e)))?;
+                        .await?;
 
                     Ok(HistoryPruningStatus::Pruned { n_pruned, newest_version_pruned })
                 }

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -1651,16 +1651,14 @@ impl DataStore {
                     // We need this to call the COUNT(*) query below. But note
                     // that this isn't really a "full" table scan; the number of
                     // rows scanned is limited by the LIMIT clause.
-                    conn.batch_execute_async(ALLOW_FULL_TABLE_SCAN_SQL)
-                        .await
-                        .map_err(|e| err.bail(TransactionError::Database(e)))?;
+                    conn.batch_execute_async(ALLOW_FULL_TABLE_SCAN_SQL).await?;
 
                     // Rather than doing a full table scan, we use a LIMIT
                     // clause to limit the number of rows returned.
                     let result = limit_query
                         .check_if_limit_reached_async(&conn)
                         .await
-                        .map_err(|e| err.bail(TransactionError::Database(e)))?;
+                        .map_err(|e| e.into_diesel(&err))?;
 
                     Ok(result)
                 }
@@ -1669,7 +1667,7 @@ impl DataStore {
             .map_err(|e| match err.take() {
                 Some(err) => err.into_public_ignore_retries(),
                 None => public_error_from_diesel(e, ErrorHandler::Server),
-            })?
+            })
     }
 
     pub async fn fm_sitrep_history_prune(
@@ -1703,23 +1701,18 @@ impl DataStore {
                     // that this isn't really a "full" table scan; the number of
                     // rows scanned is limited by the LIMIT clause.
                     conn.batch_execute_async(ALLOW_FULL_TABLE_SCAN_SQL)
-                        .await
-                        .map_err(|e| err.bail(TransactionError::Database(e)))?;
+                        .await?;
 
                     // Rather than doing a full table scan, we use a LIMIT
                     // clause to limit the number of rows returned.
                     let limit_reached = limit_query
                         .check_if_limit_reached_async(&conn)
                         .await
-                        .map_err(|e| err.bail(TransactionError::Database(e)))?
-                        .map_err(|e| {
-                            err.bail(TransactionError::CustomError(e))
-                        })?;
+                        .map_err(|e| e.into_diesel(&err))?;
 
                     // If the history table is below the limit, we're done here.
                     if let db::IsLimitReached::No { count } = limit_reached {
                         return Ok(HistoryPruningStatus::BelowLimit {
-                            threshold: limit,
                             count,
                         });
                     }
@@ -1730,8 +1723,7 @@ impl DataStore {
                     // determine the first version to delete, and delete all
                     // versions less than or equal to that version number.
                     let latest_version = Self::fm_current_sitrep_version_on_conn(&conn)
-                        .await
-                        .map_err(|e| err.bail(TransactionError::Database(e)))?
+                        .await?
                         .ok_or_else(|| {
                             let e = Error::InternalError {
                                 internal_message: format!(
@@ -1759,7 +1751,7 @@ impl DataStore {
 
                     let n_pruned = diesel::delete(history_dsl::fm_sitrep_history).filter(history_dsl::version.le(SqlU32(newest_version_pruned))).execute_async(&conn).await.map_err(|e| err.bail(TransactionError::Database(e)))?;
 
-                    Ok(HistoryPruningStatus::Pruned { threshold: limit, n_pruned, newest_version_pruned })
+                    Ok(HistoryPruningStatus::Pruned { n_pruned, newest_version_pruned })
                 }
             })
             .await

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -149,8 +149,33 @@ pub struct ChildTableGcStats {
 pub struct GcOrphansResult {
     pub sitreps_deleted: usize,
     pub sitrep_metadata_batches: usize,
-    pub batch_size: u32,
     pub child_tables: BTreeMap<SitrepChildTable, ChildTableGcStats>,
+}
+
+/// Parameters for sitrep history table pruning. This is a struct because I
+/// really didn't like having the function take two positional arguments that
+/// were both `NonZeroU32`s that you could get backwards.
+#[derive(Copy, Clone)]
+pub struct HistoryPruningParams {
+    pub limit: NonZeroU32,
+    pub batch_size: NonZeroU32,
+}
+
+/// Describes the status of pruning old records from the end of the sitrep
+/// history table.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HistoryPruningStatus {
+    /// The history table holds no more than the configured limit of
+    /// entries, so nothing was pruned.
+    NotPruned { count: u64 },
+    /// The history table exceeded the limit, and the oldest `n_pruned`
+    /// entries were deleted. `newest_version_pruned` is the version of the
+    /// newest entry that was deleted, while oldest_version_pruned
+    Pruned {
+        n_pruned: usize,
+        oldest_version_pruned: u32,
+        newest_version_pruned: u32,
+    },
 }
 
 impl DataStore {
@@ -1367,6 +1392,7 @@ impl DataStore {
     pub async fn fm_sitrep_gc_orphans(
         &self,
         opctx: &OpContext,
+        batch_size: NonZeroU32,
     ) -> Result<GcOrphansResult, Error> {
         let conn = self.pool_connection_authorized(opctx).await?;
 
@@ -1382,8 +1408,7 @@ impl DataStore {
                 sitrep_metadata_batches += 1;
                 let (deleted, next_marker) =
                     Self::delete_orphaned_sitrep_metadata_query(
-                        marker,
-                        SQL_BATCH_SIZE,
+                        marker, batch_size,
                     )
                     .get_result_async::<(i64, Option<Uuid>)>(&*conn)
                     .await
@@ -1415,9 +1440,7 @@ impl DataStore {
                 stats.batches += 1;
                 let (rows_deleted, next_marker) =
                     Self::deeply_orphaned_batch_query(
-                        table,
-                        marker,
-                        SQL_BATCH_SIZE,
+                        table, marker, batch_size,
                     )
                     .get_result_async::<(i64, Option<Uuid>)>(&*conn)
                     .await
@@ -1442,7 +1465,6 @@ impl DataStore {
         let result = GcOrphansResult {
             sitreps_deleted,
             sitrep_metadata_batches,
-            batch_size: SQL_BATCH_SIZE.get(),
             child_tables,
         };
 
@@ -1673,7 +1695,7 @@ impl DataStore {
     pub async fn fm_sitrep_history_prune(
         &self,
         opctx: &OpContext,
-        deletion_threshold: NonZeroU32,
+        HistoryPruningParams { limit, batch_size }: HistoryPruningParams,
     ) -> Result<HistoryPruningStatus, Error> {
         // The "full" table scan below is treated as a complex operation. (This
         // should only be called from the FM analysis and sitrep GC background
@@ -1683,7 +1705,7 @@ impl DataStore {
         // TODO(eliza): there should probably be an authz object for the fm sitrep?
         opctx.authorize(authz::Action::Modify, &authz::FLEET).await?;
 
-        let limit = deletion_threshold.get();
+        let limit = limit.get();
         let limit_query = check_if_limit_reached::LimitQuery::new(
             history_dsl::fm_sitrep_history,
             u64::from(limit),
@@ -1718,36 +1740,74 @@ impl DataStore {
                     }
 
                     // Otherwise, we need to delete old versions that are over
-                    // the limit. To do this, we will determine the latest
-                    // version, subtract the limit to keep from that version to
-                    // determine the first version to delete, and delete all
-                    // versions less than or equal to that version number.
-                    let latest_version = Self::fm_current_sitrep_version_on_conn(&conn)
+                    // the limit. We want to delete the oldest version first,
+                    // and we want to delete up to `batch_size` records per
+                    // query. Doing this in a batched way is a little bit
+                    // complicated, because Postgres does not support `LIMIT` or
+                    // `ORDER BY` clauses on `DELETE` statements.
+                    //
+                    // First, determine the newest version that we are ALLOWED
+                    // to prune. We may not actually delete this one, if the
+                    // batch size limits us to deleting fewer rows than the
+                    // number that are above the limit.
+                    let newest_prunable_version = {
+                        // The latest prunable version is the latest version
+                        // minus the limit. So we must first determine the
+                        // latest version...
+                        let latest_version = Self::fm_current_sitrep_version_on_conn(&conn)
+                            .await?
+                            .ok_or_else(|| {
+                                let e = Error::InternalError {
+                                    internal_message: format!(
+                                        "if the sitrep history table count is \
+                                        over the limit ({limit}), there must \
+                                        be a latest version! this makes no \
+                                        sense",
+                                    ),
+                                };
+                                err.bail(TransactionError::CustomError(e))
+                            })?
+                            .version.0;
+                        latest_version
+                            .checked_sub(limit)
+                            .ok_or_else(|| {
+                                let e = Error::InternalError {
+                                    internal_message: format!(
+                                        "if the history table is over the limit, \
+                                         subtracing the limit ({limit}) from the \
+                                         latest version (v{latest_version}) should \
+                                         give us a version to prune!",
+                                    ),
+                                };
+                                err.bail(TransactionError::CustomError(e))
+                            })?
+                    };
+
+                    // Next, determine the newest version that we actually
+                    // *will* prune, ensuring that we prune no more than
+                    // `batch_size` records. We do this by determining the
+                    // newest version we would delete if we deleted up to
+                    // `earliest_version + batch_size` records, and then taking
+                    // the minimum of that and the newest version we're allowed
+                    // to prune.
+                    let earliest_version: u32 = history_dsl::fm_sitrep_history
+                        .select(diesel::dsl::min(history_dsl::version))
+                        .first_async::<Option<SqlU32>>(&conn)
                         .await?
                         .ok_or_else(|| {
-                            let e = Error::InternalError {
-                                internal_message: format!(
-                                    "if the sitrep history table count is over \
-                                     a non-zero limit ({limit}), there must be \
-                                     a latest version! this makes no sense",
-                                ),
-                            };
+                            let e = Error::internal_error(
+                                    "min(...) only returns NULL if the \
+                                    table is empty, and we know it isn't, \
+                                    so this should be impossible."
+                            );
                             err.bail(TransactionError::CustomError(e))
-                        })?
-                        .version.0;
-                    let newest_version_pruned = latest_version
-                        .checked_sub(limit)
-                        .ok_or_else(|| {
-                            let e = Error::InternalError {
-                                internal_message: format!(
-                                    "if the history table is over the limit, \
-                                     subtracing the limit ({limit}) from the \
-                                     latest version (v{latest_version}) should \
-                                     give us a version to prune!",
-                                ),
-                            };
-                            err.bail(TransactionError::CustomError(e))
-                        })?;
+                        })?.
+                        into();
+                    let newest_version_pruned = {
+                        let max_pruned = batch_size.get() - 1;
+                        newest_prunable_version
+                            .min(earliest_version.saturating_add(max_pruned))
+                    };
 
                     let n_pruned = diesel::delete(history_dsl::fm_sitrep_history)
                         .filter(history_dsl::version.le(SqlU32(newest_version_pruned)))

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -47,6 +47,7 @@ use nexus_db_schema::schema::fm_sitrep_history::dsl as history_dsl;
 use nexus_db_schema::schema::fm_support_bundle_request::dsl as support_bundle_req_dsl;
 use nexus_types::fm;
 use nexus_types::fm::Sitrep;
+use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningStatus;
 use nexus_types::support_bundle::{BundleData, BundleDataSelection};
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
@@ -64,6 +65,7 @@ use omicron_uuid_kinds::SupportBundleUuid;
 use slog_error_chain::InlineErrorChain;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -161,8 +163,7 @@ impl DataStore {
     ) -> Result<Option<fm::SitrepVersion>, Error> {
         opctx.authorize(authz::Action::ListChildren, &authz::FLEET).await?;
         let conn = self.pool_connection_authorized(opctx).await?;
-        let version = self
-            .fm_current_sitrep_version_on_conn(&conn)
+        let version = Self::fm_current_sitrep_version_on_conn(&conn)
             .await
             .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?
             .map(Into::into);
@@ -170,7 +171,6 @@ impl DataStore {
     }
 
     async fn fm_current_sitrep_version_on_conn(
-        &self,
         conn: &async_bb8_diesel::Connection<DbConnection>,
     ) -> Result<Option<model::SitrepVersion>, DieselError> {
         history_dsl::fm_sitrep_history
@@ -227,7 +227,7 @@ impl DataStore {
         let conn = self.pool_connection_authorized(opctx).await?;
         loop {
             let version =
-                self.fm_current_sitrep_version_on_conn(&conn).await.map_err(
+                Self::fm_current_sitrep_version_on_conn(&conn).await.map_err(
                     |e| public_error_from_diesel(e, ErrorHandler::Server),
                 )?;
             let version: fm::SitrepVersion = match version {
@@ -1283,7 +1283,7 @@ impl DataStore {
                     // First, ensure that we are not deleting the current
                     // sitrep, and bail out if we would.
                     if let Some(model::SitrepVersion { sitrep_id, .. }) =
-                        self.fm_current_sitrep_version_on_conn(&conn).await?
+                        Self::fm_current_sitrep_version_on_conn(&conn).await?
                     {
                         if ids.contains(&sitrep_id.as_untyped_uuid()) {
                             return Err(err.bail(TransactionError::CustomError(Error::conflict(format!(
@@ -1670,6 +1670,103 @@ impl DataStore {
                 Some(err) => err.into_public_ignore_retries(),
                 None => public_error_from_diesel(e, ErrorHandler::Server),
             })?
+    }
+
+    pub async fn fm_sitrep_history_prune(
+        &self,
+        opctx: &OpContext,
+        deletion_threshold: NonZeroU32,
+    ) -> Result<HistoryPruningStatus, Error> {
+        // The "full" table scan below is treated as a complex operation. (This
+        // should only be called from the FM analysis and sitrep GC background
+        // tasks, for which complex operations are allowed.)
+        opctx.check_complex_operations_allowed()?;
+
+        // TODO(eliza): there should probably be an authz object for the fm sitrep?
+        opctx.authorize(authz::Action::Modify, &authz::FLEET).await?;
+
+        let limit = deletion_threshold.get();
+        let limit_query = check_if_limit_reached::LimitQuery::new(
+            history_dsl::fm_sitrep_history,
+            u64::from(limit),
+        )?;
+        let conn = self.pool_connection_authorized(opctx).await?;
+
+        let err = OptionalError::new();
+
+        self.transaction_retry_wrapper("sitrep_history_prune")
+            .transaction(&conn, |conn| {
+                let err = err.clone();
+                let limit_query = limit_query.clone();
+                async move {
+                    // We need this to call the COUNT(*) query below. But note
+                    // that this isn't really a "full" table scan; the number of
+                    // rows scanned is limited by the LIMIT clause.
+                    conn.batch_execute_async(ALLOW_FULL_TABLE_SCAN_SQL)
+                        .await
+                        .map_err(|e| err.bail(TransactionError::Database(e)))?;
+
+                    // Rather than doing a full table scan, we use a LIMIT
+                    // clause to limit the number of rows returned.
+                    let limit_reached = limit_query
+                        .check_if_limit_reached_async(&conn)
+                        .await
+                        .map_err(|e| err.bail(TransactionError::Database(e)))?
+                        .map_err(|e| {
+                            err.bail(TransactionError::CustomError(e))
+                        })?;
+
+                    // If the history table is below the limit, we're done here.
+                    if let db::IsLimitReached::No { count } = limit_reached {
+                        return Ok(HistoryPruningStatus::BelowLimit {
+                            threshold: limit,
+                            count,
+                        });
+                    }
+
+                    // Otherwise, we need to delete old versions that are over
+                    // the limit. To do this, we will determine the latest
+                    // version, subtract the limit to keep from that version to
+                    // determine the first version to delete, and delete all
+                    // versions less than or equal to that version number.
+                    let latest_version = Self::fm_current_sitrep_version_on_conn(&conn)
+                        .await
+                        .map_err(|e| err.bail(TransactionError::Database(e)))?
+                        .ok_or_else(|| {
+                            let e = Error::InternalError {
+                                internal_message: format!(
+                                    "if the sitrep history table count is over \
+                                     a non-zero limit ({limit}), there must be \
+                                     a latest version! this makes no sense",
+                                ),
+                            };
+                            err.bail(TransactionError::CustomError(e))
+                        })?
+                        .version.0;
+                    let newest_version_pruned = latest_version
+                        .checked_sub(limit)
+                        .ok_or_else(|| {
+                            let e = Error::InternalError {
+                                internal_message: format!(
+                                    "if the history table is over the limit, \
+                                     subtracing the limit ({limit}) from the \
+                                     latest version (v{latest_version}) should \
+                                     give us a version to prune!",
+                                ),
+                            };
+                            err.bail(TransactionError::CustomError(e))
+                        })?;
+
+                    let n_pruned = diesel::delete(history_dsl::fm_sitrep_history).filter(history_dsl::version.le(SqlU32(newest_version_pruned))).execute_async(&conn).await.map_err(|e| err.bail(TransactionError::Database(e)))?;
+
+                    Ok(HistoryPruningStatus::Pruned { threshold: limit, n_pruned, newest_version_pruned })
+                }
+            })
+            .await
+            .map_err(|e| match err.take() {
+                Some(err) => err.into_public_ignore_retries(),
+                None => public_error_from_diesel(e, ErrorHandler::Server),
+            })
     }
 }
 

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -12,6 +12,8 @@
 use super::DataStore;
 use crate::authz;
 use crate::context::OpContext;
+use crate::db;
+use crate::db::check_if_limit_reached;
 use crate::db::datastore::RunnableQuery;
 use crate::db::datastore::SQL_BATCH_SIZE;
 use crate::db::model;
@@ -19,15 +21,19 @@ use crate::db::model::DbTypedUuid;
 use crate::db::model::SqlU32;
 use crate::db::pagination::Paginator;
 use crate::db::pagination::paginated;
+use crate::db::queries::ALLOW_FULL_TABLE_SCAN_SQL;
 use crate::db::raw_query_builder::QueryBuilder;
 use crate::db::raw_query_builder::TypedSqlQuery;
 use async_bb8_diesel::AsyncRunQueryDsl;
+use async_bb8_diesel::AsyncSimpleConnection;
 use diesel::prelude::*;
 use diesel::result::DatabaseErrorKind;
 use diesel::result::Error as DieselError;
 use diesel::sql_types;
 use dropshot::PaginationOrder;
 use nexus_db_errors::ErrorHandler;
+use nexus_db_errors::OptionalError;
+use nexus_db_errors::TransactionError;
 use nexus_db_errors::public_error_from_diesel;
 use nexus_db_lookup::DbConnection;
 use nexus_db_schema::schema::ereport::dsl as ereport_dsl;
@@ -1609,6 +1615,61 @@ impl DataStore {
             &pagparams,
         )
         .select(model::SitrepVersion::as_select())
+    }
+
+    /// Check whether the given sitrep limit has been reached.
+    ///
+    /// This (necessarily) does a full table scan on the sitrep table up to
+    /// the limit, so `limit` must be relatively small to avoid performance
+    /// issues.
+    pub async fn fm_sitrep_check_limit_reached(
+        &self,
+        opctx: &OpContext,
+        limit: u64,
+    ) -> Result<db::IsLimitReached, Error> {
+        // The "full" table scan below is treated as a complex operation. (This
+        // should only be called from the FM analysis and sitrep GC background
+        // tasks, for which complex operations are allowed.)
+        opctx.check_complex_operations_allowed()?;
+
+        // TODO(eliza): there should probably be an authz object for the fm sitrep?
+        opctx.authorize(authz::Action::ListChildren, &authz::FLEET).await?;
+
+        let limit_query = check_if_limit_reached::LimitQuery::new(
+            sitrep_dsl::fm_sitrep,
+            limit,
+        )?;
+        let conn = self.pool_connection_authorized(opctx).await?;
+
+        let err = OptionalError::new();
+
+        self.transaction_retry_wrapper("sitrep_count")
+            .transaction(&conn, |conn| {
+                let err = err.clone();
+                let limit_query = limit_query.clone();
+                async move {
+                    // We need this to call the COUNT(*) query below. But note
+                    // that this isn't really a "full" table scan; the number of
+                    // rows scanned is limited by the LIMIT clause.
+                    conn.batch_execute_async(ALLOW_FULL_TABLE_SCAN_SQL)
+                        .await
+                        .map_err(|e| err.bail(TransactionError::Database(e)))?;
+
+                    // Rather than doing a full table scan, we use a LIMIT
+                    // clause to limit the number of rows returned.
+                    let result = limit_query
+                        .check_if_limit_reached_async(&conn)
+                        .await
+                        .map_err(|e| err.bail(TransactionError::Database(e)))?;
+
+                    Ok(result)
+                }
+            })
+            .await
+            .map_err(|e| match err.take() {
+                Some(err) => err.into_public_ignore_retries(),
+                None => public_error_from_diesel(e, ErrorHandler::Server),
+            })?
     }
 }
 

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -47,7 +47,6 @@ use nexus_db_schema::schema::fm_sitrep_history::dsl as history_dsl;
 use nexus_db_schema::schema::fm_support_bundle_request::dsl as support_bundle_req_dsl;
 use nexus_types::fm;
 use nexus_types::fm::Sitrep;
-use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningStatus;
 use nexus_types::support_bundle::{BundleData, BundleDataSelection};
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
@@ -162,19 +161,21 @@ pub struct HistoryPruningParams {
 }
 
 /// Describes the status of pruning old records from the end of the sitrep
-/// history table.
+/// history table (returned by [`DataStore::fm_sitrep_history_prune`]).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum HistoryPruningStatus {
+pub enum HistoryPruningResult {
     /// The history table holds no more than the configured limit of
     /// entries, so nothing was pruned.
     NotPruned { count: u64 },
     /// The history table exceeded the limit, and the oldest `n_pruned`
-    /// entries were deleted. `newest_version_pruned` is the version of the
-    /// newest entry that was deleted, while oldest_version_pruned
+    /// entries were deleted.
     Pruned {
+        /// The number of entries that were deleted.
         n_pruned: usize,
-        oldest_version_pruned: u32,
-        newest_version_pruned: u32,
+        /// The version number of the oldest sitrep that was pruned.
+        oldest_pruned: u32,
+        /// The version number of the newest sitrep that was pruned.
+        newest_pruned: u32,
     },
 }
 
@@ -1692,11 +1693,26 @@ impl DataStore {
             })
     }
 
+    /// Prune the `fm_sitrep_history` table if more than `limit` records exist,
+    /// deleting up to `batch_size` records.
+    ///
+    /// This function will first check if more than `limit` records exist, and
+    /// then deletes up to `batch_size` records. It will never delete records
+    /// that result in *less than* `limit` records remaining in the table, so if
+    /// the current number of records is less than `limit + batch_size`, fewer
+    /// than `batch_size` records will be deleted. If more than `limit +
+    /// batch_size` records exist, only `batch_size` records will be deleted.
+    ///
+    /// If anything is deleted, this function returns
+    /// [`HistoryPruningResult::Pruned`]. Callers who wish to prune the table
+    /// to exactly `limit` records should call this function in a loop until it
+    /// returns [`HistoryPruningResult::NotPruned`], indicating that the table
+    /// has reached the desired size.
     pub async fn fm_sitrep_history_prune(
         &self,
         opctx: &OpContext,
         HistoryPruningParams { limit, batch_size }: HistoryPruningParams,
-    ) -> Result<HistoryPruningStatus, Error> {
+    ) -> Result<HistoryPruningResult, Error> {
         // The "full" table scan below is treated as a complex operation. (This
         // should only be called from the FM analysis and sitrep GC background
         // tasks, for which complex operations are allowed.)
@@ -1734,7 +1750,7 @@ impl DataStore {
 
                     // If the history table is below the limit, we're done here.
                     if let db::IsLimitReached::No { count } = limit_reached {
-                        return Ok(HistoryPruningStatus::NotPruned {
+                        return Ok(HistoryPruningResult::NotPruned {
                             count,
                         });
                     }
@@ -1787,30 +1803,30 @@ impl DataStore {
                     // *will* prune, ensuring that we prune no more than
                     // `batch_size` records. We do this by determining the
                     // newest version we would delete if we deleted up to
-                    // `earliest_version + batch_size` records, and then taking
+                    // `oldest_version + batch_size` records, and then taking
                     // the minimum of that and the newest version we're allowed
                     // to prune.
-                    let earliest_version: u32 = history_dsl::fm_sitrep_history
+                    let oldest_pruned: u32 = history_dsl::fm_sitrep_history
                         .select(diesel::dsl::min(history_dsl::version))
                         .first_async::<Option<SqlU32>>(&conn)
                         .await?
                         .ok_or_else(|| {
                             let e = Error::internal_error(
-                                    "min(...) only returns NULL if the \
-                                    table is empty, and we know it isn't, \
-                                    so this should be impossible."
+                                "min(...) only returns NULL if the table is \
+                                 empty, and we know it isn't, so this should \
+                                 be impossible.",
                             );
                             err.bail(TransactionError::CustomError(e))
-                        })?.
-                        into();
-                    let newest_version_pruned = {
+                        })?
+                        .into();
+                    let newest_pruned = {
                         let max_pruned = batch_size.get() - 1;
                         newest_prunable_version
-                            .min(earliest_version.saturating_add(max_pruned))
+                            .min(oldest_pruned.saturating_add(max_pruned))
                     };
 
                     let n_pruned = diesel::delete(history_dsl::fm_sitrep_history)
-                        .filter(history_dsl::version.le(SqlU32(newest_version_pruned)))
+                        .filter(history_dsl::version.le(SqlU32(newest_pruned)))
                         .execute_async(&conn)
                         .await?;
 
@@ -1823,14 +1839,15 @@ impl DataStore {
                     // don't say that we pruned something if we didn't actually
                     // delete anything.
                     if n_pruned == 0 {
-                        return Ok(HistoryPruningStatus::NotPruned {
+                        return Ok(HistoryPruningResult::NotPruned {
                             count: u64::from(limit),
                         });
                     }
 
-                    Ok(HistoryPruningStatus::Pruned {
+                    Ok(HistoryPruningResult::Pruned {
                         n_pruned,
-                        newest_version_pruned,
+                        oldest_pruned,
+                        newest_pruned,
                     })
                 }
             })
@@ -3580,8 +3597,10 @@ mod tests {
 
         // Run the unified GC, which should clean up the deeply-orphaned
         // children (and any normal orphans too).
-        let result =
-            datastore.fm_sitrep_gc_orphans(opctx).await.expect("GC orphans");
+        let result = datastore
+            .fm_sitrep_gc_orphans(opctx, SQL_BATCH_SIZE)
+            .await
+            .expect("GC orphans");
         assert_eq!(
             result.child_tables[&SitrepChildTable::Case].rows_deleted,
             1
@@ -4238,7 +4257,7 @@ mod tests {
             handles.push(tokio::spawn(async move {
                 while !stop.load(Ordering::Relaxed) {
                     let result = datastore
-                        .fm_sitrep_gc_orphans(&opctx)
+                        .fm_sitrep_gc_orphans(&opctx, SQL_BATCH_SIZE)
                         .await
                         .unwrap_or_else(|e| {
                             panic!(

--- a/nexus/db-queries/src/db/pub_test_utils/fm.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/fm.rs
@@ -1,0 +1,366 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Fault-management-specific datastore test helpers.
+
+use crate::context::OpContext;
+use crate::db::DataStore;
+use crate::db::IsLimitReached;
+use crate::db::datastore::fm::InsertSitrepError;
+use chrono::Utc;
+use nexus_types::fm::Sitrep;
+use nexus_types::fm::SitrepMetadata;
+use omicron_common::api::external::DataPageParams;
+use omicron_common::api::external::Error;
+use omicron_common::api::external::Generation;
+use omicron_uuid_kinds::CollectionUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::SitrepUuid;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+/// An in-memory model of the expected contents of the sitrep tables.
+///
+/// Tests that exercise sitrep insertion, history pruning, and orphan collection
+/// generally perform a sequence of setup operations and then check the database
+/// against what those operations should have produced. This struct is the
+/// corresponding model of the expected state of the records in the database.
+/// Operations are methods on the model, which update the model and the database
+/// together, and [`Self::assert_matches`] checks the database against the
+/// model.
+///
+/// The model tracks:
+///
+/// - [`Self::history`]: every sitrep ever made current, in version order.
+///   `history[i]` is the sitrep at version `i + 1`. Entries are not
+///   removed when the history is pruned. Instead, `earliest_live_version`
+///   records the version number of the oldest sitrep expected to exist in the
+///   database. Versions < `earliest_live_version` are still tracked in the
+///   model's history, but should no longer exist in the `fm_sitrep_history`
+///   table.
+///
+/// - [`Self::live_orphans`]: the IDs of sitreps present in `fm_sitrep` but
+///   never made current. This models what is left behind when a Nexus loses the
+///   race to commit a new sitrep.
+///
+/// - [`Self::gced_orphans`]: the IDs of sitreps that the GC is expected to have
+///   deleted.
+///
+/// Expected effects on the database that happen *outside* the model's own
+/// insert methods are recorded explicitly.
+///
+/// - When GC is performed, call [`Self::record_gc`] for a sitrep that is being
+///   deleted.
+/// - When a sitrep is made current by the code under test, rather than the
+///   model, call [`Self::record_committed`] with the ID of the newly
+///   committed sitrep.
+pub struct SitrepModel {
+    datastore: Arc<DataStore>,
+    /// Every sitrep ever made current, in version order: `history[i]` is
+    /// the sitrep at version `i + 1`, including entries that have since
+    /// been pruned (see `earliest_live_version`).
+    pub history: Vec<SitrepUuid>,
+    /// Orphaned sitreps expected to be present in `fm_sitrep`.
+    pub live_orphans: BTreeSet<SitrepUuid>,
+    /// Orphaned sitreps expected to have been deleted by the GC.
+    pub gced_orphans: BTreeSet<SitrepUuid>,
+    /// The earliest version expected to remain in `fm_sitrep_history`.
+    /// Versions older than this have been pruned.
+    earliest_live_version: u32,
+}
+
+impl SitrepModel {
+    pub fn new(datastore: Arc<DataStore>) -> Self {
+        Self {
+            datastore,
+            history: Vec::new(),
+            live_orphans: BTreeSet::new(),
+            gced_orphans: BTreeSet::new(),
+            earliest_live_version: 1,
+        }
+    }
+
+    /// The number of rows expected in the `fm_sitrep` table: live
+    /// history entries, plus orphans the GC has not yet deleted.
+    pub fn sitrep_count(&self) -> u64 {
+        let live_history =
+            self.history.len() - (self.earliest_live_version as usize - 1);
+        (live_history + self.live_orphans.len()) as u64
+    }
+
+    /// Insert `n` empty sitreps through the real insert path
+    /// ([`DataStore::fm_sitrep_insert`]), each the child of the previous
+    /// current sitrep, appending them to [`Self::history`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if any insert fails, including with `ParentNotCurrent`; this
+    /// can occur if a sitrep was made current without being recorded in the
+    /// model via [`Self::record_committed`].
+    pub async fn insert_history(&mut self, opctx: &OpContext, n: usize) {
+        for _ in 0..n {
+            let version = self.history.len() + 1;
+            let id = SitrepUuid::new_v4();
+            let parent = self.history.last().copied();
+            let sitrep =
+                test_sitrep(id, parent, format!("test sitrep v{version}"));
+            self.datastore
+                .fm_sitrep_insert(opctx, sitrep, None)
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("inserting sitrep v{version} should succeed: {e}")
+                });
+            self.history.push(id);
+            eprintln!(
+                "model: inserted sitrep {id} at v{version} (parent: {parent:?})"
+            );
+        }
+    }
+
+    /// Insert an empty sitrep that is *not* made current, leaving it
+    /// orphaned, and record it in [`Self::live_orphans`]. Returns the
+    /// orphan's ID.
+    ///
+    /// The sitrep is inserted with the given (stale) `parent_sitrep_id` through
+    /// the real insert path, which writes its rows to `fm_sitrep` and then
+    /// fails with [`InsertSitrepError::ParentNotCurrent`], leaving the rows
+    /// behind for the GC task to delete. This is exactly what happens when a
+    /// Nexus loses the race to commit a new sitrep.
+    ///
+    /// The orphan is inserted with no cases or ereports. Tests that care
+    /// about an orphan's child rows being cleaned up alongside it are in
+    /// the `nexus_db_queries::db::datastore::fm` module (see
+    /// `test_sitrep_delete_deletes_cases`), so callers here may trust that
+    /// deleting the orphan deletes its children.
+    ///
+    /// # Panics
+    ///
+    /// - If the insert successfully committed the sitrep (i.e.,
+    ///   `parent_sitrep_id` was actually current (or was `None` while the
+    ///   sitrep history was empty)
+    /// - If the insert fails with an error other than `ParentNotCurrent`
+    ///   (i.e. a database error)
+    pub async fn insert_orphan(
+        &mut self,
+        opctx: &OpContext,
+        parent_sitrep_id: Option<SitrepUuid>,
+    ) -> SitrepUuid {
+        let id = SitrepUuid::new_v4();
+        let sitrep =
+            test_sitrep(id, parent_sitrep_id, "orphaned test sitrep".into());
+        match self.datastore.fm_sitrep_insert(opctx, sitrep, None).await {
+            Ok(()) => panic!(
+                "inserting sitrep {id} with parent {parent_sitrep_id:?} \
+                should fail with ParentNotCurrent, but it was made current \
+                unexpectedly. this is *probably* a test bug!"
+            ),
+            Err(InsertSitrepError::ParentNotCurrent(orphan_id)) => {
+                assert_eq!(
+                    orphan_id, id,
+                    "ParentNotCurrent should carry the ID of the sitrep we \
+                     just tried to insert"
+                );
+                self.live_orphans.insert(id);
+                eprintln!(
+                    "model: inserted sitrep {id}, orphaned \
+                     (parent: {parent_sitrep_id:?})"
+                );
+                id
+            }
+            Err(InsertSitrepError::Other(e)) => panic!(
+                "expected inserting sitrep {id} to fail with \
+                 ParentNotCurrent, but it failed with an unexpected error: {e}"
+            ),
+        }
+    }
+
+    /// Record a sitrep that was made current by something other than this
+    /// model (e.g. committed by the FM analysis task), appending it to
+    /// [`Self::history`].
+    pub fn record_committed(&mut self, id: SitrepUuid) {
+        self.history.push(id);
+        eprintln!("model: recorded sitrep {id} at v{}", self.history.len());
+    }
+
+    /// Record the expected effects of a sitrep GC activation: all
+    /// outstanding orphans are collected, and, if `newest_version_pruned`
+    /// is `Some`, history versions up to and including it are pruned (and
+    /// their sitreps collected by the same activation's orphan sweep).
+    pub fn record_gc(&mut self, newest_version_pruned: Option<u32>) {
+        if let Some(version) = newest_version_pruned {
+            assert!(
+                (version as usize) < self.history.len(),
+                "the current sitrep (v{}) must never be pruned",
+                self.history.len(),
+            );
+            self.earliest_live_version =
+                self.earliest_live_version.max(version + 1);
+        }
+        let gced = std::mem::take(&mut self.live_orphans);
+        eprintln!(
+            "model: recorded GC:\n  \
+             newest version pruned: {newest_version_pruned:?}, \
+             earliest live version now v{}",
+            self.earliest_live_version,
+        );
+        for orphan in &gced {
+            eprintln!("  - GC'd: {orphan}")
+        }
+        self.gced_orphans.extend(gced);
+    }
+
+    /// Assert that the database contents match this model:
+    ///
+    /// - `fm_sitrep_history` contains exactly the live (unpruned) versions,
+    ///   mapped to the expected sitrep IDs, and the current-sitrep query
+    ///   agrees;
+    /// - sitreps for pruned history versions and collected orphans have
+    ///   been deleted, while live history sitreps and uncollected orphans
+    ///   exist;
+    /// - the total `fm_sitrep` row count matches [`Self::sitrep_count`]
+    ///   (catching stray rows that the per-ID checks above cannot, since a
+    ///   sitrep this model never learned about has an unknown ID).
+    pub async fn assert_matches(&self, opctx: &OpContext) {
+        let Self {
+            ref datastore,
+            ref history,
+            live_orphans: ref orphans,
+            gced_orphans: ref collected_orphans,
+            earliest_live_version: first_live_version,
+        } = *self;
+        let first_live_idx = first_live_version as usize - 1;
+
+        eprintln!(
+            "model: checking database against model:\n  \
+              history v{first_live_version}..=v{} ({} pruned),\n  \
+              {} live orphans, {} GC'd orphans,\n  \
+              {} total fm_sitrep rows expected",
+            history.len(),
+            first_live_idx,
+            orphans.len(),
+            collected_orphans.len(),
+            self.sitrep_count(),
+        );
+
+        // The history table contains exactly the live versions...
+        let versions = datastore
+            .fm_sitrep_version_list(opctx, &DataPageParams::max_page())
+            .await
+            .expect("listing sitrep versions should succeed");
+        let actual: Vec<(u32, SitrepUuid)> =
+            versions.iter().map(|v| (v.version, v.id)).collect();
+        let expected: Vec<(u32, SitrepUuid)> = (first_live_version..)
+            .zip(history[first_live_idx..].iter().copied())
+            .collect();
+        assert_eq!(
+            actual,
+            expected,
+            "fm_sitrep_history should contain exactly versions {}..={}",
+            first_live_version,
+            history.len(),
+        );
+
+        // ...and the current-sitrep query agrees with the model.
+        let current = datastore
+            .fm_current_sitrep_version(opctx)
+            .await
+            .expect("reading the current sitrep version should succeed");
+        match (current, history.last()) {
+            (Some(current), Some(&id)) => {
+                assert_eq!(
+                    (current.version, current.id),
+                    (history.len() as u32, id),
+                    "the current sitrep should be the latest history entry"
+                );
+            }
+            (None, None) => {}
+            (current, expected) => panic!(
+                "current sitrep mismatch: datastore has {current:?}, \
+                 model expects {expected:?}"
+            ),
+        }
+
+        // Pruned history sitreps are deleted; live ones exist.
+        for &id in &history[..first_live_idx] {
+            assert_sitrep_deleted(datastore, opctx, id).await;
+        }
+        for &id in &history[first_live_idx..] {
+            assert_sitrep_exists(datastore, opctx, id).await;
+        }
+
+        // Uncollected orphans exist; collected ones are deleted.
+        for &id in orphans {
+            assert_sitrep_exists(datastore, opctx, id).await;
+        }
+        for &id in collected_orphans {
+            assert_sitrep_deleted(datastore, opctx, id).await;
+        }
+
+        // Finally, the total row count matches, so there are no stray
+        // sitreps unknown to the model.
+        let count = self.sitrep_count();
+        let result = datastore
+            .fm_sitrep_check_limit_reached(opctx, count + 1)
+            .await
+            .expect("counting fm_sitrep rows should succeed");
+        assert_eq!(
+            result,
+            IsLimitReached::No { count },
+            "fm_sitrep should contain exactly {count} rows"
+        );
+
+        eprintln!("model: database matches model");
+    }
+}
+
+/// Returns an empty test [`Sitrep`] with the given ID, parent, and comment.
+fn test_sitrep(
+    id: SitrepUuid,
+    parent_sitrep_id: Option<SitrepUuid>,
+    comment: String,
+) -> Sitrep {
+    Sitrep {
+        metadata: SitrepMetadata {
+            id,
+            parent_sitrep_id,
+            inv_collection_id: CollectionUuid::new_v4(),
+            next_inv_min_time_started: Utc::now(),
+            creator_id: OmicronZoneUuid::new_v4(),
+            comment,
+            time_created: Utc::now(),
+            alert_generation: Generation::new(),
+            support_bundle_generation: Generation::new(),
+        },
+        cases: Default::default(),
+        ereports_by_id: Default::default(),
+    }
+}
+
+async fn assert_sitrep_exists(
+    datastore: &DataStore,
+    opctx: &OpContext,
+    id: SitrepUuid,
+) {
+    match datastore.fm_sitrep_metadata_read(opctx, id).await {
+        Ok(_) => {}
+        Err(Error::NotFound { .. }) => {
+            panic!("sitrep {id} should exist, but it has been deleted")
+        }
+        Err(e) => panic!("unexpected error reading sitrep {id}: {e}"),
+    }
+}
+
+async fn assert_sitrep_deleted(
+    datastore: &DataStore,
+    opctx: &OpContext,
+    id: SitrepUuid,
+) {
+    match datastore.fm_sitrep_metadata_read(opctx, id).await {
+        Ok(_) => {
+            panic!("sitrep {id} should have been deleted, but it still exists")
+        }
+        Err(Error::NotFound { .. }) => {}
+        Err(e) => panic!("unexpected error reading sitrep {id}: {e}"),
+    }
+}

--- a/nexus/db-queries/src/db/pub_test_utils/fm.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/fm.rs
@@ -7,10 +7,12 @@
 use crate::context::OpContext;
 use crate::db::DataStore;
 use crate::db::IsLimitReached;
+use crate::db::datastore::fm;
 use crate::db::datastore::fm::InsertSitrepError;
 use chrono::Utc;
 use nexus_types::fm::Sitrep;
 use nexus_types::fm::SitrepMetadata;
+use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningStatus;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::Generation;
@@ -18,6 +20,7 @@ use omicron_uuid_kinds::CollectionUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SitrepUuid;
 use std::collections::BTreeSet;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 /// An in-memory model of the expected contents of the sitrep tables.
@@ -50,8 +53,11 @@ use std::sync::Arc;
 /// Expected effects on the database that happen *outside* the model's own
 /// insert methods are recorded explicitly.
 ///
-/// - When GC is performed, call [`Self::record_gc`] for a sitrep that is being
-///   deleted.
+/// - When a GC activation runs, call [`Self::simulate_gc`] with the task's
+///   configured history limit. The model computes what the GC should do
+///   given that limit, applies those effects to itself, and returns them so
+///   that the test can compare the task's reported status against the
+///   model's prediction.
 /// - When a sitrep is made current by the code under test, rather than the
 ///   model, call [`Self::record_committed`] with the ID of the newly
 ///   committed sitrep.
@@ -84,9 +90,18 @@ impl SitrepModel {
     /// The number of rows expected in the `fm_sitrep` table: live
     /// history entries, plus orphans the GC has not yet deleted.
     pub fn sitrep_count(&self) -> u64 {
-        let live_history =
-            self.history.len() - (self.earliest_live_version as usize - 1);
-        (live_history + self.live_orphans.len()) as u64
+        (self.history_count() + self.live_orphans.len()) as u64
+    }
+
+    /// The number of rows expected in the `fm_sitrep_history` table.
+    pub fn history_count(&self) -> usize {
+        (self.history.len() + 1) - self.earliest_live_version as usize
+    }
+
+    pub fn latest_version(&self) -> u32 {
+        u32::try_from(self.history.len()).expect(
+            "total number of sitreps in test exceeds a u32, that's wacky",
+        )
     }
 
     /// Insert `n` empty sitreps through the real insert path
@@ -183,31 +198,68 @@ impl SitrepModel {
         eprintln!("model: recorded sitrep {id} at v{}", self.history.len());
     }
 
-    /// Record the expected effects of a sitrep GC activation: all
-    /// outstanding orphans are collected, and, if `newest_version_pruned`
-    /// is `Some`, history versions up to and including it are pruned (and
-    /// their sitreps collected by the same activation's orphan sweep).
-    pub fn record_gc(&mut self, newest_version_pruned: Option<u32>) {
-        if let Some(version) = newest_version_pruned {
-            assert!(
-                (version as usize) < self.history.len(),
-                "the current sitrep (v{}) must never be pruned",
-                self.history.len(),
-            );
-            self.earliest_live_version =
-                self.earliest_live_version.max(version + 1);
-        }
-        let gced = std::mem::take(&mut self.live_orphans);
+    /// Simulate a sitrep GC activation with the given `history_limit`,
+    /// applying its expected effects to the model and returning them as an
+    /// [`ExpectedGc`], so that the test can compare the task's reported
+    /// status against the model's prediction.
+    ///
+    /// This simulates what the GC task *should* do:
+    ///
+    /// - If the history table holds fewer than `history_limit` rows, nothing
+    ///   is pruned.
+    /// - Otherwise, the newest `history_limit` versions are kept, and every
+    ///   version at or below `latest_version - history_limit` is pruned.
+    /// - All orphaned sitreps, including those newly orphaned by pruning
+    ///   the history, are deleted by the orphan sweep.
+    pub fn simulate_gc(&mut self, history_limit: NonZeroU32) -> ExpectedGc {
+        let latest_version = self.latest_version();
+        let history_count = u32::try_from(self.history_count())
+            .expect("test current history count exceeds u32");
+        let history_limit = history_limit.get();
         eprintln!(
-            "model: recorded GC:\n  \
-             newest version pruned: {newest_version_pruned:?}, \
-             earliest live version now v{}",
+            "model: simulating GC with history_limit={history_limit}, \
+             latest_version=v{latest_version}, history_count={history_count}"
+        );
+        let mut history_pruned = 0;
+        let pruning = if history_count < history_limit {
+            HistoryPruningStatus::BelowLimit { count: history_count.into() }
+        } else {
+            let newest_version_pruned = latest_version - history_limit;
+            // The versions pruned are
+            // `earliest_live_version..=newest_version_pruned`.
+            // Note that the indices in `history` are 0-indexed, while versions
+            // start at 1, so we must subtract to find the starting index. Since
+            // `newest_version_pruned` is 1 more than the index of the newest
+            // live version, the end index for this slice is already exclusive.
+            let earliest_pruned_idx = self.earliest_live_version as usize - 1;
+            let to_prune = &self.history
+                [earliest_pruned_idx..newest_version_pruned as usize];
+            for &id in to_prune {
+                let v = self.earliest_live_version + history_pruned;
+                eprintln!("  - pruned v{v} (sitrep {id}) from history");
+                self.live_orphans.insert(id);
+                history_pruned += 1;
+            }
+            self.earliest_live_version = newest_version_pruned + 1;
+            HistoryPruningStatus::Pruned {
+                n_pruned: history_pruned as usize,
+                newest_version_pruned,
+            }
+        };
+        let gced = std::mem::take(&mut self.live_orphans);
+        let orphans_deleted = gced.len();
+        eprintln!(
+            "model: simulated GC with history limit {history_limit}:\n  \
+             pruning: {pruning:?}, \
+             earliest live version now v{}, \
+             expecting {orphans_deleted} orphaned sitreps deleted",
             self.earliest_live_version,
         );
         for orphan in &gced {
             eprintln!("  - GC'd: {orphan}")
         }
         self.gced_orphans.extend(gced);
+        ExpectedGc { pruning, orphans_deleted }
     }
 
     /// Assert that the database contents match this model:
@@ -218,6 +270,7 @@ impl SitrepModel {
     /// - sitreps for pruned history versions and collected orphans have
     ///   been deleted, while live history sitreps and uncollected orphans
     ///   exist;
+    /// - no child tables for deleted sitreps exist in the database;
     /// - the total `fm_sitrep` row count matches [`Self::sitrep_count`]
     ///   (catching stray rows that the per-ID checks above cannot, since a
     ///   sitrep this model never learned about has an unknown ID).
@@ -314,6 +367,17 @@ impl SitrepModel {
     }
 }
 
+/// The expected outcome of a sitrep GC activation, as computed by
+/// [`SitrepModel::simulate_gc`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExpectedGc {
+    /// The pruning status the GC task should report.
+    pub pruning: HistoryPruningStatus,
+    /// The number of orphaned sitreps the task's orphan sweep should delete,
+    /// including sitreps newly orphaned by pruning the history.
+    pub orphans_deleted: usize,
+}
+
 /// Returns an empty test [`Sitrep`] with the given ID, parent, and comment.
 fn test_sitrep(
     id: SitrepUuid,
@@ -358,9 +422,16 @@ async fn assert_sitrep_deleted(
 ) {
     match datastore.fm_sitrep_metadata_read(opctx, id).await {
         Ok(_) => {
-            panic!("sitrep {id} should have been deleted, but it still exists")
+            panic!(
+                "sitrep {id} should have been deleted, but its metadata row \
+                 still exists"
+            )
         }
         Err(Error::NotFound { .. }) => {}
-        Err(e) => panic!("unexpected error reading sitrep {id}: {e}"),
+        Err(e) => {
+            panic!("unexpected error reading sitrep metadata for {id}: {e}")
+        }
     }
+
+    fm::test_utils::ensure_sitrep_children_fully_deleted(datastore, id).await;
 }

--- a/nexus/db-queries/src/db/pub_test_utils/fm.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/fm.rs
@@ -12,7 +12,7 @@ use crate::db::datastore::fm::InsertSitrepError;
 use chrono::Utc;
 use nexus_types::fm::Sitrep;
 use nexus_types::fm::SitrepMetadata;
-use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningStatus;
+use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningOutcome;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::Generation;
@@ -21,6 +21,7 @@ use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SitrepUuid;
 use std::collections::BTreeSet;
 use std::num::NonZeroU32;
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 /// An in-memory model of the expected contents of the sitrep tables.
@@ -205,26 +206,31 @@ impl SitrepModel {
     ///
     /// This simulates what the GC task *should* do:
     ///
-    /// - If the history table holds no more than `history_limit` rows, nothing
-    ///   is pruned.
+    /// - If the history table holds no more than `history_limit` rows,
+    ///   nothing is pruned.
     /// - Otherwise, the newest `history_limit` versions are kept, and every
-    ///   version at or below `latest_version - history_limit` is pruned.
-    ///   `Pruned` is only reported when at least one row was deleted.
+    ///   version at or below `latest_version - history_limit` is pruned,
+    ///   oldest versions first.
+    /// - Either way, the pruning loop should end by observing that the
+    ///   history table is within the limit, reporting the number of entries
+    ///   that remain: [`HistoryPruningOutcome::Pruned`] if this activation
+    ///   pruned something, and [`HistoryPruningOutcome::NotPruned`] if it
+    ///   didn't.
     /// - All orphaned sitreps, including those newly orphaned by pruning
     ///   the history, are deleted by the orphan sweep.
     pub fn simulate_gc(&mut self, history_limit: NonZeroU32) -> ExpectedGc {
+        let history_limit = history_limit.get();
         let latest_version = self.latest_version();
         let history_count = u32::try_from(self.history_count())
             .expect("test current history count exceeds u32");
-        let history_limit = history_limit.get();
         eprintln!(
             "model: simulating GC with history_limit={history_limit}, \
              latest_version=v{latest_version}, history_count={history_count}"
         );
-        let mut history_pruned = 0;
-        let pruning = if history_count <= history_limit {
-            HistoryPruningStatus::NotPruned { count: history_count.into() }
-        } else {
+        let mut versions_pruned = None;
+        let mut history_pruned: u32 = 0;
+        if history_count > history_limit {
+            let oldest_version_pruned = self.earliest_live_version;
             let newest_version_pruned = latest_version - history_limit;
             // The versions pruned are
             // `earliest_live_version..=newest_version_pruned`.
@@ -242,16 +248,24 @@ impl SitrepModel {
                 history_pruned += 1;
             }
             self.earliest_live_version = newest_version_pruned + 1;
-            HistoryPruningStatus::Pruned {
-                n_pruned: history_pruned as usize,
-                newest_version_pruned,
-            }
+            versions_pruned =
+                Some(oldest_version_pruned..=newest_version_pruned);
+        }
+        // Either way, the pruning loop terminates by observing that the
+        // history table is within the limit. If we pruned anything, exactly
+        // `limit` entries remain; otherwise, the count is unchanged.
+        let outcome = if history_pruned > 0 {
+            HistoryPruningOutcome::Pruned { count: u64::from(history_limit) }
+        } else {
+            HistoryPruningOutcome::NotPruned { count: history_count.into() }
         };
         let gced = std::mem::take(&mut self.live_orphans);
         let orphans_deleted = gced.len();
         eprintln!(
             "model: simulated GC with history limit {history_limit}:\n  \
-             pruning: {pruning:?}, \
+             sitreps_pruned: {history_pruned}, \
+             versions_pruned: {versions_pruned:?}, \
+             outcome: {outcome:?}, \
              earliest live version now v{}, \
              expecting {orphans_deleted} orphaned sitreps deleted",
             self.earliest_live_version,
@@ -260,7 +274,12 @@ impl SitrepModel {
             eprintln!("  - GC'd: {orphan}")
         }
         self.gced_orphans.extend(gced);
-        ExpectedGc { pruning, orphans_deleted }
+        ExpectedGc {
+            sitreps_pruned: history_pruned as usize,
+            versions_pruned,
+            outcome,
+            orphans_deleted,
+        }
     }
 
     /// Assert that the database contents match this model:
@@ -372,8 +391,13 @@ impl SitrepModel {
 /// [`SitrepModel::simulate_gc`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExpectedGc {
-    /// The pruning status the GC task should report.
-    pub pruning: HistoryPruningStatus,
+    /// The total number of history table entries that should be pruned.
+    pub sitreps_pruned: usize,
+    /// The range of versions that should be pruned (oldest..=newest), if
+    /// any.
+    pub versions_pruned: Option<RangeInclusive<u32>>,
+    /// The outcome the pruning loop should end with.
+    pub outcome: HistoryPruningOutcome,
     /// The number of orphaned sitreps the task's orphan sweep should delete,
     /// including sitreps newly orphaned by pruning the history.
     pub orphans_deleted: usize,

--- a/nexus/db-queries/src/db/pub_test_utils/fm.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/fm.rs
@@ -205,10 +205,11 @@ impl SitrepModel {
     ///
     /// This simulates what the GC task *should* do:
     ///
-    /// - If the history table holds fewer than `history_limit` rows, nothing
+    /// - If the history table holds no more than `history_limit` rows, nothing
     ///   is pruned.
     /// - Otherwise, the newest `history_limit` versions are kept, and every
     ///   version at or below `latest_version - history_limit` is pruned.
+    ///   `Pruned` is only reported when at least one row was deleted.
     /// - All orphaned sitreps, including those newly orphaned by pruning
     ///   the history, are deleted by the orphan sweep.
     pub fn simulate_gc(&mut self, history_limit: NonZeroU32) -> ExpectedGc {
@@ -221,8 +222,8 @@ impl SitrepModel {
              latest_version=v{latest_version}, history_count={history_count}"
         );
         let mut history_pruned = 0;
-        let pruning = if history_count < history_limit {
-            HistoryPruningStatus::BelowLimit { count: history_count.into() }
+        let pruning = if history_count <= history_limit {
+            HistoryPruningStatus::NotPruned { count: history_count.into() }
         } else {
             let newest_version_pruned = latest_version - history_limit;
             // The versions pruned are

--- a/nexus/db-queries/src/db/pub_test_utils/fm.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/fm.rs
@@ -9,14 +9,20 @@ use crate::db::DataStore;
 use crate::db::IsLimitReached;
 use crate::db::datastore::fm;
 use crate::db::datastore::fm::InsertSitrepError;
+use crate::db::model::SqlU32;
+use async_bb8_diesel::AsyncRunQueryDsl;
 use chrono::Utc;
+use diesel::prelude::*;
+use nexus_db_schema::schema::fm_sitrep::dsl as sitrep_dsl;
+use nexus_db_schema::schema::fm_sitrep_history::dsl as history_dsl;
 use nexus_types::fm::Sitrep;
 use nexus_types::fm::SitrepMetadata;
-use nexus_types::internal_api::background::fm_sitrep_gc::HistoryPruningOutcome;
+use nexus_types::internal_api::background::fm_sitrep_history_pruner;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::Generation;
 use omicron_uuid_kinds::CollectionUuid;
+use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SitrepUuid;
 use std::collections::BTreeSet;
@@ -54,14 +60,23 @@ use std::sync::Arc;
 /// Expected effects on the database that happen *outside* the model's own
 /// insert methods are recorded explicitly.
 ///
-/// - When a GC activation runs, call [`Self::simulate_gc`] with the task's
-///   configured history limit. The model computes what the GC should do
-///   given that limit, applies those effects to itself, and returns them so
-///   that the test can compare the task's reported status against the
-///   model's prediction.
+/// - When a `fm_sitrep_history_pruner` activation runs, call
+///   [`Self::simulate_history_pruning`] with the task's configured history
+///   limit. The model computes what pruning should do given that limit,
+///   applies those effects to itself, and returns them so that the test can
+///   compare the task's reported status against the model's prediction.
+/// - When a `fm_sitrep_gc` activation runs, call
+///   [`Self::simulate_orphan_gc`], which does the same for the orphan sweep.
 /// - When a sitrep is made current by the code under test, rather than the
 ///   model, call [`Self::record_committed`] with the ID of the newly
 ///   committed sitrep.
+///
+/// So that each task can be tested in isolation, without running the other
+/// task, the model can also *apply* either half's simulated effects directly
+/// to the database: see [`Self::prune_history`] and [`Self::gc_orphans`]. These
+/// simulate a history pruning or orphan GC pass, and then update the database
+/// state to reflect the effects. This way, each task can be tested individually
+/// against the model's in-memory simulation of what the other task *should* do.
 pub struct SitrepModel {
     datastore: Arc<DataStore>,
     /// Every sitrep ever made current, in version order: `history[i]` is
@@ -199,32 +214,35 @@ impl SitrepModel {
         eprintln!("model: recorded sitrep {id} at v{}", self.history.len());
     }
 
-    /// Simulate a sitrep GC activation with the given `history_limit`,
-    /// applying its expected effects to the model and returning them as an
-    /// [`ExpectedGc`], so that the test can compare the task's reported
-    /// status against the model's prediction.
+    /// Simulate a sitrep history pruner activation with the given
+    /// `history_limit`, applying its expected effects to the model and
+    /// returning them as an [`ExpectedPruning`], so that the test can
+    /// compare the task's reported status against the model's prediction.
     ///
-    /// This simulates what the GC task *should* do:
+    /// This simulates what the pruner task *should* do:
     ///
     /// - If the history table holds no more than `history_limit` rows,
     ///   nothing is pruned.
     /// - Otherwise, the newest `history_limit` versions are kept, and every
     ///   version at or below `latest_version - history_limit` is pruned,
-    ///   oldest versions first.
+    ///   oldest versions first. The sitreps referenced by the pruned entries
+    ///   become orphans (they are added to [`Self::live_orphans`], to be
+    ///   collected by a future orphan sweep).
     /// - Either way, the pruning loop should end by observing that the
     ///   history table is within the limit, reporting the number of entries
-    ///   that remain: [`HistoryPruningOutcome::Pruned`] if this activation
-    ///   pruned something, and [`HistoryPruningOutcome::NotPruned`] if it
-    ///   didn't.
-    /// - All orphaned sitreps, including those newly orphaned by pruning
-    ///   the history, are deleted by the orphan sweep.
-    pub fn simulate_gc(&mut self, history_limit: NonZeroU32) -> ExpectedGc {
+    ///   that remain: [`fm_sitrep_history_pruner::Outcome::Pruned`] if this
+    ///   activation pruned something, and
+    ///   [`fm_sitrep_history_pruner::Outcome::NotPruned`] if it didn't.
+    pub fn simulate_history_pruning(
+        &mut self,
+        history_limit: NonZeroU32,
+    ) -> ExpectedPruning {
         let history_limit = history_limit.get();
         let latest_version = self.latest_version();
         let history_count = u32::try_from(self.history_count())
             .expect("test current history count exceeds u32");
         eprintln!(
-            "model: simulating GC with history_limit={history_limit}, \
+            "model: simulating pruning with history_limit={history_limit}, \
              latest_version=v{latest_version}, history_count={history_count}"
         );
         let mut versions_pruned = None;
@@ -255,31 +273,118 @@ impl SitrepModel {
         // history table is within the limit. If we pruned anything, exactly
         // `limit` entries remain; otherwise, the count is unchanged.
         let outcome = if history_pruned > 0 {
-            HistoryPruningOutcome::Pruned { count: u64::from(history_limit) }
+            fm_sitrep_history_pruner::Outcome::Pruned {
+                count: u64::from(history_limit),
+            }
         } else {
-            HistoryPruningOutcome::NotPruned { count: history_count.into() }
+            fm_sitrep_history_pruner::Outcome::NotPruned {
+                count: history_count.into(),
+            }
         };
-        let gced = std::mem::take(&mut self.live_orphans);
-        let orphans_deleted = gced.len();
         eprintln!(
-            "model: simulated GC with history limit {history_limit}:\n  \
+            "model: simulated pruning history to limit {history_limit}:\n  \
              sitreps_pruned: {history_pruned}, \
              versions_pruned: {versions_pruned:?}, \
              outcome: {outcome:?}, \
-             earliest live version now v{}, \
-             expecting {orphans_deleted} orphaned sitreps deleted",
+             earliest live version now v{}",
             self.earliest_live_version,
+        );
+        ExpectedPruning {
+            sitreps_pruned: history_pruned as usize,
+            versions_pruned,
+            outcome,
+        }
+    }
+
+    /// Simulate a sitrep GC orphan sweep, applying its expected effects to
+    /// the model and returning the number of orphaned sitreps that should
+    /// have been deleted, so that the test can compare the task's reported
+    /// status against the model's prediction.
+    ///
+    /// All live orphans (both those created when a Nexus loses a commit race and
+    /// those created when committed sitreps are removed from history by the
+    /// sitrep pruner)  are expected to be deleted by the sweep.
+    pub fn simulate_orphan_gc(&mut self) -> usize {
+        let gced = std::mem::take(&mut self.live_orphans);
+        let orphans_deleted = gced.len();
+        eprintln!(
+            "model: simulated orphan GC, expecting {orphans_deleted} \
+             orphaned sitreps deleted"
         );
         for orphan in &gced {
             eprintln!("  - GC'd: {orphan}")
         }
         self.gced_orphans.extend(gced);
-        ExpectedGc {
-            sitreps_pruned: history_pruned as usize,
-            versions_pruned,
-            outcome,
-            orphans_deleted,
+        orphans_deleted
+    }
+
+    /// Prune the sitrep history to (at most) `history_limit` entries,
+    /// simulating what a `fm_sitrep_history_pruner` task activation would
+    /// do, and applying the simulated effects to the database.
+    ///
+    /// Note that this does *not* invoke the datastore's history pruning
+    /// machinery. Instead, the model determines which versions should be pruned
+    /// from its own internal representation, (by calling
+    /// [`Self::simulate_orphan_gc`]) and deletes exactly those rows from the
+    /// history table by primary key. This updates the database to match the
+    /// model, which allows tests for the GC task to construct prune-orphaned
+    /// sitreps without depending on the pruner's correctness.
+    pub async fn prune_history(&mut self, history_limit: NonZeroU32) {
+        let expected = self.simulate_history_pruning(history_limit);
+        let Some(versions) = expected.versions_pruned else {
+            return;
+        };
+        let conn = self.datastore.pool_connection_for_tests().await.unwrap();
+        let pruned: Vec<SqlU32> = versions.clone().map(SqlU32).collect();
+        let n_deleted = diesel::delete(
+            history_dsl::fm_sitrep_history
+                .filter(history_dsl::version.eq_any(pruned)),
+        )
+        .execute_async(&*conn)
+        .await
+        .expect("deleting pruned history rows should succeed");
+        assert_eq!(
+            n_deleted, expected.sitreps_pruned,
+            "the history table should contain exactly the versions \
+             (v{versions:?}) that the model chose to prune"
+        );
+    }
+
+    /// Delete all orphaned sitreps, simulating what a `fm_sitrep_gc` orphan
+    /// sweep would do, and applying the simulated effects to the database.
+    ///
+    /// As with [`Self::prune_history`], this does *not* invoke the
+    /// datastore's orphan GC machinery, which is the code under test in the
+    /// GC task's own tests. Instead, the model deletes the sitreps it knows
+    /// to be orphaned from the `fm_sitrep` table by primary key, so that the
+    /// database matches the model.
+    ///
+    /// The model only ever creates empty sitreps with no child-table records
+    /// (see [`test_sitrep`]), so deleting the metadata row is the sweep's
+    /// entire effect. If the model ever grows sitreps with children, the
+    /// child-table checks in [`Self::assert_matches`] will fail loudly here. If
+    /// that happens, we'll have to update this code to also delete all the
+    /// child table records, which I don't really want to do because it would be
+    /// annoying.
+    pub async fn gc_orphans(&mut self) {
+        let orphans: Vec<_> =
+            self.live_orphans.iter().map(|id| id.into_untyped_uuid()).collect();
+        let expected_deleted = self.simulate_orphan_gc();
+        if orphans.is_empty() {
+            return;
         }
+        let conn = self.datastore.pool_connection_for_tests().await.unwrap();
+        let n_deleted = diesel::delete(
+            sitrep_dsl::fm_sitrep.filter(sitrep_dsl::id.eq_any(orphans)),
+        )
+        .execute_async(&*conn)
+        .await
+        .expect("deleting orphaned sitreps should succeed");
+        assert_eq!(
+            n_deleted, expected_deleted,
+            "the fm_sitrep table should contain exactly the sitreps that \
+             the model believes are live orphans"
+        );
     }
 
     /// Assert that the database contents match this model:
@@ -354,10 +459,20 @@ impl SitrepModel {
             ),
         }
 
-        // Pruned history sitreps are deleted; live ones exist.
+        // Sitreps whose history entries were pruned become orphans: they
+        // are tracked in `live_orphans` until an orphan sweep moves them to
+        // `gced_orphans`, and the loops below check their existence in the
+        // database accordingly. Here, just make sure the model is tracking
+        // every pruned sitrep in one of those two sets.
         for &id in &history[..first_live_idx] {
-            assert_sitrep_deleted(datastore, opctx, id).await;
+            assert!(
+                orphans.contains(&id) || collected_orphans.contains(&id),
+                "pruned history sitrep {id} should be tracked as either a \
+                 live or a collected orphan; this is a bug in the model \
+                 itself"
+            );
         }
+        // Live history sitreps exist.
         for &id in &history[first_live_idx..] {
             assert_sitrep_exists(datastore, opctx, id).await;
         }
@@ -387,20 +502,23 @@ impl SitrepModel {
     }
 }
 
-/// The expected outcome of a sitrep GC activation, as computed by
-/// [`SitrepModel::simulate_gc`].
+/// The expected outcome of a sitrep history pruner activation, as computed
+/// by [`SitrepModel::simulate_history_pruning`].
+///
+/// This contains only the values that the model actually predicts. In
+/// particular, it does *not* predict how the pruned versions are divided
+/// into batches, as that's a property of the pruner task's implementation
+/// rather than a correctness property. Tests that care about batching should
+/// assert on the reported batch counts directly.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ExpectedGc {
+pub struct ExpectedPruning {
     /// The total number of history table entries that should be pruned.
     pub sitreps_pruned: usize,
     /// The range of versions that should be pruned (oldest..=newest), if
     /// any.
     pub versions_pruned: Option<RangeInclusive<u32>>,
     /// The outcome the pruning loop should end with.
-    pub outcome: HistoryPruningOutcome,
-    /// The number of orphaned sitreps the task's orphan sweep should delete,
-    /// including sitreps newly orphaned by pruning the history.
-    pub orphans_deleted: usize,
+    pub outcome: fm_sitrep_history_pruner::Outcome,
 }
 
 /// Returns an empty test [`Sitrep`] with the given ID, parent, and comment.

--- a/nexus/db-queries/src/db/pub_test_utils/mod.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/mod.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 pub mod crdb;
 pub mod explain;
+pub mod fm;
 pub mod helpers;
 pub mod multicast;
 

--- a/nexus/examples/config-second.toml
+++ b/nexus/examples/config-second.toml
@@ -183,6 +183,11 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
+# The sitrep history pruning task is explicitly activated when the current
+# sitrep changes, or when the sitrep capacity in the database is reaching the
+# limit. Periodic activations are necessary only as a backstop, so they need no
+# be frequent.
+fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval
 # too high.

--- a/nexus/examples/config-second.toml
+++ b/nexus/examples/config-second.toml
@@ -183,10 +183,9 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
-# The sitrep history pruning task is explicitly activated when the current
-# sitrep changes, or when the sitrep capacity in the database is reaching the
-# limit. Periodic activations are necessary only as a backstop, so they need no
-# be frequent.
+# The sitrep history pruning task is explicitly activated when the sitrep
+# capacity in the database is reaching the limit. Periodic activations are
+# necessary only as a backstop, so they need not be frequent.
 fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -167,10 +167,9 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
-# The sitrep history pruning task is explicitly activated when the current
-# sitrep changes, or when the sitrep capacity in the database is reaching the
-# limit. Periodic activations are necessary only as a backstop, so they need no
-# be frequent.
+# The sitrep history pruning task is explicitly activated when the sitrep
+# capacity in the database is reaching the limit. Periodic activations are
+# necessary only as a backstop, so they need not be frequent.
 fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -167,6 +167,11 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
+# The sitrep history pruning task is explicitly activated when the current
+# sitrep changes, or when the sitrep capacity in the database is reaching the
+# limit. Periodic activations are necessary only as a backstop, so they need no
+# be frequent.
+fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval
 # too high.

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -1209,7 +1209,7 @@ impl BackgroundTasksInitializer {
                 ),
             ),
             opctx: opctx.child(BTreeMap::new()),
-            watchers: vec![Box::new(sitrep_watcher.clone())],
+            watchers: vec![],
             activator: task_fm_sitrep_history_pruner,
         });
 

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -110,6 +110,7 @@ use super::tasks::external_endpoints;
 use super::tasks::fm_analysis::{self, FmAnalysis};
 use super::tasks::fm_rendezvous::FmRendezvous;
 use super::tasks::fm_sitrep_gc;
+use super::tasks::fm_sitrep_history_pruner;
 use super::tasks::fm_sitrep_load;
 use super::tasks::fm_sitrep_load::CurrentSitrep;
 use super::tasks::instance_reincarnation;
@@ -272,6 +273,7 @@ impl BackgroundTasksInitializer {
             task_fm_analysis: Activator::new(),
             task_fm_sitrep_loader: Activator::new(),
             task_fm_sitrep_gc: Activator::new(),
+            task_fm_sitrep_history_pruner: Activator::new(),
             task_fm_rendezvous: Activator::new(),
             task_probe_distributor: Activator::new(),
             task_multicast_reconciler: Activator::new(),
@@ -366,6 +368,7 @@ impl BackgroundTasksInitializer {
             task_fm_analysis,
             task_fm_sitrep_loader,
             task_fm_sitrep_gc,
+            task_fm_sitrep_history_pruner,
             task_fm_rendezvous,
             task_probe_distributor,
             task_multicast_reconciler,
@@ -1153,6 +1156,7 @@ impl BackgroundTasksInitializer {
                 inventory_loader: task_inventory_loader.clone(),
                 sitrep_loader: task_fm_sitrep_loader.clone(),
                 sitrep_gc: task_fm_sitrep_gc.clone(),
+                sitrep_history_pruner: task_fm_sitrep_history_pruner.clone(),
             },
             nexus_id,
             config.fm.analysis_enabled,
@@ -1191,9 +1195,28 @@ impl BackgroundTasksInitializer {
         });
 
         driver.register(TaskDefinition {
+            name: "fm_sitrep_history_pruner",
+            description:
+                "maintains the configured limit on the fault management sitrep \
+                 history table by deleting the oldest entries",
+            period: config.fm.sitrep_history_prune_period_secs,
+            task_impl: Box::new(
+                fm_sitrep_history_pruner::SitrepHistoryPruner::new(
+                    datastore.clone(),
+                    // The pruner pokes the GC task whenever it orphans some
+                    // sitreps for it to delete.
+                    task_fm_sitrep_gc.clone(),
+                ),
+            ),
+            opctx: opctx.child(BTreeMap::new()),
+            watchers: vec![Box::new(sitrep_watcher.clone())],
+            activator: task_fm_sitrep_history_pruner,
+        });
+
+        driver.register(TaskDefinition {
             name: "fm_sitrep_gc",
             description: "garbage collects fault management situation reports",
-            period: config.fm.sitrep_load_period_secs,
+            period: config.fm.sitrep_gc_period_secs,
             task_impl: Box::new(fm_sitrep_gc::SitrepGc::new(datastore.clone())),
             opctx: opctx.child(BTreeMap::new()),
             watchers: vec![Box::new(sitrep_watcher)],

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -28,6 +28,7 @@ use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SupportBundleUuid;
 use serde_json::json;
 use slog_error_chain::InlineErrorChain;
+use std::num::NonZeroU64;
 use std::sync::Arc;
 use tokio::sync::watch;
 
@@ -39,6 +40,7 @@ pub struct FmAnalysis {
     activators: Activators,
     nexus_id: OmicronZoneUuid,
     analysis_enabled: bool,
+    sitrep_limit: NonZeroU64,
 }
 
 /// This is just because I don't like it when a constructor takes multiple
@@ -98,7 +100,7 @@ impl FmAnalysis {
     ///
     /// This value was chosen totally arbitrarily. In future changes, this will
     /// become configurable at runtime, in case I've gotten it wrong.
-    pub const SITREP_LIMIT: u64 = 2500;
+    pub const DEFAULT_SITREP_LIMIT: NonZeroU64 = NonZeroU64::new(2500).unwrap();
 
     pub fn new(
         datastore: Arc<DataStore>,
@@ -115,6 +117,7 @@ impl FmAnalysis {
             activators,
             nexus_id,
             analysis_enabled,
+            sitrep_limit: Self::DEFAULT_SITREP_LIMIT,
         }
     }
 
@@ -646,9 +649,10 @@ impl FmAnalysis {
         opctx: &OpContext,
         warnings: &mut Vec<String>,
     ) -> Result<status::SitrepCapacity, status::AnalysisOutcome> {
+        let limit = self.sitrep_limit.get();
         let count = match self
             .datastore
-            .fm_sitrep_check_limit_reached(&opctx, Self::SITREP_LIMIT)
+            .fm_sitrep_check_limit_reached(&opctx, limit)
             .await
         {
             Ok(db::IsLimitReached::Yes) => {
@@ -656,14 +660,12 @@ impl FmAnalysis {
                     &opctx.log,
                     "sitrep capacity is at or above the limit, a new sitrep \
                      will not be written";
-                     "limit" => Self::SITREP_LIMIT,
+                     "limit" => limit,
                 );
                 // Activate the GC task to see if we can clean up any old
                 // sitreps.
                 self.activators.sitrep_gc.activate();
-                return Err(status::AnalysisOutcome::LimitReached {
-                    limit: Self::SITREP_LIMIT,
-                });
+                return Err(status::AnalysisOutcome::LimitReached { limit });
             }
             Ok(db::IsLimitReached::No { count }) => count,
             Err(error) => {
@@ -676,15 +678,14 @@ impl FmAnalysis {
             }
         };
 
-        let capacity =
-            status::SitrepCapacity { count, limit: Self::SITREP_LIMIT };
+        let capacity = status::SitrepCapacity { count, limit };
         let usage_percent = capacity.usage_percent();
         match usage_percent {
             0..=59 => {
                 trace!(
                     &opctx.log,
                     "sitrep count under limit, proceeding with analysis";
-                    "limit" => Self::SITREP_LIMIT,
+                    "limit" => limit,
                     "count" => count,
                     "usage_percent" => usage_percent,
                 );
@@ -694,7 +695,7 @@ impl FmAnalysis {
                     &opctx.log,
                     "sitrep count above 60% of limit, proceeding with analysis \
                      (will stop analysis if limit is reached)";
-                    "limit" => Self::SITREP_LIMIT,
+                    "limit" => limit,
                     "count" => count,
                     "usage_percent" => usage_percent,
                 );
@@ -704,13 +705,13 @@ impl FmAnalysis {
                     &opctx.log,
                     "sitrep count above 80% of limit, proceeding with analysis \
                      (will stop analysis if limit is reached)";
-                    "limit" => Self::SITREP_LIMIT,
+                    "limit" => limit,
                     "count" => count,
                     "usage_percent" => usage_percent,
                 );
                 warnings.push(format!(
-                    "sitrep count ({count}) at {usage_percent}% of limit ({})",
-                    Self::SITREP_LIMIT
+                    "sitrep count ({count}) at {usage_percent}% of limit \
+                     ({limit})",
                 ));
                 // Activate the GC task to see if we can clean up any old
                 // sitreps.

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -735,6 +735,7 @@ enum PreparationError {
 mod tests {
     use super::*;
     use nexus_db_queries::db::pub_test_utils::TestDatabase;
+    use nexus_db_queries::db::pub_test_utils::fm::SitrepModel;
     use nexus_inventory::CollectionBuilder;
     use nexus_types::alert::AlertClass;
     use nexus_types::fm::Case;
@@ -1157,6 +1158,207 @@ mod tests {
         );
         assert!(carried.unmarked_ereports.is_empty());
         assert_eq!(prep.report.closed_cases_copied_forward.len(), 1);
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    /// Exercises `check_sitrep_limit` at each capacity tier:
+    ///
+    /// - below 80% of the limit, the capacity is reported and nothing else
+    ///   happens;
+    /// - at or above 80% (but below the limit), a warning is recorded and the
+    ///   GC task is poked to try to free up space;
+    /// - at the limit, the check fails with `LimitReached` and the GC task is
+    ///   poked.
+    #[tokio::test]
+    async fn test_check_sitrep_limit() {
+        let logctx = dev::test_setup_log("test_check_sitrep_limit");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        const LIMIT: u64 = 10;
+        let (_sitrep_tx, sitrep_rx) = watch::channel(None);
+        let (_inv_tx, inv_rx) = watch::channel(None);
+        let acts = activators();
+        let mut task = FmAnalysis::new(
+            datastore.clone(),
+            sitrep_rx,
+            inv_rx,
+            acts.clone(),
+            OmicronZoneUuid::new_v4(),
+            ANALYSIS_ENABLED,
+        );
+        task.sitrep_limit = NonZeroU64::new(LIMIT).unwrap();
+
+        let mut model = SitrepModel::new(datastore.clone());
+
+        // 5 sitreps: 50% of the limit. No warning, no GC activation.
+        model.insert_history(opctx, 5).await;
+        let mut warnings = Vec::new();
+        let result = task.check_sitrep_limit(opctx, &mut warnings).await;
+        assert_eq!(
+            result,
+            Ok(status::SitrepCapacity {
+                count: model.sitrep_count(),
+                limit: LIMIT
+            })
+        );
+        assert_eq!(warnings, Vec::<String>::new());
+        acts.sitrep_gc.assert_not_activated(
+            "GC should not be activated at 50% of the sitrep limit",
+        );
+
+        // 7 sitreps: 70% of the limit. Still no warning and no GC activation
+        // (the 60% tier only changes what gets logged).
+        model.insert_history(opctx, 2).await;
+        let mut warnings = Vec::new();
+        let result = task.check_sitrep_limit(opctx, &mut warnings).await;
+        assert_eq!(
+            result,
+            Ok(status::SitrepCapacity {
+                count: model.sitrep_count(),
+                limit: LIMIT
+            })
+        );
+        assert_eq!(warnings, Vec::<String>::new());
+        acts.sitrep_gc.assert_not_activated(
+            "GC should not be activated at 70% of the sitrep limit",
+        );
+
+        // 8 sitreps: 80% of the limit. The check still succeeds, but a
+        // warning is recorded and the GC task is activated.
+        model.insert_history(opctx, 1).await;
+        let mut warnings = Vec::new();
+        let result = task.check_sitrep_limit(opctx, &mut warnings).await;
+        assert_eq!(
+            result,
+            Ok(status::SitrepCapacity {
+                count: model.sitrep_count(),
+                limit: LIMIT
+            })
+        );
+        assert_eq!(
+            warnings.len(),
+            1,
+            "expected a capacity warning at 80% of the limit, got: \
+             {warnings:?}"
+        );
+        acts.sitrep_gc.assert_activated(
+            "GC should be activated at 80% of the sitrep limit",
+        );
+
+        // 10 sitreps: at the limit. The check fails, and the GC task is
+        // activated. Note that the last two sitreps are *orphans* ---
+        // sitreps that were never made current --- which occupy capacity in
+        // the `fm_sitrep` table just like live ones do until the GC sweeps
+        // them up.
+        model.insert_orphan(opctx, None).await;
+        model.insert_orphan(opctx, None).await;
+        assert_eq!(model.sitrep_count(), LIMIT);
+        let mut warnings = Vec::new();
+        let result = task.check_sitrep_limit(opctx, &mut warnings).await;
+        assert_eq!(
+            result,
+            Err(status::AnalysisOutcome::LimitReached { limit: LIMIT })
+        );
+        assert_eq!(warnings, Vec::<String>::new());
+        acts.sitrep_gc.assert_activated(
+            "GC should be activated when the sitrep limit is reached",
+        );
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    /// Exercises the sitrep limit end-to-end through `actually_activate`:
+    /// below the limit, analysis commits a new sitrep and reports the
+    /// capacity; once the `fm_sitrep` table is at the limit, analysis still
+    /// runs but refuses to write its sitrep, reporting `LimitReached` and
+    /// activating the GC task instead.
+    #[tokio::test]
+    async fn test_analysis_respects_sitrep_limit() {
+        let logctx = dev::test_setup_log("test_analysis_respects_sitrep_limit");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        const LIMIT: u64 = 4;
+        let inv = Arc::new(CollectionBuilder::new("test").build());
+        let (_sitrep_tx, sitrep_rx) = watch::channel(None);
+        let (_inv_tx, inv_rx) = watch::channel(Some(inv.clone()));
+        let acts = activators();
+        let mut task = FmAnalysis::new(
+            datastore.clone(),
+            sitrep_rx,
+            inv_rx,
+            acts.clone(),
+            OmicronZoneUuid::new_v4(),
+            ANALYSIS_ENABLED,
+        );
+        task.sitrep_limit = NonZeroU64::new(LIMIT).unwrap();
+
+        let mut model = SitrepModel::new(datastore.clone());
+
+        // With an empty database, analysis should commit the first-ever
+        // sitrep, reporting a capacity of 0 out of `LIMIT`.
+        let result = task.actually_activate(opctx).await;
+        let sitrep_id = match result.outcome {
+            status::Outcome::RanAnalysis { analysis_status, .. } => {
+                assert_eq!(
+                    analysis_status.capacity,
+                    Some(status::SitrepCapacity { count: 0, limit: LIMIT })
+                );
+                match analysis_status.outcome {
+                    status::AnalysisOutcome::Committed { sitrep_id } => {
+                        sitrep_id
+                    }
+                    other => {
+                        panic!("expected the sitrep to be committed: {other:?}")
+                    }
+                }
+            }
+            other => panic!("expected analysis to run, got: {other:?}"),
+        };
+        acts.sitrep_gc.assert_not_activated(
+            "GC should not be activated below the sitrep limit",
+        );
+        // Committing a sitrep pokes the loader; consume that activation so
+        // the assertion below observes only the second activation's behavior.
+        acts.sitrep_loader.assert_activated(
+            "the sitrep loader should be activated after a commit",
+        );
+        model.record_committed(sitrep_id);
+
+        // Fill the `fm_sitrep` table up to the limit: two more live sitreps,
+        // plus an orphan, which counts against the limit even though it was
+        // never made current.
+        model.insert_history(opctx, 2).await;
+        model.insert_orphan(opctx, None).await;
+        assert_eq!(model.sitrep_count(), LIMIT);
+
+        // Now analysis should run, but refuse to write its sitrep.
+        let result = task.actually_activate(opctx).await;
+        match result.outcome {
+            status::Outcome::RanAnalysis { analysis_status, .. } => {
+                assert_eq!(
+                    analysis_status.outcome,
+                    status::AnalysisOutcome::LimitReached { limit: LIMIT }
+                );
+                assert_eq!(analysis_status.capacity, None);
+            }
+            other => panic!("expected analysis to run, got: {other:?}"),
+        }
+        acts.sitrep_gc.assert_activated(
+            "GC should be activated when the sitrep limit is reached",
+        );
+        acts.sitrep_loader.assert_not_activated(
+            "the sitrep loader should not be activated when no sitrep was \
+             committed",
+        );
+
+        // No new sitrep row should have been written, and the orphan should
+        // still be present --- the GC task was only poked, not run.
+        model.assert_matches(opctx).await;
 
         db.terminate().await;
         logctx.cleanup_successful();

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -1175,8 +1175,11 @@ mod tests {
     ///
     /// - below 80% of the limit, the capacity is reported and nothing else
     ///   happens;
-    /// - at or above 80% (but below the limit), a warning is recorded and the
-    ///   GC task is poked to try to free up space;
+    /// - at or above 80% (but below 95%), the GC task is poked to free up
+    ///   space, but no warning is recorded: steady-state pruning keeps the
+    ///   history at 80% of the sitrep limit, so this is normal operation;
+    /// - at or above 95%, the GC task is poked *and* a warning is recorded,
+    ///   as this suggests GC isn't keeping up;
     /// - at the limit, the check fails with `LimitReached` and the GC task is
     ///   poked.
     #[tokio::test]
@@ -1185,7 +1188,7 @@ mod tests {
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
-        const LIMIT: u64 = 10;
+        const LIMIT: u64 = 20;
         let (_sitrep_tx, sitrep_rx) = watch::channel(None);
         let (_inv_tx, inv_rx) = watch::channel(None);
         let acts = activators();
@@ -1201,8 +1204,8 @@ mod tests {
 
         let mut model = SitrepModel::new(datastore.clone());
 
-        // 5 sitreps: 50% of the limit. No warning, no GC activation.
-        model.insert_history(opctx, 5).await;
+        // 10 sitreps: 50% of the limit. No warning, no GC activation.
+        model.insert_history(opctx, 10).await;
         let mut warnings = Vec::new();
         let result = task.check_sitrep_limit(opctx, &mut warnings).await;
         assert_eq!(
@@ -1217,9 +1220,9 @@ mod tests {
             "GC should not be activated at 50% of the sitrep limit",
         );
 
-        // 7 sitreps: 70% of the limit. Still no warning and no GC activation
-        // (the 60% tier only changes what gets logged).
-        model.insert_history(opctx, 2).await;
+        // 15 sitreps: 75% of the limit, just below the GC-activation tier.
+        // Still no warning and no GC activation.
+        model.insert_history(opctx, 5).await;
         let mut warnings = Vec::new();
         let result = task.check_sitrep_limit(opctx, &mut warnings).await;
         assert_eq!(
@@ -1231,12 +1234,37 @@ mod tests {
         );
         assert_eq!(warnings, Vec::<String>::new());
         acts.sitrep_gc.assert_not_activated(
-            "GC should not be activated at 70% of the sitrep limit",
+            "GC should not be activated at 75% of the sitrep limit",
         );
 
-        // 8 sitreps: 80% of the limit. The check still succeeds, but a
-        // warning is recorded and the GC task is activated.
+        // 16 sitreps: 80% of the limit. The GC task is activated to reclaim
+        // capacity, but no warning is recorded: pruning keeps the history at
+        // 80% of the sitrep limit, so this is expected steady-state
+        // operation.
         model.insert_history(opctx, 1).await;
+        let mut warnings = Vec::new();
+        let result = task.check_sitrep_limit(opctx, &mut warnings).await;
+        assert_eq!(
+            result,
+            Ok(status::SitrepCapacity {
+                count: model.sitrep_count(),
+                limit: LIMIT
+            })
+        );
+        assert_eq!(
+            warnings,
+            Vec::<String>::new(),
+            "80% of the limit is normal steady-state operation, and should \
+             not produce a warning"
+        );
+        acts.sitrep_gc.assert_activated(
+            "GC should be activated at 80% of the sitrep limit",
+        );
+
+        // 19 sitreps: 95% of the limit. Now the check records a warning ---
+        // GC doesn't appear to be keeping up --- and activates the GC task
+        // again.
+        model.insert_history(opctx, 3).await;
         let mut warnings = Vec::new();
         let result = task.check_sitrep_limit(opctx, &mut warnings).await;
         assert_eq!(
@@ -1249,19 +1277,18 @@ mod tests {
         assert_eq!(
             warnings.len(),
             1,
-            "expected a capacity warning at 80% of the limit, got: \
+            "expected a capacity warning at 95% of the limit, got: \
              {warnings:?}"
         );
         acts.sitrep_gc.assert_activated(
-            "GC should be activated at 80% of the sitrep limit",
+            "GC should be activated at 95% of the sitrep limit",
         );
 
-        // 10 sitreps: at the limit. The check fails, and the GC task is
-        // activated. Note that the last two sitreps are *orphans* ---
-        // sitreps that were never made current --- which occupy capacity in
-        // the `fm_sitrep` table just like live ones do until the GC sweeps
-        // them up.
-        model.insert_orphan(opctx, None).await;
+        // 20 sitreps: at the limit. The check fails, and the GC task is
+        // activated. Note that the last sitrep is an *orphan* --- a sitrep
+        // that was never made current --- which occupies capacity in the
+        // `fm_sitrep` table just like live ones do until the GC sweeps
+        // it up.
         model.insert_orphan(opctx, None).await;
         assert_eq!(model.sitrep_count(), LIMIT);
         let mut warnings = Vec::new();

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -1238,9 +1238,8 @@ mod tests {
         );
 
         // 16 sitreps: 80% of the limit. The GC task is activated to reclaim
-        // capacity, but no warning is recorded: pruning keeps the history at
-        // 80% of the sitrep limit, so this is expected steady-state
-        // operation.
+        // capacity. This is roughly the expected steady state of the system, if
+        // the analysis and GC tasks are running mostly in sync.
         model.insert_history(opctx, 1).await;
         let mut warnings = Vec::new();
         let result = task.check_sitrep_limit(opctx, &mut warnings).await;
@@ -1251,19 +1250,12 @@ mod tests {
                 limit: LIMIT
             })
         );
-        assert_eq!(
-            warnings,
-            Vec::<String>::new(),
-            "80% of the limit is normal steady-state operation, and should \
-             not produce a warning"
-        );
         acts.sitrep_gc.assert_activated(
             "GC should be activated at 80% of the sitrep limit",
         );
 
-        // 19 sitreps: 95% of the limit. Now the check records a warning ---
-        // GC doesn't appear to be keeping up --- and activates the GC task
-        // again.
+        // 19 sitreps: 95% of the limit. Now the check records a warning, since
+        // GC doesn't seem to be keeping up with sitrep generation.
         model.insert_history(opctx, 3).await;
         let mut warnings = Vec::new();
         let result = task.check_sitrep_limit(opctx, &mut warnings).await;
@@ -1285,10 +1277,9 @@ mod tests {
         );
 
         // 20 sitreps: at the limit. The check fails, and the GC task is
-        // activated. Note that the last sitrep is an *orphan* --- a sitrep
-        // that was never made current --- which occupies capacity in the
-        // `fm_sitrep` table just like live ones do until the GC sweeps
-        // it up.
+        // activated. Note that the last sitrep is an orphan that was never made
+        // current. Orphans also count against the total number of sitreps in
+        // the database, until GC sweeps them up.
         model.insert_orphan(opctx, None).await;
         assert_eq!(model.sitrep_count(), LIMIT);
         let mut warnings = Vec::new();

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -681,8 +681,8 @@ impl FmAnalysis {
         let capacity = status::SitrepCapacity { count, limit };
         let usage_percent = capacity.usage_percent();
         match usage_percent {
-            0..=59 => {
-                trace!(
+            0..80 => {
+                debug!(
                     &opctx.log,
                     "sitrep count under limit, proceeding with analysis";
                     "limit" => limit,
@@ -690,21 +690,29 @@ impl FmAnalysis {
                     "usage_percent" => usage_percent,
                 );
             }
-            60..=79 => {
-                debug!(
+            // With the default history limit and max sitrep limit, we start
+            // pruning the history table at 80% of history, so this is just
+            // operational, not a warning.
+            80..95 => {
+                info!(
                     &opctx.log,
-                    "sitrep count above 60% of limit, proceeding with analysis \
-                     (will stop analysis if limit is reached)";
+                    "sitrep count above 80% of limit, proceeding with analysis \
+                     and activating GC (will stop analysis if limit is reached)";
                     "limit" => limit,
                     "count" => count,
                     "usage_percent" => usage_percent,
                 );
+                // Activate the GC task to see if we can clean up any old
+                // sitreps.
+                self.activators.sitrep_gc.activate();
             }
-            80.. => {
+            // At 95% of the limit, this is where I might start to worry that
+            // the GC task isn't running or something!
+            95.. => {
                 warn!(
                     &opctx.log,
-                    "sitrep count above 80% of limit, proceeding with analysis \
-                     (will stop analysis if limit is reached)";
+                    "sitrep count above 95% of limit, proceeding with analysis \
+                     and activating GC (will stop analysis if limit is reached)";
                     "limit" => limit,
                     "count" => count,
                     "usage_percent" => usage_percent,

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -12,6 +12,7 @@ use futures::future::BoxFuture;
 use iddqd::IdOrdMap;
 use nexus_db_model::PhysicalDiskPolicy;
 use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db;
 use nexus_db_queries::db::DataStore;
 use nexus_db_queries::db::datastore;
 use nexus_db_queries::db::identity::Asset;
@@ -90,6 +91,15 @@ impl BackgroundTask for FmAnalysis {
 }
 
 impl FmAnalysis {
+    /// The maximum number of sitreps allowed in the database.
+    ///
+    /// If this limit is exceeded, analysis will not produce additional sitreps
+    /// until some old ones are deleted.
+    ///
+    /// This value was chosen totally arbitrarily. In future changes, this will
+    /// become configurable at runtime, in case I've gotten it wrong.
+    pub const SITREP_LIMIT: u64 = 2500;
+
     pub fn new(
         datastore: Arc<DataStore>,
         sitrep_rx: watch::Receiver<Option<CurrentSitrep>>,
@@ -508,9 +518,25 @@ impl FmAnalysis {
                 start_time,
                 end_time,
                 report,
+                capacity: None,
                 outcome: status::AnalysisOutcome::Error(e.to_string()),
             };
         }
+
+        // Before writing the new sitrep to the database, check whether there is
+        // capacity to write a new sitrep.
+        let capacity = match self.check_sitrep_limit(&opctx, warnings).await {
+            Ok(capacity) => Some(capacity),
+            Err(outcome) => {
+                return status::AnalysisStatus {
+                    start_time,
+                    end_time,
+                    report,
+                    capacity: None,
+                    outcome,
+                };
+            }
+        };
 
         if let Some(parent) = inputs.parent_sitrep() {
             if parent.compare_state() == sitrep {
@@ -523,6 +549,7 @@ impl FmAnalysis {
                     start_time,
                     end_time,
                     report,
+                    capacity,
                     outcome: status::AnalysisOutcome::Unchanged,
                 };
             }
@@ -568,6 +595,7 @@ impl FmAnalysis {
                     start_time,
                     end_time,
                     report,
+                    capacity,
                     outcome: status::AnalysisOutcome::Committed { sitrep_id },
                 }
             }
@@ -586,6 +614,7 @@ impl FmAnalysis {
                     start_time,
                     end_time,
                     report,
+                    capacity,
                     outcome: status::AnalysisOutcome::NotCommitted {
                         sitrep_id,
                     },
@@ -602,6 +631,7 @@ impl FmAnalysis {
                     start_time,
                     end_time,
                     report,
+                    capacity,
                     outcome: status::AnalysisOutcome::CommitFailed {
                         sitrep_id,
                         error: e.to_string(),
@@ -609,6 +639,86 @@ impl FmAnalysis {
                 }
             }
         }
+    }
+
+    async fn check_sitrep_limit(
+        &self,
+        opctx: &OpContext,
+        warnings: &mut Vec<String>,
+    ) -> Result<status::SitrepCapacity, status::AnalysisOutcome> {
+        let count = match self
+            .datastore
+            .fm_sitrep_check_limit_reached(&opctx, Self::SITREP_LIMIT)
+            .await
+        {
+            Ok(db::IsLimitReached::Yes) => {
+                error!(
+                    &opctx.log,
+                    "sitrep capacity is at or above the limit, a new sitrep \
+                     will not be written";
+                     "limit" => Self::SITREP_LIMIT,
+                );
+                // Activate the GC task to see if we can clean up any old
+                // sitreps.
+                self.activators.sitrep_gc.activate();
+                return Err(status::AnalysisOutcome::LimitReached {
+                    limit: Self::SITREP_LIMIT,
+                });
+            }
+            Ok(db::IsLimitReached::No { count }) => count,
+            Err(error) => {
+                const MSG: &str = "failed to check sitrep limit";
+                let error = InlineErrorChain::new(&error);
+                error!(&opctx.log, "{MSG}"; &error);
+                return Err(status::AnalysisOutcome::Error(format!(
+                    "{MSG}: {error}"
+                )));
+            }
+        };
+
+        let capacity =
+            status::SitrepCapacity { count, limit: Self::SITREP_LIMIT };
+        let usage_percent = capacity.usage_percent();
+        match usage_percent {
+            0..=59 => {
+                trace!(
+                    &opctx.log,
+                    "sitrep count under limit, proceeding with analysis";
+                    "limit" => Self::SITREP_LIMIT,
+                    "count" => count,
+                    "usage_percent" => usage_percent,
+                );
+            }
+            60..=79 => {
+                debug!(
+                    &opctx.log,
+                    "sitrep count above 60% of limit, proceeding with analysis \
+                     (will stop analysis if limit is reached)";
+                    "limit" => Self::SITREP_LIMIT,
+                    "count" => count,
+                    "usage_percent" => usage_percent,
+                );
+            }
+            80.. => {
+                warn!(
+                    &opctx.log,
+                    "sitrep count above 80% of limit, proceeding with analysis \
+                     (will stop analysis if limit is reached)";
+                    "limit" => Self::SITREP_LIMIT,
+                    "count" => count,
+                    "usage_percent" => usage_percent,
+                );
+                warnings.push(format!(
+                    "sitrep count ({count}) at {usage_percent}% of limit ({})",
+                    Self::SITREP_LIMIT
+                ));
+                // Activate the GC task to see if we can clean up any old
+                // sitreps.
+                self.activators.sitrep_gc.activate();
+            }
+        }
+
+        Ok(capacity)
     }
 }
 

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -547,8 +547,41 @@ impl FmAnalysis {
             };
         }
 
+        // Is the new sitrep identical to the parent sitrep? If so, we're done.
+        if let Some(parent) = inputs.parent_sitrep() {
+            if parent.compare_state() == sitrep {
+                slog::info!(
+                    &opctx.log,
+                    "fault management analysis produced no changes from the \
+                     current sitrep"
+                );
+                return status::AnalysisStatus {
+                    start_time,
+                    end_time,
+                    report,
+                    capacity: None,
+                    outcome: status::AnalysisOutcome::Unchanged,
+                };
+            }
+        }
+
         // Before writing the new sitrep to the database, check whether there is
         // capacity to write a new sitrep.
+        //
+        // Readers who have read the similar-looking code in the
+        // `blueprint_planner` background task may note that we are doing the
+        // check for whether the sitrep has changed and the check for whether
+        // the limit is reached in the opposite order as the Reconfigurator.
+        // That is by design. In the Reconfigurator case, there isn't an
+        // automated process that's automatically deleting old blueprints, so
+        // hitting the limit is a condition that requires manual human
+        // intervention. Therefore, it's important for them to be able to warn
+        // about it as soon as it's hit. For us, it's much less important to
+        // surface, and if we've hit the limit, we will probably go back down
+        // below it soon when history pruning frees up capacity. Therefore,
+        // there's no sense doing the fairly expensive scan to check if the
+        // limit has been hit when we're not actually planning on committing the
+        // new sitrep anyway.
         let capacity = match self.check_sitrep_limit(&opctx, warnings).await {
             Ok(capacity) => Some(capacity),
             Err(outcome) => {
@@ -561,23 +594,6 @@ impl FmAnalysis {
                 };
             }
         };
-
-        if let Some(parent) = inputs.parent_sitrep() {
-            if parent.compare_state() == sitrep {
-                slog::info!(
-                    &opctx.log,
-                    "fault management analysis produced no changes from the \
-                     current sitrep"
-                );
-                return status::AnalysisStatus {
-                    start_time,
-                    end_time,
-                    report,
-                    capacity,
-                    outcome: status::AnalysisOutcome::Unchanged,
-                };
-            }
-        }
 
         let sitrep_id = sitrep.id();
 

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -50,6 +50,27 @@ pub struct Activators {
     pub inventory_loader: Activator,
     pub sitrep_loader: Activator,
     pub sitrep_gc: Activator,
+    pub sitrep_history_pruner: Activator,
+}
+
+impl Activators {
+    /// Activate the sitrep history pruning and orphan sitrep GC background
+    /// tasks to try and free up some capacity for new sitreps in the database.
+    ///
+    /// The `fm_sitrep_gc` task deletes orphaned sitreps (i.e., those which are
+    /// not in the `fm_sitrep_history`) table. Meanwhile, the
+    /// `fm_sitrep_history_pruner` task deletes old sitrep versions from the end
+    /// of the `fm_sitrep_history` table, leaving those sitreps as orphans that
+    /// can be cleaned up by the garbage collection task. When we wish to
+    /// reclaim capacity for new sitreps, we activate *both* tasks: a GC pass is
+    /// necessary to delete orphaned sitreps that may have been left behind when
+    /// an analysis task lost a race to insert a new sitrep, while the history
+    /// pruning pass is necessary to free up capacity used by sitrep versions
+    /// that *are* part of the history.
+    fn reclaim_capacity(&self) {
+        self.sitrep_history_pruner.activate();
+        self.sitrep_gc.activate();
+    }
 }
 
 impl BackgroundTask for FmAnalysis {
@@ -662,9 +683,7 @@ impl FmAnalysis {
                      will not be written";
                      "limit" => limit,
                 );
-                // Activate the GC task to see if we can clean up any old
-                // sitreps.
-                self.activators.sitrep_gc.activate();
+                self.activators.reclaim_capacity();
                 return Err(status::AnalysisOutcome::LimitReached { limit });
             }
             Ok(db::IsLimitReached::No { count }) => count,
@@ -702,12 +721,10 @@ impl FmAnalysis {
                     "count" => count,
                     "usage_percent" => usage_percent,
                 );
-                // Activate the GC task to see if we can clean up any old
-                // sitreps.
-                self.activators.sitrep_gc.activate();
+                self.activators.reclaim_capacity();
             }
             // At 95% of the limit, this is where I might start to worry that
-            // the GC task isn't running or something!
+            // the GC tasks isn't running or something!
             95.. => {
                 warn!(
                     &opctx.log,
@@ -721,9 +738,7 @@ impl FmAnalysis {
                     "sitrep count ({count}) at {usage_percent}% of limit \
                      ({limit})",
                 ));
-                // Activate the GC task to see if we can clean up any old
-                // sitreps.
-                self.activators.sitrep_gc.activate();
+                self.activators.reclaim_capacity();
             }
         }
 
@@ -765,10 +780,12 @@ mod tests {
             inventory_loader: Activator::new(),
             sitrep_loader: Activator::new(),
             sitrep_gc: Activator::new(),
+            sitrep_history_pruner: Activator::new(),
         };
         a.inventory_loader.mark_wired_up().unwrap();
         a.sitrep_loader.mark_wired_up().unwrap();
         a.sitrep_gc.mark_wired_up().unwrap();
+        a.sitrep_history_pruner.mark_wired_up().unwrap();
         a
     }
 
@@ -1219,6 +1236,9 @@ mod tests {
         acts.sitrep_gc.assert_not_activated(
             "GC should not be activated at 50% of the sitrep limit",
         );
+        acts.sitrep_history_pruner.assert_not_activated(
+            "history pruning should not be activated at 50% of the sitrep limit",
+        );
 
         // 15 sitreps: 75% of the limit, just below the GC-activation tier.
         // Still no warning and no GC activation.
@@ -1236,6 +1256,9 @@ mod tests {
         acts.sitrep_gc.assert_not_activated(
             "GC should not be activated at 75% of the sitrep limit",
         );
+        acts.sitrep_history_pruner.assert_not_activated(
+            "history pruning should not be activated at 75% of the sitrep limit",
+        );
 
         // 16 sitreps: 80% of the limit. The GC task is activated to reclaim
         // capacity. This is roughly the expected steady state of the system, if
@@ -1252,6 +1275,9 @@ mod tests {
         );
         acts.sitrep_gc.assert_activated(
             "GC should be activated at 80% of the sitrep limit",
+        );
+        acts.sitrep_history_pruner.assert_activated(
+            "history pruning should be activated at 80% of the sitrep limit",
         );
 
         // 19 sitreps: 95% of the limit. Now the check records a warning, since
@@ -1275,6 +1301,9 @@ mod tests {
         acts.sitrep_gc.assert_activated(
             "GC should be activated at 95% of the sitrep limit",
         );
+        acts.sitrep_history_pruner.assert_activated(
+            "history pruning should be activated at 95% of the sitrep limit",
+        );
 
         // 20 sitreps: at the limit. The check fails, and the GC task is
         // activated. Note that the last sitrep is an orphan that was never made
@@ -1291,6 +1320,9 @@ mod tests {
         assert_eq!(warnings, Vec::<String>::new());
         acts.sitrep_gc.assert_activated(
             "GC should be activated when the sitrep limit is reached",
+        );
+        acts.sitrep_history_pruner.assert_activated(
+            "history pruning should be activated when the sitrep limit is reached",
         );
 
         db.terminate().await;
@@ -1348,6 +1380,9 @@ mod tests {
         acts.sitrep_gc.assert_not_activated(
             "GC should not be activated below the sitrep limit",
         );
+        acts.sitrep_history_pruner.assert_not_activated(
+            "history pruning should not be activated below the sitrep limit",
+        );
         // Committing a sitrep pokes the loader; consume that activation so
         // the assertion below observes only the second activation's behavior.
         acts.sitrep_loader.assert_activated(
@@ -1376,6 +1411,9 @@ mod tests {
         }
         acts.sitrep_gc.assert_activated(
             "GC should be activated when the sitrep limit is reached",
+        );
+        acts.sitrep_history_pruner.assert_activated(
+            "history pruning should be activated when the sitrep limit is reached",
         );
         acts.sitrep_loader.assert_not_activated(
             "the sitrep loader should not be activated when no sitrep was \

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -686,10 +686,10 @@ impl FmAnalysis {
         opctx: &OpContext,
         warnings: &mut Vec<String>,
     ) -> Result<status::SitrepCapacity, status::AnalysisOutcome> {
-        let limit = self.sitrep_limit.get();
+        let limit = self.sitrep_limit;
         let count = match self
             .datastore
-            .fm_sitrep_check_limit_reached(&opctx, limit)
+            .fm_sitrep_check_limit_reached(&opctx, limit.get())
             .await
         {
             Ok(db::IsLimitReached::Yes) => {
@@ -697,7 +697,7 @@ impl FmAnalysis {
                     &opctx.log,
                     "sitrep capacity is at or above the limit, a new sitrep \
                      will not be written";
-                     "limit" => limit,
+                     "limit" => limit.get(),
                 );
                 self.activators.reclaim_capacity();
                 return Err(status::AnalysisOutcome::LimitReached { limit });
@@ -720,7 +720,7 @@ impl FmAnalysis {
                 debug!(
                     &opctx.log,
                     "sitrep count under limit, proceeding with analysis";
-                    "limit" => limit,
+                    "limit" => limit.get(),
                     "count" => count,
                     "usage_percent" => usage_percent,
                 );
@@ -733,7 +733,7 @@ impl FmAnalysis {
                     &opctx.log,
                     "sitrep count above 80% of limit, proceeding with analysis \
                      and activating GC (will stop analysis if limit is reached)";
-                    "limit" => limit,
+                    "limit" => limit.get(),
                     "count" => count,
                     "usage_percent" => usage_percent,
                 );
@@ -746,7 +746,7 @@ impl FmAnalysis {
                     &opctx.log,
                     "sitrep count above 95% of limit, proceeding with analysis \
                      and activating GC (will stop analysis if limit is reached)";
-                    "limit" => limit,
+                    "limit" => limit.get(),
                     "count" => count,
                     "usage_percent" => usage_percent,
                 );
@@ -1221,7 +1221,7 @@ mod tests {
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
-        const LIMIT: u64 = 20;
+        const LIMIT: NonZeroU64 = NonZeroU64::new(20).unwrap();
         let (_sitrep_tx, sitrep_rx) = watch::channel(None);
         let (_inv_tx, inv_rx) = watch::channel(None);
         let acts = activators();
@@ -1233,7 +1233,7 @@ mod tests {
             OmicronZoneUuid::new_v4(),
             ANALYSIS_ENABLED,
         );
-        task.sitrep_limit = NonZeroU64::new(LIMIT).unwrap();
+        task.sitrep_limit = LIMIT;
 
         let mut model = SitrepModel::new(datastore.clone());
 
@@ -1326,7 +1326,7 @@ mod tests {
         // current. Orphans also count against the total number of sitreps in
         // the database, until GC sweeps them up.
         model.insert_orphan(opctx, None).await;
-        assert_eq!(model.sitrep_count(), LIMIT);
+        assert_eq!(model.sitrep_count(), LIMIT.get());
         let mut warnings = Vec::new();
         let result = task.check_sitrep_limit(opctx, &mut warnings).await;
         assert_eq!(
@@ -1356,7 +1356,7 @@ mod tests {
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
-        const LIMIT: u64 = 4;
+        const LIMIT: NonZeroU64 = NonZeroU64::new(4).unwrap();
         let inv = Arc::new(CollectionBuilder::new("test").build());
         let (_sitrep_tx, sitrep_rx) = watch::channel(None);
         let (_inv_tx, inv_rx) = watch::channel(Some(inv.clone()));
@@ -1369,7 +1369,7 @@ mod tests {
             OmicronZoneUuid::new_v4(),
             ANALYSIS_ENABLED,
         );
-        task.sitrep_limit = NonZeroU64::new(LIMIT).unwrap();
+        task.sitrep_limit = LIMIT;
 
         let mut model = SitrepModel::new(datastore.clone());
 
@@ -1411,7 +1411,7 @@ mod tests {
         // never made current.
         model.insert_history(opctx, 2).await;
         model.insert_orphan(opctx, None).await;
-        assert_eq!(model.sitrep_count(), LIMIT);
+        assert_eq!(model.sitrep_count(), LIMIT.get());
 
         // Now analysis should run, but refuse to write its sitrep.
         let result = task.actually_activate(opctx).await;

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -61,7 +61,7 @@ impl SitrepGc {
             .fm_sitrep_history_prune(&opctx, self.history_limit)
             .await
         {
-            Ok(status::HistoryPruningStatus::BelowLimit { count }) => {
+            Ok(status::HistoryPruningStatus::NotPruned { count }) => {
                 slog::debug!(
                     &opctx.log,
                     "sitrep history depth is below the limit, no entries were \
@@ -69,7 +69,7 @@ impl SitrepGc {
                     "sitrep_history_count" => count,
                     "sitrep_history_limit" => self.history_limit.get(),
                 );
-                Ok(status::HistoryPruningStatus::BelowLimit { count })
+                Ok(status::HistoryPruningStatus::NotPruned { count })
             }
             Ok(status::HistoryPruningStatus::Pruned {
                 n_pruned,
@@ -190,7 +190,7 @@ mod tests {
         assert_eq!(status.orphaned_sitreps_deleted, 7);
         assert_eq!(
             status.history_pruning_status,
-            Ok(status::HistoryPruningStatus::BelowLimit { count: 2 })
+            Ok(status::HistoryPruningStatus::NotPruned { count: 2 })
         );
 
         db.terminate().await;
@@ -219,7 +219,7 @@ mod tests {
         assert_eq!(status.history_limit, LIMIT);
         assert_eq!(
             status.history_pruning_status,
-            Ok(status::HistoryPruningStatus::BelowLimit { count: 3 })
+            Ok(status::HistoryPruningStatus::NotPruned { count: 3 })
         );
 
         // Exactly at the limit: the limit check fires, but the newest `LIMIT`
@@ -228,10 +228,7 @@ mod tests {
         let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         assert_eq!(
             status.history_pruning_status,
-            Ok(status::HistoryPruningStatus::Pruned {
-                n_pruned: 0,
-                newest_version_pruned: 0,
-            })
+            Ok(status::HistoryPruningStatus::NotPruned { count: 5 })
         );
 
         // Over the limit: versions 1..=3 should be pruned from the history,
@@ -247,6 +244,17 @@ mod tests {
             })
         );
         assert_eq!(status.orphaned_sitreps_deleted, 3);
+
+        // Exactly at the limit again, but this time the earliest history
+        // version is v4, not v1, since we pruned v1 previously. This is the
+        // expected steady state of the system, since we try to keep exactly
+        // `LIMIT` rows in the history table.
+        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
+        assert_eq!(
+            status.history_pruning_status,
+            Ok(status::HistoryPruningStatus::NotPruned { count: 5 })
+        );
+        assert_eq!(status.orphaned_sitreps_deleted, 0);
 
         // Prune again, now that the minimum history version is no longer 1.
         // This checks that the pruning arithmetic is anchored on the latest

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -10,6 +10,8 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_db_queries::db::datastore;
 use nexus_db_queries::db::datastore::fm::GcOrphansResult;
+use nexus_db_queries::db::datastore::fm::HistoryPruningParams;
+use nexus_db_queries::db::datastore::fm::HistoryPruningResult;
 use nexus_types::internal_api::background::SitrepGcStatus as Status;
 use nexus_types::internal_api::background::fm_sitrep_gc as status;
 use serde_json::json;
@@ -61,58 +63,15 @@ impl SitrepGc {
         // First, try to prune the sitrep history if it's over the threshold.
         // Doing this first ensures that we will then attempt to GC any rows
         // abandoned by pruning the history. However, if this fails, we still
-        // want to try to GC rows that were already orphaned, so don't `?` this!
-        let mut history_pruning = status::HistoryPruningStatus::default();
-        let pruning_params = datastore::fm::HistoryPruningParams {
-            limit: self.history_limit,
-            batch_size: self.batch_size,
-        };
-        let history_pruning_outcome = loop {
-            match self.datastore.fm_sitrep_history_prune(&opctx, params).await {
-                Ok(status::HistoryPruningStatus::NotPruned { count }) => {
-                    slog::debug!(
-                        &opctx.log,
-                        "sitrep history depth is below the limit, no entries were \
-                         pruned";
-                        "sitrep_history_count" => count,
-                        "sitrep_history_limit" => self.history_limit.get(),
-                    );
-                    Ok(status::HistoryPruningStatus::NotPruned { count })
-                }
-                Ok(status::HistoryPruningStatus::Pruned {
-                    n_pruned,
-                    newest_version_pruned,
-                }) => {
-                    slog::info!(
-                        &opctx.log,
-                        "pruned old sitreps from the end of the history table";
-                        "sitrep_history_limit" => self.history_limit.get(),
-                        "sitreps_pruned" => n_pruned,
-                        "newest_version_pruned" => newest_version_pruned
-
-                    );
-                    Ok(status::HistoryPruningStatus::Pruned {
-                        n_pruned,
-                        newest_version_pruned,
-                    })
-                }
-                Err(e) => {
-                    let error = InlineErrorChain::new(&e);
-                    slog::error!(
-                        &opctx.log,
-                        "pruning the sitrep history table failed";
-                        "sitrep_history_limit" => self.history_limit.get(),
-                        &error
-                    );
-                    break status::HistoryPruningOutcome::Error(
-                        error.to_string(),
-                    );
-                }
-            };
-        };
+        // want to try to GC rows that were already orphaned.
+        let mut history_pruning_status =
+            status::HistoryPruningStatus::default();
+        let history_pruning_outcome =
+            self.prune_history(opctx, &mut history_pruning_status).await;
 
         let mut status = Status {
-            history_pruning_status: pruning_status,
+            history_limit: self.history_limit.get(),
+            history_pruning_status,
             history_pruning_outcome,
             orphaned_sitreps_deleted: 0,
             sitrep_metadata_batches: 0,
@@ -152,6 +111,95 @@ impl SitrepGc {
         }
 
         status
+    }
+
+    async fn prune_history(
+        &self,
+        opctx: &OpContext,
+        status: &mut status::HistoryPruningStatus,
+    ) -> status::HistoryPruningOutcome {
+        let params = HistoryPruningParams {
+            limit: self.history_limit,
+            batch_size: self.batch_size,
+        };
+        // Each call to `fm_sitrep_history_prune` deletes at most BATCH_SIZE of
+        // the oldest history table entries, so we must keep calling it until it
+        // tells us that there's nothing left to prune (or until it fails).
+        loop {
+            match self.datastore.fm_sitrep_history_prune(&opctx, params).await {
+                // If we have never pruned any sitreps, and the first call
+                // indicates that there are no sitreps pruned, then we haven't
+                // done anything and can complete immediately.
+                Ok(HistoryPruningResult::NotPruned { count })
+                    if status.sitreps_pruned == 0 =>
+                {
+                    slog::debug!(
+                        &opctx.log,
+                        "sitrep history depth is within the limit, no records \
+                         will be pruned";
+                        "sitrep_history_count" => count,
+                        "sitrep_history_limit" => self.history_limit.get(),
+                    );
+                    break status::HistoryPruningOutcome::NotPruned { count };
+                }
+                // Otherwise, if the call indicates nothing was pruned, that
+                // means we have completed pruning the table.
+                Ok(HistoryPruningResult::NotPruned { count }) => {
+                    slog::info!(
+                        &opctx.log,
+                        "finished pruning the sitrep history table";
+                        "sitrep_history_count" => count,
+                        "sitrep_history_limit" => self.history_limit.get(),
+                        "total_sitreps_pruned" => status.sitreps_pruned,
+                        "versions_pruned" => ?status
+                            .versions_pruned.as_ref(),
+                        "batches" => status.batches,
+                        "batch_size" => self.batch_size.get(),
+                    );
+                    break status::HistoryPruningOutcome::Pruned { count };
+                }
+                Ok(HistoryPruningResult::Pruned {
+                    n_pruned,
+                    oldest_pruned,
+                    newest_pruned,
+                }) => {
+                    slog::debug!(
+                        &opctx.log,
+                        "pruned a batch of old sitreps from the end of the \
+                         history table";
+                        "sitrep_history_limit" => self.history_limit.get(),
+                        "sitreps_pruned" => n_pruned,
+                        "versions_pruned" => ?oldest_pruned..=newest_pruned,
+                    );
+                    status.batches += 1;
+                    status.sitreps_pruned += n_pruned;
+                    // The overall range of versions pruned by this activation
+                    // starts wherever the first batch did.
+                    let oldest = status
+                        .versions_pruned
+                        .as_ref()
+                        .map_or(oldest_pruned, |r| *r.start());
+                    status.versions_pruned = Some(oldest..=newest_pruned);
+                }
+                Err(e) => {
+                    let error = InlineErrorChain::new(&e);
+                    slog::error!(
+                        &opctx.log,
+                        "pruning the sitrep history table failed";
+                        "sitrep_history_limit" => self.history_limit.get(),
+                        "total_sitreps_pruned" => status.sitreps_pruned,
+                        "versions_pruned" => ?status
+                            .versions_pruned.as_ref(),
+                        "batches" => status.batches,
+                        "batch_size" => self.batch_size.get(),
+                        &error
+                    );
+                    break status::HistoryPruningOutcome::Error(
+                        error.to_string(),
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -199,9 +247,10 @@ mod tests {
         // deleted, and the (well under-limit) history was not pruned.
         assert_eq!(status.orphaned_sitreps_deleted, 7);
         assert_eq!(
-            status.history_pruning_status,
-            Ok(status::HistoryPruningStatus::NotPruned { count: 2 })
+            status.history_pruning_outcome,
+            status::HistoryPruningOutcome::NotPruned { count: 2 }
         );
+        assert_eq!(status.history_pruning_status.sitreps_pruned, 0);
 
         db.terminate().await;
         logctx.cleanup_successful();
@@ -226,10 +275,9 @@ mod tests {
         // Below the limit: nothing should be pruned.
         model.insert_history(opctx, 3).await; // v1..=v3
         let status = run_gc_and_check(&mut task, &mut model, opctx).await;
-        assert_eq!(status.history_limit, LIMIT);
         assert_eq!(
-            status.history_pruning_status,
-            Ok(status::HistoryPruningStatus::NotPruned { count: 3 })
+            status.history_pruning_outcome,
+            status::HistoryPruningOutcome::NotPruned { count: 3 }
         );
 
         // Exactly at the limit: the limit check fires, but the newest `LIMIT`
@@ -237,8 +285,8 @@ mod tests {
         model.insert_history(opctx, 2).await; // v4, v5
         let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         assert_eq!(
-            status.history_pruning_status,
-            Ok(status::HistoryPruningStatus::NotPruned { count: 5 })
+            status.history_pruning_outcome,
+            status::HistoryPruningOutcome::NotPruned { count: 5 }
         );
 
         // Over the limit: versions 1..=3 should be pruned from the history,
@@ -248,10 +296,15 @@ mod tests {
         let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         assert_eq!(
             status.history_pruning_status,
-            Ok(status::HistoryPruningStatus::Pruned {
-                n_pruned: 3,
-                newest_version_pruned: 3,
-            })
+            status::HistoryPruningStatus {
+                batches: 1,
+                sitreps_pruned: 3,
+                versions_pruned: Some(1..=3),
+            }
+        );
+        assert_eq!(
+            status.history_pruning_outcome,
+            status::HistoryPruningOutcome::Pruned { count: 5 }
         );
         assert_eq!(status.orphaned_sitreps_deleted, 3);
 
@@ -261,8 +314,8 @@ mod tests {
         // `LIMIT` rows in the history table.
         let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         assert_eq!(
-            status.history_pruning_status,
-            Ok(status::HistoryPruningStatus::NotPruned { count: 5 })
+            status.history_pruning_outcome,
+            status::HistoryPruningOutcome::NotPruned { count: 5 }
         );
         assert_eq!(status.orphaned_sitreps_deleted, 0);
 
@@ -274,10 +327,15 @@ mod tests {
         let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         assert_eq!(
             status.history_pruning_status,
-            Ok(status::HistoryPruningStatus::Pruned {
-                n_pruned: 2,
-                newest_version_pruned: 5,
-            })
+            status::HistoryPruningStatus {
+                batches: 1,
+                sitreps_pruned: 2,
+                versions_pruned: Some(4..=5),
+            }
+        );
+        assert_eq!(
+            status.history_pruning_outcome,
+            status::HistoryPruningOutcome::Pruned { count: 5 }
         );
         assert_eq!(status.orphaned_sitreps_deleted, 2);
 
@@ -285,9 +343,64 @@ mod tests {
         logctx.cleanup_successful();
     }
 
+    /// Tests that history pruning always converges on the same eventual
+    /// outcome regardless of the batch size, even when the batch size forces
+    /// the pruning loop to run many times per activation.
+    #[tokio::test]
+    async fn test_history_pruning_batched() {
+        let logctx = dev::test_setup_log("test_history_pruning_batched");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        const LIMIT: u32 = 5;
+        // How far over the limit the history table goes before each GC
+        // activation.
+        const EXCESS_HISTORY: u32 = 7;
+        let mut task = SitrepGc::new(datastore.clone());
+        task.history_limit = NonZeroU32::new(LIMIT).unwrap();
+
+        let mut model = SitrepModel::new(datastore.clone());
+
+        // Run the same scenario with a variety of batch sizes: one row at a
+        // time, a batch size that divides the excess records evenly, unevenly,
+        // exactly one batch, and one much larger than everything batch (which
+        // also happens to be the SQL_BATCH_SIZE). The eventual outcome must
+        // always be the same; only the number of batches it takes to get there
+        // may differ.
+        for (batch_size, expected_batches) in
+            [(1, 7), (2, 4), (3, 3), (7, 1), (1000, 1)]
+        {
+            eprintln!("--- batch_size: {batch_size} ---");
+            task.batch_size = NonZeroU32::new(batch_size).unwrap();
+
+            // Insert new sitreps until the history is `EXCESS_HISTORY` entries over
+            // the limit.
+            let count = u32::try_from(model.history_count()).unwrap();
+            let needed = (LIMIT + EXCESS_HISTORY) - count;
+            model.insert_history(opctx, needed as usize).await;
+
+            // `run_gc_and_check` asserts that the pruning status, outcome,
+            // and the state of the database all match the model.
+            let status = run_gc_and_check(&mut task, &mut model, opctx).await;
+            assert_eq!(
+                status.history_pruning_status.sitreps_pruned,
+                EXCESS_HISTORY as usize
+            );
+            assert_eq!(
+                status.history_pruning_outcome,
+                status::HistoryPruningOutcome::Pruned { count: LIMIT.into() }
+            );
+            // ...and did we actually report that we did that many batches?
+            assert_eq!(status.history_pruning_status.batches, expected_batches);
+        }
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
     /// Run a GC activation and check both the task's reported status and
     /// the database contents against the model's simulation of what GC
-    /// should do with the task's configured `history_limit`.
+    /// should do with the task's configured pruning parameters.
     async fn run_gc_and_check(
         task: &mut SitrepGc,
         model: &mut SitrepModel,
@@ -296,9 +409,19 @@ mod tests {
         let status = dbg!(task.actually_activate(opctx).await);
         let expected = model.simulate_gc(task.history_limit);
         assert_eq!(
-            status.history_pruning_status,
-            Ok(expected.pruning),
-            "the task's reported pruning status should match the model's \
+            status.history_pruning_status.sitreps_pruned,
+            expected.sitreps_pruned,
+            "the number of history entries pruned should match the model's \
+             simulation"
+        );
+        assert_eq!(
+            status.history_pruning_status.versions_pruned,
+            expected.versions_pruned,
+            "the range of versions pruned should match the model's simulation"
+        );
+        assert_eq!(
+            status.history_pruning_outcome, expected.outcome,
+            "the task's reported pruning outcome should match the model's \
              simulation"
         );
         assert_eq!(

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -8,6 +8,7 @@ use crate::app::background::BackgroundTask;
 use futures::future::BoxFuture;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
+use nexus_db_queries::db::datastore;
 use nexus_db_queries::db::datastore::fm::GcOrphansResult;
 use nexus_types::internal_api::background::SitrepGcStatus as Status;
 use nexus_types::internal_api::background::fm_sitrep_gc as status;
@@ -19,6 +20,7 @@ use std::sync::Arc;
 pub struct SitrepGc {
     datastore: Arc<DataStore>,
     history_limit: NonZeroU32,
+    batch_size: NonZeroU32,
 }
 
 impl BackgroundTask for SitrepGc {
@@ -44,7 +46,11 @@ impl BackgroundTask for SitrepGc {
 
 impl SitrepGc {
     pub fn new(datastore: Arc<DataStore>) -> Self {
-        Self { datastore, history_limit: Self::DEFAULT_HISTORY_LIMIT }
+        Self {
+            datastore,
+            history_limit: Self::DEFAULT_HISTORY_LIMIT,
+            batch_size: datastore::SQL_BATCH_SIZE,
+        }
     }
 
     // Limits for abandoning sitreps from the history table.
@@ -56,70 +62,74 @@ impl SitrepGc {
         // Doing this first ensures that we will then attempt to GC any rows
         // abandoned by pruning the history. However, if this fails, we still
         // want to try to GC rows that were already orphaned, so don't `?` this!
-        let pruning = match self
-            .datastore
-            .fm_sitrep_history_prune(&opctx, self.history_limit)
-            .await
-        {
-            Ok(status::HistoryPruningStatus::NotPruned { count }) => {
-                slog::debug!(
-                    &opctx.log,
-                    "sitrep history depth is below the limit, no entries were \
-                     pruned";
-                    "sitrep_history_count" => count,
-                    "sitrep_history_limit" => self.history_limit.get(),
-                );
-                Ok(status::HistoryPruningStatus::NotPruned { count })
-            }
-            Ok(status::HistoryPruningStatus::Pruned {
-                n_pruned,
-                newest_version_pruned,
-            }) => {
-                slog::info!(
-                    &opctx.log,
-                    "pruned old sitreps from the end of the history table";
-                    "sitrep_history_limit" => self.history_limit.get(),
-                    "sitreps_pruned" => n_pruned,
-                    "newest_version_pruned" => newest_version_pruned
-
-                );
+        let mut history_pruning = status::HistoryPruningStatus::default();
+        let pruning_params = datastore::fm::HistoryPruningParams {
+            limit: self.history_limit,
+            batch_size: self.batch_size,
+        };
+        let history_pruning_outcome = loop {
+            match self.datastore.fm_sitrep_history_prune(&opctx, params).await {
+                Ok(status::HistoryPruningStatus::NotPruned { count }) => {
+                    slog::debug!(
+                        &opctx.log,
+                        "sitrep history depth is below the limit, no entries were \
+                         pruned";
+                        "sitrep_history_count" => count,
+                        "sitrep_history_limit" => self.history_limit.get(),
+                    );
+                    Ok(status::HistoryPruningStatus::NotPruned { count })
+                }
                 Ok(status::HistoryPruningStatus::Pruned {
                     n_pruned,
                     newest_version_pruned,
-                })
-            }
-            Err(e) => {
-                let error = InlineErrorChain::new(&e);
-                slog::error!(
-                    &opctx.log,
-                    "pruning the sitrep history table failed";
-                    "sitrep_history_limit" => self.history_limit.get(),
-                    &error
-                );
-                Err(error.to_string())
-            }
+                }) => {
+                    slog::info!(
+                        &opctx.log,
+                        "pruned old sitreps from the end of the history table";
+                        "sitrep_history_limit" => self.history_limit.get(),
+                        "sitreps_pruned" => n_pruned,
+                        "newest_version_pruned" => newest_version_pruned
+
+                    );
+                    Ok(status::HistoryPruningStatus::Pruned {
+                        n_pruned,
+                        newest_version_pruned,
+                    })
+                }
+                Err(e) => {
+                    let error = InlineErrorChain::new(&e);
+                    slog::error!(
+                        &opctx.log,
+                        "pruning the sitrep history table failed";
+                        "sitrep_history_limit" => self.history_limit.get(),
+                        &error
+                    );
+                    break status::HistoryPruningOutcome::Error(
+                        error.to_string(),
+                    );
+                }
+            };
         };
 
         let mut status = Status {
-            history_pruning_status: pruning,
-            history_limit: self.history_limit.get(),
+            history_pruning_status: pruning_status,
+            history_pruning_outcome,
             orphaned_sitreps_deleted: 0,
             sitrep_metadata_batches: 0,
-            batch_size: 0,
+            batch_size: self.batch_size.get(),
             child_tables: Default::default(),
             errors: Vec::new(),
         };
 
-        match self.datastore.fm_sitrep_gc_orphans(&opctx).await {
+        match self.datastore.fm_sitrep_gc_orphans(&opctx, self.batch_size).await
+        {
             Ok(GcOrphansResult {
                 sitreps_deleted,
                 sitrep_metadata_batches,
-                batch_size,
                 child_tables,
             }) => {
                 status.orphaned_sitreps_deleted = sitreps_deleted;
                 status.sitrep_metadata_batches = sitrep_metadata_batches;
-                status.batch_size = batch_size;
                 status.child_tables = child_tables
                     .into_iter()
                     .map(|(table, stats)| {

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -145,22 +145,19 @@ mod tests {
             model.insert_orphan(opctx, stale_parent).await;
         }
 
-        // Make sure everything --- including the orphans --- exists.
+        // Make sure everything, including the orphans, exists.
         model.assert_matches(opctx).await;
 
-        // Activate the background task.
-        let status = dbg!(task.actually_activate(opctx).await);
-        assert_eq!(status.errors, Vec::<String>::new());
+        // Activate the background task. The orphans should all be gone,
+        // while the current sitrep and its ancestor remain.
+        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
+        // Independently of the model's simulation: all 7 orphans were
+        // deleted, and the (well under-limit) history was not pruned.
         assert_eq!(status.orphaned_sitreps_deleted, 7);
         assert_eq!(
             status.history_pruning_status,
             Ok(status::HistoryPruningStatus::BelowLimit { count: 2 })
         );
-
-        // Now, the orphans should all be gone, while the current sitrep and
-        // its ancestor remain.
-        model.record_gc(None);
-        model.assert_matches(opctx).await;
 
         db.terminate().await;
         logctx.cleanup_successful();
@@ -184,20 +181,17 @@ mod tests {
 
         // Below the limit: nothing should be pruned.
         model.insert_history(opctx, 3).await; // v1..=v3
-        let status = dbg!(task.actually_activate(opctx).await);
+        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         assert_eq!(status.history_limit, LIMIT);
         assert_eq!(
             status.history_pruning_status,
             Ok(status::HistoryPruningStatus::BelowLimit { count: 3 })
         );
-        assert_eq!(status.orphaned_sitreps_deleted, 0);
-        assert_eq!(status.errors, Vec::<String>::new());
-        model.assert_matches(opctx).await;
 
         // Exactly at the limit: the limit check fires, but the newest `LIMIT`
         // versions are the entire history, so nothing is actually deleted.
         model.insert_history(opctx, 2).await; // v4, v5
-        let status = dbg!(task.actually_activate(opctx).await);
+        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         assert_eq!(
             status.history_pruning_status,
             Ok(status::HistoryPruningStatus::Pruned {
@@ -205,15 +199,12 @@ mod tests {
                 newest_version_pruned: 0,
             })
         );
-        assert_eq!(status.orphaned_sitreps_deleted, 0);
-        assert_eq!(status.errors, Vec::<String>::new());
-        model.assert_matches(opctx).await;
 
         // Over the limit: versions 1..=3 should be pruned from the history,
         // and the sitreps they referenced --- now orphaned --- should be
         // deleted by the orphan sweep in the same activation.
         model.insert_history(opctx, 3).await; // v6..=v8
-        let status = dbg!(task.actually_activate(opctx).await);
+        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         assert_eq!(
             status.history_pruning_status,
             Ok(status::HistoryPruningStatus::Pruned {
@@ -222,16 +213,13 @@ mod tests {
             })
         );
         assert_eq!(status.orphaned_sitreps_deleted, 3);
-        assert_eq!(status.errors, Vec::<String>::new());
-        model.record_gc(Some(3));
-        model.assert_matches(opctx).await;
 
         // Prune again, now that the minimum history version is no longer 1.
         // This checks that the pruning arithmetic is anchored on the latest
         // version rather than on the row count: history is v4..=v10 (7 rows),
         // so v4 and v5 should go.
         model.insert_history(opctx, 2).await; // v9, v10
-        let status = dbg!(task.actually_activate(opctx).await);
+        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         assert_eq!(
             status.history_pruning_status,
             Ok(status::HistoryPruningStatus::Pruned {
@@ -240,11 +228,34 @@ mod tests {
             })
         );
         assert_eq!(status.orphaned_sitreps_deleted, 2);
-        assert_eq!(status.errors, Vec::<String>::new());
-        model.record_gc(Some(5));
-        model.assert_matches(opctx).await;
 
         db.terminate().await;
         logctx.cleanup_successful();
+    }
+
+    /// Run a GC activation and check both the task's reported status and
+    /// the database contents against the model's simulation of what GC
+    /// should do with the task's configured `history_limit`.
+    async fn run_gc_and_check(
+        task: &mut SitrepGc,
+        model: &mut SitrepModel,
+        opctx: &OpContext,
+    ) -> Status {
+        let status = dbg!(task.actually_activate(opctx).await);
+        let expected = model.simulate_gc(task.history_limit);
+        assert_eq!(
+            status.history_pruning_status,
+            Ok(expected.pruning),
+            "the task's reported pruning status should match the model's \
+             simulation"
+        );
+        assert_eq!(
+            status.orphaned_sitreps_deleted, expected.orphans_deleted,
+            "the task's reported orphan deletions should match the model's \
+             simulation"
+        );
+        assert_eq!(status.errors, Vec::<String>::new());
+        model.assert_matches(opctx).await;
+        status
     }
 }

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -56,11 +56,49 @@ impl SitrepGc {
         // Doing this first ensures that we will then attempt to GC any rows
         // abandoned by pruning the history. However, if this fails, we still
         // want to try to GC rows that were already orphaned, so don't `?` this!
-        let pruning = self.datastore.fm_sitrep_history_prune(&opctx, self.history_limit).await.map_err(|e| {
-            let error = InlineErrorChain::new(&e);
-            slog::error!(&opctx.log, "pruning the sitrep history table failed"; &error);
-            error.to_string()
-        });
+        let pruning = match self
+            .datastore
+            .fm_sitrep_history_prune(&opctx, self.history_limit)
+            .await
+        {
+            Ok(status::HistoryPruningStatus::BelowLimit { count }) => {
+                slog::debug!(
+                    &opctx.log,
+                    "sitrep history depth is below the limit, no entries were \
+                     pruned";
+                    "sitrep_history_count" => count,
+                    "sitrep_history_limit" => self.history_limit.get(),
+                );
+                Ok(status::HistoryPruningStatus::BelowLimit { count })
+            }
+            Ok(status::HistoryPruningStatus::Pruned {
+                n_pruned,
+                newest_version_pruned,
+            }) => {
+                slog::info!(
+                    &opctx.log,
+                    "pruned old sitreps from the end of the history table";
+                    "sitrep_history_limit" => self.history_limit.get(),
+                    "sitreps_pruned" => n_pruned,
+                    "newest_version_pruned" => newest_version_pruned
+
+                );
+                Ok(status::HistoryPruningStatus::Pruned {
+                    n_pruned,
+                    newest_version_pruned,
+                })
+            }
+            Err(e) => {
+                let error = InlineErrorChain::new(&e);
+                slog::error!(
+                    &opctx.log,
+                    "pruning the sitrep history table failed";
+                    "sitrep_history_limit" => self.history_limit.get(),
+                    &error
+                );
+                Err(error.to_string())
+            }
+        };
 
         let mut status = Status {
             history_pruning_status: pruning,
@@ -96,14 +134,10 @@ impl SitrepGc {
                     .collect();
             }
             Err(err) => {
-                let err = InlineErrorChain::new(&err);
+                let error = InlineErrorChain::new(&err);
                 const MSG: &str = "failed to GC orphaned sitreps";
-                slog::error!(
-                    &opctx.log,
-                    "{MSG}";
-                    &err,
-                );
-                status.errors.push(format!("{MSG}: {err}"));
+                slog::error!(&opctx.log, "{MSG}"; &error);
+                status.errors.push(format!("{MSG}: {error}"));
             }
         }
 

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -10,12 +10,15 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_db_queries::db::datastore::fm::GcOrphansResult;
 use nexus_types::internal_api::background::SitrepGcStatus as Status;
+use nexus_types::internal_api::background::fm_sitrep_gc as status;
 use serde_json::json;
 use slog_error_chain::InlineErrorChain;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 pub struct SitrepGc {
     datastore: Arc<DataStore>,
+    history_deletion_threshold: NonZeroU32,
 }
 
 impl BackgroundTask for SitrepGc {
@@ -41,11 +44,36 @@ impl BackgroundTask for SitrepGc {
 
 impl SitrepGc {
     pub fn new(datastore: Arc<DataStore>) -> Self {
-        Self { datastore }
+        Self {
+            datastore,
+            history_deletion_threshold:
+                Self::DEFAULT_HISTORY_DELETION_THRESHOLD,
+        }
     }
 
+    // Limits for abandoning sitreps from the history table.
+    pub const DEFAULT_HISTORY_DELETION_THRESHOLD: NonZeroU32 =
+        NonZeroU32::new(2000).unwrap();
+
     async fn actually_activate(&mut self, opctx: &OpContext) -> Status {
-        let mut status = Status::default();
+        // First, try to prune the sitrep history if it's over the threshold.
+        // Doing this first ensures that we will then attempt to GC any rows
+        // abandoned by pruning the history. However, if this fails, we still
+        // want to try to GC rows that were already orphaned, so don't `?` this!
+        let pruning = self.datastore.fm_sitrep_history_prune(&opctx, self.history_deletion_threshold).await.map_err(|e| {
+            let error = InlineErrorChain::new(&e);
+            slog::error!(&opctx.log, "pruning the sitrep history table failed"; &error);
+            error.to_string()
+        });
+
+        let mut status = Status {
+            pruning,
+            orphaned_sitreps_deleted: 0,
+            sitrep_metadata_batches: 0,
+            batch_size: 0,
+            child_tables: Default::default(),
+            errors: Vec::new(),
+        };
 
         match self.datastore.fm_sitrep_gc_orphans(&opctx).await {
             Ok(GcOrphansResult {
@@ -62,7 +90,7 @@ impl SitrepGc {
                     .map(|(table, stats)| {
                         (
                             table.table_name().to_string(),
-                            nexus_types::internal_api::background::ChildTableGcStats {
+                            status::ChildTableGcStats {
                                 rows_deleted: stats.rows_deleted,
                                 batches: stats.batches,
                             },

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 pub struct SitrepGc {
     datastore: Arc<DataStore>,
-    history_deletion_threshold: NonZeroU32,
+    history_limit: NonZeroU32,
 }
 
 impl BackgroundTask for SitrepGc {
@@ -44,15 +44,11 @@ impl BackgroundTask for SitrepGc {
 
 impl SitrepGc {
     pub fn new(datastore: Arc<DataStore>) -> Self {
-        Self {
-            datastore,
-            history_deletion_threshold:
-                Self::DEFAULT_HISTORY_DELETION_THRESHOLD,
-        }
+        Self { datastore, history_limit: Self::DEFAULT_HISTORY_LIMIT }
     }
 
     // Limits for abandoning sitreps from the history table.
-    pub const DEFAULT_HISTORY_DELETION_THRESHOLD: NonZeroU32 =
+    pub const DEFAULT_HISTORY_LIMIT: NonZeroU32 =
         NonZeroU32::new(2000).unwrap();
 
     async fn actually_activate(&mut self, opctx: &OpContext) -> Status {
@@ -60,14 +56,15 @@ impl SitrepGc {
         // Doing this first ensures that we will then attempt to GC any rows
         // abandoned by pruning the history. However, if this fails, we still
         // want to try to GC rows that were already orphaned, so don't `?` this!
-        let pruning = self.datastore.fm_sitrep_history_prune(&opctx, self.history_deletion_threshold).await.map_err(|e| {
+        let pruning = self.datastore.fm_sitrep_history_prune(&opctx, self.history_limit).await.map_err(|e| {
             let error = InlineErrorChain::new(&e);
             slog::error!(&opctx.log, "pruning the sitrep history table failed"; &error);
             error.to_string()
         });
 
         let mut status = Status {
-            pruning,
+            history_pruning_status: pruning,
+            history_limit: self.history_limit.get(),
             orphaned_sitreps_deleted: 0,
             sitrep_metadata_batches: 0,
             batch_size: 0,

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -114,17 +114,9 @@ impl SitrepGc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
-    use nexus_db_queries::db::datastore::fm::InsertSitrepError;
     use nexus_db_queries::db::pub_test_utils::TestDatabase;
-    use nexus_types::fm;
-    use omicron_common::api::external::Error;
-    use omicron_common::api::external::Generation;
+    use nexus_db_queries::db::pub_test_utils::fm::SitrepModel;
     use omicron_test_utils::dev;
-    use omicron_uuid_kinds::CollectionUuid;
-    use omicron_uuid_kinds::OmicronZoneUuid;
-    use omicron_uuid_kinds::SitrepUuid;
-    use std::collections::BTreeSet;
 
     #[tokio::test]
     async fn test_orphaned_sitrep_gc() {
@@ -133,164 +125,126 @@ mod tests {
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
         let mut task = SitrepGc::new(datastore.clone());
+        let mut model = SitrepModel::new(datastore.clone());
 
-        // First, insert an initial sitrep. This should succeed.
-        let sitrep1 = fm::Sitrep {
-            metadata: fm::SitrepMetadata {
-                id: SitrepUuid::new_v4(),
-                inv_collection_id: CollectionUuid::new_v4(),
-                creator_id: OmicronZoneUuid::new_v4(),
-                comment: "test sitrep v1".to_string(),
-                time_created: Utc::now(),
-                parent_sitrep_id: None,
-                next_inv_min_time_started: Utc::now(),
-                alert_generation: Generation::new(),
-                support_bundle_generation: Generation::new(),
-            },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
-        };
-        datastore
-            .fm_sitrep_insert(&opctx, sitrep1.clone(), None)
-            .await
-            .expect("inserting initial sitrep should succeed");
+        // First, insert an initial sitrep (v1).
+        model.insert_history(opctx, 1).await;
 
         // Now, create some orphaned sitreps which also have no parent.
-        let mut orphans = BTreeSet::new();
-        for i in 1..5 {
-            insert_orphan(&datastore, &opctx, &mut orphans, None, 1, i).await;
+        for _ in 0..4 {
+            model.insert_orphan(opctx, None).await;
         }
 
-        // Next, create a new sitrep which descends from sitrep 1.
-        let sitrep2 = fm::Sitrep {
-            metadata: fm::SitrepMetadata {
-                id: SitrepUuid::new_v4(),
-                inv_collection_id: CollectionUuid::new_v4(),
-                creator_id: OmicronZoneUuid::new_v4(),
-                comment: "test sitrep v2".to_string(),
-                time_created: Utc::now(),
-                parent_sitrep_id: Some(sitrep1.metadata.id),
-                next_inv_min_time_started: Utc::now(),
-                alert_generation: Generation::new(),
-                support_bundle_generation: Generation::new(),
-            },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
-        };
-        datastore
-            .fm_sitrep_insert(&opctx, sitrep2.clone(), None)
-            .await
-            .expect("inserting child sitrep should succeed");
+        // Next, create a new current sitrep (v2), which descends from v1.
+        model.insert_history(opctx, 1).await;
 
-        // Now, create some orphaned sitreps which also descend from sitrep 1.
-        for i in 1..4 {
-            insert_orphan(
-                &datastore,
-                &opctx,
-                &mut orphans,
-                Some(sitrep1.metadata.id),
-                2,
-                i,
-            )
-            .await;
+        // Now, create some orphaned sitreps which also descend from the
+        // (no longer current) v1.
+        let stale_parent = Some(model.history[0]);
+        for _ in 0..3 {
+            model.insert_orphan(opctx, stale_parent).await;
         }
 
-        // Make sure the orphans exist.
-        for &id in &orphans {
-            match datastore.fm_sitrep_metadata_read(&opctx, id).await {
-                Ok(_) => {}
-                Err(Error::NotFound { .. }) => {
-                    panic!("orphaned sitrep {id} should exist");
-                }
-                Err(e) => {
-                    panic!(
-                        "unexpected error reading orphaned sitrep {id}: {e}"
-                    );
-                }
-            }
-        }
+        // Make sure everything --- including the orphans --- exists.
+        model.assert_matches(opctx).await;
 
         // Activate the background task.
         let status = dbg!(task.actually_activate(opctx).await);
-
-        // Now, the orphans should all be gone.
-        for &id in &orphans {
-            match datastore.fm_sitrep_metadata_read(&opctx, id).await {
-                Ok(_) => {
-                    panic!(
-                        "orphaned sitrep {id} should have been deleted, \
-                         but it appears to still exist!"
-                    )
-                }
-                Err(Error::NotFound { .. }) => {
-                    // Okay, it's gone.
-                }
-                Err(e) => {
-                    panic!(
-                        "unexpected error reading orphaned sitrep {id}: {e}"
-                    );
-                }
-            }
-        }
-        // But the non-orphaned sitreps should still be there!
-        datastore
-            .fm_sitrep_metadata_read(&opctx, sitrep1.id())
-            .await
-            .expect("sitrep 1 should still exist");
-        datastore
-            .fm_sitrep_metadata_read(&opctx, sitrep2.id())
-            .await
-            .expect("sitrep 2 should still exist");
-
         assert_eq!(status.errors, Vec::<String>::new());
         assert_eq!(status.orphaned_sitreps_deleted, 7);
+        assert_eq!(
+            status.history_pruning_status,
+            Ok(status::HistoryPruningStatus::BelowLimit { count: 2 })
+        );
+
+        // Now, the orphans should all be gone, while the current sitrep and
+        // its ancestor remain.
+        model.record_gc(None);
+        model.assert_matches(opctx).await;
 
         db.terminate().await;
         logctx.cleanup_successful();
     }
 
-    async fn insert_orphan(
-        datastore: &DataStore,
-        opctx: &OpContext,
-        orphans: &mut BTreeSet<SitrepUuid>,
-        parent_sitrep_id: Option<SitrepUuid>,
-        v: usize,
-        i: usize,
-    ) {
-        let sitrep = fm::Sitrep {
-            metadata: fm::SitrepMetadata {
-                id: SitrepUuid::new_v4(),
-                inv_collection_id: CollectionUuid::new_v4(),
-                creator_id: OmicronZoneUuid::new_v4(),
-                comment: format!("test sitrep v{i}; orphan {i}"),
-                time_created: Utc::now(),
-                next_inv_min_time_started: Utc::now(),
-                parent_sitrep_id,
-                alert_generation: Generation::new(),
-                support_bundle_generation: Generation::new(),
-            },
-            // We could populate the orphan sitreps with cases and ereports
-            // here, but there's a unit test
-            // `test_sitrep_delete_deletes_cases()` in the
-            // `nexus_db_queries::db::datastore::fm` module which ensures that
-            // deleting a sitrep removes all the other records associated with
-            // it, so it should be safe to trust that this works properly.
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
-        };
-        match datastore.fm_sitrep_insert(&opctx, sitrep, None).await {
-            Ok(_) => {
-                panic!("inserting sitrep v{v} orphan {i} should not succeed")
-            }
-            Err(InsertSitrepError::ParentNotCurrent(id)) => {
-                orphans.insert(id);
-            }
-            Err(InsertSitrepError::Other(e)) => {
-                panic!(
-                    "expected inserting sitrep v{v} orphan {i} to fail because \
-                     its parent is out of date, but saw an unexpected error: {e}"
-                );
-            }
-        }
+    /// Tests that the GC task prunes the sitrep history table down to (at
+    /// most) `history_limit` entries, and that the sitreps whose history
+    /// entries were pruned are garbage-collected as orphans *in the same
+    /// activation* (i.e., pruning runs before the orphan sweep).
+    #[tokio::test]
+    async fn test_history_pruning() {
+        let logctx = dev::test_setup_log("test_history_pruning");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        const LIMIT: u32 = 5;
+        let mut task = SitrepGc::new(datastore.clone());
+        task.history_limit = NonZeroU32::new(LIMIT).unwrap();
+
+        let mut model = SitrepModel::new(datastore.clone());
+
+        // Below the limit: nothing should be pruned.
+        model.insert_history(opctx, 3).await; // v1..=v3
+        let status = dbg!(task.actually_activate(opctx).await);
+        assert_eq!(status.history_limit, LIMIT);
+        assert_eq!(
+            status.history_pruning_status,
+            Ok(status::HistoryPruningStatus::BelowLimit { count: 3 })
+        );
+        assert_eq!(status.orphaned_sitreps_deleted, 0);
+        assert_eq!(status.errors, Vec::<String>::new());
+        model.assert_matches(opctx).await;
+
+        // Exactly at the limit: the limit check fires, but the newest `LIMIT`
+        // versions are the entire history, so nothing is actually deleted.
+        model.insert_history(opctx, 2).await; // v4, v5
+        let status = dbg!(task.actually_activate(opctx).await);
+        assert_eq!(
+            status.history_pruning_status,
+            Ok(status::HistoryPruningStatus::Pruned {
+                n_pruned: 0,
+                newest_version_pruned: 0,
+            })
+        );
+        assert_eq!(status.orphaned_sitreps_deleted, 0);
+        assert_eq!(status.errors, Vec::<String>::new());
+        model.assert_matches(opctx).await;
+
+        // Over the limit: versions 1..=3 should be pruned from the history,
+        // and the sitreps they referenced --- now orphaned --- should be
+        // deleted by the orphan sweep in the same activation.
+        model.insert_history(opctx, 3).await; // v6..=v8
+        let status = dbg!(task.actually_activate(opctx).await);
+        assert_eq!(
+            status.history_pruning_status,
+            Ok(status::HistoryPruningStatus::Pruned {
+                n_pruned: 3,
+                newest_version_pruned: 3,
+            })
+        );
+        assert_eq!(status.orphaned_sitreps_deleted, 3);
+        assert_eq!(status.errors, Vec::<String>::new());
+        model.record_gc(Some(3));
+        model.assert_matches(opctx).await;
+
+        // Prune again, now that the minimum history version is no longer 1.
+        // This checks that the pruning arithmetic is anchored on the latest
+        // version rather than on the row count: history is v4..=v10 (7 rows),
+        // so v4 and v5 should go.
+        model.insert_history(opctx, 2).await; // v9, v10
+        let status = dbg!(task.actually_activate(opctx).await);
+        assert_eq!(
+            status.history_pruning_status,
+            Ok(status::HistoryPruningStatus::Pruned {
+                n_pruned: 2,
+                newest_version_pruned: 5,
+            })
+        );
+        assert_eq!(status.orphaned_sitreps_deleted, 2);
+        assert_eq!(status.errors, Vec::<String>::new());
+        model.record_gc(Some(5));
+        model.assert_matches(opctx).await;
+
+        db.terminate().await;
+        logctx.cleanup_successful();
     }
 }

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -3,6 +3,24 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Background task for fault management sitrep garbage collection.
+//!
+//! This task deletes sitreps which exist in the database but whose IDs do not
+//! exist in the `fm_sitrep_history` table. Such sitreps may exist for one of two reasons:
+//!
+//! 1. Multiple Nexii raced to insert a new sitrep, and the sitrep was inserted
+//!    with a parent sitrep ID which was no longer the current sitrep. When this
+//!    occurs, the sitrep is not made current, as the state has already advanced
+//!    past it. Such a sitrep is said to be *orphaned*.
+//!
+//! 2. A sitrep was commited to the history at some point in time, but its entry
+//!    in the `fm_sitrep_history` table has been deleted. This is done
+//!    periodically by the [`fm_sitrep_history_pruner`] background task in order
+//!    to ensure that the history does not exceed a configured limit.
+//!
+//!    When that task prunes sitrep versions from the end of the history, it
+//!    activates this task to clean up those newly-abandoned sitreps.
+//!
+//! [`fm_sitrep_history_pruner`]: super::fm_sitrep_history_pruner
 
 use crate::app::background::BackgroundTask;
 use futures::future::BoxFuture;
@@ -10,8 +28,6 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_db_queries::db::datastore;
 use nexus_db_queries::db::datastore::fm::GcOrphansResult;
-use nexus_db_queries::db::datastore::fm::HistoryPruningParams;
-use nexus_db_queries::db::datastore::fm::HistoryPruningResult;
 use nexus_types::internal_api::background::SitrepGcStatus as Status;
 use nexus_types::internal_api::background::fm_sitrep_gc as status;
 use serde_json::json;
@@ -21,7 +37,6 @@ use std::sync::Arc;
 
 pub struct SitrepGc {
     datastore: Arc<DataStore>,
-    history_limit: NonZeroU32,
     batch_size: NonZeroU32,
 }
 
@@ -48,31 +63,11 @@ impl BackgroundTask for SitrepGc {
 
 impl SitrepGc {
     pub fn new(datastore: Arc<DataStore>) -> Self {
-        Self {
-            datastore,
-            history_limit: Self::DEFAULT_HISTORY_LIMIT,
-            batch_size: datastore::SQL_BATCH_SIZE,
-        }
+        Self { datastore, batch_size: datastore::SQL_BATCH_SIZE }
     }
 
-    // Limits for abandoning sitreps from the history table.
-    pub const DEFAULT_HISTORY_LIMIT: NonZeroU32 =
-        NonZeroU32::new(2000).unwrap();
-
     async fn actually_activate(&mut self, opctx: &OpContext) -> Status {
-        // First, try to prune the sitrep history if it's over the threshold.
-        // Doing this first ensures that we will then attempt to GC any rows
-        // abandoned by pruning the history. However, if this fails, we still
-        // want to try to GC rows that were already orphaned.
-        let mut history_pruning_status =
-            status::HistoryPruningStatus::default();
-        let history_pruning_outcome =
-            self.prune_history(opctx, &mut history_pruning_status).await;
-
         let mut status = Status {
-            history_limit: self.history_limit.get(),
-            history_pruning_status,
-            history_pruning_outcome,
             orphaned_sitreps_deleted: 0,
             sitrep_metadata_batches: 0,
             batch_size: self.batch_size.get(),
@@ -111,95 +106,6 @@ impl SitrepGc {
         }
 
         status
-    }
-
-    async fn prune_history(
-        &self,
-        opctx: &OpContext,
-        status: &mut status::HistoryPruningStatus,
-    ) -> status::HistoryPruningOutcome {
-        let params = HistoryPruningParams {
-            limit: self.history_limit,
-            batch_size: self.batch_size,
-        };
-        // Each call to `fm_sitrep_history_prune` deletes at most BATCH_SIZE of
-        // the oldest history table entries, so we must keep calling it until it
-        // tells us that there's nothing left to prune (or until it fails).
-        loop {
-            match self.datastore.fm_sitrep_history_prune(&opctx, params).await {
-                // If we have never pruned any sitreps, and the first call
-                // indicates that there are no sitreps pruned, then we haven't
-                // done anything and can complete immediately.
-                Ok(HistoryPruningResult::NotPruned { count })
-                    if status.sitreps_pruned == 0 =>
-                {
-                    slog::debug!(
-                        &opctx.log,
-                        "sitrep history depth is within the limit, no records \
-                         will be pruned";
-                        "sitrep_history_count" => count,
-                        "sitrep_history_limit" => self.history_limit.get(),
-                    );
-                    break status::HistoryPruningOutcome::NotPruned { count };
-                }
-                // Otherwise, if the call indicates nothing was pruned, that
-                // means we have completed pruning the table.
-                Ok(HistoryPruningResult::NotPruned { count }) => {
-                    slog::info!(
-                        &opctx.log,
-                        "finished pruning the sitrep history table";
-                        "sitrep_history_count" => count,
-                        "sitrep_history_limit" => self.history_limit.get(),
-                        "total_sitreps_pruned" => status.sitreps_pruned,
-                        "versions_pruned" => ?status
-                            .versions_pruned.as_ref(),
-                        "batches" => status.batches,
-                        "batch_size" => self.batch_size.get(),
-                    );
-                    break status::HistoryPruningOutcome::Pruned { count };
-                }
-                Ok(HistoryPruningResult::Pruned {
-                    n_pruned,
-                    oldest_pruned,
-                    newest_pruned,
-                }) => {
-                    slog::debug!(
-                        &opctx.log,
-                        "pruned a batch of old sitreps from the end of the \
-                         history table";
-                        "sitrep_history_limit" => self.history_limit.get(),
-                        "sitreps_pruned" => n_pruned,
-                        "versions_pruned" => ?oldest_pruned..=newest_pruned,
-                    );
-                    status.batches += 1;
-                    status.sitreps_pruned += n_pruned;
-                    // The overall range of versions pruned by this activation
-                    // starts wherever the first batch did.
-                    let oldest = status
-                        .versions_pruned
-                        .as_ref()
-                        .map_or(oldest_pruned, |r| *r.start());
-                    status.versions_pruned = Some(oldest..=newest_pruned);
-                }
-                Err(e) => {
-                    let error = InlineErrorChain::new(&e);
-                    slog::error!(
-                        &opctx.log,
-                        "pruning the sitrep history table failed";
-                        "sitrep_history_limit" => self.history_limit.get(),
-                        "total_sitreps_pruned" => status.sitreps_pruned,
-                        "versions_pruned" => ?status
-                            .versions_pruned.as_ref(),
-                        "batches" => status.batches,
-                        "batch_size" => self.batch_size.get(),
-                        &error
-                    );
-                    break status::HistoryPruningOutcome::Error(
-                        error.to_string(),
-                    );
-                }
-            }
-        }
     }
 }
 
@@ -244,188 +150,57 @@ mod tests {
         // while the current sitrep and its ancestor remain.
         let status = run_gc_and_check(&mut task, &mut model, opctx).await;
         // Independently of the model's simulation: all 7 orphans were
-        // deleted, and the (well under-limit) history was not pruned.
+        // deleted.
         assert_eq!(status.orphaned_sitreps_deleted, 7);
-        assert_eq!(
-            status.history_pruning_outcome,
-            status::HistoryPruningOutcome::NotPruned { count: 2 }
-        );
-        assert_eq!(status.history_pruning_status.sitreps_pruned, 0);
 
         db.terminate().await;
         logctx.cleanup_successful();
     }
 
-    /// Tests that the GC task prunes the sitrep history table down to (at
-    /// most) `history_limit` entries, and that the sitreps whose history
-    /// entries were pruned are garbage-collected as orphans *in the same
-    /// activation* (i.e., pruning runs before the orphan sweep).
+    /// Tests that the GC task deletes sitreps orphaned by history pruning.
+    ///
+    /// This test performs the pruning half via the model (which updates the
+    /// database as though the history pruning task had just run), so that the
+    /// GC task can be tested in isolation from the pruner task.
     #[tokio::test]
-    async fn test_history_pruning() {
-        let logctx = dev::test_setup_log("test_history_pruning");
+    async fn test_gc_deletes_sitreps_pruned_from_history() {
+        let logctx =
+            dev::test_setup_log("test_gc_deletes_sitreps_pruned_from_history");
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
         const LIMIT: u32 = 5;
         let mut task = SitrepGc::new(datastore.clone());
-        task.history_limit = NonZeroU32::new(LIMIT).unwrap();
-
         let mut model = SitrepModel::new(datastore.clone());
 
-        // Below the limit: nothing should be pruned.
-        model.insert_history(opctx, 3).await; // v1..=v3
-        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
-        assert_eq!(
-            status.history_pruning_outcome,
-            status::HistoryPruningOutcome::NotPruned { count: 3 }
-        );
+        // 8 sitreps, and a history limit of 5: pruning should orphan the
+        // sitreps at v1..=v3.
+        model.insert_history(opctx, 8).await;
+        model.prune_history(NonZeroU32::new(LIMIT).unwrap()).await;
+        // The pruned sitreps are now orphans: still present in `fm_sitrep`,
+        // but no longer referenced by the history table.
+        model.assert_matches(opctx).await;
 
-        // Exactly at the limit: the limit check fires, but the newest `LIMIT`
-        // versions are the entire history, so nothing is actually deleted.
-        model.insert_history(opctx, 2).await; // v4, v5
+        // Now, the GC task should clean them up.
         let status = run_gc_and_check(&mut task, &mut model, opctx).await;
-        assert_eq!(
-            status.history_pruning_outcome,
-            status::HistoryPruningOutcome::NotPruned { count: 5 }
-        );
-
-        // Over the limit: versions 1..=3 should be pruned from the history,
-        // and the sitreps they referenced --- now orphaned --- should be
-        // deleted by the orphan sweep in the same activation.
-        model.insert_history(opctx, 3).await; // v6..=v8
-        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
-        assert_eq!(
-            status.history_pruning_status,
-            status::HistoryPruningStatus {
-                batches: 1,
-                sitreps_pruned: 3,
-                versions_pruned: Some(1..=3),
-            }
-        );
-        assert_eq!(
-            status.history_pruning_outcome,
-            status::HistoryPruningOutcome::Pruned { count: 5 }
-        );
         assert_eq!(status.orphaned_sitreps_deleted, 3);
-
-        // Exactly at the limit again, but this time the earliest history
-        // version is v4, not v1, since we pruned v1 previously. This is the
-        // expected steady state of the system, since we try to keep exactly
-        // `LIMIT` rows in the history table.
-        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
-        assert_eq!(
-            status.history_pruning_outcome,
-            status::HistoryPruningOutcome::NotPruned { count: 5 }
-        );
-        assert_eq!(status.orphaned_sitreps_deleted, 0);
-
-        // Prune again, now that the minimum history version is no longer 1.
-        // This checks that the pruning arithmetic is anchored on the latest
-        // version rather than on the row count: history is v4..=v10 (7 rows),
-        // so v4 and v5 should go.
-        model.insert_history(opctx, 2).await; // v9, v10
-        let status = run_gc_and_check(&mut task, &mut model, opctx).await;
-        assert_eq!(
-            status.history_pruning_status,
-            status::HistoryPruningStatus {
-                batches: 1,
-                sitreps_pruned: 2,
-                versions_pruned: Some(4..=5),
-            }
-        );
-        assert_eq!(
-            status.history_pruning_outcome,
-            status::HistoryPruningOutcome::Pruned { count: 5 }
-        );
-        assert_eq!(status.orphaned_sitreps_deleted, 2);
-
-        db.terminate().await;
-        logctx.cleanup_successful();
-    }
-
-    /// Tests that history pruning always converges on the same eventual
-    /// outcome regardless of the batch size, even when the batch size forces
-    /// the pruning loop to run many times per activation.
-    #[tokio::test]
-    async fn test_history_pruning_batched() {
-        let logctx = dev::test_setup_log("test_history_pruning_batched");
-        let db = TestDatabase::new_with_datastore(&logctx.log).await;
-        let (opctx, datastore) = (db.opctx(), db.datastore());
-
-        const LIMIT: u32 = 5;
-        // How far over the limit the history table goes before each GC
-        // activation.
-        const EXCESS_HISTORY: u32 = 7;
-        let mut task = SitrepGc::new(datastore.clone());
-        task.history_limit = NonZeroU32::new(LIMIT).unwrap();
-
-        let mut model = SitrepModel::new(datastore.clone());
-
-        // Run the same scenario with a variety of batch sizes: one row at a
-        // time, a batch size that divides the excess records evenly, unevenly,
-        // exactly one batch, and one much larger than everything batch (which
-        // also happens to be the SQL_BATCH_SIZE). The eventual outcome must
-        // always be the same; only the number of batches it takes to get there
-        // may differ.
-        for (batch_size, expected_batches) in
-            [(1, 7), (2, 4), (3, 3), (7, 1), (1000, 1)]
-        {
-            eprintln!("--- batch_size: {batch_size} ---");
-            task.batch_size = NonZeroU32::new(batch_size).unwrap();
-
-            // Insert new sitreps until the history is `EXCESS_HISTORY` entries over
-            // the limit.
-            let count = u32::try_from(model.history_count()).unwrap();
-            let needed = (LIMIT + EXCESS_HISTORY) - count;
-            model.insert_history(opctx, needed as usize).await;
-
-            // `run_gc_and_check` asserts that the pruning status, outcome,
-            // and the state of the database all match the model.
-            let status = run_gc_and_check(&mut task, &mut model, opctx).await;
-            assert_eq!(
-                status.history_pruning_status.sitreps_pruned,
-                EXCESS_HISTORY as usize
-            );
-            assert_eq!(
-                status.history_pruning_outcome,
-                status::HistoryPruningOutcome::Pruned { count: LIMIT.into() }
-            );
-            // ...and did we actually report that we did that many batches?
-            assert_eq!(status.history_pruning_status.batches, expected_batches);
-        }
 
         db.terminate().await;
         logctx.cleanup_successful();
     }
 
     /// Run a GC activation and check both the task's reported status and
-    /// the database contents against the model's simulation of what GC
-    /// should do with the task's configured pruning parameters.
+    /// the database contents against the model's simulation of what the
+    /// orphan sweep should do.
     async fn run_gc_and_check(
         task: &mut SitrepGc,
         model: &mut SitrepModel,
         opctx: &OpContext,
     ) -> Status {
         let status = dbg!(task.actually_activate(opctx).await);
-        let expected = model.simulate_gc(task.history_limit);
+        let expected_orphans_deleted = model.simulate_orphan_gc();
         assert_eq!(
-            status.history_pruning_status.sitreps_pruned,
-            expected.sitreps_pruned,
-            "the number of history entries pruned should match the model's \
-             simulation"
-        );
-        assert_eq!(
-            status.history_pruning_status.versions_pruned,
-            expected.versions_pruned,
-            "the range of versions pruned should match the model's simulation"
-        );
-        assert_eq!(
-            status.history_pruning_outcome, expected.outcome,
-            "the task's reported pruning outcome should match the model's \
-             simulation"
-        );
-        assert_eq!(
-            status.orphaned_sitreps_deleted, expected.orphans_deleted,
+            status.orphaned_sitreps_deleted, expected_orphans_deleted,
             "the task's reported orphan deletions should match the model's \
              simulation"
         );

--- a/nexus/src/app/background/tasks/fm_sitrep_history_pruner.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_history_pruner.rs
@@ -1,0 +1,367 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Background task for pruning the fault management sitrep history.
+//!
+//! This task enforces an upper bound on the number of entries in the
+//! `fm_sitrep_history` table by deleting the entries with the oldest version
+//! numbers when the table exceeds the configured limit. Deleting a history
+//! entry makes the sitrep it references an orphan, so whenever this task prunes
+//! something, it activates the [`fm_sitrep_gc`](super::fm_sitrep_gc) background
+//! task, which actually deletes the contents of the newly-orphaned sitreps.
+//!
+//! History pruning and orphan GC are deliberately separate tasks: pruning runs
+//! in a loop until the history table is back within the limit, and if new
+//! sitreps are being committed quickly, that loop may run for multiple batches.
+//! Orphaned sitreps are produced both by pruning the history *and* when two
+//! Nexii race to commit a new sitrep. Keeping these two related processes
+//! separate ensures that one cannot prevent the other from running if it keeps
+//! having more work to do.
+
+use crate::app::background::Activator;
+use crate::app::background::BackgroundTask;
+use futures::future::BoxFuture;
+use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::DataStore;
+use nexus_db_queries::db::datastore;
+use nexus_db_queries::db::datastore::fm::HistoryPruningParams;
+use nexus_db_queries::db::datastore::fm::HistoryPruningResult;
+use nexus_types::internal_api::background::SitrepHistoryPrunerStatus as Status;
+use nexus_types::internal_api::background::fm_sitrep_history_pruner as status;
+use serde_json::json;
+use slog_error_chain::InlineErrorChain;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+pub struct SitrepHistoryPruner {
+    datastore: Arc<DataStore>,
+    /// Activator for the `fm_sitrep_gc` background task, which we poke
+    /// whenever pruning has orphaned some sitreps for it to delete.
+    sitrep_gc: Activator,
+    // History limit and batch size. These are currently hard-coded but may be
+    // made configurable in the future. However, they are fields on this struct
+    // so that we can use smaller limits when running tests.
+    history_limit: NonZeroU32,
+    batch_size: NonZeroU32,
+}
+
+impl BackgroundTask for SitrepHistoryPruner {
+    fn activate<'a>(
+        &'a mut self,
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
+        Box::pin(async {
+            let status = self.actually_activate(opctx).await;
+            match serde_json::to_value(status) {
+                Ok(val) => val,
+                Err(err) => {
+                    let err = format!(
+                        "could not serialize task status: {}",
+                        InlineErrorChain::new(&err)
+                    );
+                    json!({ "error": err })
+                }
+            }
+        })
+    }
+}
+
+impl SitrepHistoryPruner {
+    /// The maximum number of entries to retain in the sitrep history table.
+    ///
+    /// This value was chosen totally arbitrarily. In future changes, this
+    /// will become configurable at runtime, in case I've gotten it wrong.
+    pub const DEFAULT_HISTORY_LIMIT: NonZeroU32 =
+        NonZeroU32::new(2000).unwrap();
+
+    pub fn new(datastore: Arc<DataStore>, sitrep_gc: Activator) -> Self {
+        Self {
+            datastore,
+            sitrep_gc,
+            history_limit: Self::DEFAULT_HISTORY_LIMIT,
+            batch_size: datastore::SQL_BATCH_SIZE,
+        }
+    }
+
+    async fn actually_activate(&mut self, opctx: &OpContext) -> Status {
+        let mut pruned = status::SitrepsPruned::default();
+        let params = HistoryPruningParams {
+            limit: self.history_limit,
+            batch_size: self.batch_size,
+        };
+        // Each call to `fm_sitrep_history_prune` deletes at most BATCH_SIZE of
+        // the oldest history table entries, so we must keep calling it until it
+        // tells us that there's nothing left to prune (or until it fails).
+        let outcome = loop {
+            match self.datastore.fm_sitrep_history_prune(&opctx, params).await {
+                // If we have never pruned any sitreps, and the first call
+                // indicates that there are no sitreps pruned, then we haven't
+                // done anything and can complete immediately.
+                Ok(HistoryPruningResult::NotPruned { count })
+                    if pruned.total == 0 =>
+                {
+                    slog::debug!(
+                        &opctx.log,
+                        "sitrep history depth is within the limit, no records \
+                         will be pruned";
+                        "sitrep_history_count" => count,
+                        "sitrep_history_limit" => self.history_limit.get(),
+                    );
+                    break status::Outcome::NotPruned { count };
+                }
+                // Otherwise, if the call indicates nothing was pruned, that
+                // means we have completed pruning the table.
+                Ok(HistoryPruningResult::NotPruned { count }) => {
+                    slog::info!(
+                        &opctx.log,
+                        "finished pruning the sitrep history table";
+                        "sitrep_history_count" => count,
+                        "sitrep_history_limit" => self.history_limit.get(),
+                        "total_sitreps_pruned" => pruned.total,
+                        "versions_pruned" => ?pruned
+                            .versions.as_ref(),
+                        "batches" => pruned.batches,
+                        "batch_size" => self.batch_size.get(),
+                    );
+                    // Note that although the *query* reported that nothing
+                    // was pruned, this arm is only reachable when a previous
+                    // iteration pruned something, so the activation as a
+                    // whole is a `Pruned` outcome.
+                    break status::Outcome::Pruned { count };
+                }
+                Ok(HistoryPruningResult::Pruned {
+                    n_pruned,
+                    oldest_pruned,
+                    newest_pruned,
+                }) => {
+                    slog::debug!(
+                        &opctx.log,
+                        "pruned a batch of old sitreps from the end of the \
+                         history table";
+                        "sitrep_history_limit" => self.history_limit.get(),
+                        "sitreps_pruned" => n_pruned,
+                        "versions_pruned" => ?oldest_pruned..=newest_pruned,
+                    );
+                    pruned.batches += 1;
+                    pruned.total += n_pruned;
+                    // The overall range of versions pruned by this activation
+                    // starts wherever the first batch did.
+                    let oldest = pruned
+                        .versions
+                        .as_ref()
+                        .map_or(oldest_pruned, |r| *r.start());
+                    pruned.versions = Some(oldest..=newest_pruned);
+                    // We've just orphaned a batch of sitreps, so poke the GC
+                    // task to come clean them up. Doing this per-batch, rather
+                    // than once when the loop completes, lets the GC start
+                    // reclaiming space concurrently while we keep pruning a
+                    // long backlog.
+                    self.sitrep_gc.activate();
+                }
+                Err(e) => {
+                    let error = InlineErrorChain::new(&e);
+                    slog::error!(
+                        &opctx.log,
+                        "pruning the sitrep history table failed";
+                        "sitrep_history_limit" => self.history_limit.get(),
+                        "total_sitreps_pruned" => pruned.total,
+                        "versions_pruned" => ?pruned
+                            .versions.as_ref(),
+                        "batches" => pruned.batches,
+                        "batch_size" => self.batch_size.get(),
+                        &error
+                    );
+                    break status::Outcome::Error(error.to_string());
+                }
+            }
+        };
+
+        Status {
+            history_limit: self.history_limit.get(),
+            batch_size: self.batch_size.get(),
+            outcome,
+            pruned,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nexus_db_queries::db::pub_test_utils::TestDatabase;
+    use nexus_db_queries::db::pub_test_utils::fm::SitrepModel;
+    use omicron_test_utils::dev;
+
+    /// Tests that the task prunes the sitrep history table down to (at most)
+    /// `history_limit` entries, deleting oldest versions first, and activates
+    /// the GC task if (and only if) it actually deleted something from the
+    /// history.
+    #[tokio::test]
+    async fn test_history_pruning() {
+        let logctx = dev::test_setup_log("test_history_pruning");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        const LIMIT: u32 = 5;
+        let gc = Activator::new();
+        gc.mark_wired_up().unwrap();
+        let mut task = SitrepHistoryPruner::new(datastore.clone(), gc.clone());
+        task.history_limit = NonZeroU32::new(LIMIT).unwrap();
+
+        let mut model = SitrepModel::new(datastore.clone());
+
+        // Below the limit: nothing should be pruned.
+        model.insert_history(opctx, 3).await; // v1..=v3
+        let status =
+            run_prune_and_check(&mut task, &gc, &mut model, opctx).await;
+        assert_eq!(status.history_limit, LIMIT);
+        assert_eq!(status.outcome, status::Outcome::NotPruned { count: 3 });
+
+        // Exactly at the limit: the limit check fires, but the newest `LIMIT`
+        // versions are the entire history, so nothing is actually deleted.
+        model.insert_history(opctx, 2).await; // v4, v5
+        let status =
+            run_prune_and_check(&mut task, &gc, &mut model, opctx).await;
+        assert_eq!(status.outcome, status::Outcome::NotPruned { count: 5 });
+
+        // Over the limit: versions 1..=3 should be pruned from the history,
+        // orphaning the sitreps they referenced, and the GC task should be
+        // activated to clean them up.
+        model.insert_history(opctx, 3).await; // v6..=v8
+        let status =
+            run_prune_and_check(&mut task, &gc, &mut model, opctx).await;
+        assert_eq!(status.pruned.total, 3);
+        assert_eq!(status.pruned.versions, Some(1..=3));
+        assert_eq!(status.outcome, status::Outcome::Pruned { count: 5 });
+
+        // Exactly at the limit again, but this time the earliest history
+        // version is v4, not v1, since we pruned v1 previously. This is the
+        // expected steady state of the system, since we try to keep exactly
+        // `LIMIT` rows in the history table.
+        let status =
+            run_prune_and_check(&mut task, &gc, &mut model, opctx).await;
+        assert_eq!(status.outcome, status::Outcome::NotPruned { count: 5 });
+
+        // Prune again, now that the minimum history version is no longer 1.
+        // This checks that the pruning arithmetic is anchored on the latest
+        // version rather than on the row count: history is v4..=v10 (7 rows),
+        // so v4 and v5 should go.
+        model.insert_history(opctx, 2).await; // v9, v10
+        let status =
+            run_prune_and_check(&mut task, &gc, &mut model, opctx).await;
+        assert_eq!(status.pruned.total, 2);
+        assert_eq!(status.pruned.versions, Some(4..=5));
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    /// Tests that history pruning always converges on the same eventual
+    /// outcome regardless of the batch size, even when the batch size forces
+    /// the pruning loop to run many times per activation.
+    #[tokio::test]
+    async fn test_history_pruning_batched() {
+        let logctx = dev::test_setup_log("test_history_pruning_batched");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        const LIMIT: u32 = 5;
+        // How far over the limit the history table goes before each pruner
+        // activation.
+        const EXCESS_HISTORY: u32 = 7;
+        let gc = Activator::new();
+        gc.mark_wired_up().unwrap();
+        let mut task = SitrepHistoryPruner::new(datastore.clone(), gc.clone());
+        task.history_limit = NonZeroU32::new(LIMIT).unwrap();
+
+        let mut model = SitrepModel::new(datastore.clone());
+
+        // Run the same scenario with a variety of batch sizes: one row at a
+        // time, a batch size that divides the excess records evenly, unevenly,
+        // exactly one batch, and one much larger than everything batch (which
+        // also happens to be the SQL_BATCH_SIZE). The eventual outcome must
+        // always be the same; only the number of batches it takes to get there
+        // may differ.
+        for (batch_size, expected_batches) in
+            [(1, 7), (2, 4), (3, 3), (7, 1), (1000, 1)]
+        {
+            eprintln!("--- batch_size: {batch_size} ---");
+            task.batch_size = NonZeroU32::new(batch_size).unwrap();
+
+            // Insert new sitreps until the history is `EXCESS_HISTORY`
+            // entries over the limit.
+            let count = u32::try_from(model.history_count()).unwrap();
+            let needed = (LIMIT + EXCESS_HISTORY) - count;
+            model.insert_history(opctx, needed as usize).await;
+
+            let status =
+                run_prune_and_check(&mut task, &gc, &mut model, opctx).await;
+            assert_eq!(status.pruned.total, EXCESS_HISTORY as usize);
+            assert_eq!(
+                status.outcome,
+                status::Outcome::Pruned { count: LIMIT.into() }
+            );
+            // ...and did we actually report that we did that many batches?
+            assert_eq!(status.pruned.batches, expected_batches);
+        }
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    /// Activate the sitrep history pruner task and check the task's reported
+    /// status, the database contents, and the GC task's activation against the
+    /// model's simulation of what pruning should do with the task's configured
+    /// `history_limit`.
+    ///
+    /// If pruning orphaned any sitreps, this asserts that the pruner activated
+    /// the GC task, and then performs the orphan sweep the GC task *would* do
+    /// (via the model, which also checks its effects), so that the database is
+    /// updated to reflect the state as though the activated GC pass had run.
+    /// When a subsequent activation runs, it will see a database that appears
+    /// to have been GCed. This lets the pruner be tested in isolation, without
+    /// running the actual GC task.
+    async fn run_prune_and_check(
+        task: &mut SitrepHistoryPruner,
+        gc: &Activator,
+        model: &mut SitrepModel,
+        opctx: &OpContext,
+    ) -> Status {
+        let status = dbg!(task.actually_activate(opctx).await);
+        let expected = model.simulate_history_pruning(task.history_limit);
+        assert_eq!(
+            status.pruned.total, expected.sitreps_pruned,
+            "the number of history entries pruned should match the model's \
+             simulation"
+        );
+        assert_eq!(
+            status.pruned.versions, expected.versions_pruned,
+            "the range of versions pruned should match the model's simulation"
+        );
+        assert_eq!(
+            status.outcome, expected.outcome,
+            "the task's reported pruning outcome should match the model's \
+             simulation"
+        );
+        // The database should now match the model: pruned history entries
+        // are gone, but the newly-orphaned sitreps still exist, since the GC
+        // task hasn't actually run.
+        model.assert_matches(opctx).await;
+
+        if status.pruned.total > 0 {
+            gc.assert_activated(
+                "the GC task should be activated when sitreps were pruned",
+            );
+            // Apply the effects of the orphan sweep that the GC task would
+            // perform once activated, so that the next scenario starts clean.
+            model.gc_orphans().await;
+            model.assert_matches(opctx).await;
+        } else {
+            gc.assert_not_activated(
+                "the GC task should not be activated when nothing was pruned",
+            );
+        }
+        status
+    }
+}

--- a/nexus/src/app/background/tasks/mod.rs
+++ b/nexus/src/app/background/tasks/mod.rs
@@ -24,6 +24,7 @@ pub mod external_endpoints;
 pub mod fm_analysis;
 pub mod fm_rendezvous;
 pub mod fm_sitrep_gc;
+pub mod fm_sitrep_history_pruner;
 pub mod fm_sitrep_load;
 pub mod instance_reincarnation;
 pub mod instance_updater;

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -207,10 +207,9 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
-# The sitrep history pruning task is explicitly activated when the current
-# sitrep changes, or when the sitrep capacity in the database is reaching the
-# limit. Periodic activations are necessary only as a backstop, so they need no
-# be frequent.
+# The sitrep history pruning task is explicitly activated when the sitrep
+# capacity in the database is reaching the limit. Periodic activations are
+# necessary only as a backstop, so they need not be frequent.
 fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -207,6 +207,11 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
+# The sitrep history pruning task is explicitly activated when the current
+# sitrep changes, or when the sitrep capacity in the database is reaching the
+# limit. Periodic activations are necessary only as a backstop, so they need no
+# be frequent.
+fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval
 # too high.

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -927,7 +927,12 @@ pub mod fm_sitrep_gc {
     /// history table.
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     pub enum HistoryPruningStatus {
-        BelowLimit { count: u64 },
+        /// The history table holds no more than the configured limit of
+        /// entries, so nothing was pruned.
+        NotPruned { count: u64 },
+        /// The history table exceeded the limit, and the oldest `n_pruned`
+        /// entries were deleted. `newest_version_pruned` is the version of the
+        /// newest entry that was deleted.
         Pruned { n_pruned: usize, newest_version_pruned: u32 },
     }
 

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -991,6 +991,22 @@ pub mod fm_analysis {
         pub end_time: DateTime<Utc>,
         pub report: crate::fm::analysis_reports::AnalysisReport,
         pub outcome: AnalysisOutcome,
+        pub capacity: Option<SitrepCapacity>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+    pub struct SitrepCapacity {
+        pub count: u64,
+        pub limit: u64,
+    }
+
+    impl SitrepCapacity {
+        // NOTE(eliza): this _could_ be implemented as a float to get a couple
+        // decimal places, but I don't really think we need to be that precise,
+        // and matching on ranges nicely is cute...
+        pub fn usage_percent(&self) -> u64 {
+            self.count.saturating_mul(100) / self.limit
+        }
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -1001,6 +1017,10 @@ pub mod fm_analysis {
         /// Analysis produced a sitrep identical to the current sitrep,
         /// so we threw it away and did nothing.
         Unchanged,
+
+        /// Analysis produced a new sitrep, but the sitrep limit has been
+        /// reached, so it was not written to the database.
+        LimitReached { limit: u64 },
 
         /// Analysis produced a new sitrep, but we failed to make it
         /// the current sitrep.

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -909,9 +909,8 @@ pub enum SitrepLoadStatus {
 /// The status of a `fm_sitrep_gc` background task activation.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SitrepGcStatus {
-    pub history_limit: u32,
-    pub history_pruning_status:
-        Result<fm_sitrep_gc::HistoryPruningStatus, String>,
+    pub history_pruning_status: fm_sitrep_gc::HistoryPruningStatus,
+    pub history_pruning_outcome: fm_sitrep_gc::HistoryPruningOutcome,
     pub orphaned_sitreps_deleted: usize,
     pub sitrep_metadata_batches: usize,
     pub batch_size: u32,
@@ -922,18 +921,22 @@ pub struct SitrepGcStatus {
 
 pub mod fm_sitrep_gc {
     use super::*;
+    use std::ops::RangeInclusive;
 
     /// Describes the status of pruning old records from the end of the sitrep
     /// history table.
+    #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+    pub struct HistoryPruningStatus {
+        pub limit: u32,
+        pub batches: usize,
+        pub sitreps_pruned: usize,
+        pub versions_pruned: Option<RangeInclusive<u32>>,
+    }
+
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-    pub enum HistoryPruningStatus {
-        /// The history table holds no more than the configured limit of
-        /// entries, so nothing was pruned.
+    pub enum HistoryPruningOutcome {
         NotPruned { count: u64 },
-        /// The history table exceeded the limit, and the oldest `n_pruned`
-        /// entries were deleted. `newest_version_pruned` is the version of the
-        /// newest entry that was deleted.
-        Pruned { n_pruned: usize, newest_version_pruned: u32 },
+        Error(String),
     }
 
     /// Per-child-table GC statistics, used by [`SitrepGcStatus`].

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -909,7 +909,9 @@ pub enum SitrepLoadStatus {
 /// The status of a `fm_sitrep_gc` background task activation.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SitrepGcStatus {
-    pub pruning: Result<fm_sitrep_gc::HistoryPruningStatus, String>,
+    pub history_limit: u32,
+    pub history_pruning_status:
+        Result<fm_sitrep_gc::HistoryPruningStatus, String>,
     pub orphaned_sitreps_deleted: usize,
     pub sitrep_metadata_batches: usize,
     pub batch_size: u32,
@@ -925,8 +927,8 @@ pub mod fm_sitrep_gc {
     /// history table.
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     pub enum HistoryPruningStatus {
-        BelowLimit { threshold: u32, count: u64 },
-        Pruned { threshold: u32, n_pruned: usize, newest_version_pruned: u32 },
+        BelowLimit { count: u64 },
+        Pruned { n_pruned: usize, newest_version_pruned: u32 },
     }
 
     /// Per-child-table GC statistics, used by [`SitrepGcStatus`].

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -906,24 +906,37 @@ pub enum SitrepLoadStatus {
     Loaded { version: crate::fm::SitrepVersion, time_loaded: DateTime<Utc> },
 }
 
-/// Per-child-table GC statistics, used by [`SitrepGcStatus`].
-#[derive(
-    Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq,
-)]
-pub struct ChildTableGcStats {
-    pub rows_deleted: usize,
-    pub batches: usize,
-}
-
 /// The status of a `fm_sitrep_gc` background task activation.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SitrepGcStatus {
+    pub pruning: Result<fm_sitrep_gc::HistoryPruningStatus, String>,
     pub orphaned_sitreps_deleted: usize,
     pub sitrep_metadata_batches: usize,
     pub batch_size: u32,
     /// Per-child-table statistics, keyed by table name.
-    pub child_tables: BTreeMap<String, ChildTableGcStats>,
+    pub child_tables: BTreeMap<String, fm_sitrep_gc::ChildTableGcStats>,
     pub errors: Vec<String>,
+}
+
+pub mod fm_sitrep_gc {
+    use super::*;
+
+    /// Describes the status of pruning old records from the end of the sitrep
+    /// history table.
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+    pub enum HistoryPruningStatus {
+        BelowLimit { threshold: u32, count: u64 },
+        Pruned { threshold: u32, n_pruned: usize, newest_version_pruned: u32 },
+    }
+
+    /// Per-child-table GC statistics, used by [`SitrepGcStatus`].
+    #[derive(
+        Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq,
+    )]
+    pub struct ChildTableGcStats {
+        pub rows_deleted: usize,
+        pub batches: usize,
+    }
 }
 
 /// The status of a `fm_analysis` background task activation.

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -909,6 +909,8 @@ pub enum SitrepLoadStatus {
 /// The status of a `fm_sitrep_gc` background task activation.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SitrepGcStatus {
+    /// The maximum number of entries to retain in the history table.
+    pub history_limit: u32,
     pub history_pruning_status: fm_sitrep_gc::HistoryPruningStatus,
     pub history_pruning_outcome: fm_sitrep_gc::HistoryPruningOutcome,
     pub orphaned_sitreps_deleted: usize,
@@ -927,15 +929,29 @@ pub mod fm_sitrep_gc {
     /// history table.
     #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
     pub struct HistoryPruningStatus {
-        pub limit: u32,
+        /// The number of batched delete queries executed by this activation.
         pub batches: usize,
+        /// The total number of history table entries deleted by this
+        /// activation, across all batches.
         pub sitreps_pruned: usize,
+        /// The range of sitrep versions deleted by this activation
+        /// (oldest..=newest), if any were deleted.
         pub versions_pruned: Option<RangeInclusive<u32>>,
     }
 
+    /// Describes how the history pruning part of a GC activation ended.
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     pub enum HistoryPruningOutcome {
+        /// The history table was already within the limit (with `count`
+        /// entries), so nothing was deleted.
         NotPruned { count: u64 },
+        /// Entries were pruned from the history table, which is now within
+        /// the limit (with `count` entries remaining). The details of what
+        /// was pruned are recorded in [`HistoryPruningStatus`].
+        Pruned { count: u64 },
+        /// A pruning query failed. Any batches that completed before the
+        /// error still happened, and are recorded in
+        /// [`HistoryPruningStatus`].
         Error(String),
     }
 

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -997,6 +997,7 @@ pub struct FmAnalysisStatus {
 pub mod fm_analysis {
     use super::*;
     use crate::fm::analysis_reports;
+    use std::num::NonZeroU64;
 
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     pub struct PreparationStatus {
@@ -1047,7 +1048,7 @@ pub mod fm_analysis {
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     pub struct SitrepCapacity {
         pub count: u64,
-        pub limit: u64,
+        pub limit: NonZeroU64,
     }
 
     impl SitrepCapacity {
@@ -1070,7 +1071,7 @@ pub mod fm_analysis {
 
         /// Analysis produced a new sitrep, but the sitrep limit has been
         /// reached, so it was not written to the database.
-        LimitReached { limit: u64 },
+        LimitReached { limit: NonZeroU64 },
 
         /// Analysis produced a new sitrep, but we failed to make it
         /// the current sitrep.

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -971,7 +971,7 @@ pub mod fm_sitrep_history_pruner {
         Pruned { count: u64 },
         /// A pruning query failed. Any batches that completed before the
         /// error still happened, and are recorded in
-        /// [`SirepsPruned`].
+        /// [`SitrepsPruned`].
         Error(String),
     }
 }

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -909,10 +909,6 @@ pub enum SitrepLoadStatus {
 /// The status of a `fm_sitrep_gc` background task activation.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SitrepGcStatus {
-    /// The maximum number of entries to retain in the history table.
-    pub history_limit: u32,
-    pub history_pruning_status: fm_sitrep_gc::HistoryPruningStatus,
-    pub history_pruning_outcome: fm_sitrep_gc::HistoryPruningOutcome,
     pub orphaned_sitreps_deleted: usize,
     pub sitrep_metadata_batches: usize,
     pub batch_size: u32,
@@ -923,37 +919,6 @@ pub struct SitrepGcStatus {
 
 pub mod fm_sitrep_gc {
     use super::*;
-    use std::ops::RangeInclusive;
-
-    /// Describes the status of pruning old records from the end of the sitrep
-    /// history table.
-    #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-    pub struct HistoryPruningStatus {
-        /// The number of batched delete queries executed by this activation.
-        pub batches: usize,
-        /// The total number of history table entries deleted by this
-        /// activation, across all batches.
-        pub sitreps_pruned: usize,
-        /// The range of sitrep versions deleted by this activation
-        /// (oldest..=newest), if any were deleted.
-        pub versions_pruned: Option<RangeInclusive<u32>>,
-    }
-
-    /// Describes how the history pruning part of a GC activation ended.
-    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-    pub enum HistoryPruningOutcome {
-        /// The history table was already within the limit (with `count`
-        /// entries), so nothing was deleted.
-        NotPruned { count: u64 },
-        /// Entries were pruned from the history table, which is now within
-        /// the limit (with `count` entries remaining). The details of what
-        /// was pruned are recorded in [`HistoryPruningStatus`].
-        Pruned { count: u64 },
-        /// A pruning query failed. Any batches that completed before the
-        /// error still happened, and are recorded in
-        /// [`HistoryPruningStatus`].
-        Error(String),
-    }
 
     /// Per-child-table GC statistics, used by [`SitrepGcStatus`].
     #[derive(
@@ -962,6 +927,52 @@ pub mod fm_sitrep_gc {
     pub struct ChildTableGcStats {
         pub rows_deleted: usize,
         pub batches: usize,
+    }
+}
+
+/// The status of a `fm_sitrep_history_pruner` background task activation.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SitrepHistoryPrunerStatus {
+    /// The maximum number of entries to retain in the history table.
+    pub history_limit: u32,
+    /// The maximum number of history table entries deleted per query.
+    pub batch_size: u32,
+    /// Tracks how many sitreps were deleted during this activation.
+    pub pruned: fm_sitrep_history_pruner::SitrepsPruned,
+    /// The outcome of this activation (i.e. why it ended, and the last observed
+    /// history table count).
+    pub outcome: fm_sitrep_history_pruner::Outcome,
+}
+
+pub mod fm_sitrep_history_pruner {
+    use super::*;
+
+    #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+    pub struct SitrepsPruned {
+        /// The number of batched delete queries executed by this activation.
+        pub batches: usize,
+        /// The total number of history table entries deleted by this
+        /// activation, across all batches.
+        pub total: usize,
+        /// The range of sitrep versions deleted by this activation
+        /// (oldest..=newest), if any were deleted.
+        pub versions: Option<std::ops::RangeInclusive<u32>>,
+    }
+
+    /// Describes how a `fm_sitrep_history_pruner` activation ended.
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+    pub enum Outcome {
+        /// The history table was already within the limit (with `count`
+        /// entries), so nothing was deleted.
+        NotPruned { count: u64 },
+        /// Entries were pruned from the history table, which is now within
+        /// the limit (with `count` entries remaining). The details of what
+        /// was pruned are recorded in [`SitrepsPruned`].
+        Pruned { count: u64 },
+        /// A pruning query failed. Any batches that completed before the
+        /// error still happened, and are recorded in
+        /// [`SirepsPruned`].
+        Error(String),
     }
 }
 

--- a/smf/nexus/multi-sled/config-partial.toml
+++ b/smf/nexus/multi-sled/config-partial.toml
@@ -105,6 +105,11 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
+# The sitrep history pruning task is explicitly activated when the current
+# sitrep changes, or when the sitrep capacity in the database is reaching the
+# limit. Periodic activations are necessary only as a backstop, so they need no
+# be frequent.
+fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval
 # too high.

--- a/smf/nexus/multi-sled/config-partial.toml
+++ b/smf/nexus/multi-sled/config-partial.toml
@@ -105,10 +105,9 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
-# The sitrep history pruning task is explicitly activated when the current
-# sitrep changes, or when the sitrep capacity in the database is reaching the
-# limit. Periodic activations are necessary only as a backstop, so they need no
-# be frequent.
+# The sitrep history pruning task is explicitly activated when the sitrep
+# capacity in the database is reaching the limit. Periodic activations are
+# necessary only as a backstop, so they need not be frequent.
 fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval

--- a/smf/nexus/single-sled/config-partial.toml
+++ b/smf/nexus/single-sled/config-partial.toml
@@ -105,6 +105,11 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
+# The sitrep history pruning task is explicitly activated when the current
+# sitrep changes, or when the sitrep capacity in the database is reaching the
+# limit. Periodic activations are necessary only as a backstop, so they need no
+# be frequent.
+fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval
 # too high.

--- a/smf/nexus/single-sled/config-partial.toml
+++ b/smf/nexus/single-sled/config-partial.toml
@@ -105,10 +105,9 @@ fm.analysis_period_secs = 120
 # is activated every time the current sitrep changes. Periodic activations are
 # only necessary to ensure that it always happens eventually.
 fm.sitrep_gc_period_secs = 600
-# The sitrep history pruning task is explicitly activated when the current
-# sitrep changes, or when the sitrep capacity in the database is reaching the
-# limit. Periodic activations are necessary only as a backstop, so they need no
-# be frequent.
+# The sitrep history pruning task is explicitly activated when the sitrep
+# capacity in the database is reaching the limit. Periodic activations are
+# necessary only as a backstop, so they need not be frequent.
 fm.sitrep_history_prune_period_secs = 600
 # Updating database state to match the current sitrep is triggered whenever a
 # new sitrep is loaded, so we need not set the periodic activation interval


### PR DESCRIPTION
## Motivation

As discussed in #9384, we currently do not delete sitreps which have been
committed to the history, nor do we enforce any upper bound on the number of
sitreps which may exist. This leads to unbounded use of storage by the fault
management system. Now that we have multiple diagnosis engines which are
actually in the product and may be actively creating sitreps, we should probably
stop them from using unbounded amounts of storage.

The fault management system is designed to be able to function if only the
current sitrep exists, but persisting previous ones is useful for human-driven
debugging, either by engineering to debug issues with the FM system itself, or
by support, to see how a problem has evolved over time. Therefore, it's nice to
keep a decently-sized history, even if it's not actually required for the
correct operation of the system.

## Solution

This branch implements an upper bound on the total number of sitreps which may
exist in the database. This is done using the same mechanism as how the
Reconfigurator bounds the maximum number of blueprints in the database, which I
factored out into a reusable query in #10889. When the `fm_analysis` task has
performed an analysis step, we execute the query to check if the number of
sitreps has reached the limit, and if so, we do not commit our generated sitrep.
Like the Reconfigurator, we still emit the analysis report as part of the task's
status object, so that `omdb` can display what _would_ have been done if we had
reached the limit.

Unlike the Reconfigurator, which does not delete historic blueprints and instead
expects them to manually archived, we *also* attempt to automatically ensure
that we should never actually reach the upper bound for a long period of time.
The Reconfigurator expects that most new blueprints are created as part of an
update, and choosing an upper bound that allows several updates to occur without
hitting the limit, and then expects that you can just go in and use `omdb` to
either archive or delete the old ones periodically. This is nice since it makes
the decision of whether old blueprints should be archived or just deleted an
explicit human choice. However, it makes less sense for us, because we have less
control over the circumstances under which the FM system will generate new
sitreps. Faults may occur at any time and are not triggered by operator action.
And, we expect the steady state of the system to be periodically generating new
sitreps as new inventories are collected, even if we don't detect any problems.
Therefore, we must always ensure we have capacity for new sitreps.

Thus, this branch *also* introduces a new `fm_sitrep_history_pruner` background
task, which enforces a limit on the number of entries in the `fm_sitrep_history`
table. When the task runs, it removes the oldest entries from the table if the
total number of entries exceeds the history limit. The abandoned sitreps are now
eligible for garbage collection by the `fm_sitrep_gc` background task, either on
this Nexus or elsewhere. The history limit is set to a lower value than the upper
bound on total sitreps (which includes orphans), so that we have some additional
slop space to account for orphaned sitreps from races or the GC task being delayed
for some reason.

## Future Work

Currently, both limits are hard-coded to values I completely made up (2500 max
sitreps, and 2000 entries in the history table). A subsequent PR will make these
values overridable via a runtime config system similar to the reconfigurator's
(which I started sketching out in #10816, but isn't quite done yet). I figured
that, in case I got these wrong, it would be worth having a way to override them
to get a live system unstuck, if it comes to that. Hopefully it won't have to be
used.

Also, this branch does *not* currently archive the old sitreps pruned off the
end of the history before they're deleted, which I had mentioned in #9384. I'd
really like to add a thing to stuff them in the debug dataset or something, and
eventually clear them out of *there*, as well, if there's space, but it didn't
seem as urgent as having *some* kind of upper bound on the number of sitreps.

Fixes #9384 