### PR TITLE
[fm] never make a 20MB log line ever again

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -3617,22 +3617,19 @@ fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
         }
     };
 
-    let AnalysisStatus {
-        start_time,
-        end_time,
-        report: analysis_report,
-        outcome,
-        capacity,
-    } = analysis_status;
-    match outcome {
+    let AnalysisStatus { start_time, end_time, outcome, capacity } =
+        analysis_status;
+    let sitrep_id = match outcome {
         AnalysisOutcome::Error(error) => {
             println!("{ERRICON} analysis failed: {error}");
+            None
         }
         AnalysisOutcome::Unchanged => {
             println!(
                 "    no changes from the current situation report ({:?})",
                 parent_sitrep_id
             );
+            None
         }
         AnalysisOutcome::LimitReached { limit } => {
             println!(
@@ -3640,6 +3637,7 @@ fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
                  limit ({limit} sitreps) has been reached!"
             );
             println!("    no new sitrep was written.");
+            None
         }
         AnalysisOutcome::NotCommitted { sitrep_id } => {
             println!(
@@ -3650,6 +3648,7 @@ fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
                 of date"
             );
             println!("    sitrep ID: {sitrep_id:?}");
+            Some(sitrep_id)
         }
         AnalysisOutcome::CommitFailed { sitrep_id, error } => {
             println!(
@@ -3658,11 +3657,20 @@ fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
             );
             println!("    sitrep ID: {sitrep_id:?}");
             println!("    error:     {error}");
+            Some(sitrep_id)
         }
         AnalysisOutcome::Committed { sitrep_id } => {
             println!("    analyzed the situation, and committed a new sitrep!");
             println!("    sitrep ID: {sitrep_id:?}");
+            Some(sitrep_id)
         }
+    };
+    if let Some(sitrep_id) = sitrep_id {
+        println!(
+            "    note: you can view the sitrep and its reports with:\n      \
+                   $ omdb db sitrep show {sitrep_id}\n      \
+                   $ omdb db sitrep analysis-report {sitrep_id} "
+        )
     }
     println!();
 
@@ -3680,19 +3688,13 @@ fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
         println!("      count: {:>6}", capacity.count);
     }
 
-    let PreparationStatus { warnings, report: prep_report } = prep_status;
-    println!("    preparation report:");
-    print!("{}", prep_report.display_multiline(6).colored(colored));
+    let PreparationStatus { warnings } = prep_status;
     if !warnings.is_empty() {
         println!("{ERRICON}   non-fatal errors preparing analysis inputs:");
         for error in warnings {
             println!("      > {error}")
         }
     }
-
-    println!();
-    println!("    analysis report:");
-    print!("{}", analysis_report.display_multiline(6).colored(colored));
     print_start_end_time(start_time, end_time, 4);
 }
 

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -728,14 +728,7 @@ impl NexusArgs {
             }) => cmd_nexus_background_tasks_list(&client).await,
             NexusCommands::BackgroundTasks(BackgroundTasksArgs {
                 command: BackgroundTasksCommands::Show(args),
-            }) => {
-                cmd_nexus_background_tasks_show(
-                    &client,
-                    args,
-                    omdb.output.color,
-                )
-                .await
-            }
+            }) => cmd_nexus_background_tasks_show(&client, args).await,
             NexusCommands::BackgroundTasks(BackgroundTasksArgs {
                 command: BackgroundTasksCommands::PrintReport(args),
             }) => {
@@ -1006,7 +999,6 @@ async fn cmd_nexus_background_tasks_list(
 async fn cmd_nexus_background_tasks_show(
     client: &nexus_lockstep_client::Client,
     args: &BackgroundTasksShowArgs,
-    color: ColorChoice,
 ) -> Result<(), anyhow::Error> {
     let response =
         client.bgtask_list().await.context("listing background tasks")?;
@@ -1056,7 +1048,6 @@ async fn cmd_nexus_background_tasks_show(
 
     let opts = BackgroundTasksPrintOpts {
         show_executing_info: !args.no_executing_info,
-        colored: should_colorize(color, supports_color::Stream::Stdout),
     };
 
     // Some tasks should be grouped and printed together in a certain order,
@@ -1155,8 +1146,6 @@ async fn cmd_nexus_background_tasks_activate(
 #[derive(Clone, Debug)]
 struct BackgroundTasksPrintOpts {
     show_executing_info: bool,
-    /// Whether to style output with ANSI terminal colors.
-    colored: bool,
 }
 
 fn print_task(bgtask: &BackgroundTask, opts: &BackgroundTasksPrintOpts) {
@@ -1205,7 +1194,7 @@ fn print_task(bgtask: &BackgroundTask, opts: &BackgroundTasksPrintOpts) {
     // unstable -- it gets exposed by background tasks as unstructured
     // (schemaless) data.  We make a best effort to interpret it.
     if let LastResult::Completed(completed) = &bgtask.last {
-        print_task_details(&bgtask, &completed.details, opts.colored);
+        print_task_details(&bgtask, &completed.details);
     }
 }
 
@@ -1249,11 +1238,7 @@ fn print_start_end_time(
 /// undocumented and unstable (subject to change).  That does make this code
 /// both ugly and brittle.  It's not a fatal error to fail to parse these, but
 /// we do warn the user if that happens.
-fn print_task_details(
-    bgtask: &BackgroundTask,
-    details: &serde_json::Value,
-    colored: bool,
-) {
+fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
     // All tasks might produce an "error" property.  If we find one, print that
     // out and stop.
     #[derive(Deserialize)]
@@ -1386,7 +1371,7 @@ fn print_task_details(
             print_task_webhook_deliverator(details);
         }
         "fm_analysis" => {
-            print_task_fm_analysis(details, colored);
+            print_task_fm_analysis(details);
         }
         "fm_config_loader" => {
             print_task_fm_config_loader(details);
@@ -3520,7 +3505,7 @@ mod ereporter_status_fields {
     pub const NUM_WIDTH: usize = 4;
 }
 
-fn print_task_fm_analysis(details: &serde_json::Value, colored: bool) {
+fn print_task_fm_analysis(details: &serde_json::Value) {
     use nexus_types::internal_api::background::fm_analysis::{
         AnalysisOutcome, AnalysisStatus, Outcome, PreparationStatus,
     };

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -703,20 +703,6 @@ task: "fm_analysis"
     =================================
     no changes from the current situation report (Some(..........<REDACTED_UUID>........... (sitrep)))
 
-    preparation report:
-      parent sitrep:        ..........<REDACTED_UUID>...........
-      inventory collection: ..........<REDACTED_UUID>...........
-      <FM_INPUT_INV_COMPARISON_REDACTED>
-      total known ereport restart IDs: 0
-      no new ereports since the parent sitrep
-      no cases copied forward
-
-      no in-service control plane disks
-
-    analysis report:
-      sitrep ID: ..........<REDACTED_UUID>...........
-      no analysis log
-      no cases changed in this analysis step
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 
 task: "fm_config_loader"
@@ -1428,20 +1414,6 @@ task: "fm_analysis"
     =================================
     no changes from the current situation report (Some(..........<REDACTED_UUID>........... (sitrep)))
 
-    preparation report:
-      parent sitrep:        ..........<REDACTED_UUID>...........
-      inventory collection: ..........<REDACTED_UUID>...........
-      <FM_INPUT_INV_COMPARISON_REDACTED>
-      total known ereport restart IDs: 0
-      no new ereports since the parent sitrep
-      no cases copied forward
-
-      no in-service control plane disks
-
-    analysis report:
-      sitrep ID: ..........<REDACTED_UUID>...........
-      no analysis log
-      no cases changed in this analysis step
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 
 task: "fm_config_loader"

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -7,7 +7,9 @@ use crate::app::background::BackgroundTask;
 use crate::app::background::tasks::fm_sitrep_load::CurrentSitrep;
 use anyhow::Context;
 use chrono::Utc;
+use fm::analysis_input::Input;
 use fm::analysis_input::InvalidInputs;
+use fm::analysis_reports::InputReport;
 use futures::future::BoxFuture;
 use iddqd::IdOrdMap;
 use nexus_db_model::PhysicalDiskPolicy;
@@ -217,7 +219,7 @@ impl FmAnalysis {
         );
 
         // Prepare analysis inputs.
-        let (inputs, prep_status) = match self
+        let (inputs, prep_status, input_report) = match self
             .prepare_inputs(&opctx, parent_sitrep, inv)
             .await
         {
@@ -271,7 +273,7 @@ impl FmAnalysis {
 
         // Okay, actually run analysis and generate a new sitrep.
         let outcome = self
-            .analyze(&opctx, inputs, &prep_status.report, &cfg, &mut warnings)
+            .analyze(&opctx, inputs, &input_report, &cfg, &mut warnings)
             .await;
 
         FmAnalysisStatus {
@@ -291,10 +293,8 @@ impl FmAnalysis {
         opctx: &OpContext,
         parent_sitrep: Option<CurrentSitrep>,
         inv: Arc<inventory::Collection>,
-    ) -> Result<
-        (fm::analysis_input::Input, status::PreparationStatus),
-        PreparationError,
-    > {
+    ) -> Result<(Input, status::PreparationStatus, InputReport), PreparationError>
+    {
         let mut warnings = Vec::new();
 
         let in_service_disks =
@@ -327,7 +327,7 @@ impl FmAnalysis {
         .context("failed to load existing support bundle markers")?;
 
         let (input, report) = builder.build();
-        Ok((input, status::PreparationStatus { warnings, report }))
+        Ok((input, status::PreparationStatus { warnings }, report))
     }
 
     /// Load all in-service control plane disks, projected down to FM's
@@ -545,8 +545,8 @@ impl FmAnalysis {
     async fn analyze(
         &mut self,
         opctx: &OpContext,
-        inputs: fm::analysis_input::Input,
-        input_report: &nexus_types::fm::analysis_reports::InputReport,
+        inputs: Input,
+        input_report: &InputReport,
         cfg: &FmConfig,
         warnings: &mut Vec<String>,
     ) -> status::AnalysisStatus {
@@ -567,7 +567,6 @@ impl FmAnalysis {
             return status::AnalysisStatus {
                 start_time,
                 end_time,
-                report,
                 capacity: None,
                 outcome: status::AnalysisOutcome::Error(e.to_string()),
             };
@@ -584,7 +583,6 @@ impl FmAnalysis {
                 return status::AnalysisStatus {
                     start_time,
                     end_time,
-                    report,
                     capacity: None,
                     outcome: status::AnalysisOutcome::Unchanged,
                 };
@@ -615,7 +613,6 @@ impl FmAnalysis {
                     return status::AnalysisStatus {
                         start_time,
                         end_time,
-                        report,
                         capacity: None,
                         outcome,
                     };
@@ -661,7 +658,6 @@ impl FmAnalysis {
                 status::AnalysisStatus {
                     start_time,
                     end_time,
-                    report,
                     capacity,
                     outcome: status::AnalysisOutcome::Committed { sitrep_id },
                 }
@@ -680,7 +676,6 @@ impl FmAnalysis {
                 status::AnalysisStatus {
                     start_time,
                     end_time,
-                    report,
                     capacity,
                     outcome: status::AnalysisOutcome::NotCommitted {
                         sitrep_id,
@@ -697,7 +692,6 @@ impl FmAnalysis {
                 status::AnalysisStatus {
                     start_time,
                     end_time,
-                    report,
                     capacity,
                     outcome: status::AnalysisOutcome::CommitFailed {
                         sitrep_id,
@@ -1216,7 +1210,7 @@ mod tests {
             OmicronZoneUuid::new_v4(),
         );
 
-        let (input, prep) = task
+        let (input, prep, _report) = task
             .prepare_inputs(opctx, Some(parent), inv)
             .await
             .expect("input preparation should succeed");

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -1210,7 +1210,7 @@ mod tests {
             OmicronZoneUuid::new_v4(),
         );
 
-        let (input, prep, _report) = task
+        let (input, prep, report) = task
             .prepare_inputs(opctx, Some(parent), inv)
             .await
             .expect("input preparation should succeed");
@@ -1224,7 +1224,7 @@ mod tests {
         assert!(input.open_cases().contains_key(&open_case_id));
         assert_eq!(input.open_cases().len(), 1);
         assert_eq!(
-            prep.report.open_cases.keys().collect::<Vec<_>>(),
+            report.open_cases.keys().collect::<Vec<_>>(),
             vec![&open_case_id]
         );
 
@@ -1240,8 +1240,7 @@ mod tests {
         );
         // ...while the closed case with an unsatisfied alert request is
         // copied forward, with that request reported as outstanding.
-        let carried = prep
-            .report
+        let carried = report
             .closed_cases_copied_forward
             .get(&unsatisfied_case_id)
             .expect("unsatisfied closed case must be copied forward");
@@ -1250,7 +1249,7 @@ mod tests {
             BTreeSet::from([unsatisfied_alert_id])
         );
         assert!(carried.unmarked_ereports.is_empty());
-        assert_eq!(prep.report.closed_cases_copied_forward.len(), 1);
+        assert_eq!(report.closed_cases_copied_forward.len(), 1);
 
         db.terminate().await;
         logctx.cleanup_successful();

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -1231,12 +1231,11 @@ mod tests {
         // The closed case whose only alert request has a marker is dropped
         // from the carry-forward set entirely...
         assert!(
-            !prep
-                .report
+            !report
                 .closed_cases_copied_forward
                 .contains_key(&satisfied_case_id),
             "satisfied closed case should be dropped, got: {:?}",
-            prep.report.closed_cases_copied_forward,
+            report.closed_cases_copied_forward,
         );
         // ...while the closed case with an unsatisfied alert request is
         // copied forward, with that request reported as outstanding.

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -1032,7 +1032,6 @@ pub struct FmAnalysisStatus {
 pub mod fm_analysis {
     use super::*;
     use crate::fm::FmConfigSource;
-    use crate::fm::analysis_reports;
     use std::num::{NonZeroU32, NonZeroU64};
 
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -1040,7 +1039,6 @@ pub mod fm_analysis {
         /// Errors encountered during the preparation step which did *not*
         /// prevent the analysis step from completing.
         pub warnings: Vec<String>,
-        pub report: analysis_reports::InputReport,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -1081,7 +1079,6 @@ pub mod fm_analysis {
     pub struct AnalysisStatus {
         pub start_time: DateTime<Utc>,
         pub end_time: DateTime<Utc>,
-        pub report: crate::fm::analysis_reports::AnalysisReport,
         pub outcome: AnalysisOutcome,
         pub capacity: Option<SitrepCapacity>,
     }


### PR DESCRIPTION
When the `fm_analysis` background task produces a new sitrep, the `FmAnalysisStatus` object it returns will contain a JSON copy of the sitrep and its analysis and input reports. This was intended so that we can show the whole thing in `omdb nexus background-tasks show`. However, these objects can get quite large, and the entire status object is also included in a log line when the activation completes. Since the reports are now also stored in the DB, we don't need to include them in the status.

This commit removes the sitrep, input report, and analysis report from the status object, and instead just contains their IDs. I've added some help text to note that you can use other `omdb` commands to view them. It could be nice to make this a bit fancier, such as by tracking whether the reports actually made it into the DB, but I wanted to keep this small in scope, and do that in a follow-up. Much of the size of this diff is actually just due to the fact that apparently the sitrep and reports were the only thing in `omdb nexus background-tasks status` that was actually using ANSI colors, so that all had to be removed as well.

Fixes #11019