### PR TITLE
Specify either hard-coded or detected disks

### DIFF
--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -502,7 +502,7 @@ struct SledAgentConfig {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 enum SledAgentExternalDisks {
-    Virtual {
+    Hardcoded {
         vdevs: Vec<Utf8PathBuf>,
     },
     #[serde(other)]
@@ -524,7 +524,7 @@ fn ensure_vdevs(
 ) -> Result<()> {
     let config = SledAgentConfig::read(sled_agent_config)?;
 
-    let SledAgentExternalDisks::Virtual { vdevs } = &config.external_disks
+    let SledAgentExternalDisks::Hardcoded { vdevs } = &config.external_disks
     else {
         bail!("No vdevs found in this configuration");
     };
@@ -575,7 +575,8 @@ fn destroy_vdevs(
 
     // Remove the vdev files themselves, if they are regular files
     let config = SledAgentConfig::read(sled_agent_config)?;
-    if let SledAgentExternalDisks::Virtual { vdevs } = &config.external_disks {
+    if let SledAgentExternalDisks::Hardcoded { vdevs } = &config.external_disks
+    {
         for vdev in vdevs {
             let vdev_path = if vdev.is_absolute() {
                 vdev.to_owned()

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -181,6 +181,7 @@ impl Config {
 #[cfg(test)]
 mod test {
     use super::*;
+    use slog_error_chain::InlineErrorChain;
 
     #[test]
     fn test_smf_configs() {
@@ -197,7 +198,7 @@ mod test {
                     if entry.file_name() == "config.toml" {
                         let path = entry.path();
                         Config::from_file(&path).unwrap_or_else(|e| {
-                            panic!("Failed to parse config {path}: {e}")
+                            panic!("Failed to parse config {path}: {}", InlineErrorChain::new(&e))
                         });
                         configs_seen += 1;
                     }

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -198,7 +198,10 @@ mod test {
                     if entry.file_name() == "config.toml" {
                         let path = entry.path();
                         Config::from_file(&path).unwrap_or_else(|e| {
-                            panic!("Failed to parse config {path}: {}", InlineErrorChain::new(&e))
+                            panic!(
+                                "Failed to parse config {path}: {}",
+                                InlineErrorChain::new(&e)
+                            )
                         });
                         configs_seen += 1;
                     }

--- a/sled-agent/src/long_running_tasks.rs
+++ b/sled-agent/src/long_running_tasks.rs
@@ -361,7 +361,8 @@ async fn upsert_synthetic_disks_if_needed(
     raw_disks_tx: &RawDisksSender,
     config: &Config,
 ) {
-    if let ExternalDisks::Virtual { vdevs } = &config.external_disks {
+    if let ExternalDisks::Hardcoded { vdevs, disks: _ } = &config.external_disks
+    {
         for (i, vdev) in vdevs.iter().enumerate() {
             info!(
                 log,

--- a/sled-hardware/src/illumos/mod.rs
+++ b/sled-hardware/src/illumos/mod.rs
@@ -172,12 +172,12 @@ impl HardwareSnapshot {
                     )?;
                 }
             }
-            ExternalDisks::HardcodedPhysical { disks: hardcoded_disks } => {
+
+            ExternalDisks::Hardcoded { vdevs: _, disks: hardcoded_disks } => {
                 for disk in hardcoded_disks {
                     disks.insert(disk.identity().clone(), disk.clone());
                 }
             }
-            ExternalDisks::Virtual { .. } => {}
         }
 
         Ok(Self { tofino, disks })
@@ -554,7 +554,7 @@ fn poll_device_tree(
                     // functionality, sled-agent can be supplied a fixed list of
                     // UnparsedDisks. Add those to the HardwareSnapshot here if
                     // they are missing (which they will be for non-sleds).
-                    if let ExternalDisks::HardcodedPhysical { disks } =
+                    if let ExternalDisks::Hardcoded { vdevs: _, disks } =
                         external_disks
                     {
                         for disk in disks {

--- a/sled-hardware/src/lib.rs
+++ b/sled-hardware/src/lib.rs
@@ -68,11 +68,14 @@ pub enum DataLinks {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum ExternalDisks {
-    /// Instead of detecting physical disks, use the provided file-backed vdevs.
-    Virtual { vdevs: Vec<String> },
-    /// Instead of detecting physical disks, inject the provided ones during
-    /// device polling.
-    HardcodedPhysical { disks: Vec<UnparsedDisk> },
+    Hardcoded {
+        /// Use the provided file-backed vdevs
+        vdevs: Vec<String>,
+
+        /// Inject these raw disks during device polling
+        disks: Vec<UnparsedDisk>,
+    },
+
     /// Detect physical external disks connected to the sled.
     DetectPhysical,
 }

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -91,7 +91,7 @@ switch_zone_maghemite_links = ["tfportrear0_0"]
 # These paths have the prefix of either "u2" or "m2", followed by an underscore,
 # followed by a string that is embedded into their fake serial values.
 [external_disks]
-kind = "virtual"
+kind = "hardcoded"
 vdevs = [
   "m2_0.vdev",
   "m2_1.vdev",
@@ -106,6 +106,7 @@ vdevs = [
   "u2_7.vdev",
   "u2_8.vdev",
 ]
+disks = []
 
 [data_links]
 kind = "virtual"


### PR DESCRIPTION
Change the ExternalDisks enum to configure sled-agent to either detect all physical disks, or accept a list of hard-coded vdevs and/or UnparsedDisk objects. The new `Hardcoded` variant combines the existing variants `Virtual` and `HardcodedPhysical`.