### PR TITLE
Oximeter: Backfill unit tests for kstat metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6365,9 +6365,9 @@ dependencies = [
 
 [[package]]
 name = "kstat-rs"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27964e4632377753acb0898ce6f28770d50cbca1339200ae63d700cff97b5c2b"
+checksum = "52d0786643a0b49f595bd1fc81e1c1aa7bad8555bc820c6892f4d28cb20cf210"
 dependencies = [
  "libc",
  "thiserror 1.0.69",
@@ -9899,6 +9899,7 @@ dependencies = [
  "ipnet",
  "ipnetwork",
  "itertools 0.13.0",
+ "itertools 0.15.0",
  "jiff",
  "lalrpop-util",
  "lazy_static",
@@ -11121,7 +11122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "proc-macro2",
  "quote",
  "rand 0.8.6",
@@ -12025,7 +12026,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14706,7 +14707,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -607,7 +607,7 @@ ispf = { git = "https://github.com/oxidecomputer/ispf" }
 jiff = "0.2.15"
 key-manager = { path = "key-manager" }
 key-manager-types = { path = "key-manager/types" }
-kstat-rs = "0.2.4"
+kstat-rs = "0.2.5"
 libc = "0.2.174"
 linkme = "0.3"
 libipcc = { git = "https://github.com/oxidecomputer/ipcc-rs", rev = "524eb8f125003dff50b9703900c6b323f00f9e1b" }

--- a/oximeter/instruments/src/kstat/link.rs
+++ b/oximeter/instruments/src/kstat/link.rs
@@ -101,12 +101,6 @@ impl SledDataLink {
         Self { target, time_synced }
     }
 
-    /// Create a new `SledDataLink` with the given target .
-    #[cfg(test)]
-    pub fn unsynced(target: SledDataLinkTarget) -> Self {
-        Self { target, time_synced: false }
-    }
-
     /// Return the name of the link.
     pub fn link_name(&self) -> &str {
         &self.target.link_name
@@ -140,19 +134,21 @@ impl KstatTarget for SledDataLink {
         &self,
         kstats: KstatList<'_, '_>,
     ) -> Result<Vec<Sample>, Error> {
-        let Some((creation_time, kstat, data)) = kstats.first() else {
-            return Ok(vec![]);
-        };
-        let snapshot_time = hrtime_to_utc(kstat.ks_snaptime)?;
-        let Data::Named(named) = data else {
-            return Err(Error::ExpectedNamedKstat);
-        };
-        named
-            .iter()
-            .filter_map(|nd| {
-                extract_link_kstats(self, nd, *creation_time, snapshot_time)
-            })
-            .collect()
+        let mut samples = Vec::new();
+        for (creation_time, kstat, data) in kstats.iter() {
+            let snapshot_time = hrtime_to_utc(kstat.ks_snaptime)?;
+            let Data::Named(named) = data else {
+                return Err(Error::ExpectedNamedKstat);
+            };
+            let result = named
+                .iter()
+                .filter_map(|nd| {
+                    extract_link_kstats(self, nd, *creation_time, snapshot_time)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            samples.extend(result);
+        }
+        Ok(samples)
     }
 }
 
@@ -175,8 +171,94 @@ impl Target for SledDataLink {
     }
 }
 
-#[cfg(all(test, target_os = "illumos"))]
+#[cfg(test)]
 mod tests {
+    use super::*;
+    use kstat_rs::Kstat;
+    use kstat_rs::NamedData;
+    use oximeter::Datum;
+    use uuid::uuid;
+
+    const RACK_ID: Uuid = uuid!("de784702-cafb-41a9-b3e5-93af189def29");
+    const SLED_ID: Uuid = uuid!("88240343-5262-45f4-86f1-3c82fe383f2a");
+
+    fn data_link(link_name: &'static str) -> SledDataLink {
+        SledDataLink::new(
+            SledDataLinkTarget {
+                rack_id: RACK_ID,
+                sled_id: SLED_ID,
+                sled_serial: "test-serial".into(),
+                link_name: link_name.into(),
+                kind: "vnic".into(),
+                sled_model: "test-gimlet".into(),
+                sled_revision: 1,
+                zone_name: "global".into(),
+            },
+            true,
+        )
+    }
+
+    #[test]
+    fn test_interested_positive() {
+        let link = data_link("opte0");
+        assert!(link.interested(&Kstat::with_null_kstat("link", 0, "opte0")));
+    }
+
+    #[test]
+    fn test_interested_negative() {
+        let mut link = data_link("opte1");
+
+        assert!(!link.interested(&Kstat::with_null_kstat("link", 0, "opte2")));
+        assert!(!link.interested(&Kstat::with_null_kstat("link", 0, "opte10")));
+        assert!(!link.interested(&Kstat::with_null_kstat("xde", 0, "opte1")));
+        assert!(!link.interested(&Kstat::with_null_kstat("link", 1, "opte1")));
+
+        link.time_synced = false;
+        assert!(!link.interested(&Kstat::with_null_kstat("link", 0, "opte1")));
+    }
+
+    fn cumulative_value(sample: &Sample) -> u64 {
+        match sample.measurement.datum() {
+            Datum::CumulativeU64(value) => value.value(),
+            other => panic!("expected a CumulativeU64, found {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_to_samples() {
+        let link = data_link("opte0");
+        let data = Data::Named(vec![
+            Named { name: "rbytes64", value: NamedData::UInt64(1) },
+            Named { name: "obytes64", value: NamedData::UInt64(2) },
+            Named { name: "ipackets64", value: NamedData::UInt64(3) },
+            Named { name: "opackets64", value: NamedData::UInt64(4) },
+            Named { name: "ierrors", value: NamedData::UInt32(5) },
+            Named { name: "oerrors", value: NamedData::UInt32(6) },
+            Named { name: "unmatched", value: NamedData::UInt32(7) },
+        ]);
+        let kstat = Kstat::with_null_kstat("link", 0, "opte0");
+        let samples = link.to_samples(&[(Utc::now(), kstat, data)]).unwrap();
+        let values: Vec<_> = samples
+            .iter()
+            .map(|s| (s.timeseries_name.to_string(), cumulative_value(s)))
+            .collect();
+
+        assert_eq!(
+            values,
+            [
+                ("sled_data_link:bytes_received".to_string(), 1),
+                ("sled_data_link:bytes_sent".to_string(), 2),
+                ("sled_data_link:packets_received".to_string(), 3),
+                ("sled_data_link:packets_sent".to_string(), 4),
+                ("sled_data_link:errors_received".to_string(), 5),
+                ("sled_data_link:errors_sent".to_string(), 6),
+            ]
+        );
+    }
+}
+
+#[cfg(all(test, target_os = "illumos"))]
+mod illumos_tests {
     use super::*;
     use crate::kstat::CollectionDetails;
     use crate::kstat::KstatSampler;
@@ -278,36 +360,6 @@ mod tests {
     }
 
     #[test]
-    fn test_kstat_interested() {
-        let link = TestEtherstub::new();
-        let target = SledDataLinkTarget {
-            rack_id: RACK_ID,
-            sled_id: SLED_ID,
-            sled_serial: SLED_SERIAL.into(),
-            link_name: link.name.clone().into(),
-            kind: KIND.into(),
-            sled_model: SLED_MODEL.into(),
-            sled_revision: SLED_REVISION,
-            zone_name: ZONE_NAME.into(),
-        };
-        // not with a synced sled (by default)
-        let mut dl = SledDataLink::unsynced(target);
-
-        let ctl = Ctl::new().unwrap();
-        let ctl = ctl.update().unwrap();
-        let kstat = ctl
-            .filter(Some("link"), Some(0), Some(link.name.as_str()))
-            .next()
-            .unwrap();
-
-        assert!(!dl.interested(&kstat));
-
-        // with a synced sled
-        dl.time_synced = true;
-        assert!(dl.interested(&kstat));
-    }
-
-    #[test]
     fn test_sled_datalink() {
         let link = TestEtherstub::new();
         let target = SledDataLinkTarget {
@@ -330,7 +382,21 @@ mod tests {
         let creation_time = hrtime_to_utc(kstat.ks_crtime).unwrap();
         let data = ctl.read(&mut kstat).unwrap();
         let samples = dl.to_samples(&[(creation_time, kstat, data)]).unwrap();
-        println!("{samples:#?}");
+
+        let mut names: Vec<_> =
+            samples.iter().map(|s| s.timeseries_name.to_string()).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            [
+                "sled_data_link:bytes_received",
+                "sled_data_link:bytes_sent",
+                "sled_data_link:errors_received",
+                "sled_data_link:errors_sent",
+                "sled_data_link:packets_received",
+                "sled_data_link:packets_sent",
+            ]
+        );
     }
 
     #[tokio::test]

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -81,7 +81,8 @@ idna = { version = "1.1.0" }
 indexmap = { version = "2.14.0", features = ["serde"] }
 ipnet = { version = "2.11.0", features = ["serde"] }
 ipnetwork = { version = "0.21.1", features = ["schemars", "serde"] }
-itertools = { version = "0.13.0" }
+itertools-3575ec1268b04181 = { package = "itertools", version = "0.15.0" }
+itertools-594e8ee84c453af0 = { package = "itertools", version = "0.13.0" }
 jiff = { version = "0.2.34", features = ["serde"] }
 lalrpop-util = { version = "0.19.12" }
 lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }
@@ -230,7 +231,8 @@ idna = { version = "1.1.0" }
 indexmap = { version = "2.14.0", features = ["serde"] }
 ipnet = { version = "2.11.0", features = ["serde"] }
 ipnetwork = { version = "0.21.1", features = ["schemars", "serde"] }
-itertools = { version = "0.13.0" }
+itertools-3575ec1268b04181 = { package = "itertools", version = "0.15.0" }
+itertools-594e8ee84c453af0 = { package = "itertools", version = "0.13.0" }
 jiff = { version = "0.2.34", features = ["serde"] }
 lalrpop-util = { version = "0.19.12" }
 lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }


### PR DESCRIPTION
Current tests for kstat metrics only run on illumos, and only test that reading a given kstat succeeds. We don't assert that kstats of a given name, class, etc., are actually handled correctly. This patch adds unit tests so that we can assert that the `interested` and `to_samples` methods of a given kstat sampler behave as expected on various synthetic inputs. We also bump kstat-rs to get the `Kstat::with_null_kstat` constructor, so that we can construct arbitrary synthetic kstats for testing purposes.

Note: this shouldn't be merged until we merge https://github.com/oxidecomputer/kstat-rs/pull/4 and bump kstat-rs properly, rather than pointing to my branch. Submitting this as a draft until that patch or similar is merged.