### PR TITLE
Require full service IP Pool details at RSS time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
  "sled-agent-types",
  "sled-hardware-types",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "wicketd-commission-types",
 ]
 
 [[package]]
@@ -17752,6 +17752,7 @@ dependencies = [
  "sled-hardware-types",
  "slog-error-chain",
  "test-strategy",
+ "thiserror 2.0.18",
  "toml 0.8.23",
  "uuid",
 ]

--- a/openapi/wicketd-commission/wicketd-commission-1.0.0-c4aa6c.json.gitstub
+++ b/openapi/wicketd-commission/wicketd-commission-1.0.0-c4aa6c.json.gitstub
@@ -1,0 +1,1 @@
+73bbf8e62a86faa8cdd1cbc9a8db0d38a839ceb9:openapi/wicketd-commission/wicketd-commission-1.0.0-c4aa6c.json

--- a/openapi/wicketd-commission/wicketd-commission-2.0.0-875f6b.json
+++ b/openapi/wicketd-commission/wicketd-commission-2.0.0-875f6b.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "paths": {
     "/bootstrap-sleds": {
@@ -1766,7 +1766,7 @@
         "additionalProperties": false
       },
       "PutRssUserConfigInsensitive": {
-        "description": "The portion of the RSS configuration that can be posted in one shot.\n\nIt is provided by the operator uploading a TOML file. Sensitive values (certificates, the recovery password hash, and BGP authentication keys) are set separately.",
+        "description": "The portion of the RSS configuration that can be posted in one shot.\n\nIt is provided by the operator uploading a TOML file. Sensitive values (certificates, the recovery password hash, and BGP authentication keys) are set separately.\n\nThis version replaces the flat `internal_services_ip_pool_ranges` of the initial version with fully-specified [`service_ip_pools`], letting operators name and describe each pool.\n\n[`service_ip_pools`]: Self::service_ip_pools",
         "type": "object",
         "properties": {
           "allowed_source_ips": {
@@ -1812,13 +1812,6 @@
             "default": false,
             "type": "boolean"
           },
-          "internal_services_ip_pool_ranges": {
-            "description": "Ranges of the service IP pool which may be used for internal services.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IpRange"
-            }
-          },
           "ntp_servers": {
             "description": "The external NTP server addresses.",
             "type": "array",
@@ -1833,6 +1826,25 @@
                 "$ref": "#/components/schemas/UserSpecifiedRackNetworkConfig"
               }
             ]
+          },
+          "service_ip_pools": {
+            "title": "IdOrdMap",
+            "description": "The service IP pools which may be used for internal services.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ServiceIpPoolConfig"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceIpPoolConfig"
+            },
+            "uniqueItems": true
           }
         },
         "required": [
@@ -1841,11 +1853,10 @@
           "dns_servers",
           "external_dns_ips",
           "external_dns_zone_name",
-          "internal_services_ip_pool_ranges",
           "ntp_servers",
-          "rack_network_config"
-        ],
-        "additionalProperties": false
+          "rack_network_config",
+          "service_ip_pools"
+        ]
       },
       "RackInitUuid": {
         "x-rust-type": {
@@ -2475,6 +2486,36 @@
               "state"
             ]
           }
+        ]
+      },
+      "ServiceIpPoolConfig": {
+        "description": "Full details of a system-service IP pool, provided at rack setup (RSS).",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "Description of the IP Pool",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the IP Pool",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "ranges": {
+            "description": "List of IP address ranges in the pool.\n\nThere is guaranteed to be at least one range, and all ranges are of the same IP version.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IpRange"
+            }
+          }
+        },
+        "required": [
+          "description",
+          "name",
+          "ranges"
         ]
       },
       "SetBgpAuthKeyStatus": {

--- a/openapi/wicketd-commission/wicketd-commission-latest.json
+++ b/openapi/wicketd-commission/wicketd-commission-latest.json
@@ -1,1 +1,1 @@
-wicketd-commission-1.0.0-c4aa6c.json
+wicketd-commission-2.0.0-875f6b.json

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -1721,12 +1721,6 @@
             "default": false,
             "type": "boolean"
           },
-          "internal_services_ip_pool_ranges": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IpRange"
-            }
-          },
           "ntp_servers": {
             "type": "array",
             "items": {
@@ -1740,6 +1734,24 @@
                 "$ref": "#/components/schemas/UserSpecifiedRackNetworkConfig"
               }
             ]
+          },
+          "service_ip_pools": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ServiceIpPoolConfig"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceIpPoolConfig"
+            },
+            "uniqueItems": true
           }
         },
         "required": [
@@ -1747,8 +1759,8 @@
           "dns_servers",
           "external_dns_ips",
           "external_dns_zone_name",
-          "internal_services_ip_pool_ranges",
-          "ntp_servers"
+          "ntp_servers",
+          "service_ip_pools"
         ]
       },
       "CurrentRssUserConfigSensitive": {
@@ -3638,7 +3650,7 @@
         ]
       },
       "PutRssUserConfigInsensitive": {
-        "description": "The portion of the RSS configuration that can be posted in one shot.\n\nIt is provided by the operator uploading a TOML file. Sensitive values (certificates, the recovery password hash, and BGP authentication keys) are set separately.",
+        "description": "The portion of the RSS configuration that can be posted in one shot.\n\nIt is provided by the operator uploading a TOML file. Sensitive values (certificates, the recovery password hash, and BGP authentication keys) are set separately.\n\nThis version replaces the flat `internal_services_ip_pool_ranges` of the initial version with fully-specified [`service_ip_pools`], letting operators name and describe each pool.\n\n[`service_ip_pools`]: Self::service_ip_pools",
         "type": "object",
         "properties": {
           "allowed_source_ips": {
@@ -3684,13 +3696,6 @@
             "default": false,
             "type": "boolean"
           },
-          "internal_services_ip_pool_ranges": {
-            "description": "Ranges of the service IP pool which may be used for internal services.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IpRange"
-            }
-          },
           "ntp_servers": {
             "description": "The external NTP server addresses.",
             "type": "array",
@@ -3705,6 +3710,25 @@
                 "$ref": "#/components/schemas/UserSpecifiedRackNetworkConfig"
               }
             ]
+          },
+          "service_ip_pools": {
+            "title": "IdOrdMap",
+            "description": "The service IP pools which may be used for internal services.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ServiceIpPoolConfig"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceIpPoolConfig"
+            },
+            "uniqueItems": true
           }
         },
         "required": [
@@ -3713,11 +3737,10 @@
           "dns_servers",
           "external_dns_ips",
           "external_dns_zone_name",
-          "internal_services_ip_pool_ranges",
           "ntp_servers",
-          "rack_network_config"
-        ],
-        "additionalProperties": false
+          "rack_network_config",
+          "service_ip_pools"
+        ]
       },
       "RackInitUuid": {
         "x-rust-type": {
@@ -4407,6 +4430,36 @@
               "status"
             ]
           }
+        ]
+      },
+      "ServiceIpPoolConfig": {
+        "description": "Full details of a system-service IP pool, provided at rack setup (RSS).",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "Description of the IP Pool",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the IP Pool",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "ranges": {
+            "description": "List of IP address ranges in the pool.\n\nThere is guaranteed to be at least one range, and all ranges are of the same IP version.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IpRange"
+            }
+          }
+        },
+        "required": [
+          "description",
+          "name",
+          "ranges"
         ]
       },
       "SetBgpAuthKeyStatus": {

--- a/sled-agent/bootstrap-agent-lockstep-types/Cargo.toml
+++ b/sled-agent/bootstrap-agent-lockstep-types/Cargo.toml
@@ -18,6 +18,6 @@ serde.workspace = true
 sled-agent-types.workspace = true
 sled-hardware-types.workspace = true
 strum.workspace = true
-thiserror.workspace = true
+wicketd-commission-types.workspace = true
 
 omicron-workspace-hack.workspace = true

--- a/sled-agent/bootstrap-agent-lockstep-types/src/lib.rs
+++ b/sled-agent/bootstrap-agent-lockstep-types/src/lib.rs
@@ -14,14 +14,11 @@ use iddqd::IdOrdItem;
 use iddqd::IdOrdMap;
 use iddqd::id_upcast;
 use omicron_common::address::AZ_PREFIX_LENGTH;
-use omicron_common::address::IpRange;
-use omicron_common::address::IpVersion;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::RACK_PREFIX_LENGTH;
 use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::address::get_64_subnet;
 use omicron_common::api::external::AllowedSourceIps;
-use omicron_common::api::external::Error;
 use omicron_common::api::external::Name;
 use omicron_common::api::external::UserId;
 use omicron_common::api::internal::nexus::Certificate;
@@ -36,6 +33,8 @@ use std::net::Ipv6Addr;
 use strum::EnumCount;
 use strum::EnumIter;
 use strum::IntoEnumIterator;
+pub use wicketd_commission_types::rack_setup::ServiceIpPoolConfig;
+pub use wicketd_commission_types::rack_setup::ServiceIpPoolError;
 
 /// Configuration for the "rack setup service".
 ///
@@ -372,104 +371,6 @@ pub struct ReplicatedNetworkConfigContents {
     /// serialization/deserialization of the contents is performed outside the
     /// replication engine, which just deals with a binary blob.
     pub base64_blob: String,
-}
-
-/// Full details of a system-service IP pool, provided at rack setup (RSS).
-#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
-#[serde(try_from = "UnvalidatedServiceIpPoolConfig")]
-pub struct ServiceIpPoolConfig {
-    /// Name of the IP Pool
-    pub name: Name,
-    /// Description of the IP Pool
-    pub description: String,
-    /// List of IP address ranges in the pool.
-    ///
-    /// There is guaranteed to be at least one range, and all ranges are of the
-    /// same IP version.
-    // NOTE: Private to ensure the above invariants. `new()` checks them, and we
-    // deserialize through `UnvalidatedServiceIpPoolConfig` to check them.
-    ranges: Vec<IpRange>,
-}
-
-impl ServiceIpPoolConfig {
-    /// Construct a new service IP pool configuration.
-    ///
-    /// Errors if `ranges` is empty, or if the ranges are a mix of IPv4 and
-    /// IPv6 addresses.
-    pub fn new(
-        name: Name,
-        description: String,
-        ranges: Vec<IpRange>,
-    ) -> Result<Self, ServiceIpPoolError> {
-        let mut versions = ranges.iter().map(|r| r.version());
-        let Some(first) = versions.next() else {
-            return Err(ServiceIpPoolError::EmptyRanges);
-        };
-        if versions.any(|v| v != first) {
-            return Err(ServiceIpPoolError::MixedIpVersions);
-        }
-        Ok(Self { name, description, ranges })
-    }
-
-    /// The ranges belonging to this pool.
-    ///
-    /// Guaranteed to be non-empty and all of the same IP version.
-    pub fn ranges(&self) -> &[IpRange] {
-        &self.ranges
-    }
-
-    /// The IP version of this pool, derived from its ranges.
-    pub fn ip_version(&self) -> IpVersion {
-        // Safety: the constructor guarantees at least one range, and that all
-        // ranges share an IP version.
-        self.ranges[0].version()
-    }
-}
-
-/// Errors constructing a `ServiceIpPoolConfig`.
-#[derive(Clone, Copy, Debug, thiserror::Error)]
-pub enum ServiceIpPoolError {
-    #[error("must provide at least one IP range")]
-    EmptyRanges,
-    #[error("ranges have mixed IP versions")]
-    MixedIpVersions,
-}
-
-impl From<ServiceIpPoolError> for Error {
-    fn from(value: ServiceIpPoolError) -> Self {
-        Error::internal_error(format!(
-            "error constructing service IP pool config: {value}"
-        ))
-    }
-}
-
-impl iddqd::IdOrdItem for ServiceIpPoolConfig {
-    type Key<'a> = &'a Name;
-
-    fn key(&self) -> Self::Key<'_> {
-        &self.name
-    }
-
-    id_upcast!();
-}
-
-#[derive(Deserialize)]
-struct UnvalidatedServiceIpPoolConfig {
-    name: Name,
-    description: String,
-    ranges: Vec<IpRange>,
-}
-
-impl TryFrom<UnvalidatedServiceIpPoolConfig> for ServiceIpPoolConfig {
-    type Error = ServiceIpPoolError;
-
-    fn try_from(
-        value: UnvalidatedServiceIpPoolConfig,
-    ) -> Result<Self, Self::Error> {
-        let UnvalidatedServiceIpPoolConfig { name, description, ranges } =
-            value;
-        ServiceIpPoolConfig::new(name, description, ranges)
-    }
 }
 
 #[derive(

--- a/wicket-common/src/example.rs
+++ b/wicket-common/src/example.rs
@@ -23,10 +23,10 @@ use crate::{
 };
 use wicketd_commission_types::rack_setup::{
     AllowedSourceIps, BgpAuthKeyId, IpRange, Ipv4Range, ManualPortConfig,
-    PutRssUserConfigInsensitive, UplinkAddress, UserSpecifiedBgpPeerConfig,
-    UserSpecifiedImportExportPolicy, UserSpecifiedPortConfig,
-    UserSpecifiedRackNetworkConfig, UserSpecifiedRouterPeerAddr,
-    UserSpecifiedUplinkAddressConfig,
+    PutRssUserConfigInsensitive, ServiceIpPoolConfig, UplinkAddress,
+    UserSpecifiedBgpPeerConfig, UserSpecifiedImportExportPolicy,
+    UserSpecifiedPortConfig, UserSpecifiedRackNetworkConfig,
+    UserSpecifiedRouterPeerAddr, UserSpecifiedUplinkAddressConfig,
 };
 
 /// A collection of example data structures.
@@ -138,10 +138,17 @@ impl ExampleRackSetupData {
         let dns_servers =
             vec!["1.1.1.1".parse().unwrap(), "2.2.2.2".parse().unwrap()];
         let external_dns_zone_name = "oxide.computer".to_owned();
-        let internal_services_ip_pool_ranges = vec![IpRange::V4(Ipv4Range {
-            first: "10.0.0.1".parse().unwrap(),
-            last: "10.0.0.5".parse().unwrap(),
-        })];
+        let service_ip_pools = id_ord_map! {
+            ServiceIpPoolConfig::new(
+                "oxide-service-pool-v4".parse().unwrap(),
+                "IPv4 IP Pool for Oxide Services".to_string(),
+                vec![IpRange::V4(Ipv4Range {
+                    first: "10.0.0.1".parse().unwrap(),
+                    last: "10.0.0.5".parse().unwrap(),
+                })],
+            )
+            .unwrap(),
+        };
         let external_dns_ips = vec!["10.0.0.1".parse().unwrap()];
         let ntp_servers = vec!["ntp1.com".into(), "ntp2.com".into()];
 
@@ -314,7 +321,7 @@ impl ExampleRackSetupData {
             bootstrap_sleds,
             dns_servers,
             external_dns_zone_name,
-            internal_services_ip_pool_ranges,
+            service_ip_pools,
             external_dns_ips,
             ntp_servers,
             rack_network_config: Some(rack_network_config),
@@ -344,9 +351,7 @@ impl ExampleRackSetupData {
             external_dns_zone_name: current_insensitive
                 .external_dns_zone_name
                 .clone(),
-            internal_services_ip_pool_ranges: current_insensitive
-                .internal_services_ip_pool_ranges
-                .clone(),
+            service_ip_pools: current_insensitive.service_ip_pools.clone(),
             external_dns_ips: current_insensitive.external_dns_ips.clone(),
             ntp_servers: current_insensitive.ntp_servers.clone(),
             rack_network_config: current_insensitive

--- a/wicket-common/src/rack_setup.rs
+++ b/wicket-common/src/rack_setup.rs
@@ -19,19 +19,19 @@ use tufaceous_artifact::ArtifactHash;
 use wicketd_commission_types::rack_setup::AllowedSourceIps;
 use wicketd_commission_types::rack_setup::BgpAuthKey;
 use wicketd_commission_types::rack_setup::BgpAuthKeyId;
-use wicketd_commission_types::rack_setup::IpRange;
+use wicketd_commission_types::rack_setup::ServiceIpPoolConfig;
 use wicketd_commission_types::rack_setup::UserSpecifiedRackNetworkConfig;
 
 use crate::inventory::SpIdentifier;
 
 /// The subset of `RackInitializeRequest` that the user fills in as clear text
 /// (e.g., via an uploaded config file).
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct CurrentRssUserConfigInsensitive {
     pub bootstrap_sleds: IdOrdMap<BootstrapSledDescription>,
     pub ntp_servers: Vec<String>,
     pub dns_servers: Vec<IpAddr>,
-    pub internal_services_ip_pool_ranges: Vec<IpRange>,
+    pub service_ip_pools: IdOrdMap<ServiceIpPoolConfig>,
     pub external_dns_ips: Vec<IpAddr>,
     pub external_dns_zone_name: String,
     pub rack_network_config: Option<UserSpecifiedRackNetworkConfig>,

--- a/wicket/src/cli/rack_setup/config_toml.rs
+++ b/wicket/src/cli/rack_setup/config_toml.rs
@@ -27,6 +27,7 @@ use wicket_common::rack_setup::CurrentRssUserConfigInsensitive;
 use wicketd_commission_types::rack_setup::AllowedSourceIps;
 use wicketd_commission_types::rack_setup::IpRange;
 use wicketd_commission_types::rack_setup::ManualPortConfig;
+use wicketd_commission_types::rack_setup::ServiceIpPoolConfig;
 use wicketd_commission_types::rack_setup::UplinkAddress;
 use wicketd_commission_types::rack_setup::UserSpecifiedBgpPeerConfig;
 use wicketd_commission_types::rack_setup::UserSpecifiedImportExportPolicy;
@@ -67,23 +68,7 @@ impl TomlTemplate {
             .map(|s| Value::String(Formatted::new(s.to_string())))
             .collect();
 
-        *doc.get_mut("internal_services_ip_pool_ranges")
-            .unwrap()
-            .as_array_mut()
-            .unwrap() = config
-            .internal_services_ip_pool_ranges
-            .iter()
-            .map(|r| {
-                let mut t = InlineTable::new();
-                let (first, last) = match r {
-                    IpRange::V4(r) => (r.first.to_string(), r.last.to_string()),
-                    IpRange::V6(r) => (r.first.to_string(), r.last.to_string()),
-                };
-                t.insert("first", Value::String(Formatted::new(first)));
-                t.insert("last", Value::String(Formatted::new(last)));
-                Value::InlineTable(t)
-            })
-            .collect();
+        populate_service_ip_pool_tables(&mut doc, &config.service_ip_pools);
 
         *doc.get_mut("external_dns_ips").unwrap().as_array_mut().unwrap() =
             config
@@ -92,12 +77,7 @@ impl TomlTemplate {
                 .map(|s| Value::String(Formatted::new(s.to_string())))
                 .collect();
 
-        for array in [
-            "ntp_servers",
-            "dns_servers",
-            "internal_services_ip_pool_ranges",
-            "external_dns_ips",
-        ] {
+        for array in ["ntp_servers", "dns_servers", "external_dns_ips"] {
             format_multiline_array(
                 doc.get_mut(array).unwrap().as_array_mut().unwrap(),
             );
@@ -125,6 +105,74 @@ impl TomlTemplate {
 
         Self { doc }
     }
+}
+
+fn populate_service_ip_pool_tables(
+    doc: &mut DocumentMut,
+    pools: &IdOrdMap<ServiceIpPoolConfig>,
+) {
+    // With no pools in the current config, leave the template's block (its
+    // explanatory comment and a placeholder pool) in place to give some
+    // scaffolding to the operator.
+    if pools.is_empty() {
+        return;
+    }
+
+    let existing = doc
+        .get_mut("service_ip_pools")
+        .unwrap()
+        .as_array_of_tables_mut()
+        .unwrap();
+
+    // Cache the comment from the template to reapply it later after inserting
+    // the existing tables.
+    let comment = existing.get(0).and_then(|t| t.decor().prefix().cloned());
+
+    let mut tables: ArrayOfTables = pools
+        .iter()
+        .map(|pool| {
+            let mut table = Table::new();
+            table.insert(
+                "name",
+                Item::Value(Value::String(Formatted::new(
+                    pool.name.to_string(),
+                ))),
+            );
+            table.insert(
+                "description",
+                Item::Value(Value::String(Formatted::new(
+                    pool.description.clone(),
+                ))),
+            );
+            let ranges = pool
+                .ranges()
+                .iter()
+                .map(|r| {
+                    let mut t = InlineTable::new();
+                    let (first, last) = match r {
+                        IpRange::V4(r) => {
+                            (r.first.to_string(), r.last.to_string())
+                        }
+                        IpRange::V6(r) => {
+                            (r.first.to_string(), r.last.to_string())
+                        }
+                    };
+                    t.insert("first", Value::String(Formatted::new(first)));
+                    t.insert("last", Value::String(Formatted::new(last)));
+                    Value::InlineTable(t)
+                })
+                .collect::<Array>();
+            table.insert("ranges", Item::Value(Value::Array(ranges)));
+            table
+        })
+        .collect();
+
+    // Reapply the template's section comment to the first pool.
+    if let Some(comment) = comment {
+        tables.get_mut(0).unwrap().decor_mut().set_prefix(comment);
+    }
+
+    *existing = tables;
 }
 
 // Populate the allowed source IP list, which can be specified as a specified as
@@ -675,5 +723,29 @@ mod tests {
         let parsed: PutRssUserConfigInsensitive =
             toml::de::from_str(&template).unwrap();
         assert_eq!(example.put_insensitive, parsed);
+    }
+
+    #[test]
+    fn empty_config_emits_service_pool_scaffold() {
+        // There are no pools in a new rack. `populate` should leave the dummy
+        // scaffolding in the template's `[[service_ip_pools]]` table, with
+        // empty values, since it provides a useful comment and example for the
+        // operator to create their own data from.
+        let empty = CurrentRssUserConfigInsensitive {
+            bootstrap_sleds: IdOrdMap::new(),
+            ntp_servers: Vec::new(),
+            dns_servers: Vec::new(),
+            service_ip_pools: IdOrdMap::new(),
+            external_dns_ips: Vec::new(),
+            external_dns_zone_name: String::new(),
+            rack_network_config: None,
+            allowed_source_ips: None,
+            external_jumbo_frames_opt_in_enabled: false,
+        };
+        let template = TomlTemplate::populate(&empty).to_string();
+        expectorate::assert_contents(
+            "tests/output/example_empty.toml",
+            &template,
+        );
     }
 }

--- a/wicket/src/ui/panes/rack_setup.rs
+++ b/wicket/src/ui/panes/rack_setup.rs
@@ -518,7 +518,7 @@ fn rss_config_text<'a>(
         bootstrap_sleds,
         ntp_servers,
         dns_servers,
-        internal_services_ip_pool_ranges,
+        service_ip_pools,
         external_dns_ips,
         external_dns_zone_name,
         rack_network_config,
@@ -1134,15 +1134,34 @@ fn rss_config_text<'a>(
     );
     append_list(
         &mut spans,
-        "Internal services IP pool ranges: ".into(),
-        internal_services_ip_pool_ranges
+        "Service IP pools: ".into(),
+        service_ip_pools
             .iter()
-            .map(|r| {
-                let s = match r {
-                    IpRange::V4(r) => format!("{} - {}", r.first, r.last),
-                    IpRange::V6(r) => format!("{} - {}", r.first, r.last),
-                };
-                plain_list_item(s)
+            .flat_map(|pool| {
+                // Pools are displayed as a header line with the name and
+                // description, and then an indented list with one bullet for
+                // each IP range in the pool. This is vertically-expansive, but
+                // the ranges can easily be cut off on small terminals,
+                // especially for IPv6 addresses.
+                let header = vec![
+                    Span::styled("  • ", label_style),
+                    Span::styled(pool.name.to_string(), ok_style),
+                    Span::styled(
+                        format!(" ({})", pool.description),
+                        label_style,
+                    ),
+                ];
+                let ranges = pool.ranges().iter().map(|r| {
+                    let s = match r {
+                        IpRange::V4(r) => format!("{} - {}", r.first, r.last),
+                        IpRange::V6(r) => format!("{} - {}", r.first, r.last),
+                    };
+                    vec![
+                        Span::styled("    • ", label_style),
+                        Span::styled(s, ok_style),
+                    ]
+                });
+                std::iter::once(header).chain(ranges)
             })
             .collect(),
     );
@@ -1209,4 +1228,104 @@ fn rss_config_text<'a>(
     spans.push(Line::default());
 
     Text::from(spans)
+}
+
+#[cfg(test)]
+mod preview {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::widgets::Paragraph;
+    use std::collections::BTreeMap;
+    use wicket_common::example::ExampleRackSetupData;
+    use wicket_common::rack_setup::GetBgpAuthKeyInfoResponse;
+
+    // This "test" isn't really a test. It's a quick-and-dirty way to visual
+    // inspect the RSS-configuration pane at various terminal widths. This can
+    // be useful to get a sense of the layout, and also to ensure that data
+    // isn't clipped or badly-formatted. The pane uses a `Paragraph`, which does
+    // not wrap lines by default, so long lines (like several IPv6 addresses,
+    // for example) can bet cut off.
+    //
+    // Run this explicitly with:
+    //
+    //   cargo test -p wicket -- --ignored --nocapture preview_rss_config_pane
+    #[test]
+    #[ignore = "manual TUI-rendering preview, not an assertion"]
+    fn preview_rss_config_pane() {
+        let example = ExampleRackSetupData::non_empty();
+        // Add a second, IPv6 pool with two ranges so the preview exercises the
+        // long-address / multi-range case.
+        let mut insensitive = example.current_insensitive;
+        insensitive
+            .service_ip_pools
+            .insert_unique(
+                wicketd_commission_types::rack_setup::ServiceIpPoolConfig::new(
+                    "oxide-service-pool-v6".parse().unwrap(),
+                    "IPv6 IP Pool for Oxide Services".to_string(),
+                    vec![
+                        IpRange::try_from((
+                            "fd00:1122:3344:0100::1"
+                                .parse::<std::net::Ipv6Addr>()
+                                .unwrap(),
+                            "fd00:1122:3344:0100::a"
+                                .parse::<std::net::Ipv6Addr>()
+                                .unwrap(),
+                        ))
+                        .unwrap(),
+                        IpRange::try_from((
+                            "fd00:1122:3344:0200::1"
+                                .parse::<std::net::Ipv6Addr>()
+                                .unwrap(),
+                            "fd00:1122:3344:0200::14"
+                                .parse::<std::net::Ipv6Addr>()
+                                .unwrap(),
+                        ))
+                        .unwrap(),
+                    ],
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let config = CurrentRssUserConfig {
+            insensitive,
+            sensitive: CurrentRssUserConfigSensitive {
+                num_external_certificates: 1,
+                recovery_silo_password_set: true,
+                bgp_auth_keys: GetBgpAuthKeyInfoResponse {
+                    data: BTreeMap::new(),
+                },
+            },
+        };
+        let text = rss_config_text(
+            Ok(&RackOperationStatus::Uninitialized),
+            Some(&config),
+        );
+
+        // Render the pane text the same way `draw()` does (a non-wrapping
+        // `Paragraph`) into fixed-width buffers, and dump them. The `|` markers
+        // show the exact right edge at each width.
+        for width in [60u16, 72, 78, 100] {
+            let height = text.height() as u16;
+            let backend = TestBackend::new(width, height);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    frame.render_widget(
+                        Paragraph::new(text.clone()),
+                        frame.area(),
+                    );
+                })
+                .unwrap();
+            let buf = terminal.backend().buffer();
+            println!("\n================= width = {width} =================");
+            for y in 0..buf.area.height {
+                let mut line = String::new();
+                for x in 0..buf.area.width {
+                    line.push_str(buf[(x, y)].symbol());
+                }
+                println!("|{}|", line.trim_end());
+            }
+        }
+    }
 }

--- a/wicket/tests/output/example_empty.toml
+++ b/wicket/tests/output/example_empty.toml
@@ -13,14 +13,16 @@ external_dns_zone_name = ""
 # the DNS domain delegated to the rack by the customer. Each of these addresses
 # must be contained in one of the "internal services" IP Pool ranges listed
 # below.
-external_dns_ips = []
+external_dns_ips = [
+]
 
 # External NTP servers; e.g., "ntp.eng.oxide.computer".
 ntp_servers = [
 ]
 
 # External DNS server IP Addresses; e.g., "1.1.1.1", "9.9.9.9".
-dns_servers = []
+dns_servers = [
+]
 
 # List of sleds to initialize.
 #

--- a/wicket/tests/output/example_non_empty.toml
+++ b/wicket/tests/output/example_non_empty.toml
@@ -29,19 +29,6 @@ dns_servers = [
     "2.2.2.2",
 ]
 
-# Ranges of the service IP pool which may be used for internal services.
-#
-# Elements of this list should be of the form:
-#
-#    { first = "first_ip", last = "last_ip" }
-#
-# where `last_ip` is equal to or higher than `first_ip`; e.g.,
-#
-#    { first = "172.20.26.1", last = "172.20.26.10" }
-internal_services_ip_pool_ranges = [
-    { first = "10.0.0.1", last = "10.0.0.5" },
-]
-
 # List of sleds to initialize.
 #
 # Confirm this list contains all expected sleds before continuing!
@@ -56,6 +43,24 @@ bootstrap_sleds = [
 # runtime via the Nexus `/v1/system/networking/settings` endpoint after rack
 # initialization.
 external_jumbo_frames_opt_in_enabled = false
+
+# The IP pools from which addresses are assigned to externally-facing services
+# (external DNS, Nexus, and boundary NTP).
+#
+# Specify one pool per `[[service_ip_pools]]` stanza; copy the stanza to define
+# more than one pool (e.g. an IPv4 pool and an IPv6 pool). All ranges within a
+# single pool must be of the same IP version. Each range has the form
+# `{ first = "first_ip", last = "last_ip" }`, where `last_ip` is equal to or
+# higher than `first_ip`. For example, a pool with two ranges:
+#
+#     ranges = [
+#         { first = "1.1.1.1", last = "1.1.1.10" },
+#         { first = "1.1.1.20", last = "1.1.1.30" },
+#     ]
+[[service_ip_pools]]
+name = "oxide-service-pool-v4"
+description = "IPv4 IP Pool for Oxide Services"
+ranges = [{ first = "10.0.0.1", last = "10.0.0.5" }]
 
 # Allowlist of source IPs that can make requests to user-facing services.
 #

--- a/wicketd-commission-api/src/lib.rs
+++ b/wicketd-commission-api/src/lib.rs
@@ -11,7 +11,7 @@ use dropshot::{
     RequestContext, StreamingBody, TypedBody,
 };
 use dropshot_api_manager_types::api_versions;
-use wicketd_commission_types_versions::latest;
+use wicketd_commission_types_versions::{latest, v1};
 
 // NOTE: The commission API is server-side versioned, but changing it requires
 // coordinating with rkdeploy (it must stay on the oldest version supported
@@ -29,6 +29,7 @@ api_versions!([
     // |  example for the next person.
     // v
     // (next_int, IDENT),
+    (2, FULL_SERVICE_IP_POOL_DETAILS),
     (1, INITIAL),
 ]);
 
@@ -197,11 +198,25 @@ pub trait WicketdCommissionApi {
     #[endpoint {
         method = PUT,
         path = "/rack-setup/config",
+        versions = VERSION_FULL_SERVICE_IP_POOL_DETAILS..,
     }]
     async fn put_rss_config(
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<latest::rack_setup::PutRssUserConfigInsensitive>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
+
+    #[endpoint {
+        operation_id = "put_rss_config",
+        method = PUT,
+        path = "/rack-setup/config",
+        versions = ..VERSION_FULL_SERVICE_IP_POOL_DETAILS,
+    }]
+    async fn put_rss_config_v1(
+        rqctx: RequestContext<Self::Context>,
+        body: TypedBody<v1::rack_setup::PutRssUserConfigInsensitive>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        Self::put_rss_config(rqctx, body.map(Into::into)).await
+    }
 
     /// Reset all RSS configuration to default values
     #[endpoint {

--- a/wicketd-commission-types/versions/Cargo.toml
+++ b/wicketd-commission-types/versions/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 sled-agent-types-versions.workspace = true
 sled-hardware-types.workspace = true
 slog-error-chain.workspace = true
+thiserror.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/wicketd-commission-types/versions/src/full_service_ip_pool_details/mod.rs
+++ b/wicketd-commission-types/versions/src/full_service_ip_pool_details/mod.rs
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Version `FULL_SERVICE_IP_POOL_DETAILS` of the wicketd commissioning API.
+//!
+//! This version replaces `PutRssUserConfigInsensitive`'s flat
+//! `internal_services_ip_pool_ranges` with structured, operator-specified
+//! `service_ip_pools`. All other rack-setup types (and the inventory and
+//! update trees) are unchanged from `v1`.
+
+pub mod rack_setup;

--- a/wicketd-commission-types/versions/src/full_service_ip_pool_details/rack_setup.rs
+++ b/wicketd-commission-types/versions/src/full_service_ip_pool_details/rack_setup.rs
@@ -11,12 +11,8 @@
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 
-use iddqd::IdOrdItem;
 use iddqd::IdOrdMap;
-use iddqd::id_upcast;
 use omicron_common::address::IpRange;
-use omicron_common::address::IpVersion;
-use omicron_common::api::external::Error;
 use omicron_common::api::external::Name;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -178,7 +174,7 @@ pub struct ServiceIpPoolConfig {
     /// same IP version.
     // NOTE: Private to ensure the above invariants. `new()` checks them, and we
     // deserialize through `UnvalidatedServiceIpPoolConfig` to check them.
-    ranges: Vec<IpRange>,
+    pub(crate) ranges: Vec<IpRange>,
 }
 
 impl ServiceIpPoolConfig {
@@ -200,20 +196,6 @@ impl ServiceIpPoolConfig {
         }
         Ok(Self { name, description, ranges })
     }
-
-    /// The ranges belonging to this pool.
-    ///
-    /// Guaranteed to be non-empty and all of the same IP version.
-    pub fn ranges(&self) -> &[IpRange] {
-        &self.ranges
-    }
-
-    /// The IP version of this pool, derived from its ranges.
-    pub fn ip_version(&self) -> IpVersion {
-        // Safety: the constructor guarantees at least one range, and that all
-        // ranges share an IP version.
-        self.ranges[0].version()
-    }
 }
 
 /// Errors constructing a `ServiceIpPoolConfig`.
@@ -223,24 +205,6 @@ pub enum ServiceIpPoolError {
     EmptyRanges,
     #[error("ranges have mixed IP versions")]
     MixedIpVersions,
-}
-
-impl From<ServiceIpPoolError> for Error {
-    fn from(value: ServiceIpPoolError) -> Self {
-        Error::internal_error(format!(
-            "error constructing service IP pool config: {value}"
-        ))
-    }
-}
-
-impl IdOrdItem for ServiceIpPoolConfig {
-    type Key<'a> = &'a Name;
-
-    fn key(&self) -> Self::Key<'_> {
-        &self.name
-    }
-
-    id_upcast!();
 }
 
 #[derive(Deserialize)]

--- a/wicketd-commission-types/versions/src/full_service_ip_pool_details/rack_setup.rs
+++ b/wicketd-commission-types/versions/src/full_service_ip_pool_details/rack_setup.rs
@@ -1,0 +1,353 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Rack setup (RSS) types for the `FULL_SERVICE_IP_POOL_DETAILS` version.
+//!
+//! Only [`PutRssUserConfigInsensitive`] and [`ServiceIpPoolConfig`] are
+//! (re)defined here; every other rack-setup type is re-exported unchanged from
+//! [`crate::v1::rack_setup`].
+
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+
+use iddqd::IdOrdItem;
+use iddqd::IdOrdMap;
+use iddqd::id_upcast;
+use omicron_common::address::IpRange;
+use omicron_common::address::IpVersion;
+use omicron_common::api::external::Error;
+use omicron_common::api::external::Name;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::v1;
+use crate::v1::rack_setup::AllowedSourceIps;
+use crate::v1::rack_setup::UserSpecifiedRackNetworkConfig;
+
+/// The portion of the RSS configuration that can be posted in one shot.
+///
+/// It is provided by the operator uploading a TOML file. Sensitive values
+/// (certificates, the recovery password hash, and BGP authentication keys) are
+/// set separately.
+///
+/// This version replaces the flat `internal_services_ip_pool_ranges` of the
+/// initial version with fully-specified [`service_ip_pools`], letting operators
+/// name and describe each pool.
+///
+/// [`service_ip_pools`]: Self::service_ip_pools
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(try_from = "UnvalidatedPutRssUserConfigInsensitive")]
+pub struct PutRssUserConfigInsensitive {
+    /// The slot numbers of the sleds to bring up during RSS.
+    ///
+    /// wicketd maps these back to sleds with the correct identifiers based on
+    /// the bootstrap sleds it reports.
+    pub bootstrap_sleds: BTreeSet<u16>,
+    /// The external NTP server addresses.
+    pub ntp_servers: Vec<String>,
+    /// The external DNS server addresses.
+    pub dns_servers: Vec<IpAddr>,
+    /// The service IP pools which may be used for internal services.
+    pub service_ip_pools: IdOrdMap<ServiceIpPoolConfig>,
+    /// Service IP addresses on which external DNS servers are run.
+    pub external_dns_ips: Vec<IpAddr>,
+    /// The DNS zone name delegated to the rack for external DNS.
+    pub external_dns_zone_name: String,
+    /// The user-specified rack network configuration.
+    pub rack_network_config: UserSpecifiedRackNetworkConfig,
+    /// IPs or subnets allowed to make requests to user-facing services.
+    pub allowed_source_ips: AllowedSourceIps,
+    /// Enable the fleet-wide jumbo-frames opt-in.
+    #[serde(default)]
+    pub external_jumbo_frames_opt_in_enabled: bool,
+}
+
+// Shadow of `PutRssUserConfigInsensitive` that deserializes the pools as a
+// plain `Vec` (the natural TOML/JSON array shape) before the `TryFrom` folds
+// them into an `IdOrdMap`, failing on duplicate pool names.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UnvalidatedPutRssUserConfigInsensitive {
+    bootstrap_sleds: BTreeSet<u16>,
+    ntp_servers: Vec<String>,
+    dns_servers: Vec<IpAddr>,
+    service_ip_pools: Vec<ServiceIpPoolConfig>,
+    external_dns_ips: Vec<IpAddr>,
+    external_dns_zone_name: String,
+    rack_network_config: UserSpecifiedRackNetworkConfig,
+    allowed_source_ips: AllowedSourceIps,
+    #[serde(default)]
+    external_jumbo_frames_opt_in_enabled: bool,
+}
+
+impl TryFrom<UnvalidatedPutRssUserConfigInsensitive>
+    for PutRssUserConfigInsensitive
+{
+    type Error = String;
+
+    fn try_from(
+        value: UnvalidatedPutRssUserConfigInsensitive,
+    ) -> Result<Self, Self::Error> {
+        let service_ip_pools =
+            IdOrdMap::from_iter_unique(value.service_ip_pools)
+                .map_err(|e| format!("duplicate service IP pool name: {e}"))?;
+        Ok(Self {
+            bootstrap_sleds: value.bootstrap_sleds,
+            ntp_servers: value.ntp_servers,
+            dns_servers: value.dns_servers,
+            service_ip_pools,
+            external_dns_ips: value.external_dns_ips,
+            external_dns_zone_name: value.external_dns_zone_name,
+            rack_network_config: value.rack_network_config,
+            allowed_source_ips: value.allowed_source_ips,
+            external_jumbo_frames_opt_in_enabled: value
+                .external_jumbo_frames_opt_in_enabled,
+        })
+    }
+}
+
+// Well-known names/descriptions for the pools created from previous versions of
+// the API, where we specified on the IP ranges alone.
+const SERVICE_POOL_IPV4_NAME: &str = "oxide-service-pool-v4";
+const SERVICE_POOL_IPV6_NAME: &str = "oxide-service-pool-v6";
+
+// Synthesize named per-version pools from a flat list of ranges (how prior API
+// versions specified service IPs). One pool is created per IP version that has
+// at least one range, using the well-known names above.
+fn service_ip_pools_from_ranges(
+    ranges: Vec<IpRange>,
+) -> IdOrdMap<ServiceIpPoolConfig> {
+    let (v4_ranges, v6_ranges): (Vec<IpRange>, Vec<IpRange>) =
+        ranges.into_iter().partition(|range| range.is_ipv4());
+    let mut service_ip_pools = IdOrdMap::new();
+    for (name, description, ranges) in [
+        (SERVICE_POOL_IPV4_NAME, "IPv4 IP Pool for Oxide Services", v4_ranges),
+        (SERVICE_POOL_IPV6_NAME, "IPv6 IP Pool for Oxide Services", v6_ranges),
+    ] {
+        match ServiceIpPoolConfig::new(
+            name.parse().unwrap(),
+            description.to_string(),
+            ranges,
+        ) {
+            Ok(p) => service_ip_pools
+                .insert_unique(p)
+                .expect("well-known pool names are distinct"),
+            Err(ServiceIpPoolError::EmptyRanges) => {}
+            Err(ServiceIpPoolError::MixedIpVersions) => {
+                unreachable!("just partitioned");
+            }
+        }
+    }
+    service_ip_pools
+}
+
+impl From<v1::rack_setup::PutRssUserConfigInsensitive>
+    for PutRssUserConfigInsensitive
+{
+    fn from(old: v1::rack_setup::PutRssUserConfigInsensitive) -> Self {
+        Self {
+            bootstrap_sleds: old.bootstrap_sleds,
+            ntp_servers: old.ntp_servers,
+            dns_servers: old.dns_servers,
+            service_ip_pools: service_ip_pools_from_ranges(
+                old.internal_services_ip_pool_ranges,
+            ),
+            external_dns_ips: old.external_dns_ips,
+            external_dns_zone_name: old.external_dns_zone_name,
+            rack_network_config: old.rack_network_config,
+            allowed_source_ips: old.allowed_source_ips,
+            external_jumbo_frames_opt_in_enabled: old
+                .external_jumbo_frames_opt_in_enabled,
+        }
+    }
+}
+
+/// Full details of a system-service IP pool, provided at rack setup (RSS).
+#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[serde(try_from = "UnvalidatedServiceIpPoolConfig")]
+pub struct ServiceIpPoolConfig {
+    /// Name of the IP Pool
+    pub name: Name,
+    /// Description of the IP Pool
+    pub description: String,
+    /// List of IP address ranges in the pool.
+    ///
+    /// There is guaranteed to be at least one range, and all ranges are of the
+    /// same IP version.
+    // NOTE: Private to ensure the above invariants. `new()` checks them, and we
+    // deserialize through `UnvalidatedServiceIpPoolConfig` to check them.
+    ranges: Vec<IpRange>,
+}
+
+impl ServiceIpPoolConfig {
+    /// Construct a new service IP pool configuration.
+    ///
+    /// Errors if `ranges` is empty, or if the ranges are a mix of IPv4 and
+    /// IPv6 addresses.
+    pub fn new(
+        name: Name,
+        description: String,
+        ranges: Vec<IpRange>,
+    ) -> Result<Self, ServiceIpPoolError> {
+        let mut versions = ranges.iter().map(|r| r.version());
+        let Some(first) = versions.next() else {
+            return Err(ServiceIpPoolError::EmptyRanges);
+        };
+        if versions.any(|v| v != first) {
+            return Err(ServiceIpPoolError::MixedIpVersions);
+        }
+        Ok(Self { name, description, ranges })
+    }
+
+    /// The ranges belonging to this pool.
+    ///
+    /// Guaranteed to be non-empty and all of the same IP version.
+    pub fn ranges(&self) -> &[IpRange] {
+        &self.ranges
+    }
+
+    /// The IP version of this pool, derived from its ranges.
+    pub fn ip_version(&self) -> IpVersion {
+        // Safety: the constructor guarantees at least one range, and that all
+        // ranges share an IP version.
+        self.ranges[0].version()
+    }
+}
+
+/// Errors constructing a `ServiceIpPoolConfig`.
+#[derive(Clone, Copy, Debug, thiserror::Error)]
+pub enum ServiceIpPoolError {
+    #[error("must provide at least one IP range")]
+    EmptyRanges,
+    #[error("ranges have mixed IP versions")]
+    MixedIpVersions,
+}
+
+impl From<ServiceIpPoolError> for Error {
+    fn from(value: ServiceIpPoolError) -> Self {
+        Error::internal_error(format!(
+            "error constructing service IP pool config: {value}"
+        ))
+    }
+}
+
+impl IdOrdItem for ServiceIpPoolConfig {
+    type Key<'a> = &'a Name;
+
+    fn key(&self) -> Self::Key<'_> {
+        &self.name
+    }
+
+    id_upcast!();
+}
+
+#[derive(Deserialize)]
+struct UnvalidatedServiceIpPoolConfig {
+    name: Name,
+    description: String,
+    ranges: Vec<IpRange>,
+}
+
+impl TryFrom<UnvalidatedServiceIpPoolConfig> for ServiceIpPoolConfig {
+    type Error = ServiceIpPoolError;
+
+    fn try_from(
+        value: UnvalidatedServiceIpPoolConfig,
+    ) -> Result<Self, Self::Error> {
+        let UnvalidatedServiceIpPoolConfig { name, description, ranges } =
+            value;
+        ServiceIpPoolConfig::new(name, description, ranges)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omicron_common::address;
+
+    fn v4_range(first: &str, last: &str) -> address::IpRange {
+        address::IpRange::try_from((
+            first.parse::<std::net::Ipv4Addr>().unwrap(),
+            last.parse::<std::net::Ipv4Addr>().unwrap(),
+        ))
+        .unwrap()
+    }
+
+    fn v6_range(first: &str, last: &str) -> address::IpRange {
+        address::IpRange::try_from((
+            first.parse::<std::net::Ipv6Addr>().unwrap(),
+            last.parse::<std::net::Ipv6Addr>().unwrap(),
+        ))
+        .unwrap()
+    }
+
+    fn find_pool<'a>(
+        pools: &'a IdOrdMap<ServiceIpPoolConfig>,
+        name: &str,
+    ) -> Option<&'a ServiceIpPoolConfig> {
+        pools.iter().find(|p| p.name.as_str() == name)
+    }
+
+    // A rack whose service ranges are all IPv4 should produce a single IPv4
+    // service pool and no IPv6 pool.
+    #[test]
+    fn service_ip_pools_v4_only() {
+        let range = v4_range("192.168.1.20", "192.168.1.29");
+        let pools = service_ip_pools_from_ranges(vec![range]);
+
+        assert_eq!(pools.len(), 1);
+        let pool =
+            find_pool(&pools, SERVICE_POOL_IPV4_NAME).expect("v4 pool present");
+        assert_eq!(pool.ranges(), &[range]);
+        assert!(
+            find_pool(&pools, SERVICE_POOL_IPV6_NAME).is_none(),
+            "no v6 pool expected"
+        );
+    }
+
+    // A rack whose service ranges are all IPv6 should produce a single IPv6
+    // service pool and no IPv4 pool.
+    #[test]
+    fn service_ip_pools_v6_only() {
+        let range = v6_range("fd00::20", "fd00::29");
+        let pools = service_ip_pools_from_ranges(vec![range]);
+
+        assert_eq!(pools.len(), 1);
+        let pool =
+            find_pool(&pools, SERVICE_POOL_IPV6_NAME).expect("v6 pool present");
+        assert_eq!(pool.ranges(), &[range]);
+        assert!(
+            find_pool(&pools, SERVICE_POOL_IPV4_NAME).is_none(),
+            "no v4 pool expected"
+        );
+    }
+
+    // A dual-stack rack should produce one pool per version.
+    #[test]
+    fn service_ip_pools_dual_stack() {
+        let v4 = v4_range("192.168.1.20", "192.168.1.29");
+        let v6 = v6_range("fd00::20", "fd00::29");
+        let pools = service_ip_pools_from_ranges(vec![v4, v6]);
+
+        assert_eq!(pools.len(), 2);
+        assert_eq!(
+            find_pool(&pools, SERVICE_POOL_IPV4_NAME).unwrap().ranges(),
+            &[v4]
+        );
+        assert_eq!(
+            find_pool(&pools, SERVICE_POOL_IPV6_NAME).unwrap().ranges(),
+            &[v6]
+        );
+    }
+
+    // With no ranges the helper produces no pools. The requirement that a real
+    // rack init request carry at least one pool is enforced by wicketd at the
+    // time it tries to start rack setup.
+    #[test]
+    fn service_ip_pools_empty() {
+        let pools = service_ip_pools_from_ranges(vec![]);
+        assert!(pools.is_empty());
+    }
+}

--- a/wicketd-commission-types/versions/src/full_service_ip_pool_details/rack_setup.rs
+++ b/wicketd-commission-types/versions/src/full_service_ip_pool_details/rack_setup.rs
@@ -198,6 +198,16 @@ impl ServiceIpPoolConfig {
     }
 }
 
+impl iddqd::IdOrdItem for ServiceIpPoolConfig {
+    type Key<'a> = &'a Name;
+
+    fn key(&self) -> Self::Key<'_> {
+        &self.name
+    }
+
+    iddqd::id_upcast!();
+}
+
 /// Errors constructing a `ServiceIpPoolConfig`.
 #[derive(Clone, Copy, Debug, thiserror::Error)]
 pub enum ServiceIpPoolError {

--- a/wicketd-commission-types/versions/src/impls/rack_setup.rs
+++ b/wicketd-commission-types/versions/src/impls/rack_setup.rs
@@ -6,17 +6,18 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::str::FromStr;
 
-use omicron_common::api::external::Name;
+use omicron_common::address::{IpRange, IpVersion};
+use omicron_common::api::external::{Error, Name};
 use sled_agent_types_versions::latest::early_networking::{
     BgpPeerConfig, ImportExportPolicy, SwitchSlot,
 };
 use sled_agent_types_versions::v30::early_networking::UplinkAddressConfig;
 
 use crate::latest::rack_setup::{
-    BgpAuthKeyId, ManualPortConfig, UplinkAddress, UplinkIpNet,
-    UserSpecifiedBgpPeerConfig, UserSpecifiedImportExportPolicy,
-    UserSpecifiedPortConfig, UserSpecifiedRackNetworkConfig,
-    UserSpecifiedUplinkAddressConfig,
+    BgpAuthKeyId, ManualPortConfig, ServiceIpPoolConfig, ServiceIpPoolError,
+    UplinkAddress, UplinkIpNet, UserSpecifiedBgpPeerConfig,
+    UserSpecifiedImportExportPolicy, UserSpecifiedPortConfig,
+    UserSpecifiedRackNetworkConfig, UserSpecifiedUplinkAddressConfig,
 };
 
 impl UserSpecifiedRackNetworkConfig {
@@ -174,6 +175,40 @@ impl From<UserSpecifiedImportExportPolicy> for ImportExportPolicy {
             }
         }
     }
+}
+
+impl ServiceIpPoolConfig {
+    /// The ranges belonging to this pool.
+    ///
+    /// Guaranteed to be non-empty and all of the same IP version.
+    pub fn ranges(&self) -> &[IpRange] {
+        &self.ranges
+    }
+
+    /// The IP version of this pool, derived from its ranges.
+    pub fn ip_version(&self) -> IpVersion {
+        // Safety: the constructor guarantees at least one range, and that all
+        // ranges share an IP version.
+        self.ranges[0].version()
+    }
+}
+
+impl From<ServiceIpPoolError> for omicron_common::api::external::Error {
+    fn from(value: ServiceIpPoolError) -> Self {
+        Error::internal_error(format!(
+            "error constructing service IP pool config: {value}"
+        ))
+    }
+}
+
+impl iddqd::IdOrdItem for ServiceIpPoolConfig {
+    type Key<'a> = &'a Name;
+
+    fn key(&self) -> Self::Key<'_> {
+        &self.name
+    }
+
+    iddqd::id_upcast!();
 }
 
 #[cfg(test)]

--- a/wicketd-commission-types/versions/src/impls/rack_setup.rs
+++ b/wicketd-commission-types/versions/src/impls/rack_setup.rs
@@ -201,16 +201,6 @@ impl From<ServiceIpPoolError> for omicron_common::api::external::Error {
     }
 }
 
-impl iddqd::IdOrdItem for ServiceIpPoolConfig {
-    type Key<'a> = &'a Name;
-
-    fn key(&self) -> Self::Key<'_> {
-        &self.name
-    }
-
-    iddqd::id_upcast!();
-}
-
 #[cfg(test)]
 mod tests {
     use crate::latest::rack_setup::{

--- a/wicketd-commission-types/versions/src/latest.rs
+++ b/wicketd-commission-types/versions/src/latest.rs
@@ -73,7 +73,6 @@ pub mod rack_setup {
     pub use crate::v1::rack_setup::NewPasswordHash;
     pub use crate::v1::rack_setup::PrivateKeyPem;
     pub use crate::v1::rack_setup::PutRecoveryUserPasswordHash;
-    pub use crate::v1::rack_setup::PutRssUserConfigInsensitive;
     pub use crate::v1::rack_setup::RackOperation;
     pub use crate::v1::rack_setup::RackOperationKind;
     pub use crate::v1::rack_setup::RackOperationState;
@@ -94,6 +93,9 @@ pub mod rack_setup {
     pub use crate::v1::rack_setup::UserSpecifiedRackNetworkConfig;
     pub use crate::v1::rack_setup::UserSpecifiedRouterPeerAddr;
     pub use crate::v1::rack_setup::UserSpecifiedUplinkAddressConfig;
+    pub use crate::v2::rack_setup::PutRssUserConfigInsensitive;
+    pub use crate::v2::rack_setup::ServiceIpPoolConfig;
+    pub use crate::v2::rack_setup::ServiceIpPoolError;
 }
 
 pub mod update {

--- a/wicketd-commission-types/versions/src/lib.rs
+++ b/wicketd-commission-types/versions/src/lib.rs
@@ -30,3 +30,5 @@ mod impls;
 pub mod latest;
 #[path = "initial/mod.rs"]
 pub mod v1;
+#[path = "full_service_ip_pool_details/mod.rs"]
+pub mod v2;

--- a/wicketd/src/rss_config.rs
+++ b/wicketd/src/rss_config.rs
@@ -22,7 +22,6 @@ use bootstrap_agent_lockstep_types::ServiceIpPoolConfig;
 use display_error_chain::DisplayErrorChain;
 use iddqd::IdOrdMap;
 use omicron_certificates::CertificateError;
-use omicron_common::address;
 use omicron_common::address::IpRange;
 use omicron_common::address::Ipv4Range;
 use omicron_common::address::Ipv6Range;
@@ -54,54 +53,6 @@ use wicketd_commission_types::rack_setup::UserSpecifiedRouterPeerAddr;
 const RECOVERY_SILO_NAME: &str = "recovery";
 const RECOVERY_SILO_USERNAME: &str = "recovery";
 
-// TODO(#8946) Remove these when we plumb the names all the way from the RSS
-// config file.
-const SERVICE_POOL_IPV4_NAME: &str = "oxide-service-pool-v4";
-const SERVICE_POOL_IPV6_NAME: &str = "oxide-service-pool-v6";
-
-// Synthesize the system-service IP pool configuration from a flat list of IP
-// ranges.
-//
-// TODO(#8946): IP Pools need to be plumbed all the way from the RSS
-// configuration file. In the meantime, we synthesize the pool configuration
-// here using our well-known names and descriptions. One pool is created per
-// IP version that has at least one range; a version with no ranges is
-// omitted, so a v4-only or v6-only rack produces a single pool.
-fn service_ip_pools_from_ranges(
-    ranges: &[address::IpRange],
-) -> Result<IdOrdMap<ServiceIpPoolConfig>> {
-    let (service_ipv4_ranges, service_ipv6_ranges): (Vec<_>, Vec<_>) =
-        ranges.iter().partition(|range| range.is_ipv4());
-    let mut service_ip_pools = IdOrdMap::new();
-    if !service_ipv4_ranges.is_empty() {
-        let service_ipv4_pool = ServiceIpPoolConfig::new(
-            SERVICE_POOL_IPV4_NAME.parse().unwrap(),
-            String::from("IPv4 IP Pool for Oxide Services"),
-            service_ipv4_ranges,
-        )
-        .context("creating IPv4 service pool config")?;
-        if service_ip_pools.insert_unique(service_ipv4_pool).is_err() {
-            anyhow::bail!(
-                "duplicate IPv4 service pool name: '{SERVICE_POOL_IPV4_NAME}'"
-            );
-        }
-    }
-    if !service_ipv6_ranges.is_empty() {
-        let service_ipv6_pool = ServiceIpPoolConfig::new(
-            SERVICE_POOL_IPV6_NAME.parse().unwrap(),
-            String::from("IPv6 IP Pool for Oxide Services"),
-            service_ipv6_ranges,
-        )
-        .context("creating IPv6 service pool config")?;
-        if service_ip_pools.insert_unique(service_ipv6_pool).is_err() {
-            anyhow::bail!(
-                "duplicate IPv6 service pool name: '{SERVICE_POOL_IPV6_NAME}'"
-            );
-        }
-    }
-    Ok(service_ip_pools)
-}
-
 #[derive(Default)]
 struct PartialCertificate {
     cert: Option<String>,
@@ -115,7 +66,7 @@ pub(crate) struct CurrentRssConfig {
     pub common: RssOrMultirackJoinConfigCommon,
     ntp_servers: Vec<String>,
     dns_servers: Vec<IpAddr>,
-    internal_services_ip_pool_ranges: Vec<address::IpRange>,
+    service_ip_pools: IdOrdMap<ServiceIpPoolConfig>,
     external_dns_ips: Vec<IpAddr>,
     external_dns_zone_name: String,
     external_certificates: Vec<Certificate>,
@@ -164,8 +115,8 @@ impl CurrentRssConfig {
         if self.dns_servers.is_empty() {
             bail!("at least one DNS server is required");
         }
-        if self.internal_services_ip_pool_ranges.is_empty() {
-            bail!("at least one internal services IP pool range is required");
+        if self.service_ip_pools.is_empty() {
+            bail!("at least one service IP pool is required");
         }
         if self.external_dns_ips.is_empty() {
             bail!("at least one external DNS IP address is required");
@@ -257,9 +208,7 @@ impl CurrentRssConfig {
                 recovery_silo_password_hash.to_string(),
             );
 
-        let service_ip_pools = service_ip_pools_from_ranges(
-            &self.internal_services_ip_pool_ranges,
-        )?;
+        let service_ip_pools = self.service_ip_pools.clone();
 
         let request = RackInitializeRequest {
             trust_quorum_peers,
@@ -392,8 +341,7 @@ impl CurrentRssConfig {
 
         self.ntp_servers = config.ntp_servers;
         self.dns_servers = config.dns_servers;
-        self.internal_services_ip_pool_ranges =
-            config.internal_services_ip_pool_ranges;
+        self.service_ip_pools = config.service_ip_pools;
         self.external_dns_ips = config.external_dns_ips;
         self.external_dns_zone_name = config.external_dns_zone_name;
         self.allowed_source_ips = Some(config.allowed_source_ips);
@@ -435,9 +383,7 @@ impl From<&'_ CurrentRssConfig> for CurrentRssUserConfig {
                 bootstrap_sleds,
                 ntp_servers: rss.ntp_servers.clone(),
                 dns_servers: rss.dns_servers.clone(),
-                internal_services_ip_pool_ranges: rss
-                    .internal_services_ip_pool_ranges
-                    .clone(),
+                service_ip_pools: rss.service_ip_pools.clone(),
                 external_dns_ips: rss.external_dns_ips.clone(),
                 external_dns_zone_name: rss.external_dns_zone_name.clone(),
                 rack_network_config: rss.rack_network_config.clone(),
@@ -1159,94 +1105,5 @@ mod tests {
         assert_eq!(config.external_certificates[0].key, key);
         assert_eq!(config.external_certificates[1].cert, other_cert);
         assert_eq!(config.external_certificates[1].key, other_key);
-    }
-
-    fn v4_range(first: &str, last: &str) -> address::IpRange {
-        address::IpRange::try_from((
-            first.parse::<std::net::Ipv4Addr>().unwrap(),
-            last.parse::<std::net::Ipv4Addr>().unwrap(),
-        ))
-        .unwrap()
-    }
-
-    fn v6_range(first: &str, last: &str) -> address::IpRange {
-        address::IpRange::try_from((
-            first.parse::<std::net::Ipv6Addr>().unwrap(),
-            last.parse::<std::net::Ipv6Addr>().unwrap(),
-        ))
-        .unwrap()
-    }
-
-    fn find_pool<'a>(
-        pools: &'a IdOrdMap<ServiceIpPoolConfig>,
-        name: &str,
-    ) -> Option<&'a ServiceIpPoolConfig> {
-        pools.iter().find(|p| p.name.as_str() == name)
-    }
-
-    // A rack whose service ranges are all IPv4 should produce a single IPv4
-    // service pool and no IPv6 pool.
-    #[test]
-    fn service_ip_pools_v4_only() {
-        let range = v4_range("192.168.1.20", "192.168.1.29");
-        let pools = service_ip_pools_from_ranges(&[range])
-            .expect("v4-only ranges should synthesize a pool");
-
-        assert_eq!(pools.len(), 1);
-        let pool =
-            find_pool(&pools, SERVICE_POOL_IPV4_NAME).expect("v4 pool present");
-        assert_eq!(pool.ranges(), &[range]);
-        assert!(
-            find_pool(&pools, SERVICE_POOL_IPV6_NAME).is_none(),
-            "no v6 pool expected"
-        );
-    }
-
-    // A rack whose service ranges are all IPv6 should produce a single IPv6
-    // service pool and no IPv4 pool.
-    #[test]
-    fn service_ip_pools_v6_only() {
-        let range = v6_range("fd00::20", "fd00::29");
-        let pools = service_ip_pools_from_ranges(&[range])
-            .expect("v6-only ranges should synthesize a pool");
-
-        assert_eq!(pools.len(), 1);
-        let pool =
-            find_pool(&pools, SERVICE_POOL_IPV6_NAME).expect("v6 pool present");
-        assert_eq!(pool.ranges(), &[range]);
-        assert!(
-            find_pool(&pools, SERVICE_POOL_IPV4_NAME).is_none(),
-            "no v4 pool expected"
-        );
-    }
-
-    // A dual-stack rack should produce one pool per version.
-    #[test]
-    fn service_ip_pools_dual_stack() {
-        let v4 = v4_range("192.168.1.20", "192.168.1.29");
-        let v6 = v6_range("fd00::20", "fd00::29");
-        let pools = service_ip_pools_from_ranges(&[v4, v6])
-            .expect("dual-stack ranges should synthesize both pools");
-
-        assert_eq!(pools.len(), 2);
-        assert_eq!(
-            find_pool(&pools, SERVICE_POOL_IPV4_NAME).unwrap().ranges(),
-            &[v4]
-        );
-        assert_eq!(
-            find_pool(&pools, SERVICE_POOL_IPV6_NAME).unwrap().ranges(),
-            &[v6]
-        );
-    }
-
-    // With no ranges the helper produces no pools. The requirement that a real
-    // rack init request carry at least one pool is enforced separately, both by
-    // `start_rss_request` (on the flat range list) and by
-    // `RackInitializeRequest`'s validation at deserialization time.
-    #[test]
-    fn service_ip_pools_empty() {
-        let pools = service_ip_pools_from_ranges(&[])
-            .expect("empty ranges should synthesize no pools");
-        assert!(pools.is_empty());
     }
 }

--- a/wicketd/tests/integration_tests/commission.rs
+++ b/wicketd/tests/integration_tests/commission.rs
@@ -484,7 +484,7 @@ async fn test_commission_rss_config() {
         bootstrap_sleds: expected_slots,
         ntp_servers: expected_ntp_servers,
         dns_servers: expected_dns_servers,
-        internal_services_ip_pool_ranges: expected_pool_ranges,
+        service_ip_pools: expected_service_ip_pools,
         external_dns_ips: expected_external_dns_ips,
         external_dns_zone_name: expected_dns_zone_name,
         rack_network_config: expected_rack_network_config,
@@ -496,7 +496,7 @@ async fn test_commission_rss_config() {
         bootstrap_sleds,
         ntp_servers,
         dns_servers,
-        internal_services_ip_pool_ranges,
+        service_ip_pools,
         external_dns_ips,
         external_dns_zone_name,
         rack_network_config,
@@ -510,8 +510,8 @@ async fn test_commission_rss_config() {
     assert_eq!(ntp_servers, expected_ntp_servers, "ntp_servers stored");
     assert_eq!(dns_servers, expected_dns_servers, "dns_servers stored");
     assert_eq!(
-        internal_services_ip_pool_ranges, expected_pool_ranges,
-        "internal_services_ip_pool_ranges stored"
+        service_ip_pools, expected_service_ip_pools,
+        "service_ip_pools stored"
     );
     assert_eq!(
         external_dns_ips, expected_external_dns_ips,


### PR DESCRIPTION
- Move the `ServiceIpPoolConfig` type to the versioned commissioning API version 2, plumbing the pools all the way from the RSS config TOML.
- Handle full pools in wicket TUI, and add an ignored test that will print out the RSS screen to a test backend for quick visual inspection.
- Closes #8946