### PR TITLE
add #[must_use] to ParallelTaskSet::spawn

### DIFF
--- a/cockroach-metrics/src/lib.rs
+++ b/cockroach-metrics/src/lib.rs
@@ -354,7 +354,7 @@ impl CockroachClusterAdminClient {
                 results.push(result);
             }
         }
-        results.append(&mut tasks.join_all().await);
+        results.append(&mut tasks.join_remaining().await);
 
         // Collect all successful results
         let mut successful_results = Vec::new();
@@ -431,7 +431,7 @@ impl CockroachClusterAdminClient {
                 results.push(result);
             }
         }
-        results.append(&mut tasks.join_all().await);
+        results.append(&mut tasks.join_remaining().await);
 
         // Collect all successful results
         let mut successful_results = Vec::new();

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -7305,9 +7305,10 @@ async fn cmd_db_validate_artifact_replication(
     check_limit(&sleds, limit, || String::from("listing sleds"));
 
     let mut task_set = ParallelTaskSet::new();
+    let mut outputs = Vec::new();
     for sled in sleds {
         let log = opctx.log.clone();
-        task_set
+        if let Some(output) = task_set
             .spawn(async move {
                 let url = format!("http://{}", sled.address());
                 let client = sled_agent_client::Client::new(&url, log);
@@ -7317,10 +7318,14 @@ async fn cmd_db_validate_artifact_replication(
                     .map(|res| res.into_inner());
                 (sled, sled_config)
             })
-            .await;
+            .await
+        {
+            outputs.push(output);
+        }
     }
     let mut rows = Vec::new();
-    for (sled, sled_config_result) in task_set.join_all().await {
+    outputs.extend(task_set.join_all().await);
+    for (sled, sled_config_result) in outputs {
         let state = match sled_config_result {
             Ok(sled_config) => {
                 match config.generation.cmp(&sled_config.generation) {

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -7324,7 +7324,7 @@ async fn cmd_db_validate_artifact_replication(
         }
     }
     let mut rows = Vec::new();
-    outputs.extend(task_set.join_all().await);
+    outputs.extend(task_set.join_remaining().await);
     for (sled, sled_config_result) in outputs {
         let state = match sled_config_result {
             Ok(sled_config) => {

--- a/nexus/src/app/background/tasks/trust_quorum.rs
+++ b/nexus/src/app/background/tasks/trust_quorum.rs
@@ -89,6 +89,7 @@ impl TrustQuorumManager {
 
         // For each rack, do the work
         let mut workers = ParallelTaskSet::new();
+        let mut outputs = Vec::new();
         for (rack_id, epoch) in epochs_by_rack_id {
             let log = log.clone();
             let opctx = opctx.child(BTreeMap::from([
@@ -96,7 +97,7 @@ impl TrustQuorumManager {
                 ("epoch".into(), epoch.to_string()),
             ]));
             let datastore = self.datastore.clone();
-            workers
+            if let Some(output) = workers
                 .spawn(async move {
                     let res = drive_reconfiguration(
                         log, opctx, datastore, rack_id, epoch,
@@ -104,12 +105,16 @@ impl TrustQuorumManager {
                     .await;
                     (rack_id, epoch, res)
                 })
-                .await;
+                .await
+            {
+                outputs.push(output);
+            }
         }
 
         let mut statuses = vec![];
         let mut errors = vec![];
-        while let Some((rack_id, epoch, res)) = workers.join_next().await {
+        outputs.extend(workers.join_all().await);
+        for (rack_id, epoch, res) in outputs {
             // Propagate panics: we don't cancel the worker tasks, so this
             // can only fail if the task itself already panicked.
             match res {

--- a/nexus/src/app/background/tasks/trust_quorum.rs
+++ b/nexus/src/app/background/tasks/trust_quorum.rs
@@ -113,7 +113,7 @@ impl TrustQuorumManager {
 
         let mut statuses = vec![];
         let mut errors = vec![];
-        outputs.extend(workers.join_all().await);
+        outputs.extend(workers.join_remaining().await);
         for (rack_id, epoch, res) in outputs {
             // Propagate panics: we don't cancel the worker tasks, so this
             // can only fail if the task itself already panicked.

--- a/parallel-task-set/src/lib.rs
+++ b/parallel-task-set/src/lib.rs
@@ -128,7 +128,7 @@ impl<T: 'static + Send> ParallelTaskSet<T> {
     /// # Panics
     ///
     /// This method panics any of the tasks return a JoinError
-    pub async fn join_all(self) -> Vec<T> {
+    pub async fn join_remaining(self) -> Vec<T> {
         self.set.join_all().await
     }
 }
@@ -189,7 +189,7 @@ mod test {
             }
         }
 
-        let watermarks = set.join_all().await;
+        let watermarks = set.join_remaining().await;
         for watermark in watermarks {
             check_watermark(watermark);
         }

--- a/parallel-task-set/src/lib.rs
+++ b/parallel-task-set/src/lib.rs
@@ -63,7 +63,7 @@ impl<T: 'static + Send> ParallelTaskSet<T> {
 
     /// Spawn the provided `next_future`, potentially waiting until a previously
     /// spawned task completes if the `ParallelTaskSet` is at its concurrency
-    /// limit.
+    /// limit, and returning the previously spawned task's output.
     ///
     /// Note that, *unlike* [`join_next()`], this method returning `None` does
     /// NOT indicate that the set is empty, just that it was not necessary to
@@ -73,6 +73,8 @@ impl<T: 'static + Send> ParallelTaskSet<T> {
     /// once all tasks have been spawned.
     ///
     /// [`join_next()`]: Self::join_next
+    #[must_use = "ParallelTaskSet::spawn returns a task output once \
+        `max_parallelism` tasks are spawned"]
     pub async fn spawn<F>(&mut self, future: F) -> Option<T>
     where
         F: Future<Output = T> + Send + 'static,
@@ -111,7 +113,11 @@ impl<T: 'static + Send> ParallelTaskSet<T> {
         self.set.join_next().await.map(|r| r.expect("Failed to join task"))
     }
 
-    /// Wait for all commands to execute and return their output.
+    /// Wait for all remaining tasks to complete and return their output.
+    ///
+    /// Note that, unlike [`JoinSet`], this **cannot** be used to collect all of
+    /// the output at once, because [`spawn`][Self::spawn] will return outputs
+    /// once `max_parallelism` tasks are added to the set.
     ///
     /// # Panics
     ///

--- a/parallel-task-set/src/lib.rs
+++ b/parallel-task-set/src/lib.rs
@@ -61,9 +61,15 @@ impl<T: 'static + Send> ParallelTaskSet<T> {
         Self { semaphore, set }
     }
 
-    /// Spawn the provided `next_future`, potentially waiting until a previously
-    /// spawned task completes if the `ParallelTaskSet` is at its concurrency
-    /// limit, and returning the previously spawned task's output.
+    /// Spawn the provided `next_future`, potentially returning the output of a
+    /// previously-spawned task.
+    ///
+    /// If this `ParallelTaskSet` is at its `max_parallelism`, this method will
+    /// first wait until a previously-spawned task is complete, so that no more
+    /// than `max_parallelism` tasks are active. If this occurs, this method
+    /// will return that task's output. Otherwise, if waiting for an existing
+    /// task is not necessary, this method returns `None`, even if some tasks
+    /// are ready.
     ///
     /// Note that, *unlike* [`join_next()`], this method returning `None` does
     /// NOT indicate that the set is empty, just that it was not necessary to

--- a/sled-diagnostics/src/lib.rs
+++ b/sled-diagnostics/src/lib.rs
@@ -55,7 +55,7 @@ pub async fn ipadm_info()
             results.push(res);
         }
     }
-    results.extend(commands.join_all().await);
+    results.extend(commands.join_remaining().await);
     results
 }
 
@@ -78,7 +78,7 @@ pub async fn dladm_info()
             results.push(res);
         }
     }
-    results.extend(commands.join_all().await);
+    results.extend(commands.join_remaining().await);
     results
 }
 
@@ -113,7 +113,7 @@ pub async fn pargs_oxide_processes(
         }
     }
 
-    results.extend(commands.join_all().await);
+    results.extend(commands.join_remaining().await);
     results
 }
 
@@ -142,7 +142,7 @@ pub async fn pstack_oxide_processes(
             results.push(res);
         }
     }
-    results.extend(commands.join_all().await);
+    results.extend(commands.join_remaining().await);
     results
 }
 
@@ -171,7 +171,7 @@ pub async fn pfiles_oxide_processes(
             results.push(res);
         }
     }
-    results.extend(commands.join_all().await);
+    results.extend(commands.join_remaining().await);
     results
 }
 


### PR DESCRIPTION
ParallelTaskSet::spawn is easy to misuse if you are used to Tokio's JoinSet. This was pointed out to me by @davepacheco in https://github.com/oxidecomputer/omicron/pull/10820#discussion_r3604417580.

It is much less easy to misuse it if we add #[must_use] to the spawn method. I also added some more documentation.

In addition to my misuse this found another misuse in the trust quorum background task, but fortunately it does not (yet) have impact because the number of tasks spawned is bounded by the number of racks in the control plane which is currently 1. (cc @andrewjstone to verify)