### PR TITLE
gateway: polls sps every 2s rather than every 1s.

### DIFF
--- a/gateway/src/metrics.rs
+++ b/gateway/src/metrics.rs
@@ -134,8 +134,11 @@ const METRIC_REQUEST_MAX_SIZE: usize = 10 * 1024 * 1024;
 
 /// Poll interval for requesting sensor readings from SPs.
 ///
-/// Bryan wants to try polling at 1Hz, so let's do that for now.
-const SP_POLL_INTERVAL: Duration = Duration::from_secs(1);
+/// Note: because each gateway polls each SP, and each gateway has an
+/// effectively random polling offset based on the time at which it happens to
+/// start, our coverage of sensor readings is effectively a bit higher than the
+/// configured polling interval.
+const SP_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 ///The interval at which we will ask Oximeter to collect our metric samples.
 ///

--- a/oximeter/collector/src/results_sink.rs
+++ b/oximeter/collector/src/results_sink.rs
@@ -145,6 +145,19 @@ pub async fn database_batcher(
 // ClickHouse is slow or unreachable), new samples evict the oldest ones once
 // this limit is reached. This bounds memory consumption while preferring
 // recent data.
+//
+// Note: sizing this constant, as well as DbConfig::DEFAULT_BATCH_SIZE, should
+// consider the average rate of samples flowing in and out of the queue, as well
+// as the number of samples likely to arrive at the same moment. Even if the
+// queue drains quickly, if we receive more than MAX_BUFFER_SIZE_MULTIPLIER *
+// batch_size samples at the same time, we'll necessarily drop samples. For
+// example, as of this writing, the mgs producer produces about 21,600 samples
+// for each collection: 32 sleds * 135 sensors/sled * 5 samples/sensor. In the
+// worst case, where oximeter samples the two mgs producers at the same time,
+// mgs alone generates 43,200 samples every 10s. If we increase average metrics
+// volume, or especially the number of samples we expect to receive within a
+// short interval, we'll increase this constant (and/or
+// DbConfig::DEFAULT_BATCH_SIZE) accordingly.
 const MAX_BUFFER_SIZE_MULTIPLIER: usize = 100;
 
 // A handoff point for a batch of samples from collectors and the database


### PR DESCRIPTION
This patch includes a tiny configuration change, as well as lots of commentary explaining the motivation. To recapitulate some of that commentary: as described in #10552, our test racks drop metrics when oximeter collects a large volume of samples during a short period of time. On average, oximeter drains its database queue faster than it collects samples, but if we collect more than DEFAULT_BATCH_SIZE * MAX_BUFFER_SIZE_MULTIPLIER metrics during a short interval, we overflow the queue and drop the oldest samples. This can happen regularly when multiple high-volume producers are collected from around the same time. The worst offender here is mgs, which currently produces about 40k samples per collection from each gateway; if oximeter is unlucky enough to poll both gateways around the same time, it's immediately at 80% of its maximum queue size.

This patch configures mgs to poll the sps every 2s rather than every 1s, halving the volume of the spikiest oximeter producer. We also add notes to the relevant constants explaining how they should be sized, and what might cause us to change them in the future.

Note: my original plan was to increase the size of the oximeter database queue, but if we don't identify any downsides to polling the sps every 2s rather than every 1s, this change is safer.

Part of #10552.