### PR TITLE
Exclude system services IP pools from list for older clients

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1419,7 +1419,13 @@ impl NexusExternalApi for NexusExternalApiImpl {
             let paginated_by = name_or_id_pagination(&pag_params, scan_params)?;
             let opctx =
                 crate::context::op_context_for_external_api(&rqctx).await?;
-            let filter = ip_pool::SystemIpPoolFilter::default();
+            // Before the API supported assigning IP pools to silos or system
+            // services, this endpoint only listed pools available to silos.
+            // Preserve that behavior for old clients.
+            let filter = ip_pool::SystemIpPoolFilter {
+                assignment: Some(ip_pool::IpPoolAssignment::Silos),
+                ..Default::default()
+            };
             let pools = nexus
                 .ip_pools_list_operator(&opctx, &filter, &paginated_by)
                 .await?

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -57,6 +57,7 @@ use nexus_types::external_api::policy::SiloRole;
 use nexus_types::external_api::silo::Silo;
 use nexus_types::external_api::silo::SiloIdentityMode;
 use nexus_types::identity::Resource;
+use nexus_types_versions::v2025_11_20_00;
 use omicron_common::address::Ipv6Range;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::IdentityMetadataUpdateParams;
@@ -67,6 +68,7 @@ use omicron_nexus::TestInterfaces;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::InstanceUuid;
 use sled_agent_client::TestInterfaces as SledTestInterfaces;
+use std::collections::BTreeSet;
 use uuid::Uuid;
 
 type ControlPlaneTestContext =
@@ -271,6 +273,52 @@ async fn get_ip_pools(
     } else {
         items
     }
+}
+
+#[nexus_test]
+async fn test_old_ip_pool_api_excludes_system_service_pools(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+    let pool1 = create_ipv4_pool(client, "zz-old-client-pool-1").await;
+    let pool2 = create_ipv4_pool(client, "zz-old-client-pool-2").await;
+    let old_api_version =
+        nexus_external_api::VERSION_RENAME_POOL_ENDPOINTS.to_string();
+
+    // The old general IP Pool list predates API support for assigning pools to
+    // silos or system services. It should retain its original semantics and
+    // return only pools available to silos, while the separate service-pool
+    // endpoint remains available to old clients.
+    let page = NexusRequest::new(
+        RequestBuilder::new(client, Method::GET, "/v1/system/ip-pools?limit=2")
+            .header(
+                omicron_common::api::VERSION_HEADER,
+                old_api_version.as_str(),
+            )
+            .expect_status(Some(StatusCode::OK)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute_and_parse_unwrap::<ResultsPage<v2025_11_20_00::ip_pool::IpPool>>()
+    .await;
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(
+        page.items.iter().map(|pool| pool.id()).collect::<BTreeSet<_>>(),
+        BTreeSet::from([pool1.id(), pool2.id()]),
+    );
+
+    let service_pool = NexusRequest::new(
+        RequestBuilder::new(client, Method::GET, "/v1/system/ip-pools-service")
+            .header(
+                omicron_common::api::VERSION_HEADER,
+                old_api_version.as_str(),
+            )
+            .expect_status(Some(StatusCode::OK)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute_and_parse_unwrap::<v2025_11_20_00::ip_pool::IpPool>()
+    .await;
+    assert_eq!(service_pool.ip_version, IpVersion::V4);
+    assert!(![pool1.id(), pool2.id()].contains(&service_pool.id()));
 }
 
 // this test exists primarily because of a bug in the initial implementation


### PR DESCRIPTION
As of #10557, the IP pool list endpoint now includes both system and silo pools, with an `assignment` field indicating which is which. But the version of the endpoint for older clients cannot include that field. If we include system services pools in the list for old clients, there will be no indication of the assignment and it may be mysterious to the user why these pools seem to behave differently (the names might help, but it's still weird). Since the dedicated service pools endpoints are still there for the older clients, I think we should just filter out service pools from this list in the old version of the endpoint.