### PR TITLE
[32/n] clean up remaining rack reset code

### DIFF
--- a/clients/wicketd-client/src/lib.rs
+++ b/clients/wicketd-client/src/lib.rs
@@ -27,7 +27,6 @@ progenitor::generate_api!(
         RackInitId = { derives = [PartialEq, Eq, PartialOrd, Ord] },
         RackNetworkConfigV2 = { derives = [PartialEq, Eq, PartialOrd, Ord] },
         RackOperationStatus = { derives = [PartialEq, Eq, PartialOrd, Ord] },
-        RackResetId = { derives = [PartialEq, Eq, PartialOrd, Ord] },
         RotImageDetails = { derives = [PartialEq, Eq, PartialOrd, Ord]},
         UplinkConfig = { derives = [PartialEq, Eq, PartialOrd, Ord] },
     },

--- a/uuid-kinds/src/lib.rs
+++ b/uuid-kinds/src/lib.rs
@@ -84,7 +84,6 @@ impl_typed_uuid_kinds! {
         Propolis = {},
         Rack = {},
         RackInit = {},
-        RackReset = {},
         ReconfiguratorSimOp = {},
         ReconfiguratorSimState = {},
         Region = {},

--- a/wicket/src/keymap.rs
+++ b/wicket/src/keymap.rs
@@ -75,8 +75,7 @@ pub enum Cmd {
     AbortUpdate,
 
     /// Reset screen-specific state (e.g., clearing the state for a
-    /// completed/failed update, or resetting the rack from the rack setup
-    /// screen).
+    /// completed/failed update).
     ResetState,
 
     /// Begin rack setup.
@@ -148,9 +147,6 @@ pub enum ShowPopupCmd {
 
     /// A response to a rack-setup request.
     StartRackSetupResponse(Result<(), String>),
-
-    /// A response to a rack-reset request.
-    StartRackResetResponse(Result<(), String>),
 }
 
 /// We allow certain multi-key sequences, and explicitly enumerate the starting

--- a/wicketd-commission-types/versions/src/initial/rack_setup.rs
+++ b/wicketd-commission-types/versions/src/initial/rack_setup.rs
@@ -734,9 +734,6 @@ impl RackOperationKind {
     /// The well-known kind for a rack initialization operation.
     pub const INITIALIZE: Self = Self(Cow::Borrowed("initialize"));
 
-    /// The well-known kind for a rack reset operation.
-    pub const RESET: Self = Self(Cow::Borrowed("reset"));
-
     /// Returns the operation kind as a string.
     pub fn as_str(&self) -> &str {
         &self.0


### PR DESCRIPTION
Mostly leftover stuff from the semantic merge between #10518 and #10857.
