### PR TITLE
Remove hardcoded service IP pool names

### DIFF
--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -4434,9 +4434,13 @@ mod tests {
             // Create (idempotently) the service pool of the appropriate version
             // for each range. We only need at most two (one V4, one V6), but our
             // example system doesn't have many ranges so this should be fine.
-            let service_pool =
-                create_service_ip_pool(&opctx, datastore, pool_range.version())
-                    .await;
+            let service_pool = create_service_ip_pool(
+                &opctx,
+                datastore,
+                "oxide-service-pool-v4",
+                pool_range.version(),
+            )
+            .await;
             datastore
                 .ip_pool_add_range(
                     &opctx,
@@ -4523,6 +4527,7 @@ mod tests {
         let service_pool = create_service_ip_pool(
             &opctx,
             datastore,
+            "oxide-service-pool-v4",
             omicron_common::api::external::IpVersion::V4,
         )
         .await;

--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -849,6 +849,7 @@ mod tests {
             let service_pool = create_service_ip_pool(
                 opctx,
                 datastore,
+                "oxide-service-pool-v4",
                 omicron_common::api::external::IpVersion::V4,
             )
             .await;

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -1452,9 +1452,13 @@ mod tests {
 
         // A system-service IP pool must exist for listing service IPs to
         // authorize against.
-        let service_pool =
-            create_service_ip_pool(opctx, &datastore, external::IpVersion::V4)
-                .await;
+        let service_pool = create_service_ip_pool(
+            opctx,
+            &datastore,
+            "oxide-service-pool-v4",
+            external::IpVersion::V4,
+        )
+        .await;
 
         // No IPs, to start
         let ips = read_all_service_ips(&datastore, opctx).await;
@@ -1550,9 +1554,13 @@ mod tests {
         // Set up an service IP pool range with one IP in it.
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let ip_range = IpRange::try_from((ip, ip)).unwrap();
-        let service_pool =
-            create_service_ip_pool(opctx, &datastore, external::IpVersion::V4)
-                .await;
+        let service_pool = create_service_ip_pool(
+            opctx,
+            &datastore,
+            "oxide-service-pool-v4",
+            external::IpVersion::V4,
+        )
+        .await;
         datastore
             .ip_pool_add_range(
                 opctx,

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -2903,8 +2903,20 @@ mod test {
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
         // Create the v4 and v6 system-service pools the loop expects to find.
-        create_service_ip_pool(opctx, datastore, IpVersion::V4.into()).await;
-        create_service_ip_pool(opctx, datastore, IpVersion::V6.into()).await;
+        create_service_ip_pool(
+            opctx,
+            datastore,
+            "oxide-service-pool-v4",
+            IpVersion::V4.into(),
+        )
+        .await;
+        create_service_ip_pool(
+            opctx,
+            datastore,
+            "oxide-service-pool-v6",
+            IpVersion::V6.into(),
+        )
+        .await;
 
         for version in [IpVersion::V4, IpVersion::V6] {
             // confirm system services pools are identified correctly
@@ -5693,12 +5705,20 @@ mod test {
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
         // Create the v4 and v6 system-service pools we exercise below.
-        let ipv4 =
-            create_service_ip_pool(opctx, datastore, IpVersion::V4.into())
-                .await;
-        let ipv6 =
-            create_service_ip_pool(opctx, datastore, IpVersion::V6.into())
-                .await;
+        let ipv4 = create_service_ip_pool(
+            opctx,
+            datastore,
+            "oxide-service-pool-v4",
+            IpVersion::V4.into(),
+        )
+        .await;
+        let ipv6 = create_service_ip_pool(
+            opctx,
+            datastore,
+            "oxide-service-pool-v6",
+            IpVersion::V6.into(),
+        )
+        .await;
 
         // We should be able to delete one of these.
         let _ = datastore
@@ -5766,12 +5786,20 @@ mod test {
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
         // Create the v4 and v6 system-service pools we exercise below.
-        let ipv4 =
-            create_service_ip_pool(opctx, datastore, IpVersion::V4.into())
-                .await;
-        let ipv6 =
-            create_service_ip_pool(opctx, datastore, IpVersion::V6.into())
-                .await;
+        let ipv4 = create_service_ip_pool(
+            opctx,
+            datastore,
+            "oxide-service-pool-v4",
+            IpVersion::V4.into(),
+        )
+        .await;
+        let ipv6 = create_service_ip_pool(
+            opctx,
+            datastore,
+            "oxide-service-pool-v6",
+            IpVersion::V6.into(),
+        )
+        .await;
 
         // We should be able to assign one of these for silo use.
         let _ = datastore
@@ -5851,10 +5879,20 @@ mod test {
         // Create the v4 system-service pool, add a range, allocate an external
         // IP. Also create a v6 pool so that reassigning the v4 pool for silo
         // use is allowed at the end (more than one system-service pool remains).
-        let ipv4 =
-            create_service_ip_pool(opctx, datastore, IpVersion::V4.into())
-                .await;
-        create_service_ip_pool(opctx, datastore, IpVersion::V6.into()).await;
+        let ipv4 = create_service_ip_pool(
+            opctx,
+            datastore,
+            "oxide-service-pool-v4",
+            IpVersion::V4.into(),
+        )
+        .await;
+        create_service_ip_pool(
+            opctx,
+            datastore,
+            "oxide-service-pool-v6",
+            IpVersion::V6.into(),
+        )
+        .await;
         let ip_range = IpRange::V4(Ipv4Range {
             first: Ipv4Addr::new(1, 1, 1, 1),
             last: Ipv4Addr::new(1, 1, 1, 10),

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -11,8 +11,6 @@ use crate::authz::ApiResource;
 use crate::context::OpContext;
 use crate::db::collection_insert::AsyncInsertError;
 use crate::db::collection_insert::DatastoreCollection;
-use crate::db::datastore::SERVICE_IPV4_POOL_NAME;
-use crate::db::datastore::SERVICE_IPV6_POOL_NAME;
 use crate::db::identity::Resource;
 use crate::db::model::IncompleteIpPoolResource;
 use crate::db::model::IpKind;
@@ -43,7 +41,6 @@ use nexus_db_errors::ErrorHandler;
 use nexus_db_errors::public_error_from_diesel;
 use nexus_db_errors::public_error_from_diesel_lookup;
 use nexus_db_lookup::DbConnection;
-use nexus_db_lookup::LookupPath;
 use nexus_db_model::InternetGateway;
 use nexus_db_model::InternetGatewayIpPool;
 use nexus_db_model::IpVersion;
@@ -792,29 +789,6 @@ impl DataStore {
             authz::IpPool::new(authz::FLEET, pool.id(), lookup_type);
         opctx.authorize(authz::Action::CreateChild, &authz_pool).await?;
         Ok((authz_pool, pool))
-    }
-
-    /// Look up system services IP pool by its well-known name.
-    ///
-    /// This method may require an index by Availability Zone in the future.
-    //
-    // The only remaining callers are the deprecated `ip-pools-service` API
-    // handlers. Everything else resolves system-service pools by assignment via
-    // `ip_pools_service_lookup_by_version` / `_both_versions`. This method and
-    // the well-known name constants are removed once those handlers move off
-    // the builtin names. See https://github.com/oxidecomputer/omicron/issues/8950.
-    pub async fn ip_pools_service_lookup(
-        &self,
-        opctx: &OpContext,
-        ip_version: IpVersion,
-    ) -> LookupResult<(authz::IpPool, IpPool)> {
-        let name = match ip_version {
-            IpVersion::V4 => SERVICE_IPV4_POOL_NAME,
-            IpVersion::V6 => SERVICE_IPV6_POOL_NAME,
-        };
-        let name =
-            Name(name.parse().expect("should be able to parse builtin names"));
-        LookupPath::new(&opctx, self).ip_pool_name(&name).fetch().await
     }
 
     /// Creates a new IP pool.

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -214,12 +214,6 @@ pub use webhook_delivery::WebhookDeliveryFilters;
 // TODO: This should likely turn into a configuration option.
 pub const REGION_REDUNDANCY_THRESHOLD: usize = 3;
 
-/// The name of the built-in IPv4 IP pool for Oxide services.
-pub const SERVICE_IPV4_POOL_NAME: &str = "oxide-service-pool-v4";
-
-/// The name of the built-in IPv6 IP pool for Oxide services.
-pub const SERVICE_IPV6_POOL_NAME: &str = "oxide-service-pool-v6";
-
 /// "limit" to be used in SQL queries that paginate through large result sets
 ///
 /// This value is chosen to be small enough to avoid any queries being too

--- a/nexus/db-queries/src/db/datastore/network_interface.rs
+++ b/nexus/db-queries/src/db/datastore/network_interface.rs
@@ -1109,6 +1109,7 @@ mod tests {
         create_service_ip_pool(
             &opctx,
             &datastore,
+            "oxide-service-pool-v4",
             omicron_common::api::external::IpVersion::V4,
         )
         .await;

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1070,8 +1070,6 @@ impl DataStore {
 mod test {
     use super::*;
     use crate::db::datastore::Discoverability;
-    use crate::db::datastore::SERVICE_IPV4_POOL_NAME;
-    use crate::db::datastore::SERVICE_IPV6_POOL_NAME;
     use crate::db::model::ExternalIp;
     use crate::db::model::IpKind;
     use crate::db::model::IpPoolRange;
@@ -1593,7 +1591,7 @@ mod test {
                     blueprint: blueprint.clone(),
                     service_ip_pools: IdOrdMap::from_iter_unique([
                         service_pool_config(
-                            SERVICE_IPV4_POOL_NAME,
+                            "oxide-service-pool-v4",
                             vec![service_ip_pool_range],
                         ),
                     ])
@@ -1667,7 +1665,7 @@ mod test {
             .await
             .unwrap();
         let svc_pool = &svc_pools.first().expect("v4 service ip pool").db_pool;
-        assert_eq!(svc_pool.name().as_str(), SERVICE_IPV4_POOL_NAME);
+        assert_eq!(svc_pool.name().as_str(), "oxide-service-pool-v4");
 
         let observed_ip_pool_ranges = get_all_ip_pool_ranges(&datastore).await;
         assert_eq!(observed_ip_pool_ranges.len(), 1);
@@ -1791,7 +1789,7 @@ mod test {
                     datasets: vec![],
                     service_ip_pools: IdOrdMap::from_iter_unique([
                         service_pool_config(
-                            SERVICE_IPV4_POOL_NAME,
+                            "oxide-service-pool-v4",
                             vec![service_ip_pool_range],
                         ),
                     ])
@@ -1874,7 +1872,7 @@ mod test {
             .await
             .unwrap();
         let svc_pool = &svc_pools.first().expect("v4 service ip pool").db_pool;
-        assert_eq!(svc_pool.name().as_str(), SERVICE_IPV4_POOL_NAME);
+        assert_eq!(svc_pool.name().as_str(), "oxide-service-pool-v4");
 
         let observed_ip_pool_ranges = get_all_ip_pool_ranges(&datastore).await;
         assert_eq!(observed_ip_pool_ranges.len(), 1);
@@ -2000,7 +1998,7 @@ mod test {
                     datasets: datasets.clone(),
                     service_ip_pools: IdOrdMap::from_iter_unique([
                         service_pool_config(
-                            SERVICE_IPV6_POOL_NAME,
+                            "oxide-service-pool-v6",
                             vec![service_ip_pool_range],
                         ),
                     ])
@@ -2071,7 +2069,7 @@ mod test {
             .await
             .unwrap();
         let svc_pool = &svc_pools.first().expect("v6 service ip pool").db_pool;
-        assert_eq!(svc_pool.name().as_str(), SERVICE_IPV6_POOL_NAME);
+        assert_eq!(svc_pool.name().as_str(), "oxide-service-pool-v6");
 
         let observed_ip_pool_ranges = get_all_ip_pool_ranges(&datastore).await;
         assert_eq!(observed_ip_pool_ranges.len(), 1);
@@ -2176,7 +2174,7 @@ mod test {
                     blueprint: blueprint.clone(),
                     service_ip_pools: IdOrdMap::from_iter_unique([
                         service_pool_config(
-                            SERVICE_IPV4_POOL_NAME,
+                            "oxide-service-pool-v4",
                             vec![service_ip_pool_range],
                         ),
                     ])
@@ -2257,7 +2255,7 @@ mod test {
                     blueprint: blueprint.clone(),
                     service_ip_pools: IdOrdMap::from_iter_unique([
                         service_pool_config(
-                            SERVICE_IPV4_POOL_NAME,
+                            "oxide-service-pool-v4",
                             vec![service_ip_pool_range],
                         ),
                     ])

--- a/nexus/db-queries/src/db/pub_test_utils/helpers.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/helpers.rs
@@ -7,8 +7,6 @@
 use crate::authz;
 use crate::context::OpContext;
 use crate::db::DataStore;
-use crate::db::datastore::SERVICE_IPV4_POOL_NAME;
-use crate::db::datastore::SERVICE_IPV6_POOL_NAME;
 use crate::db::datastore::ServiceIpPool;
 use nexus_db_lookup::LookupPath;
 
@@ -665,10 +663,10 @@ pub async fn create_service_ip_pool(
 ) -> ServiceIpPool {
     let (name, description) = match version {
         external::IpVersion::V4 => {
-            (SERVICE_IPV4_POOL_NAME, "IPv4 IP Pool for Oxide Services")
+            ("oxide-service-pool-v4", "IPv4 IP Pool for Oxide Services")
         }
         external::IpVersion::V6 => {
-            (SERVICE_IPV6_POOL_NAME, "IPv6 IP Pool for Oxide Services")
+            ("oxide-service-pool-v6", "IPv6 IP Pool for Oxide Services")
         }
     };
     let name: external::Name = name.parse().expect("valid service pool name");

--- a/nexus/db-queries/src/db/pub_test_utils/helpers.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/helpers.rs
@@ -659,16 +659,10 @@ fn make_test_repo(version: u32) -> TufRepoDescription {
 pub async fn create_service_ip_pool(
     opctx: &OpContext,
     datastore: &DataStore,
+    name: &str,
     version: external::IpVersion,
 ) -> ServiceIpPool {
-    let (name, description) = match version {
-        external::IpVersion::V4 => {
-            ("oxide-service-pool-v4", "IPv4 IP Pool for Oxide Services")
-        }
-        external::IpVersion::V6 => {
-            ("oxide-service-pool-v6", "IPv6 IP Pool for Oxide Services")
-        }
-    };
+    let description = format!("IP{version} IP Pool for Oxide Services");
     let name: external::Name = name.parse().expect("valid service pool name");
     let pool = IpPool::new(
         &external::IdentityMetadataCreateParams {

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -1528,6 +1528,7 @@ mod tests {
         let service_pool = create_service_ip_pool(
             context.db.opctx(),
             context.db.datastore(),
+            "oxide-service-pool-v4",
             IpVersion::V4,
         )
         .await;
@@ -1745,6 +1746,7 @@ mod tests {
         let service_pool = create_service_ip_pool(
             context.db.opctx(),
             context.db.datastore(),
+            "oxide-service-pool-v4",
             IpVersion::V4,
         )
         .await;
@@ -2444,6 +2446,7 @@ mod tests {
         let service_pool = create_service_ip_pool(
             context.db.opctx(),
             context.db.datastore(),
+            "oxide-service-pool-v6",
             IpVersion::V6,
         )
         .await;

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -541,7 +541,7 @@ impl super::Nexus {
     // support for more than one service pool per IP version and can't express
     // which they mean. So at this point, we require exactly one, and return an
     // error if that's not the case. This can only really happen if the client
-    // is using mixed API versions: a new one to create  second pool, and the
+    // is using mixed API versions: a new one to create a second pool, and the
     // old one to manipulate them. That should be really unlikely, but also
     // point the user to the new API version if they do happen to land here.
     async fn ip_pool_service_single(
@@ -559,12 +559,10 @@ impl super::Nexus {
             )
             .await?;
         if pools.len() > 1 {
-            return Err(Error::invalid_request(format!(
+            return Err(Error::invalid_request(
                 "more than one system-service IP pool of the requested IP \
-                 version exists; use the /v1/system/ip-pools API (added in \
-                 API version {}) to manage service IP pools",
-                nexus_external_api::VERSION_ADD_SYSTEM_IP_POOL_APIS,
-            )));
+                 version exists; update the client to manage these pools",
+            ));
         }
         let pool = pools.pop().ok_or_else(|| {
             Error::non_resourcetype_not_found(

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -756,14 +756,10 @@ mod tests {
 
         // Create a second IPv4 system-service pool. The deprecated path can no
         // longer disambiguate, so it fails rather than guessing.
-        //
-        // NOTE: The `create_service_ip_pool` helper names its pool
-        // "oxide-service-pool-v4", distinct from the test context's
-        // "ipv4-service-pool". Also assert we really do end up with two pools,
-        // to ensure the test fails the way we expect.
         create_service_ip_pool(
             &opctx,
             datastore,
+            "oxide-service-pool-v4",
             omicron_common::api::external::IpVersion::V4,
         )
         .await;

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -39,6 +39,7 @@ use omicron_common::api::external::UpdateResult;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use ref_cast::RefCast;
 use std::matches;
+use std::num::NonZeroU32;
 use uuid::Uuid;
 
 /// Validate multicast-specific constraints for IP ranges.
@@ -534,15 +535,51 @@ impl super::Nexus {
     //
     // Remove the service-specific methods when the HTTP endpoints they back
     // are also removed.
+
+    // Resolve the single system-service IP pool of the given version backing
+    // the deprecated `ip-pools-service` endpoints. These endpoints predate
+    // support for more than one service pool per IP version and can't express
+    // which they mean. So at this point, we require exactly one, and return an
+    // error if that's not the case. This can only really happen if the client
+    // is using mixed API versions: a new one to create  second pool, and the
+    // old one to manipulate them. That should be really unlikely, but also
+    // point the user to the new API version if they do happen to land here.
+    async fn ip_pool_service_single(
+        &self,
+        opctx: &OpContext,
+        version: IpVersion,
+    ) -> LookupResult<(authz::IpPool, db::model::IpPool)> {
+        // Fetch up to two, so we can distinguish none / one / more-than-one.
+        let mut pools = self
+            .db_datastore
+            .ip_pools_service_lookup_by_version(
+                opctx,
+                version,
+                NonZeroU32::new(2).unwrap(),
+            )
+            .await?;
+        if pools.len() > 1 {
+            return Err(Error::invalid_request(format!(
+                "more than one system-service IP pool of the requested IP \
+                 version exists; use the /v1/system/ip-pools API (added in \
+                 API version {}) to manage service IP pools",
+                nexus_external_api::VERSION_ADD_SYSTEM_IP_POOL_APIS,
+            )));
+        }
+        let pool = pools.pop().ok_or_else(|| {
+            Error::non_resourcetype_not_found(
+                "no system-service IP pool of the requested IP version",
+            )
+        })?;
+        Ok((pool.authz_pool, pool.db_pool))
+    }
+
     pub(crate) async fn ip_pool_service_fetch(
         &self,
         opctx: &OpContext,
     ) -> LookupResult<db::model::IpPool> {
-        // TODO: https://github.com/oxidecomputer/omicron/issues/8881
-        let (authz_pool, db_pool) = self
-            .db_datastore
-            .ip_pools_service_lookup(opctx, IpVersion::V4)
-            .await?;
+        let (authz_pool, db_pool) =
+            self.ip_pool_service_single(opctx, IpVersion::V4).await?;
         opctx.authorize(authz::Action::Read, &authz_pool).await?;
         Ok(db_pool)
     }
@@ -552,11 +589,8 @@ impl super::Nexus {
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, IpNetwork>,
     ) -> ListResultVec<db::model::IpPoolRange> {
-        // TODO: https://github.com/oxidecomputer/omicron/issues/8881
-        let (authz_pool, ..) = self
-            .db_datastore
-            .ip_pools_service_lookup(opctx, IpVersion::V4)
-            .await?;
+        let (authz_pool, ..) =
+            self.ip_pool_service_single(opctx, IpVersion::V4).await?;
         opctx.authorize(authz::Action::Read, &authz_pool).await?;
         self.db_datastore
             .ip_pool_list_ranges(opctx, &authz_pool, pagparams)
@@ -568,10 +602,8 @@ impl super::Nexus {
         opctx: &OpContext,
         range: &ip_pool::IpRange,
     ) -> UpdateResult<db::model::IpPoolRange> {
-        let (authz_pool, db_pool) = self
-            .db_datastore
-            .ip_pools_service_lookup(opctx, range.version().into())
-            .await?;
+        let (authz_pool, db_pool) =
+            self.ip_pool_service_single(opctx, range.version().into()).await?;
         opctx.authorize(authz::Action::Modify, &authz_pool).await?;
 
         // Disallow V6 ranges until IPv6 is fully supported by the networking
@@ -668,9 +700,14 @@ impl super::Nexus {
         opctx: &OpContext,
         range: &ip_pool::IpRange,
     ) -> DeleteResult {
+        // The range already lives in a specific pool; resolve it by a contained
+        // address rather than assuming a single service pool.
         let (authz_pool, ..) = self
             .db_datastore
-            .ip_pools_service_lookup(opctx, range.version().into())
+            .ip_pool_fetch_containing_address_for_services(
+                opctx,
+                range.first_address(),
+            )
             .await?;
         opctx.authorize(authz::Action::Modify, &authz_pool).await?;
         self.db_datastore.ip_pool_delete_range(opctx, &authz_pool, range).await
@@ -680,8 +717,88 @@ impl super::Nexus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nexus_db_queries::db::pub_test_utils::helpers::create_service_ip_pool;
+    use nexus_test_utils_macros::nexus_test;
     use omicron_common::address::IpRange;
+    use omicron_common::address::Ipv4Range;
+    use slog::o;
     use std::net::{Ipv4Addr, Ipv6Addr};
+
+    type ControlPlaneTestContext =
+        nexus_test_utils::ControlPlaneTestContext<crate::Server>;
+
+    // The deprecated `ip-pools-service` range endpoints resolve "the" service
+    // pool by IP version. With exactly one such pool they behave as before.
+    // With more than one, they can no longer tell which pool the caller means
+    // and must fail rather than guess.
+    #[nexus_test(server = crate::Server)]
+    async fn test_ip_pool_service_add_range_requires_single_pool(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let nexus = &cptestctx.server.server_context().nexus;
+        let datastore = nexus.datastore();
+        let opctx = nexus_db_queries::context::OpContext::for_tests(
+            cptestctx.logctx.log.new(o!()),
+            datastore.clone(),
+        );
+
+        // Test context has exactly one IPv4 service pool, so the API should
+        // work fine in this case.
+        let range = IpRange::V4(
+            Ipv4Range::new(
+                "203.0.113.10".parse().unwrap(),
+                "203.0.113.20".parse().unwrap(),
+            )
+            .unwrap(),
+        );
+        nexus
+            .ip_pool_service_add_range(&opctx, &range)
+            .await
+            .expect("add range succeeds with a single service pool");
+
+        // Create a second IPv4 system-service pool. The deprecated path can no
+        // longer disambiguate, so it fails rather than guessing.
+        //
+        // NOTE: The `create_service_ip_pool` helper names its pool
+        // "oxide-service-pool-v4", distinct from the test context's
+        // "ipv4-service-pool". Also assert we really do end up with two pools,
+        // to ensure the test fails the way we expect.
+        create_service_ip_pool(
+            &opctx,
+            datastore,
+            omicron_common::api::external::IpVersion::V4,
+        )
+        .await;
+        let v4_service_pools = datastore
+            .ip_pools_service_lookup_by_version(
+                &opctx,
+                IpVersion::V4,
+                NonZeroU32::new(3).unwrap(),
+            )
+            .await
+            .expect("listed v4 system-service pools");
+        assert_eq!(
+            v4_service_pools.len(),
+            2,
+            "expected exactly two IPv4 system-service pools",
+        );
+
+        let range2 = IpRange::V4(
+            Ipv4Range::new(
+                "203.0.113.30".parse().unwrap(),
+                "203.0.113.40".parse().unwrap(),
+            )
+            .unwrap(),
+        );
+        let err = nexus
+            .ip_pool_service_add_range(&opctx, &range2)
+            .await
+            .expect_err("add range fails with more than one service pool");
+        assert!(
+            err.to_string().contains("more than one system-service IP pool"),
+            "unexpected error: {err}",
+        );
+    }
 
     // IPv6 underlay validation tests
 


### PR DESCRIPTION
- Remove the hardcoded consts for the service IP Pools. The API endpoints that relied on them are deprecated, and we now use the new methods internally.
- Add a smoke test that prevents users from using the old API to add ranges if there is now more than one IP Pool, since that older API has no way to express which one it should be in.
- Closes #8950