### PR TITLE
Oximeter: Add opte metrics.

### DIFF
--- a/illumos-utils/src/opte/mod.rs
+++ b/illumos-utils/src/opte/mod.rs
@@ -33,6 +33,7 @@ use oxnet::IpNet;
 use oxnet::Ipv4Net;
 use oxnet::Ipv6Net;
 pub use port::Port;
+pub use port::PortInfo;
 pub use port_manager::MulticastGroupCfg;
 pub use port_manager::PortCreateParams;
 pub use port_manager::PortManager;

--- a/illumos-utils/src/opte/port.rs
+++ b/illumos-utils/src/opte/port.rs
@@ -14,10 +14,12 @@ use omicron_common::api::internal::shared::RouterId;
 use omicron_common::api::internal::shared::RouterKind;
 use oxnet::Ipv4Net;
 use oxnet::Ipv6Net;
+use sled_agent_types::inventory::NetworkInterfaceKind;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
+use uuid::Uuid;
 
 #[derive(Debug)]
 pub struct PortData {
@@ -158,4 +160,11 @@ impl Port {
             ..self.system_router_key()
         })
     }
+}
+
+/// An OPTE port, along with its control plane metadata.
+pub struct PortInfo {
+    pub port: Port,
+    pub nic_id: Uuid,
+    pub nic_kind: NetworkInterfaceKind,
 }

--- a/illumos-utils/src/opte/port_manager.rs
+++ b/illumos-utils/src/opte/port_manager.rs
@@ -1156,6 +1156,14 @@ impl PortTicket {
         Self { id, kind, manager }
     }
 
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    pub fn kind(&self) -> NetworkInterfaceKind {
+        self.kind
+    }
+
     fn release_inner(&mut self) -> Result<(), Error> {
         let mut ports = self.manager.ports.lock().unwrap();
         let Some(port) = ports.remove(&(self.id, self.kind)) else {

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -12,7 +12,7 @@ use crate::addrobj::{
 use crate::contract;
 use crate::dladm::Etherstub;
 use crate::link::{Link, VnicAllocator};
-use crate::opte::{Port, PortTicket};
+use crate::opte::{Port, PortInfo, PortTicket};
 use crate::zone::Zones;
 use crate::zone::{AddressRequest, ROUTE};
 use crate::zpool::{PathInPool, ZpoolOrRamdisk};
@@ -496,6 +496,10 @@ impl RunningZone {
         self.inner.opte_ports()
     }
 
+    pub fn opte_port_info(&self) -> impl Iterator<Item = PortInfo> {
+        self.inner.opte_port_info()
+    }
+
     /// Remove the OPTE ports on this zone from the port manager.
     pub fn release_opte_ports(&mut self) {
         for (_, ticket) in self.inner.opte_ports.drain(..) {
@@ -750,6 +754,15 @@ impl InstalledZone {
     /// Returns references to the OPTE ports for this zone.
     pub fn opte_ports(&self) -> impl Iterator<Item = &Port> {
         self.opte_ports.iter().map(|(port, _)| port)
+    }
+
+    /// Returns references to the OPTE ports and metadata for this zone.
+    pub fn opte_port_info(&self) -> impl Iterator<Item = PortInfo> {
+        self.opte_ports.iter().map(|(port, ticket)| PortInfo {
+            port: port.clone(),
+            nic_id: ticket.id(),
+            nic_kind: ticket.kind(),
+        })
     }
 
     /// Returns the filesystem path to the zone's root in the GZ.

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -31,7 +31,7 @@ uuid = { workspace = true, optional = true }
 omicron-workspace-hack.workspace = true
 
 [features]
-default = ["http-instruments", "cpu", "datalink", "zfs", "zone"]
+default = ["http-instruments", "cpu", "datalink", "opte_port", "zfs", "zone"]
 http-instruments = [
     "dep:chrono",
     "dep:dropshot",
@@ -59,6 +59,7 @@ kstat = [
 ]
 cpu = ["kstat"]
 datalink = ["kstat"]
+opte_port = ["kstat"]
 zfs = [
     "dep:anyhow",
     "dep:illumos-utils",

--- a/oximeter/instruments/src/kstat/link.rs
+++ b/oximeter/instruments/src/kstat/link.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Report metrics about Ethernet data links on the host system
+//! Report metrics about Ethernet data links on the host system.
 
 use crate::kstat::ConvertNamedData;
 use crate::kstat::Error;

--- a/oximeter/instruments/src/kstat/mod.rs
+++ b/oximeter/instruments/src/kstat/mod.rs
@@ -89,6 +89,8 @@ use std::time::Duration;
 pub mod cpu;
 #[cfg(any(feature = "datalink", test))]
 pub mod link;
+#[cfg(any(feature = "opte_port", test))]
+pub mod opte_port;
 mod sampler;
 #[cfg(any(feature = "zone", test))]
 pub mod zone;

--- a/oximeter/instruments/src/kstat/opte_port.rs
+++ b/oximeter/instruments/src/kstat/opte_port.rs
@@ -1,0 +1,373 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Report metrics about OPTE ports on the host system.
+
+use crate::kstat::{
+    ConvertNamedData, Error, KstatList, KstatTarget, hrtime_to_utc,
+};
+use chrono::{DateTime, Utc};
+use kstat_rs::{Data, Kstat, Named};
+use oximeter::{FieldType, FieldValue, Sample, Target, types::Cumulative};
+
+oximeter::use_timeseries!("opte-port.toml");
+pub use self::opte_port::OptePort as OptePortTarget;
+
+#[derive(Clone, Debug)]
+pub struct OptePort {
+    /// The target for this port.
+    pub target: OptePortTarget,
+    /// Flag indicating whether the sled associated with this link is synced with
+    /// NTP.
+    pub time_synced: bool,
+}
+
+impl OptePort {
+    pub fn new(target: OptePortTarget, time_synced: bool) -> Self {
+        Self { target, time_synced }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.target.port_name
+    }
+}
+
+// OPTE includes multiple kstat providers:
+//
+// * An `XdeStats` provider, which uses a fixed ks_name of "xde".
+// * A `PortStats` provider, which uses the port name (e.g. opte0) as its
+//   ks_name.
+// * A `RouteCacheStats` provider, which uses <PORT_NAME>_route_cache as its
+//   ks_name.
+// * A `LayerStats` provider, which uses <PORT_NAME>_<LAYER_NAME> as its
+//   ks_name.
+//
+// We capture metrics from the `PortStats` and `RouteCacheStats` providers as of
+// this writing, and may add others in the future.
+
+fn is_port_kstat(port_name: &str, ks_name: &str) -> bool {
+    ks_name == port_name
+}
+
+fn is_route_cache_kstat(port_name: &str, ks_name: &str) -> bool {
+    let Some(suffix) = ks_name.strip_prefix(port_name) else {
+        return false;
+    };
+    suffix == "_route_cache"
+}
+
+impl KstatTarget for OptePort {
+    fn interested(&self, kstat: &Kstat<'_>) -> bool {
+        self.time_synced
+            && kstat.ks_module == "xde"
+            && kstat.ks_instance == 0
+            && (is_port_kstat(self.name(), kstat.ks_name)
+                || is_route_cache_kstat(self.name(), kstat.ks_name))
+    }
+
+    fn to_samples(
+        &self,
+        kstats: KstatList<'_, '_>,
+    ) -> Result<Vec<Sample>, Error> {
+        let mut samples: Vec<Sample> = vec![];
+        for (creation_time, kstat, data) in kstats.iter() {
+            let snapshot_time = hrtime_to_utc(kstat.ks_snaptime)?;
+            let Data::Named(named) = data else {
+                return Err(Error::ExpectedNamedKstat);
+            };
+            let extract = if is_port_kstat(self.name(), kstat.ks_name) {
+                extract_port_kstat
+            } else if is_route_cache_kstat(self.name(), kstat.ks_name) {
+                extract_route_cache_kstat
+            } else {
+                continue;
+            };
+            let result = named
+                .iter()
+                .filter_map(|nd| {
+                    extract(self, nd, *creation_time, snapshot_time)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            samples.extend(result);
+        }
+        Ok(samples)
+    }
+}
+
+// NOTE: Delegate to the inner target type for this implementation.
+impl Target for OptePort {
+    fn name(&self) -> &'static str {
+        self.target.name()
+    }
+
+    fn field_names(&self) -> &'static [&'static str] {
+        self.target.field_names()
+    }
+
+    fn field_types(&self) -> Vec<FieldType> {
+        self.target.field_types()
+    }
+
+    fn field_values(&self) -> Vec<FieldValue> {
+        self.target.field_values()
+    }
+}
+
+// Note: As of this writing, OPTE exposes 141 distinct kstat values per port. We
+// expose a limited subset as oximeter metrics to limit cardinality. Because the
+// cardinality of OPTE port metrics is proportional to the number of NICs
+// attached to a running instance, and because we allow one instance per CPU
+// thread and eight NICs per instance, the worst-case cardinality of these
+// metrics would be very high if we included all OPTE metrics.
+
+/// Extract a subset of values from a port kstat.
+///
+/// Note: OPTE exposes `in_uft_capacity` and `out_uft_capacity` kstat values,
+/// but because they're constant values of 524288, we don't expose them as
+/// oximeter metrics.
+fn extract_port_kstat(
+    target: &OptePort,
+    named_data: &Named,
+    creation_time: DateTime<Utc>,
+    snapshot_time: DateTime<Utc>,
+) -> Option<Result<Sample, Error>> {
+    let Named { name, value } = named_data;
+    if *name == "in_uft_hit" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::InUftHits {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "in_uft_miss" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::InUftMisses {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "in_uft_flows" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::InUftFlows { datum: x };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "in_uft_evictions" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::InUftEvictions {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "out_uft_hit" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::OutUftHits {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "out_uft_miss" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::OutUftMisses {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "out_uft_flows" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::OutUftFlows { datum: x };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "out_uft_evictions" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::OutUftEvictions {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else {
+        None
+    }
+}
+
+/// Extract a subset of values from a route cache kstat.
+///
+/// Note: OPTE exposes a `capacity` kstat value for the route cache, but
+/// because it's a constant (8192), we don't expose it as an oximeter metric.
+fn extract_route_cache_kstat(
+    target: &OptePort,
+    named_data: &Named,
+    creation_time: DateTime<Utc>,
+    snapshot_time: DateTime<Utc>,
+) -> Option<Result<Sample, Error>> {
+    let Named { name, value } = named_data;
+    if *name == "hit" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::RouteCacheHits {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "miss" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::RouteCacheMisses {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "occupancy" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::RouteCacheOccupancy { datum: x };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "table_full" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = opte_port::RouteCacheTableFull {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kstat_rs::NamedData;
+    use oximeter::Datum;
+    use uuid::Uuid;
+    use uuid::uuid;
+
+    const NIC_ID: Uuid = uuid!("de784702-cafb-41a9-b3e5-93af189def29");
+    const PARENT_ID: Uuid = uuid!("de784702-cafb-41a9-b3e5-93af189def29");
+
+    const RACK_ID: Uuid = uuid!("de784702-cafb-41a9-b3e5-93af189def29");
+    const SLED_ID: Uuid = uuid!("88240343-5262-45f4-86f1-3c82fe383f2a");
+    const SLED_MODEL: &str = "fake-gimlet";
+    const SLED_REVISION: u32 = 1;
+    const SLED_SERIAL: &str = "fake-serial";
+    const ZONE_NAME: &str = "global";
+
+    fn opte_port(name: &'static str) -> OptePort {
+        OptePort::new(
+            OptePortTarget {
+                port_name: name.into(),
+                interface_kind: "instance".into(),
+                interface_id: NIC_ID,
+                parent_id: PARENT_ID,
+                zone_name: ZONE_NAME.into(),
+
+                rack_id: RACK_ID,
+                sled_id: SLED_ID,
+                sled_serial: SLED_SERIAL.into(),
+                sled_model: SLED_MODEL.into(),
+                sled_revision: SLED_REVISION,
+            },
+            true,
+        )
+    }
+
+    #[test]
+    fn test_interested_positive() {
+        let port = opte_port("opte1");
+        assert!(port.interested(&Kstat::with_null_kstat("xde", 0, "opte1")));
+        assert!(port.interested(&Kstat::with_null_kstat(
+            "xde",
+            0,
+            "opte1_route_cache"
+        )));
+    }
+
+    #[test]
+    fn test_interested_negative() {
+        let mut port = opte_port("opte1");
+        assert!(!port.interested(&Kstat::with_null_kstat("xde", 0, "opte0")));
+        assert!(!port.interested(&Kstat::with_null_kstat("link", 0, "opte1")));
+        assert!(!port.interested(&Kstat::with_null_kstat("xde", 0, "opte10")));
+        assert!(!port.interested(&Kstat::with_null_kstat(
+            "xde",
+            0,
+            "opte0_route_cache"
+        )));
+
+        port.time_synced = false;
+        assert!(!port.interested(&Kstat::with_null_kstat("xde", 0, "opte1")));
+    }
+
+    fn datum_value(sample: &Sample) -> u64 {
+        match sample.measurement.datum() {
+            Datum::CumulativeU64(value) => value.value(),
+            Datum::U64(value) => *value,
+            other => panic!("expected a CumulativeU64, found {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_to_samples() {
+        let port = opte_port("opte1");
+
+        let port_data = Data::Named(vec![
+            Named { name: "in_uft_hit", value: NamedData::UInt64(1) },
+            Named { name: "in_uft_miss", value: NamedData::UInt64(2) },
+            Named { name: "in_uft_flows", value: NamedData::UInt64(3) },
+            Named { name: "in_uft_evictions", value: NamedData::UInt64(4) },
+            Named { name: "out_uft_hit", value: NamedData::UInt64(5) },
+            Named { name: "out_uft_miss", value: NamedData::UInt64(6) },
+            Named { name: "out_uft_flows", value: NamedData::UInt64(7) },
+            Named { name: "out_uft_evictions", value: NamedData::UInt64(8) },
+            Named { name: "unused", value: NamedData::UInt64(9) },
+        ]);
+        let cache_data = Data::Named(vec![
+            Named { name: "hit", value: NamedData::UInt64(10) },
+            Named { name: "miss", value: NamedData::UInt64(11) },
+            Named { name: "occupancy", value: NamedData::UInt64(12) },
+            Named { name: "table_full", value: NamedData::UInt64(13) },
+            Named { name: "unused", value: NamedData::UInt64(14) },
+        ]);
+        let port_kstat = Kstat::with_null_kstat("xde", 0, "opte1");
+        let cache_kstat = Kstat::with_null_kstat("xde", 0, "opte1_route_cache");
+
+        let samples = port
+            .to_samples(&[
+                (Utc::now(), port_kstat, port_data),
+                (Utc::now(), cache_kstat, cache_data),
+            ])
+            .unwrap();
+        let values = samples
+            .iter()
+            .map(|s| (s.timeseries_name.to_string(), datum_value(s)))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            values,
+            [
+                ("opte_port:in_uft_hits".to_string(), 1),
+                ("opte_port:in_uft_misses".to_string(), 2),
+                ("opte_port:in_uft_flows".to_string(), 3),
+                ("opte_port:in_uft_evictions".to_string(), 4),
+                ("opte_port:out_uft_hits".to_string(), 5),
+                ("opte_port:out_uft_misses".to_string(), 6),
+                ("opte_port:out_uft_flows".to_string(), 7),
+                ("opte_port:out_uft_evictions".to_string(), 8),
+                ("opte_port:route_cache_hits".to_string(), 10),
+                ("opte_port:route_cache_misses".to_string(), 11),
+                ("opte_port:route_cache_occupancy".to_string(), 12),
+                ("opte_port:route_cache_table_full".to_string(), 13),
+            ]
+        )
+    }
+}

--- a/oximeter/oximeter/schema/opte-port.toml
+++ b/oximeter/oximeter/schema/opte-port.toml
@@ -1,0 +1,159 @@
+format_version = 1
+
+[target]
+name = "opte_port"
+description = "An OPTE port implementing a VPC network interface for an instance, service, or probe"
+authz_scope = "fleet"
+versions = [
+  { version = 1, fields = [ "port_name", "interface_id", "interface_kind", "parent_id", "zone_name", "rack_id", "sled_id", "sled_model", "sled_revision", "sled_serial" ] },
+]
+
+[fields.port_name]
+type = "string"
+description = "Name of the OPTE port"
+
+[fields.interface_kind]
+type = "string"
+description = "The kind of the OPTE port's network interface"
+
+[fields.interface_id]
+type = "uuid"
+description = "The ID of the OPTE port's network interface"
+
+[fields.parent_id]
+type = "uuid"
+description = "The ID of the OPTE port's parent (instance, service, or probe)"
+
+[fields.zone_name]
+type = "string"
+description = "Name of the zone owning the port"
+
+[fields.rack_id]
+type = "uuid"
+description = "ID for the port's rack"
+
+[fields.sled_id]
+type = "uuid"
+description = "ID for the port's sled"
+
+[fields.sled_model]
+type = "string"
+description = "Model number of the port's sled"
+
+[fields.sled_revision]
+type = "u32"
+description = "Revision number of the sled"
+
+[fields.sled_serial]
+type = "string"
+description = "Serial number of the sled"
+
+# Metrics derived from xde:0:opte*:*
+[[metrics]]
+name = "in_uft_hits"
+description = "Inbound Unified Flow Table (UFT) cache hits"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "in_uft_misses"
+description = "Inbound Unified Flow Table (UFT) cache misses"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "in_uft_flows"
+description = "Number of cached inbound Unified Flow Table (UFT) flows"
+units = "count"
+datum_type = "u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "in_uft_evictions"
+description = "Inbound Unified Flow Table (UFT) cache evictions"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "out_uft_hits"
+description = "Outbound Unified Flow Table (UFT) cache hits"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "out_uft_misses"
+description = "Outbound Unified Flow Table (UFT) cache misses"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "out_uft_flows"
+description = "Number of cached outbound Unified Flow Table (UFT) flows"
+units = "count"
+datum_type = "u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "out_uft_evictions"
+description = "Outbound Unified Flow Table (UFT) cache evictions"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+# Metrics derived from xde:0:opte*_route_cache:*
+[[metrics]]
+name = "route_cache_hits"
+description = "Outbound packets that reused a cached nexthop"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "route_cache_misses"
+description = "Outbound packets that required a nexthop lookup from the OS"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "route_cache_occupancy"
+description = "Current number of cached nexthops"
+units = "count"
+datum_type = "u64"
+versions = [
+    { added_in = 1, fields = [] }
+]
+
+[[metrics]]
+name = "route_cache_table_full"
+description = "Nexthop lookups not cached because the cache was at capacity"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [] }
+]

--- a/sled-agent/src/metrics.rs
+++ b/sled-agent/src/metrics.rs
@@ -4,6 +4,8 @@
 
 //! Metrics produced by the sled-agent for collection by oximeter.
 
+use illumos_utils::opte::Port;
+use illumos_utils::opte::PortInfo;
 use illumos_utils::running_zone::RunningZone;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
 use omicron_common::api::internal::nexus::ProducerKind;
@@ -20,11 +22,14 @@ use oximeter_instruments::kstat::cpu::SledCpu;
 use oximeter_instruments::kstat::cpu::SledCpuTarget;
 use oximeter_instruments::kstat::link::SledDataLink;
 use oximeter_instruments::kstat::link::SledDataLinkTarget;
+use oximeter_instruments::kstat::opte_port::OptePort;
+use oximeter_instruments::kstat::opte_port::OptePortTarget;
 use oximeter_instruments::kstat::zone::Zone;
 use oximeter_instruments::kstat::zone::ZoneTarget;
 use oximeter_instruments::zfs::usage::ZfsUsageProducer;
 use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
+use sled_agent_types::inventory::NetworkInterfaceKind;
 use slog::Logger;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -36,6 +41,7 @@ use tokio::sync::mpsc::error::TrySendError;
 use uuid::Uuid;
 
 type TrackedLinks = HashMap<String, Target>;
+type TrackedOptePorts = HashMap<String, TargetOptePort>;
 
 /// The interval on which we ask `oximeter` to poll us for metric data.
 const METRIC_COLLECTION_INTERVAL: Duration = Duration::from_secs(30);
@@ -124,7 +130,13 @@ pub enum Message {
     /// Stop tracking the named VNIC.
     UntrackVnic { name: String },
     /// Track the named OPTE port.
-    TrackOptePort { zone_name: String, name: String },
+    TrackOptePort {
+        port_name: String,
+        interface_kind: String,
+        interface_id: Uuid,
+        parent_id: Uuid,
+        zone_name: String,
+    },
     /// Stop tracking the named OPTE port.
     UntrackOptePort { name: String },
     /// Notify the task that a sled has been synced with NTP.
@@ -150,6 +162,11 @@ struct Target {
     sled_datalink: SledDataLink,
 }
 
+struct TargetOptePort {
+    id: TargetId,
+    opte_port: OptePort,
+}
+
 fn get_collection_details(kind: &str) -> CollectionDetails {
     if is_transient_link(kind) {
         CollectionDetails::duration(
@@ -171,6 +188,7 @@ async fn metrics_task(
     mut rx: mpsc::Receiver<Message>,
 ) {
     let mut tracked_links: TrackedLinks = HashMap::new();
+    let mut tracked_opte_ports: TrackedOptePorts = HashMap::new();
     let mut tracked_zone: Option<Zone> = None;
     let mut tracked_sled_cpu: Option<SledCpu> = None;
     let mut sled_time_synced: bool = false;
@@ -237,24 +255,62 @@ async fn metrics_task(
                 remove_datalink(&log, &mut tracked_links, &kstat_sampler, name)
                     .await
             }
-            Message::TrackOptePort { zone_name, name } => {
+            Message::TrackOptePort {
+                zone_name,
+                port_name,
+                interface_id,
+                interface_kind,
+                parent_id,
+            } => {
                 let target = SledDataLinkTarget {
                     kind: LinkKind::OPTE.into(),
-                    link_name: name.into(),
+                    link_name: port_name.clone().into(),
                     rack_id: sled_identifiers.rack_id,
                     sled_id: sled_identifiers.sled_id,
                     sled_model: sled_identifiers.model.clone().into(),
                     sled_revision: sled_identifiers.revision,
                     sled_serial: sled_identifiers.serial.clone().into(),
-                    zone_name: zone_name.into(),
+                    zone_name: zone_name.clone().into(),
                 };
                 let link = SledDataLink::new(target, sled_time_synced);
                 add_datalink(&log, &mut tracked_links, &kstat_sampler, link)
                     .await;
+                let port_target = OptePortTarget {
+                    port_name: port_name.into(),
+                    interface_id,
+                    interface_kind: interface_kind.into(),
+                    parent_id,
+                    zone_name: zone_name.into(),
+                    rack_id: sled_identifiers.rack_id,
+                    sled_id: sled_identifiers.sled_id,
+                    sled_model: sled_identifiers.model.clone().into(),
+                    sled_revision: sled_identifiers.revision,
+                    sled_serial: sled_identifiers.serial.clone().into(),
+                };
+                let port = OptePort::new(port_target, sled_time_synced);
+                add_opte_port(
+                    &log,
+                    &mut tracked_opte_ports,
+                    &kstat_sampler,
+                    port,
+                )
+                .await;
             }
             Message::UntrackOptePort { name } => {
-                remove_datalink(&log, &mut tracked_links, &kstat_sampler, name)
-                    .await
+                remove_datalink(
+                    &log,
+                    &mut tracked_links,
+                    &kstat_sampler,
+                    name.clone(),
+                )
+                .await;
+                remove_opte_port(
+                    &log,
+                    &mut tracked_opte_ports,
+                    &kstat_sampler,
+                    name,
+                )
+                .await;
             }
             Message::TimeSynced { sled_id } => {
                 assert!(
@@ -266,6 +322,12 @@ async fn metrics_task(
                     sync_sled_datalinks(
                         &log,
                         &mut tracked_links,
+                        &kstat_sampler,
+                    )
+                    .await;
+                    sync_sled_opte_ports(
+                        &log,
+                        &mut tracked_opte_ports,
                         &kstat_sampler,
                     )
                     .await;
@@ -404,6 +466,125 @@ async fn sync_sled_datalinks(
 /// its expiration behavior.
 fn is_transient_link(kind: &str) -> bool {
     kind == LinkKind::VNIC || kind == LinkKind::OPTE
+}
+
+/// Start tracking a new OPTE port of the specified kind.
+async fn add_opte_port(
+    log: &Logger,
+    tracked_ports: &mut HashMap<String, TargetOptePort>,
+    kstat_sampler: &KstatSampler,
+    port: OptePort,
+) {
+    match tracked_ports.entry(port.name().to_string()) {
+        Entry::Vacant(entry) => {
+            let details = CollectionDetails::duration(
+                LINK_SAMPLE_INTERVAL,
+                TRANSIENT_LINK_EXPIRATION_INTERVAL,
+                N_MAX_LINK_SAMPLES,
+            );
+            let port_to_add = port.clone();
+            match kstat_sampler.add_target(port_to_add, details).await {
+                Ok(id) => {
+                    debug!(
+                        log,
+                        "added new port to kstat sampler";
+                        "port_name" => entry.key(),
+                    );
+                    entry.insert(TargetOptePort { id, opte_port: port });
+                }
+                Err(err) => {
+                    error!(
+                        log,
+                        "failed to add port to kstat sampler, \
+                         no metrics will be collected for it";
+                        "port_name" => entry.key(),
+                        "error" => ?err,
+                    );
+                }
+            }
+        }
+        Entry::Occupied(entry) => {
+            debug!(
+                log,
+                "received message to track port, \
+                but it is already being tracked";
+                "port_name" => entry.key(),
+            );
+        }
+    }
+}
+
+/// Stop tracking a port by name.
+async fn remove_opte_port(
+    log: &Logger,
+    tracked_ports: &mut HashMap<String, TargetOptePort>,
+    kstat_sampler: &KstatSampler,
+    name: String,
+) {
+    match tracked_ports.remove(&name) {
+        Some(target) => match kstat_sampler.remove_target(target.id).await {
+            Ok(_) => {
+                debug!(
+                    log,
+                    "removed port from tracked ports";
+                    "port_name" => name,
+                );
+            }
+            Err(err) => {
+                error!(
+                    log,
+                    "failed to remove port from kstat sampler, \
+                     metrics may still be produced for it";
+                    "port_name" => name,
+                    "error" => ?err,
+                );
+            }
+        },
+        None => {
+            debug!(
+                log,
+                "received message to delete port, but \
+                it is not in the list of tracked ports";
+                "port_name" => name,
+            );
+        }
+    }
+}
+
+/// Update tracked ports when a sled is synced.
+async fn sync_sled_opte_ports(
+    log: &Logger,
+    tracked_ports: &mut TrackedOptePorts,
+    kstat_sampler: &KstatSampler,
+) {
+    for (port_name, target) in tracked_ports.iter_mut() {
+        target.opte_port.time_synced = true;
+        let details = CollectionDetails::duration(
+            LINK_SAMPLE_INTERVAL,
+            TRANSIENT_LINK_EXPIRATION_INTERVAL,
+            N_MAX_LINK_SAMPLES,
+        );
+        match kstat_sampler
+            .update_target(target.opte_port.clone(), details)
+            .await
+        {
+            Ok(_) => {
+                debug!(
+                    log,
+                    "updated port already tracked by kstat sampler";
+                    "port_name" => port_name,
+                );
+            }
+            Err(err) => {
+                error!(
+                    log,
+                    "failed to update port already tracked by kstat sampler";
+                    "port_name" => port_name,
+                    "error" => ?err,
+                );
+            }
+        }
+    }
 }
 
 /// Start tracking zone metrics for the sled.
@@ -693,12 +874,20 @@ impl MetricsRequestQueue {
     pub fn track_opte_port(
         &self,
         zone_name: impl Into<String>,
-        name: impl Into<String>,
+        port_info: &PortInfo,
     ) -> Result<(), Error> {
+        let (parent_kind, parent_id) = match port_info.nic_kind {
+            NetworkInterfaceKind::Instance { id } => ("instance", id),
+            NetworkInterfaceKind::Service { id } => ("service", id),
+            NetworkInterfaceKind::Probe { id } => ("probe", id),
+        };
         self.0
             .try_send(Message::TrackOptePort {
                 zone_name: zone_name.into(),
-                name: name.into(),
+                port_name: port_info.port.name().into(),
+                interface_id: port_info.nic_id,
+                interface_kind: parent_kind.into(),
+                parent_id,
             })
             .map_err(|e| Error::SendFailed(e))
     }
@@ -707,12 +896,9 @@ impl MetricsRequestQueue {
     ///
     /// This is non-blocking, and returns an error if the task is currently
     /// unavailable.
-    pub fn untrack_opte_port(
-        &self,
-        name: impl Into<String>,
-    ) -> Result<(), Error> {
+    pub fn untrack_opte_port(&self, port: &Port) -> Result<(), Error> {
         self.0
-            .try_send(Message::UntrackOptePort { name: name.into() })
+            .try_send(Message::UntrackOptePort { name: port.name().into() })
             .map_err(|e| Error::SendFailed(e))
     }
 
@@ -745,8 +931,8 @@ impl MetricsRequestQueue {
                 errors.push(e);
             }
         }
-        for port in running_zone.opte_port_names() {
-            if let Err(e) = self.track_opte_port(zone_name, port) {
+        for port_info in running_zone.opte_port_info() {
+            if let Err(e) = self.track_opte_port(zone_name, &port_info) {
                 errors.push(e);
             }
         }
@@ -773,7 +959,7 @@ impl MetricsRequestQueue {
                 errors.push(e);
             }
         }
-        for port in running_zone.opte_port_names() {
+        for port in running_zone.opte_ports() {
             if let Err(e) = self.untrack_opte_port(port) {
                 errors.push(e);
             }


### PR DESCRIPTION
Expose a subset of opte kstats as oximeter metrics, limited to uft and route cache metrics initially. We track each opte port in sled-agent so that we can collate control plane metadata (nic id, parent id, etc.) with kstat values.

Part of #10892.

Note: this is mostly a mechanical change, extracting more metrics from opte's new kstats. We already know how to track and untrack links, so we can mostly reuse that logic. I think the interesting parts are which metrics to include (I'm proposing a subset related to uft and route cache performance and occupancy) and how often to sample them (I'm using the link sampling interval of 10s for now). It's easier to add features than remove them, so I'd like to identify the minimal useful set of opte metrics for now, then think about expanding the set later on.

Marking as draft while I deploy to a racklette for testing, and write up notes on cardinality.