### PR TITLE
Temporarily comment out flaky BGP proptest

### DIFF
--- a/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler/tests.rs
@@ -2,6 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/// `proptest_full_reconciliation()` is currently commented out, because it's
+/// regularly hitting a bug in mgd:
+/// <https://github.com/oxidecomputer/maghemite/issues/867>. This is causing
+/// pretty frequent test flake failures in omicron's CI
+/// (<https://github.com/oxidecomputer/omicron/issues/10959>). To avoid needing
+/// to comment out a bunch of imports and helper functions, we're adding these
+/// `allow`s; they should be removed and the test restored once a fix for
+/// maghemite#867 is pulled into omicron.
+#![allow(dead_code, unused_imports)]
+
 use super::*;
 use assert_matches::assert_matches;
 use gateway_messages::SpPort;
@@ -576,6 +586,10 @@ async fn run_one_proptest_input(
     assert!(unnumbered_peers_to_create.is_empty());
 }
 
+/// DISABLED TEMPORARILY.
+///
+/// See the note at the top of this module.
+/*
 #[tokio::test(flavor = "multi_thread")]
 async fn proptest_full_reconciliation() {
     let logctx =
@@ -611,3 +625,4 @@ async fn proptest_full_reconciliation() {
     mgsctx.teardown().await;
     logctx.cleanup_successful();
 }
+*/

--- a/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler/tests.rs
@@ -2,16 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// `proptest_full_reconciliation()` is currently commented out, because it's
-// regularly hitting a bug in mgd:
-// <https://github.com/oxidecomputer/maghemite/issues/867>. This is causing
-// pretty frequent test flake failures in omicron's CI
-// (<https://github.com/oxidecomputer/omicron/issues/10959>). To avoid needing
-// to comment out a bunch of imports and helper functions, we're adding these
-// `allow`s; they should be removed and the test restored once a fix for
-// maghemite#867 is pulled into omicron.
-#![allow(dead_code, unused_imports)]
-
 use super::*;
 use assert_matches::assert_matches;
 use gateway_messages::SpPort;
@@ -588,8 +578,14 @@ async fn run_one_proptest_input(
 
 // DISABLED TEMPORARILY.
 //
-// See the note at the top of this module.
-/*
+// `proptest_full_reconciliation()` is regularly hitting a bug in mgd:
+// <https://github.com/oxidecomputer/maghemite/issues/867>. This is causing
+// pretty frequent test flake failures in omicron's CI
+// (<https://github.com/oxidecomputer/omicron/issues/10959>), so `#[ignore]`
+// this test.
+//
+// This should be removed once a fix for maghemite#867 is pulled into omicron.
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn proptest_full_reconciliation() {
     let logctx =
@@ -625,4 +621,3 @@ async fn proptest_full_reconciliation() {
     mgsctx.teardown().await;
     logctx.cleanup_successful();
 }
-*/

--- a/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler/tests.rs
@@ -2,14 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-/// `proptest_full_reconciliation()` is currently commented out, because it's
-/// regularly hitting a bug in mgd:
-/// <https://github.com/oxidecomputer/maghemite/issues/867>. This is causing
-/// pretty frequent test flake failures in omicron's CI
-/// (<https://github.com/oxidecomputer/omicron/issues/10959>). To avoid needing
-/// to comment out a bunch of imports and helper functions, we're adding these
-/// `allow`s; they should be removed and the test restored once a fix for
-/// maghemite#867 is pulled into omicron.
+// `proptest_full_reconciliation()` is currently commented out, because it's
+// regularly hitting a bug in mgd:
+// <https://github.com/oxidecomputer/maghemite/issues/867>. This is causing
+// pretty frequent test flake failures in omicron's CI
+// (<https://github.com/oxidecomputer/omicron/issues/10959>). To avoid needing
+// to comment out a bunch of imports and helper functions, we're adding these
+// `allow`s; they should be removed and the test restored once a fix for
+// maghemite#867 is pulled into omicron.
 #![allow(dead_code, unused_imports)]
 
 use super::*;
@@ -586,9 +586,9 @@ async fn run_one_proptest_input(
     assert!(unnumbered_peers_to_create.is_empty());
 }
 
-/// DISABLED TEMPORARILY.
-///
-/// See the note at the top of this module.
+// DISABLED TEMPORARILY.
+//
+// See the note at the top of this module.
 /*
 #[tokio::test(flavor = "multi_thread")]
 async fn proptest_full_reconciliation() {


### PR DESCRIPTION
The underlying issue here is https://github.com/oxidecomputer/maghemite/issues/867, but we're seeing [quite a lot of flakes](https://github.com/oxidecomputer/omicron/issues/10959), so disable this test for now.