### PR TITLE
[update-status] Revert 10964

### DIFF
--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -1433,6 +1433,9 @@ mod test {
     }
 
     #[nexus_test(server = crate::Server)]
+    // TODO-K: Enable once https://github.com/oxidecomputer/omicron/issues/10997
+    // is worked on
+    #[ignore]
     async fn test_contact_support_services_errors_only(
         cptestctx: &ControlPlaneTestContext,
     ) {
@@ -2234,6 +2237,9 @@ mod test {
     }
 
     #[test]
+    // TODO-K: Enable once https://github.com/oxidecomputer/omicron/issues/10997
+    // is worked on
+    #[ignore]
     fn test_problems_unhealthy_services_errors_only() {
         let logctx =
             test_setup_log("test_problems_unhealthy_services_errors_only");

--- a/nexus/types/src/inventory.rs
+++ b/nexus/types/src/inventory.rs
@@ -324,7 +324,11 @@ impl Collection {
             .filter_map(|sled_agent| {
                 match &sled_agent.smf_services_enabled_not_online {
                     SvcsEnabledNotOnlineResult::SvcsEnabledNotOnline(svcs)
-                        if svcs.is_empty() =>
+                        // This should check if svcs.is_empty() which includes
+                        // parsing errors. We have a bug with this at the moment
+                        // https://github.com/oxidecomputer/omicron/issues/10997
+                        // This check should change once that issue is resolved
+                        if svcs.services.is_empty() =>
                     {
                         None
                     }


### PR DESCRIPTION
We caught a parsing bug -> #10997 which surfaced when #10964 was merged . Since we want to release soon, this PR temporarily reverts #10964 

For context: the `errors` field that we are no longer checking can only ever be filled with parsing errors, so it's not a huge deal if we're not checking this for now