### PR TITLE
[nexus] reject (some) invalid webhook receiver URLs at create/update

### DIFF
--- a/nexus/src/app/external_client.rs
+++ b/nexus/src/app/external_client.rs
@@ -118,6 +118,78 @@ impl ExternalIpPolicy {
         Self { underlay_subnets, loopback_policy }
     }
 
+    /// Returns an [`Err`]`(`[`ExternalUrlError`]`)`if the provided `url`'s host
+    /// is an underlay or loopback IP address, or [`Ok`]`(())` if it is not one.
+    ///
+    /// # Notes
+    ///
+    /// This method does *not* resolve domain names! To conclusively determine
+    /// if a URL points to an external or internal endpoint, domain names must
+    /// be resolved to addresses, which must then also be checked against the
+    /// external IP policy. This method doesn't do that: it only checks that the
+    /// URL's actual string value does not contain an internal IP. Use
+    /// [`external_dns::Resolver`] when resolving the URL's domain name to
+    /// addresses to also ensure that the URL does not resolve to an underlay or
+    /// loopback IP address. This is necessary because a URL which resolves to
+    /// an external IP when this method is called may later resolve to an
+    /// underlay IP at the time when a connection to that URL is actually
+    /// established, so this method cannot ensure that it is external based on
+    /// the static properties of the URL string.
+    ///
+    /// # Returns
+    ///
+    /// * `Err`(`[`ExternalUrlError::Localhost`]`)` if the URL's host is a
+    ///    domain name in   the `localhost.` zone.
+    /// * `Err`(`[`ExternalUrlError::NotExternalIp`]`(`[`ExternalIpError`]`))`
+    ///    if the URL's host is an IP address and the external URL policy
+    ///    rejects that address.
+    /// * `Ok(())` if the URL's host is an external IP address, or if it is a
+    ///    domain name. As described [above](#notes), this method does not
+    ///    resolve the URL's domain name to an IP address, so URLs which have
+    ///    DNS names as their host must be resolved using
+    ///    [`external_dns::Resolver`] when they are actually connected to.
+    pub fn ensure_external_url(
+        &self,
+        url: &Url,
+    ) -> Result<(), ExternalUrlError> {
+        match url.host() {
+            // Domain names are mostly allowed here: if the name *resolves* to a
+            // non-external IP, that will be rejected by `external_dns::Resolver`,
+            // later. The exception is, of course, "localhost". As per RFC 6761 §
+            // 6.3, resolvers may answer names in it with loopback addresses without
+            // consulting DNS at all, so reject it eagerly here rather than relying
+            // on the resolver --- unless the loopback policy permits it, in which
+            // case the name is passed through to the resolver like any other.
+            Some(url::Host::Domain(domain))
+                if self.loopback_policy == TreatLoopbackAsExternal::No =>
+            {
+                let name = domain.trim_end_matches('.');
+                // The special-use "localhost." zone can, according to RFC 6761 §
+                // 6.3, contain subdomains. Although this usage is pretty uncommon,
+                // it would also resolve to a loopback address and therefore must be
+                // rejected as well.
+                let last_label = name.rsplit('.').next().unwrap_or(name);
+                if last_label.eq_ignore_ascii_case("localhost") {
+                    return Err(ExternalUrlError::Localhost {
+                        host: domain.to_string(),
+                    });
+                }
+            }
+            Some(url::Host::Domain(_)) => {}
+            // If the host is an IP address, check that it is considered an external
+            // IP.
+            Some(url::Host::Ipv6(v6)) => {
+                self.ensure_external_ip(IpAddr::V6(v6))?;
+            }
+            Some(url::Host::Ipv4(v4)) => {
+                self.ensure_external_ip(IpAddr::V4(v4))?;
+            }
+            None => {}
+        }
+
+        Ok(())
+    }
+
     /// Returns `Ok(ip)` if `ip` is external to the rack, and an
     /// error describing why it is not otherwise.
     ///
@@ -335,7 +407,7 @@ impl ExternalClientBuilder {
             let inner = redirect.unwrap_or_default();
             let ip_policy = ip_policy.clone();
             redirect::Policy::custom(move |attempt| {
-                match ensure_external_url(attempt.url(), &ip_policy) {
+                match ip_policy.ensure_external_url(attempt.url()) {
                     Ok(()) => inner.redirect(attempt),
                     Err(error) => attempt.error(error),
                 }
@@ -483,7 +555,7 @@ impl ExternalHttpClient {
         url: U,
     ) -> Result<reqwest::RequestBuilder, ExternalUrlError> {
         let url = url.into_url()?;
-        ensure_external_url(&url, &self.ip_policy)?;
+        self.ip_policy.ensure_external_url(&url)?;
         Ok(self.client.request(method, url))
     }
 
@@ -559,52 +631,10 @@ impl ExternalHttpClient {
         // really my favorite thing?
         //
         // Sigh. Whatever. It's fine.
-        ensure_external_url(request.url(), &self.ip_policy)?;
+        self.ip_policy.ensure_external_url(request.url())?;
         let client = self.client.clone();
         Ok(async move { client.execute(request).await })
     }
-}
-
-fn ensure_external_url(
-    url: &Url,
-    policy: &ExternalIpPolicy,
-) -> Result<(), ExternalUrlError> {
-    match url.host() {
-        // Domain names are mostly allowed here: if the name *resolves* to a
-        // non-external IP, that will be rejected by `external_dns::Resolver`,
-        // later. The exception is, of course, "localhost". As per RFC 6761 §
-        // 6.3, resolvers may answer names in it with loopback addresses without
-        // consulting DNS at all, so reject it eagerly here rather than relying
-        // on the resolver --- unless the loopback policy permits it, in which
-        // case the name is passed through to the resolver like any other.
-        Some(url::Host::Domain(domain))
-            if policy.loopback_policy == TreatLoopbackAsExternal::No =>
-        {
-            let name = domain.trim_end_matches('.');
-            // The special-use "localhost." zone can, according to RFC 6761 §
-            // 6.3, contain subdomains. Although this usage is pretty uncommon,
-            // it would also resolve to a loopback address and therefore must be
-            // rejected as well.
-            let last_label = name.rsplit('.').next().unwrap_or(name);
-            if last_label.eq_ignore_ascii_case("localhost") {
-                return Err(ExternalUrlError::Localhost {
-                    host: domain.to_string(),
-                });
-            }
-        }
-        Some(url::Host::Domain(_)) => {}
-        // If the host is an IP address, check that it is considered an external
-        // IP.
-        Some(url::Host::Ipv6(v6)) => {
-            policy.ensure_external_ip(IpAddr::V6(v6))?;
-        }
-        Some(url::Host::Ipv4(v4)) => {
-            policy.ensure_external_ip(IpAddr::V4(v4))?;
-        }
-        None => {}
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -630,7 +660,7 @@ mod test {
             TreatLoopbackAsExternal::No,
         );
         let url = "http://[2001:db8::1]/".parse::<Url>().unwrap();
-        let result = ensure_external_url(&url, &policy);
+        let result = policy.ensure_external_url(&url);
         assert!(
             matches!(
                 &result,
@@ -1305,7 +1335,7 @@ mod test {
             .parse::<Url>()
             .unwrap_or_else(|e| panic!("test URL {url:?} must parse: {e}"));
         let result =
-            ensure_external_url(&url, &test_policy(loopback)).map(|()| url);
+            test_policy(loopback).ensure_external_url(&url).map(|()| url);
         eprintln!("  --> {result:?};\n");
         result
     }

--- a/nexus/src/app/webhook.rs
+++ b/nexus/src/app/webhook.rs
@@ -78,6 +78,7 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::Duration;
 use std::time::Instant;
+use url::Url;
 
 impl Nexus {
     pub fn webhook_secret_lookup<'a>(
@@ -97,6 +98,12 @@ impl Nexus {
         opctx: &OpContext,
         params: alert::WebhookCreate,
     ) -> CreateResult<WebhookReceiverConfig> {
+        // First, check if the endpoint URL has an IP host that will be rejected
+        // by the external IP policy. This doesn't check if a DNS name resolves
+        // to invalid IPs, since they must be checked at the time when we
+        // actually establish a connection. But, checking IP hosts now lets us
+        // fail fast for URLs that will *never* be acceptable.
+        self.check_endpoint_url(&opctx.log, &params.endpoint)?;
         self.datastore().webhook_rx_create(&opctx, params).await
     }
 
@@ -107,6 +114,17 @@ impl Nexus {
         params: alert::WebhookReceiverUpdate,
     ) -> UpdateResult<()> {
         let (authz_rx,) = rx.lookup_for(authz::Action::Modify).await?;
+
+        if let Some(ref url) = params.endpoint {
+            // Before updating the receiver in the database, check if the new
+            // endpoint URL has an IP host that will be rejected by the external
+            // IP policy. This doesn't check if a DNS name resolves to invalid
+            // IPs, since they must be checked at the time when we actually
+            // establish a connection. But, checking IP hosts now lets us fail
+            // fast for URLs that will *never* be acceptable.
+            self.check_endpoint_url(&opctx.log, url)?;
+        }
+
         let _ = self
             .datastore()
             .webhook_rx_update(opctx, &authz_rx, params)
@@ -320,6 +338,64 @@ impl Nexus {
             resends_started,
         })
     }
+
+    /// Check that a webhook receiver endpoint passed to
+    /// [`Self::webhook_receiver_create`] or [`Self::webhook_receiver_update`]
+    /// is not an underlay or loopback IP address.
+    ///
+    /// This does not resolve domain names, so it does not catch all possible
+    /// underlay IP addresses. Webhook receivers whose endpoint URLs are DNS
+    /// names that resolve to underlay network IP addresses will instead fail
+    /// when we attempt to actually send a delivery request to them. Resolving
+    /// the domain name now and checking the resolved IPs against the external
+    /// URL policy would be insufficient, since a domain that resolves to okay
+    /// addresses now may resolve to disallowed addresses later. This check is
+    /// NOT intended as the only place we reject disallowed addresses. Instead,
+    /// it is intended to fail fast so that an operator who has indadvertantly
+    /// attempted to create a webhook receiver with an endpoint URL that will
+    /// *never* work can be informed of their mistake immediately, rather than
+    /// waiting until we actually try to send a request to it.
+    ///
+    /// The webhook delivery client will always check URLs immediately before
+    /// sending a delivery request, and will check resolved IPs when
+    /// establishing connections. Thus, it's fine for *this* check to be
+    /// best-effort.
+    fn check_endpoint_url(
+        &self,
+        log: &slog::Logger,
+        endpoint: &Url,
+    ) -> Result<(), Error> {
+        match self.external_resolver.ip_policy().ensure_external_url(endpoint) {
+            Ok(()) => Ok(()),
+            Err(ExternalUrlError::IntoUrl(_)) => Err(Error::internal_error(
+                "this shouldn't happen, since the URL \
+                     has already been parsed as a URL",
+            )),
+            Err(ExternalUrlError::NotExternalIp(
+                ExternalIpError::RackNotInitialized { .. },
+            )) => Err(Error::internal_error(
+                "attempted to create a webhook receiver before RSS has \
+                     completed. this shouldn't happen, as the external API \
+                     should not be served at this point!",
+            )),
+            Err(error) => {
+                let error = InlineErrorChain::new(&error);
+                slog::warn!(
+                    &log,
+                    "{ERR_IP_POLICY} (while creating/updating a receiver)";
+                    "endpoint" => %endpoint,
+                    &error,
+                );
+                Err(Error::invalid_value(
+                    "endpoint",
+                    format!(
+                        "the URL '{endpoint}' contains an address that may not \
+                         be used for a webhook receiver endpoint. {error}"
+                    ),
+                ))
+            }
+        }
+    }
 }
 
 /// Construct an [`ExternalHttpClient`] configured for webhook delivery
@@ -366,6 +442,9 @@ pub(crate) struct ReceiverClient<'a> {
     hdr_rx_id: http::HeaderValue,
     nexus_id: OmicronZoneUuid,
 }
+
+const ERR_IP_POLICY: &str =
+    "webhook receiver endpoint URL rejected by external IP policy";
 
 impl<'a> ReceiverClient<'a> {
     pub(crate) fn new(
@@ -483,8 +562,6 @@ impl<'a> ReceiverClient<'a> {
         };
         const ERR_BEFORE_RSS: &str =
             "cannot deliver webhook requests before RSS";
-        const ERR_IP_POLICY: &str =
-            "webhook receiver endpoint URL rejected by external IP policy";
         let handle_ext_url_error = |err: ExternalUrlError| {
             // Log a different message depending on whether the webhook
             // receiver URL is an invalid URL, or if it was rejected by the

--- a/nexus/tests/integration_tests/webhooks.rs
+++ b/nexus/tests/integration_tests/webhooks.rs
@@ -20,10 +20,11 @@ use nexus_types::external_api::alert::{
     AlertDelivery, AlertDeliveryAttempts, AlertDeliveryId, AlertDeliveryState,
     AlertDeliveryTrigger, AlertProbeResult, AlertReceiver, AlertSubscription,
     AlertSubscriptionCreate, AlertSubscriptionCreated, WebhookCreate,
-    WebhookDeliveryAttemptResult, WebhookReceiver, WebhookSecret,
-    WebhookSecretCreate, WebhookSecrets,
+    WebhookDeliveryAttemptResult, WebhookReceiver, WebhookReceiverUpdate,
+    WebhookSecret, WebhookSecretCreate, WebhookSecrets,
 };
 use omicron_common::api::external::IdentityMetadataCreateParams;
+use omicron_common::api::external::IdentityMetadataUpdateParams;
 use omicron_common::api::external::NameOrId;
 use omicron_uuid_kinds::AlertReceiverUuid;
 use omicron_uuid_kinds::AlertUuid;
@@ -453,6 +454,108 @@ async fn test_webhook_receiver_names_are_unique(
         dbg!(&error).message,
         "already exists: alert-receiver \"my-great-webhook\""
     );
+}
+
+#[nexus_test]
+async fn test_webhook_receiver_create_rejects_invalid_urls(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+
+    let rack_subnet: ipnetwork::Ipv6Network =
+        nexus_test_utils::RACK_SUBNET.parse().unwrap();
+    let underlay_ip =
+        rack_subnet.nth(3).expect("3rd underlay addr should exist");
+    let underlay_url = format!("http://[{underlay_ip}]/im-underlay-lol");
+    let invalid_urls = [
+        &underlay_url,
+        // TODO(eliza): it would also be nice to test that URLs that don't
+        // *parse* are rejected, but because the API type uses a `Url` rather
+        // than a string, we can't use the actual API params type to construct
+        // an invalid request here. We'd have to make our own JSON to do that.
+    ];
+
+    for url in invalid_urls {
+        let error = resource_helpers::object_create_error(
+            &client,
+            WEBHOOK_RECEIVERS_BASE_PATH,
+            &WebhookCreate {
+                identity: my_great_webhook_identity(),
+                endpoint: dbg!(url).parse().expect("this should be a URL"),
+                secrets: vec![MY_COOL_SECRET.to_string()],
+                subscriptions: vec!["test.foo.bar".parse().unwrap()],
+            },
+            http::StatusCode::BAD_REQUEST,
+        )
+        .await;
+
+        assert!(
+            dbg!(&error)
+                .message
+                .starts_with("unsupported value for \"endpoint\"")
+        );
+    }
+}
+
+#[nexus_test]
+async fn test_webhook_receiver_update_rejects_invalid_urls(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+    let created_webhook = webhook_create(
+        &cptestctx,
+        &WebhookCreate {
+            identity: my_great_webhook_identity(),
+            endpoint: "https://example.com/this-url-is-okay"
+                .parse()
+                .expect("this should be a valid URL"),
+            secrets: vec![MY_COOL_SECRET.to_string()],
+            subscriptions: vec!["test.foo".parse().unwrap()],
+        },
+    )
+    .await;
+    dbg!(&created_webhook);
+
+    let rack_subnet: ipnetwork::Ipv6Network =
+        nexus_test_utils::RACK_SUBNET.parse().unwrap();
+    let underlay_ip =
+        rack_subnet.nth(3).expect("3rd underlay addr should exist");
+    let underlay_url = format!("http://[{underlay_ip}]/im-underlay-lol");
+    let invalid_urls = [
+        &underlay_url,
+        // TODO(eliza): it would also be nice to test that URLs that don't
+        // *parse* are rejected, but because the API type uses a `Url` rather
+        // than a string, we can't use the actual API params type to construct
+        // an invalid request here. We'd have to make our own JSON to do that.
+    ];
+
+    let rx_update_url = format!(
+        "{WEBHOOK_RECEIVERS_BASE_PATH}/{}",
+        created_webhook.identity.id
+    );
+    for url in invalid_urls {
+        let error = resource_helpers::object_put_error(
+            &client,
+            &rx_update_url,
+            &WebhookReceiverUpdate {
+                identity: IdentityMetadataUpdateParams {
+                    name: None,
+                    description: None,
+                },
+                endpoint: Some(
+                    dbg!(url).parse().expect("this should be a URL"),
+                ),
+            },
+            http::StatusCode::BAD_REQUEST,
+        )
+        .await;
+
+        assert!(
+            dbg!(&error)
+                .message
+                .starts_with("unsupported value for \"endpoint\"")
+        );
+    }
 }
 
 #[nexus_test]


### PR DESCRIPTION
This builds on top of #10919 and #10835 by adding code to the `webhook_receiver_create` and `webhook_receiver_update` API endpoints to validate the provided receiver endpoint URL against the external IP policy added in #10835. This check does not resolve DNS names, and only rejects URLs that contain IP addresses that are on the underlay network. This is an explicit design decision: since the address(es) a DNS name resolves to may change, URLs whose hosts are DNS names must always be validated at the time where they are resolved to addresses that we actually intend to connect to, rather than when the endpoint is configured. This is fine, since the intent here is just to fail fast in the case that an operator accidentally configures a webhook receiver with a URL that will *never* succeed. We still check all URLs when actually making requests (added in #10835). The additional check at create- and update-time just helps to guard against operators accidentally creating webhook receivers with invalid URLs and not discovering that they are broken until we actually attempt to send a webhook to that endpoint.

> [!NOTE]
> This resurrects my previous PR #10929, which was taken from us before its time by a tragic GitHub Stacked PRs accident. It didn't ever make it onto `main`, and the web UI now shows the branch as having "0 commits", which is...weird.
>
> @inickles already approved that PR, so I'd kinda like to just go ahead and merge this one unless anyone is bothered about that.