### PR TITLE
[support-bundle] Record full error chains in host info error files

### DIFF
--- a/support-bundle-collection/src/steps/host_info.rs
+++ b/support-bundle-collection/src/steps/host_info.rs
@@ -297,9 +297,10 @@ where
                 })?;
         }
         Err(err) => {
+            let err_string = InlineErrorChain::new(&err).to_string();
             tokio::fs::write(
                 path.join(format!("{command}_err.txt")),
-                err.to_string(),
+                err_string,
             )
             .await?;
         }
@@ -377,11 +378,9 @@ async fn save_zone_log_zip_or_error(
             }
         }
         Err(err) => {
-            tokio::fs::write(
-                path.join(format!("{zone}.logs.err")),
-                err.to_string(),
-            )
-            .await?;
+            let err_string = InlineErrorChain::new(&err).to_string();
+            tokio::fs::write(path.join(format!("{zone}.logs.err")), err_string)
+                .await?;
         }
     };
 


### PR DESCRIPTION
The error files written into a support bundle when a diagnostics command fails (`{command}_err.txt`) or a zone-log download fails (`{zone}.logs.err`) were populated with `err.to_string()`, which drops all inner error information from the sled-agent client error chain.

Use `InlineErrorChain` for both writes so the full chain is recorded in the bundle.

Fixes #10981