### PR TITLE
oximeter/db: fix panic in set_retention_policy() on an empty database

### DIFF
--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -1087,7 +1087,14 @@ impl Client {
 
         // Skip the timeseries schema table, which doesn't have a TTL, and
         // prepend the database name.
-        let mut tables = Vec::with_capacity(oximeter_tables.len() - 1);
+        //
+        // NOTE: `oximeter_tables` may legitimately be empty, e.g., if this
+        // is called before the oximeter database schema has been created.
+        // Use `saturating_sub()` so that case doesn't panic; it's only used
+        // to size the output `Vec`, so being off by one costs at most one
+        // extra (unused) allocation slot.
+        let mut tables =
+            Vec::with_capacity(oximeter_tables.len().saturating_sub(1));
         for table in
             oximeter_tables.into_iter().filter(|n| n != "timeseries_schema")
         {
@@ -2114,6 +2121,29 @@ mod tests {
             ClickHouseDeployment::new_single_node(&logctx).await.unwrap();
         let client = Client::new(db.native_address().into(), &logctx.log);
         client.ping().await.expect("Should be able to ping existing server");
+        db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn set_retention_policy_before_db_init_does_not_panic() {
+        let logctx = test_setup_log(
+            "set_retention_policy_before_db_init_does_not_panic",
+        );
+        let mut db =
+            ClickHouseDeployment::new_single_node(&logctx).await.unwrap();
+        let client = Client::new(db.native_address().into(), &logctx.log);
+
+        // Deliberately do *not* call `init_db()` here. The oximeter
+        // database (and its tables) don't exist yet, so
+        // `list_retention_policy_tables()` will see zero tables. This
+        // should be handled gracefully as a no-op, not panic on an
+        // integer underflow while sizing its output `Vec`.
+        let policy = RetentionPolicyRequest { days: Days::new(30).unwrap() };
+        client.set_retention_policy(policy, false).await.expect(
+            "setting a retention policy with no tables present yet should succeed as a no-op",
+        );
+
         db.cleanup().await.unwrap();
         logctx.cleanup_successful();
     }


### PR DESCRIPTION
`list_retention_policy_tables()` sizes its output `Vec` using `oximeter_tables.len() - 1`. If `oximeter_tables` happens to be empty, that subtraction underflows and panics.

This isn't just theoretical — it happens if `set_retention_policy()` gets called before the oximeter schema exists yet (nothing currently stops that from happening, e.g. via the clickhouse-admin retention task or `omdb clickhouse-admin set-retention-policy`).

The fix is small: use `saturating_sub(1)` instead. It's only there as a capacity hint for the `Vec` anyway, so being off by one when the list happens to be empty doesn't hurt anything — it just avoids the crash.

Added a test (`set_retention_policy_before_db_init_does_not_panic`) that spins up a ClickHouse instance without initializing the schema and confirms `set_retention_policy()` now returns cleanly instead of panicking.