### PR TITLE
Handle dual-stack NICs at rack initialization

### DIFF
--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -413,9 +413,6 @@ impl DataStore {
         log: &Logger,
     ) -> Result<bool, TransactionError<Error>> {
         // See the comment in is_external_ip_already_allocated().
-        //
-        // TODO-completeness: Ensure this works for dual-stack Omicron service
-        // zone NICs. See https://github.com/oxidecomputer/omicron/issues/9313.
         if cfg!(any(test, feature = "testing")) {
             match (
                 nic.ip_config.ipv4_addr().map(|ip| ip.is_loopback()),
@@ -677,11 +674,14 @@ mod tests {
     use omicron_common::address::IpRangeIter;
     use omicron_common::address::Ipv4Range;
     use omicron_common::address::NEXUS_OPTE_IPV4_SUBNET;
+    use omicron_common::address::NEXUS_OPTE_IPV6_SUBNET;
     use omicron_common::address::NTP_OPTE_IPV4_SUBNET;
     use omicron_common::address::NUM_SOURCE_NAT_PORTS;
     use omicron_common::api::external::Generation;
     use omicron_common::api::external::MacAddr;
     use omicron_common::api::external::Vni;
+    use omicron_common::api::internal::shared::PrivateIpv4Config;
+    use omicron_common::api::internal::shared::PrivateIpv6Config;
     use omicron_common::zpool_name::ZpoolName;
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::ExternalIpUuid;
@@ -747,13 +747,28 @@ mod tests {
                 id: ExternalIpUuid::new_v4(),
                 ip: external_ips.next().expect("exhausted external_ips"),
             };
-            let nexus_private_ip_config = PrivateIpConfig::new_ipv4(
-                NEXUS_OPTE_IPV4_SUBNET
-                    .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES)
-                    .unwrap(),
-                *NEXUS_OPTE_IPV4_SUBNET,
-            )
-            .unwrap();
+            // Give Nexus a dual-stack NIC so we have a way to exercise the
+            // paths allocating / handling those addresses. External DNS and NTP
+            // are still single-stack IPv4.
+            let nexus_private_ip_config = PrivateIpConfig::DualStack {
+                v4: PrivateIpv4Config::new(
+                    NEXUS_OPTE_IPV4_SUBNET
+                        .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES)
+                        .unwrap(),
+                    *NEXUS_OPTE_IPV4_SUBNET,
+                )
+                .unwrap(),
+                v6: PrivateIpv6Config::new(
+                    NEXUS_OPTE_IPV6_SUBNET
+                        .nth(
+                            u128::try_from(NUM_INITIAL_RESERVED_IP_ADDRESSES)
+                                .unwrap(),
+                        )
+                        .unwrap(),
+                    *NEXUS_OPTE_IPV6_SUBNET,
+                )
+                .unwrap(),
+            };
             let nexus_nic = NetworkInterface {
                 id: Uuid::new_v4(),
                 kind: NetworkInterfaceKind::Service {
@@ -1046,14 +1061,13 @@ mod tests {
             assert_eq!(db_dns_nics[0].subnet_id, DNS_VPC_SUBNET.id());
             assert_eq!(*db_dns_nics[0].mac, self.dns_nic.mac);
             assert_eq!(
-                db_nexus_nics[0].ipv4,
-                self.nexus_nic.ip_config.ipv4_addr().copied().map(Into::into),
+                db_dns_nics[0].ipv4,
+                self.dns_nic.ip_config.ipv4_addr().copied().map(Into::into),
             );
             assert_eq!(
-                db_nexus_nics[0].ipv6,
-                self.nexus_nic.ip_config.ipv6_addr().copied().map(Into::into),
+                db_dns_nics[0].ipv6,
+                self.dns_nic.ip_config.ipv6_addr().copied().map(Into::into),
             );
-            assert!(db_nexus_nics[0].ipv6.is_none());
             assert_eq!(*db_dns_nics[0].slot, self.dns_nic.slot);
             assert_eq!(db_dns_nics[0].primary, self.dns_nic.primary);
 
@@ -1074,14 +1088,13 @@ mod tests {
             assert_eq!(db_ntp_nics[0].subnet_id, NTP_VPC_SUBNET.id());
             assert_eq!(*db_ntp_nics[0].mac, self.ntp_nic.mac);
             assert_eq!(
-                db_nexus_nics[0].ipv4,
-                self.nexus_nic.ip_config.ipv4_addr().copied().map(Into::into),
+                db_ntp_nics[0].ipv4,
+                self.ntp_nic.ip_config.ipv4_addr().copied().map(Into::into),
             );
             assert_eq!(
-                db_nexus_nics[0].ipv6,
-                self.nexus_nic.ip_config.ipv6_addr().copied().map(Into::into),
+                db_ntp_nics[0].ipv6,
+                self.ntp_nic.ip_config.ipv6_addr().copied().map(Into::into),
             );
-            assert!(db_nexus_nics[0].ipv6.is_none());
             assert_eq!(*db_ntp_nics[0].slot, self.ntp_nic.slot);
             assert_eq!(db_ntp_nics[0].primary, self.ntp_nic.primary);
         }
@@ -1350,22 +1363,23 @@ mod tests {
                 as &dyn Fn(OmicronZoneUuid, &mut NetworkInterface) -> String,
             // non-matching IP
             &|zone_id, nic| {
-                // Take the last IP still in the subnet.
-                if let Some(subnet) = nic.ip_config.ipv4_subnet() {
-                    let new =
-                        PrivateIpConfig::new_ipv4(subnet.last_addr(), *subnet)
-                            .unwrap();
-                    nic.ip_config = new;
-                } else if let Some(subnet) = nic.ip_config.ipv6_subnet() {
-                    let new =
-                        PrivateIpConfig::new_ipv6(subnet.last_addr(), *subnet)
-                            .unwrap();
-                    nic.ip_config = new;
-                } else {
-                    todo!(
-                        "See https://github.com/oxidecomputer/omicron/issues/9313"
-                    );
-                }
+                // Take the last address in each family's subnet.
+                let ipv4 = nic.ip_config.ipv4_subnet().map(|subnet| {
+                    PrivateIpv4Config::new(subnet.last_addr(), *subnet).unwrap()
+                });
+                let ipv6 = nic.ip_config.ipv6_subnet().map(|subnet| {
+                    PrivateIpv6Config::new(subnet.last_addr(), *subnet).unwrap()
+                });
+                nic.ip_config = match (ipv4, ipv6) {
+                    (Some(v4), None) => PrivateIpConfig::V4(v4),
+                    (None, Some(v6)) => PrivateIpConfig::V6(v6),
+                    (Some(v4), Some(v6)) => {
+                        PrivateIpConfig::DualStack { v4, v6 }
+                    }
+                    (None, None) => {
+                        unreachable!("a NIC always has an IPv4 or IPv6 subnet")
+                    }
+                };
                 format!("zone {zone_id} already has 1 non-matching NIC")
             },
         ] {

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -540,21 +540,17 @@ impl DataStore {
         let zone_type = &zone_config.zone_type;
         let zone_report_str = zone_type.kind().report_str();
 
-        // TODO-completeness: Support dual-stack NICs for services. See
-        // https://github.com/oxidecomputer/omicron/issues/9313.
         let extract_ip_config =
-            |nic: &NetworkInterface| -> Result<PrivateIpStackCreate, Error> {
+            |nic: &NetworkInterface| -> PrivateIpStackCreate {
                 match &nic.ip_config {
                     PrivateIpConfig::V4(ipv4) => {
-                        Ok(PrivateIpStackCreate::from_ipv4(*ipv4.ip()))
+                        PrivateIpStackCreate::from_ipv4(*ipv4.ip())
                     }
                     PrivateIpConfig::V6(ipv6) => {
-                        Ok(PrivateIpStackCreate::from_ipv6(*ipv6.ip()))
+                        PrivateIpStackCreate::from_ipv6(*ipv6.ip())
                     }
-                    PrivateIpConfig::DualStack { .. } => {
-                        Err(Error::invalid_request(
-                            "Dual-stack service NICs are not yet supported",
-                        ))
+                    PrivateIpConfig::DualStack { v4, v6 } => {
+                        PrivateIpStackCreate::new_dual_stack(*v4.ip(), *v6.ip())
                     }
                 }
             };
@@ -565,8 +561,7 @@ impl DataStore {
             ) => {
                 let external_ip =
                     OmicronZoneExternalIp::Floating(dns_address.into_ip());
-                let ip_config =
-                    extract_ip_config(nic).map_err(RackInitError::AddingNic)?;
+                let ip_config = extract_ip_config(nic);
                 let db_nic = IncompleteNetworkInterface::new_service(
                     nic.id,
                     zone_config.id.into_untyped_uuid(),
@@ -591,8 +586,7 @@ impl DataStore {
                 ..
             }) => {
                 let external_ip = OmicronZoneExternalIp::Floating(*external_ip);
-                let ip_config =
-                    extract_ip_config(nic).map_err(RackInitError::AddingNic)?;
+                let ip_config = extract_ip_config(nic);
                 let db_nic = IncompleteNetworkInterface::new_service(
                     nic.id,
                     zone_config.id.into_untyped_uuid(),
@@ -615,8 +609,7 @@ impl DataStore {
                 blueprint_zone_type::BoundaryNtp { external_ip, nic, .. },
             ) => {
                 let external_ip = OmicronZoneExternalIp::Snat(*external_ip);
-                let ip_config =
-                    extract_ip_config(nic).map_err(RackInitError::AddingNic)?;
+                let ip_config = extract_ip_config(nic);
                 let db_nic = IncompleteNetworkInterface::new_service(
                     nic.id,
                     zone_config.id.into_untyped_uuid(),
@@ -1102,10 +1095,13 @@ mod test {
     use omicron_common::address::Ipv4Range;
     use omicron_common::address::Ipv6Range;
     use omicron_common::address::NEXUS_OPTE_IPV4_SUBNET;
+    use omicron_common::address::NEXUS_OPTE_IPV6_SUBNET;
     use omicron_common::api::external::http_pagination::PaginatedBy;
     use omicron_common::api::external::{
         IdentityMetadataCreateParams, MacAddr,
     };
+    use omicron_common::api::internal::shared::PrivateIpv4Config;
+    use omicron_common::api::internal::shared::PrivateIpv6Config;
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::BlueprintUuid;
     use omicron_uuid_kinds::GenericUuid;
@@ -1907,6 +1903,126 @@ mod test {
         assert_eq!(
             dns_config_external.zones[0].records.get("api.sys"),
             Some(&external_records)
+        );
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn rack_set_initialized_with_dual_stack_private_nexus_addresses() {
+        let test_name =
+            "rack_set_initialized_with_dual_stack_private_nexus_addresses";
+        let logctx = dev::test_setup_log(test_name);
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let sled = create_test_sled(&datastore, SledUuid::new_v4()).await;
+
+        // The Nexus zone's external IP is IPv4. Its private NIC is dual-stack.
+        let nexus_external_ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let service_ip_pool_range = IpRange::from(nexus_external_ip);
+        let external_ip_policy = ExternalIpPolicy::single_pool_no_external_dns(
+            service_ip_pool_range,
+        );
+
+        let mut system = SystemDescription::new();
+        system
+            .set_external_ip_policy(external_ip_policy.clone())
+            .sled(SledBuilder::new().id(sled.id()))
+            .expect("failed to add sled");
+
+        let mut builder =
+            blueprint_builder_with_empty_parent(&opctx.log, &system, test_name);
+
+        // Build the dual-stack private NIC by hand. The
+        // `ExternalNetworkingAllocator` would otherwise generate a single-stack
+        // NIC matching just the external IP.
+        let v4 = PrivateIpv4Config::new(
+            NEXUS_OPTE_IPV4_SUBNET
+                .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES)
+                .unwrap(),
+            *NEXUS_OPTE_IPV4_SUBNET,
+        )
+        .unwrap();
+        let expected_v4_address = *v4.ip();
+        let v6 = PrivateIpv6Config::new(
+            NEXUS_OPTE_IPV6_SUBNET
+                .nth(u128::try_from(NUM_INITIAL_RESERVED_IP_ADDRESSES).unwrap())
+                .unwrap(),
+            *NEXUS_OPTE_IPV6_SUBNET,
+        )
+        .unwrap();
+        let expected_v6_address = *v6.ip();
+        let nexus_nic_ip_config = PrivateIpConfig::DualStack { v4, v6 };
+        let mut macs = MacAddr::iter_system();
+        builder
+            .sled_add_zone_nexus(
+                sled.id(),
+                BlueprintZoneImageSource::InstallDataset,
+                ExternalNetworkingChoice {
+                    external_ip: nexus_external_ip,
+                    nic_ip_config: nexus_nic_ip_config,
+                    nic_mac: macs.next().unwrap(),
+                },
+                *Generation::new(),
+                &OperatorNexusConfig {
+                    external_tls: false,
+                    external_dns_servers: &[],
+                },
+            )
+            .expect("added Nexus");
+
+        let mut blueprint = builder.build(BlueprintSource::Test);
+        blueprint.parent_blueprint_id = None; // treat this as the initial bp
+
+        let rack = datastore
+            .rack_set_initialized(
+                &opctx,
+                RackInit {
+                    blueprint: blueprint.clone(),
+                    service_ip_pools: IdOrdMap::from_iter_unique([
+                        service_pool_config(
+                            "oxide-service-pool-v4",
+                            vec![service_ip_pool_range],
+                        ),
+                    ])
+                    .unwrap(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("an initialized rack");
+        assert!(rack.initialized);
+
+        // The Nexus zone's (IPv4) external IP was allocated.
+        let external_ips = get_all_external_ips(&datastore).await;
+        assert_eq!(external_ips.len(), 1);
+        assert!(external_ips[0].is_service);
+        assert_eq!(external_ips[0].ip.ip(), nexus_external_ip);
+
+        // Its service NIC was allocated with *both* private IP families, i.e.
+        // the dual-stack NIC round-tripped through rack init.
+        let zone_id =
+            blueprint.in_service_zones().next().expect("a Nexus zone").1.id;
+        let conn = datastore.pool_connection_for_tests().await.unwrap();
+        let nics = datastore
+            .service_list_network_interfaces_on_connection(
+                &conn,
+                zone_id.into_untyped_uuid(),
+            )
+            .await
+            .expect("listed service NICs");
+        assert_eq!(nics.len(), 1);
+        assert_eq!(
+            nics[0].ipv4.expect("a private IPv4 address"),
+            expected_v4_address.into(),
+            "Nexus dual-stack service NIC has incorrect private IPv4 address",
+        );
+        assert_eq!(
+            nics[0].ipv6.expect("a private IPv6 address"),
+            expected_v6_address.into(),
+            "Nexus dual-stack service NIC has incorrect private IPv6 address",
         );
 
         db.terminate().await;


### PR DESCRIPTION
- Add handling for dual-stack NICs in the `rack_set_initialized()` method, and add a specific test for it.
- Fix some old copy-paste in related tests that checked Nexus NICs instead of DNS / NTP