### PR TITLE
Allow omdb sled removal for TQ by BaseboardId

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -46,6 +46,7 @@ use nexus_lockstep_client::types::LastResult;
 use nexus_lockstep_client::types::PhysicalDiskPath;
 use nexus_lockstep_client::types::SagaState;
 use nexus_lockstep_client::types::SledSelector;
+use nexus_lockstep_client::types::TrustQuorumSledSelector;
 use nexus_saga_recovery::LastPass;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::ClickhouseMode;
@@ -610,10 +611,35 @@ struct TrustQuorumConfigArgs {
 #[derive(Debug, Args)]
 struct TrustQuorumRemoveSledArgs {
     // remove is _extremely_ dangerous, so we also require a database
-    // connection to perform some safety checks
+    // connection to perform some safety checks. These are only possible when
+    // removing by sled ID; a sled identified by baseboard may have no database
+    // record at all.
     #[clap(flatten)]
     db_url_opts: DbUrlOptions,
-    sled_id: SledUuid,
+
+    /// ID of the sled to remove
+    #[clap(
+        long,
+        conflicts_with_all = ["part_number", "serial_number"],
+        required_unless_present_any = ["part_number", "serial_number"],
+    )]
+    sled_id: Option<SledUuid>,
+
+    /// part number of the sled to remove, for a sled with no database record
+    #[clap(long, requires = "serial_number")]
+    part_number: Option<String>,
+
+    /// serial number of the sled to remove, for a sled with no database record
+    #[clap(long, requires = "part_number")]
+    serial_number: Option<String>,
+}
+
+impl TrustQuorumRemoveSledArgs {
+    fn baseboard_id(&self) -> Option<BaseboardId> {
+        let part_number = self.part_number.clone()?;
+        let serial_number = self.serial_number.clone()?;
+        Some(BaseboardId { part_number, serial_number })
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -5471,39 +5497,41 @@ async fn cmd_nexus_trust_quorum_remove_sled(
     args: &TrustQuorumRemoveSledArgs,
     omdb: &Omdb,
     log: &slog::Logger,
-    destruction_token: DestructiveOperationToken,
-) -> Result<(), anyhow::Error> {
-    let datastore = args.db_url_opts.connect(omdb, log).await?;
-    let result = cmd_nexus_trust_quorum_remove_sled_with_datastore(
-        &datastore,
-        client,
-        args,
-        log,
-        destruction_token,
-    )
-    .await;
-    datastore.terminate().await;
-    result
-}
-
-// `omdb nexus trust-quorum remove-sled`, but borrowing a datastore
-async fn cmd_nexus_trust_quorum_remove_sled_with_datastore(
-    datastore: &Arc<DataStore>,
-    client: &nexus_lockstep_client::Client,
-    args: &TrustQuorumRemoveSledArgs,
-    log: &slog::Logger,
     _destruction_token: DestructiveOperationToken,
 ) -> Result<(), anyhow::Error> {
-    use nexus_db_queries::context::OpContext;
-    let opctx = OpContext::for_omdb(log.clone(), datastore.clone());
-    let opctx = &opctx;
-
-    // First, we need to look up the sled so we know its serial number.
-    let (_authz_sled, sled) = LookupPath::new(opctx, datastore)
-        .sled_id(args.sled_id)
-        .fetch()
-        .await
-        .with_context(|| format!("failed to find sled {}", args.sled_id))?;
+    // Identify the sled being removed: the selector we send to Nexus, the
+    // serial number the operator must type to confirm, and a description of the
+    // sled for the warning below. A sled identified by its baseboard may have
+    // no database record, so we only look one up when given a sled ID.
+    let (selector, serial_number, description) = match args.baseboard_id() {
+        Some(baseboard_id) => {
+            let serial_number = baseboard_id.serial_number.clone();
+            let description =
+                format!("sled {baseboard_id} from the trust-quorum");
+            (
+                TrustQuorumSledSelector::Baseboard(baseboard_id),
+                serial_number,
+                description,
+            )
+        }
+        None => {
+            let sled_id =
+                args.sled_id.expect("clap requires a sled ID or a baseboard");
+            let datastore = args.db_url_opts.connect(omdb, log).await?;
+            let sled = lookup_sled_by_id(&datastore, sled_id, log).await;
+            datastore.terminate().await;
+            let sled = sled?;
+            (
+                TrustQuorumSledSelector::SledId(sled_id),
+                sled.serial_number().to_string(),
+                format!(
+                    "sled {sled_id} ({}) from the trust-quorum for rack {}",
+                    sled.serial_number(),
+                    sled.rack_id,
+                ),
+            )
+        }
+    };
 
     // Helper to get confirmation messages from the user.
     let mut prompt = ConfirmationPrompt::new();
@@ -5528,14 +5556,10 @@ async fn cmd_nexus_trust_quorum_remove_sled_with_datastore(
     );
 
     println!(
-        "WARNING: This operation will PERMANENTLY and IRRECOVABLY remove sled \
-        {} ({}) from the trust-quorum for rack {}. To proceed, type the \
-        sled's serial number.",
-        args.sled_id,
-        sled.serial_number(),
-        sled.rack_id
+        "WARNING: This operation will PERMANENTLY and IRRECOVABLY remove \
+        {description}. To proceed, type the sled's serial number."
     );
-    prompt.read_and_validate("sled serial number", sled.serial_number())?;
+    prompt.read_and_validate("sled serial number", &serial_number)?;
 
     println!(
         "About to start the trust quorum reconfiguration to remove the sled."
@@ -5558,7 +5582,7 @@ async fn cmd_nexus_trust_quorum_remove_sled_with_datastore(
     );
 
     let epoch = client
-        .trust_quorum_remove_sled(&args.sled_id.into_untyped_uuid())
+        .trust_quorum_remove_sled(&selector)
         .await
         .context("trust quorum remove sled")?
         .into_inner();
@@ -5566,6 +5590,24 @@ async fn cmd_nexus_trust_quorum_remove_sled_with_datastore(
     println!("Started trust quorum reconfiguration at epoch {epoch}\n");
 
     Ok(())
+}
+
+// Look up a sled by ID, for the safety checks in `omdb nexus trust-quorum
+// remove-sled`.
+async fn lookup_sled_by_id(
+    datastore: &Arc<DataStore>,
+    sled_id: SledUuid,
+    log: &slog::Logger,
+) -> Result<nexus_db_model::Sled, anyhow::Error> {
+    let opctx = OpContext::for_omdb(log.clone(), datastore.clone());
+
+    let (_authz_sled, sled) = LookupPath::new(&opctx, datastore)
+        .sled_id(sled_id)
+        .fetch()
+        .await
+        .with_context(|| format!("failed to find sled {sled_id}"))?;
+
+    Ok(sled)
 }
 
 /// Runs `omdb nexus support-bundles create`

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -46,7 +46,6 @@ use nexus_lockstep_client::types::LastResult;
 use nexus_lockstep_client::types::PhysicalDiskPath;
 use nexus_lockstep_client::types::SagaState;
 use nexus_lockstep_client::types::SledSelector;
-use nexus_lockstep_client::types::TrustQuorumSledSelector;
 use nexus_saga_recovery::LastPass;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::ClickhouseMode;
@@ -616,6 +615,9 @@ struct TrustQuorumRemoveSledArgs {
     // record at all.
     #[clap(flatten)]
     db_url_opts: DbUrlOptions,
+
+    /// ID of the rack to remove the sled from
+    rack_id: RackUuid,
 
     /// ID of the sled to remove
     #[clap(
@@ -5499,20 +5501,16 @@ async fn cmd_nexus_trust_quorum_remove_sled(
     log: &slog::Logger,
     _destruction_token: DestructiveOperationToken,
 ) -> Result<(), anyhow::Error> {
-    // Identify the sled being removed: the selector we send to Nexus, the
-    // serial number the operator must type to confirm, and a description of the
-    // sled for the warning below. A sled identified by its baseboard may have
-    // no database record, so we only look one up when given a sled ID.
-    let (selector, serial_number, description) = match args.baseboard_id() {
+    // Trust quorum membership is tracked by baseboard, so a sled ID has to be
+    // resolved into one. A sled given by baseboard may have no database record
+    // to resolve, which is the reason for accepting one.
+    let (baseboard_id, description) = match args.baseboard_id() {
         Some(baseboard_id) => {
-            let serial_number = baseboard_id.serial_number.clone();
-            let description =
-                format!("sled {baseboard_id} from the trust-quorum");
-            (
-                TrustQuorumSledSelector::Baseboard(baseboard_id),
-                serial_number,
-                description,
-            )
+            let description = format!(
+                "sled {baseboard_id} from the trust-quorum for rack {}",
+                args.rack_id,
+            );
+            (baseboard_id, description)
         }
         None => {
             let sled_id =
@@ -5521,15 +5519,16 @@ async fn cmd_nexus_trust_quorum_remove_sled(
             let sled = lookup_sled_by_id(&datastore, sled_id, log).await;
             datastore.terminate().await;
             let sled = sled?;
-            (
-                TrustQuorumSledSelector::SledId(sled_id),
-                sled.serial_number().to_string(),
-                format!(
-                    "sled {sled_id} ({}) from the trust-quorum for rack {}",
-                    sled.serial_number(),
-                    sled.rack_id,
-                ),
-            )
+            let description = format!(
+                "sled {sled_id} ({}) from the trust-quorum for rack {}",
+                sled.serial_number(),
+                args.rack_id,
+            );
+            let baseboard_id = BaseboardId {
+                part_number: sled.part_number().to_string(),
+                serial_number: sled.serial_number().to_string(),
+            };
+            (baseboard_id, description)
         }
     };
 
@@ -5559,7 +5558,8 @@ async fn cmd_nexus_trust_quorum_remove_sled(
         "WARNING: This operation will PERMANENTLY and IRRECOVABLY remove \
         {description}. To proceed, type the sled's serial number."
     );
-    prompt.read_and_validate("sled serial number", &serial_number)?;
+    prompt
+        .read_and_validate("sled serial number", &baseboard_id.serial_number)?;
 
     println!(
         "About to start the trust quorum reconfiguration to remove the sled."
@@ -5582,7 +5582,7 @@ async fn cmd_nexus_trust_quorum_remove_sled(
     );
 
     let epoch = client
-        .trust_quorum_remove_sled(&selector)
+        .trust_quorum_remove_sled(args.rack_id.as_untyped_uuid(), &baseboard_id)
         .await
         .context("trust quorum remove sled")?
         .into_inner();

--- a/nexus/lockstep-api/src/lib.rs
+++ b/nexus/lockstep-api/src/lib.rs
@@ -43,7 +43,6 @@ use nexus_types::internal_api::views::Saga;
 use nexus_types::internal_api::views::SupportBundleInfo;
 use nexus_types::internal_api::views::UpdateStatus;
 use nexus_types::trust_quorum::TrustQuorumConfig;
-use nexus_types::trust_quorum::TrustQuorumSledSelector;
 use nexus_types_versions::latest::headers::RangeRequest;
 use nexus_types_versions::latest::instance::Instance;
 use omicron_common::api::external::http_pagination::PaginatedById;
@@ -52,6 +51,7 @@ use omicron_uuid_kinds::*;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
+use sled_hardware_types::BaseboardId;
 use trust_quorum_types::types::Epoch;
 use uuid::Uuid;
 
@@ -580,18 +580,21 @@ pub trait NexusLockstepApi {
     ///
     /// This is a required first step towards expunging a sled
     ///
-    /// The sled may be identified either by its ID or by its baseboard. Only
-    /// the latter works for a sled that has no database record.
+    /// The sled is identified by its baseboard, since trust quorum membership
+    /// is tracked by baseboard and the sled may have no database record.
     ///
     /// Return the epoch of the proposed configuration so it can be polled
     /// asynchronously.
     #[endpoint {
         method = POST,
-        path = "/trust-quorum/remove"
+        path = "/trust-quorum/remove/{rack_id}"
     }]
     async fn trust_quorum_remove_sled(
         rqctx: RequestContext<Self::Context>,
-        sled: TypedBody<TrustQuorumSledSelector>,
+        path_params: Path<
+            nexus_types::external_api::rack::RackMembershipConfigPathParams,
+        >,
+        sled: TypedBody<BaseboardId>,
     ) -> Result<HttpResponseOk<Epoch>, HttpError>;
 
     // Fault management

--- a/nexus/lockstep-api/src/lib.rs
+++ b/nexus/lockstep-api/src/lib.rs
@@ -43,6 +43,7 @@ use nexus_types::internal_api::views::Saga;
 use nexus_types::internal_api::views::SupportBundleInfo;
 use nexus_types::internal_api::views::UpdateStatus;
 use nexus_types::trust_quorum::TrustQuorumConfig;
+use nexus_types::trust_quorum::TrustQuorumSledSelector;
 use nexus_types_versions::latest::headers::RangeRequest;
 use nexus_types_versions::latest::instance::Instance;
 use omicron_common::api::external::http_pagination::PaginatedById;
@@ -579,15 +580,18 @@ pub trait NexusLockstepApi {
     ///
     /// This is a required first step towards expunging a sled
     ///
+    /// The sled may be identified either by its ID or by its baseboard. Only
+    /// the latter works for a sled that has no database record.
+    ///
     /// Return the epoch of the proposed configuration so it can be polled
     /// asynchronously.
     #[endpoint {
         method = POST,
-        path = "/trust-quorum/remove/{sled}"
+        path = "/trust-quorum/remove"
     }]
     async fn trust_quorum_remove_sled(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<SledSelector>,
+        sled: TypedBody<TrustQuorumSledSelector>,
     ) -> Result<HttpResponseOk<Epoch>, HttpError>;
 
     // Fault management

--- a/nexus/src/app/trust_quorum.rs
+++ b/nexus/src/app/trust_quorum.rs
@@ -8,9 +8,10 @@ use nexus_auth::authz;
 use nexus_auth::context::OpContext;
 use nexus_types::trust_quorum::{
     IsLrtqUpgrade, ProposedTrustQuorumConfig, TrustQuorumConfig,
+    TrustQuorumSledSelector,
 };
 use omicron_common::api::external::Error;
-use omicron_uuid_kinds::{RackUuid, SledUuid};
+use omicron_uuid_kinds::RackUuid;
 use sled_hardware_types::BaseboardId;
 use std::collections::BTreeSet;
 use std::time::Duration;
@@ -90,16 +91,27 @@ impl super::Nexus {
     pub(crate) async fn tq_remove_sled(
         &self,
         opctx: &OpContext,
-        sled_id: SledUuid,
+        sled: TrustQuorumSledSelector,
     ) -> Result<Epoch, Error> {
-        // Look up the sled to get its rack_id and baseboard_id
-        let (.., sled) = self.sled_lookup(opctx, &sled_id)?.fetch().await?;
-        let rack_id = sled.rack_id();
-        let authz_tq = authz::TrustQuorumConfig::for_rack_id(rack_id);
-        let sled_to_remove = BaseboardId {
-            part_number: sled.part_number().to_string(),
-            serial_number: sled.serial_number().to_string(),
+        let (rack_id, sled_to_remove) = match sled {
+            TrustQuorumSledSelector::SledId(sled_id) => {
+                // Look up the sled to get its rack_id and baseboard_id
+                let (.., sled) =
+                    self.sled_lookup(opctx, &sled_id)?.fetch().await?;
+                let baseboard_id = BaseboardId {
+                    part_number: sled.part_number().to_string(),
+                    serial_number: sled.serial_number().to_string(),
+                };
+                (sled.rack_id(), baseboard_id)
+            }
+            // A sled identified by baseboard may have no database record to
+            // look up a rack_id in. We only operate on a single rack, which we
+            // know from Nexus.
+            TrustQuorumSledSelector::Baseboard(baseboard_id) => {
+                (self.rack_id(), baseboard_id)
+            }
         };
+        let authz_tq = authz::TrustQuorumConfig::for_rack_id(rack_id);
 
         let (latest_committed_config, latest_epoch) = self
             .tq_load_latest_possible_committed_config(opctx, authz_tq.clone())

--- a/nexus/src/app/trust_quorum.rs
+++ b/nexus/src/app/trust_quorum.rs
@@ -8,7 +8,6 @@ use nexus_auth::authz;
 use nexus_auth::context::OpContext;
 use nexus_types::trust_quorum::{
     IsLrtqUpgrade, ProposedTrustQuorumConfig, TrustQuorumConfig,
-    TrustQuorumSledSelector,
 };
 use omicron_common::api::external::Error;
 use omicron_uuid_kinds::RackUuid;
@@ -91,26 +90,9 @@ impl super::Nexus {
     pub(crate) async fn tq_remove_sled(
         &self,
         opctx: &OpContext,
-        sled: TrustQuorumSledSelector,
+        rack_id: RackUuid,
+        sled_to_remove: BaseboardId,
     ) -> Result<Epoch, Error> {
-        let (rack_id, sled_to_remove) = match sled {
-            TrustQuorumSledSelector::SledId(sled_id) => {
-                // Look up the sled to get its rack_id and baseboard_id
-                let (.., sled) =
-                    self.sled_lookup(opctx, &sled_id)?.fetch().await?;
-                let baseboard_id = BaseboardId {
-                    part_number: sled.part_number().to_string(),
-                    serial_number: sled.serial_number().to_string(),
-                };
-                (sled.rack_id(), baseboard_id)
-            }
-            // A sled identified by baseboard may have no database record to
-            // look up a rack_id in. We only operate on a single rack, which we
-            // know from Nexus.
-            TrustQuorumSledSelector::Baseboard(baseboard_id) => {
-                (self.rack_id(), baseboard_id)
-            }
-        };
         let authz_tq = authz::TrustQuorumConfig::for_rack_id(rack_id);
 
         let (latest_committed_config, latest_epoch) = self

--- a/nexus/src/lockstep_api/http_entrypoints.rs
+++ b/nexus/src/lockstep_api/http_entrypoints.rs
@@ -54,6 +54,7 @@ use nexus_types::internal_api::views::SupportBundleInfo;
 use nexus_types::internal_api::views::UpdateStatus;
 use nexus_types::internal_api::views::to_list;
 use nexus_types::trust_quorum::TrustQuorumConfig;
+use nexus_types::trust_quorum::TrustQuorumSledSelector;
 use nexus_types_versions::latest::headers::RangeRequest;
 use nexus_types_versions::latest::instance::Instance;
 use omicron_common::api::external::Error;
@@ -1131,15 +1132,15 @@ impl NexusLockstepApi for NexusLockstepApiImpl {
 
     async fn trust_quorum_remove_sled(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<SledSelector>,
+        sled: TypedBody<TrustQuorumSledSelector>,
     ) -> Result<HttpResponseOk<Epoch>, HttpError> {
         let apictx = &rqctx.context().context;
         let nexus = &apictx.nexus;
-        let sled_id = path_params.into_inner().sled;
+        let sled = sled.into_inner();
         let handler = async {
             let opctx =
                 crate::context::op_context_for_internal_api(&rqctx).await;
-            let epoch = nexus.tq_remove_sled(&opctx, sled_id).await?;
+            let epoch = nexus.tq_remove_sled(&opctx, sled).await?;
             Ok(HttpResponseOk(epoch))
         };
         apictx

--- a/nexus/src/lockstep_api/http_entrypoints.rs
+++ b/nexus/src/lockstep_api/http_entrypoints.rs
@@ -54,7 +54,6 @@ use nexus_types::internal_api::views::SupportBundleInfo;
 use nexus_types::internal_api::views::UpdateStatus;
 use nexus_types::internal_api::views::to_list;
 use nexus_types::trust_quorum::TrustQuorumConfig;
-use nexus_types::trust_quorum::TrustQuorumSledSelector;
 use nexus_types_versions::latest::headers::RangeRequest;
 use nexus_types_versions::latest::instance::Instance;
 use omicron_common::api::external::Error;
@@ -66,6 +65,7 @@ use omicron_common::api::external::http_pagination::ScanParams;
 use omicron_common::api::external::http_pagination::data_page_params_for;
 use omicron_uuid_kinds::*;
 use range_requests::PotentialRange;
+use sled_hardware_types::BaseboardId;
 use slog_error_chain::InlineErrorChain;
 use trust_quorum_types::types::Epoch;
 
@@ -1132,15 +1132,18 @@ impl NexusLockstepApi for NexusLockstepApiImpl {
 
     async fn trust_quorum_remove_sled(
         rqctx: RequestContext<Self::Context>,
-        sled: TypedBody<TrustQuorumSledSelector>,
+        path_params: Path<RackMembershipConfigPathParams>,
+        sled: TypedBody<BaseboardId>,
     ) -> Result<HttpResponseOk<Epoch>, HttpError> {
         let apictx = &rqctx.context().context;
         let nexus = &apictx.nexus;
+        let rack_id =
+            RackUuid::from_untyped_uuid(path_params.into_inner().rack_id);
         let sled = sled.into_inner();
         let handler = async {
             let opctx =
                 crate::context::op_context_for_internal_api(&rqctx).await;
-            let epoch = nexus.tq_remove_sled(&opctx, sled).await?;
+            let epoch = nexus.tq_remove_sled(&opctx, rack_id, sled).await?;
             Ok(HttpResponseOk(epoch))
         };
         apictx

--- a/nexus/types/src/trust_quorum.rs
+++ b/nexus/types/src/trust_quorum.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::bail;
 use chrono::{DateTime, Utc};
-use omicron_uuid_kinds::{RackUuid, SledUuid};
+use omicron_uuid_kinds::RackUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
@@ -240,17 +240,6 @@ impl TrustQuorumConfig {
             _ => 4,
         }
     }
-}
-
-/// Identifies a sled to remove from the trust quorum.
-///
-/// Selecting by baseboard is necessary to remove a sled that has no database
-/// record, since in that case there is no sled ID to resolve to a baseboard.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case", tag = "type", content = "value")]
-pub enum TrustQuorumSledSelector {
-    SledId(SledUuid),
-    Baseboard(BaseboardId),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/nexus/types/src/trust_quorum.rs
+++ b/nexus/types/src/trust_quorum.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::bail;
 use chrono::{DateTime, Utc};
-use omicron_uuid_kinds::RackUuid;
+use omicron_uuid_kinds::{RackUuid, SledUuid};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
@@ -240,6 +240,17 @@ impl TrustQuorumConfig {
             _ => 4,
         }
     }
+}
+
+/// Identifies a sled to remove from the trust quorum.
+///
+/// Selecting by baseboard is necessary to remove a sled that has no database
+/// record, since in that case there is no sled ID to resolve to a baseboard.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+pub enum TrustQuorumSledSelector {
+    SledId(SledUuid),
+    Baseboard(BaseboardId),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/openapi/nexus-lockstep.json
+++ b/openapi/nexus-lockstep.json
@@ -1539,23 +1539,21 @@
         }
       }
     },
-    "/trust-quorum/remove/{sled}": {
+    "/trust-quorum/remove": {
       "post": {
         "summary": "Remove a sled from the trust quorum",
-        "description": "This is a required first step towards expunging a sled\n\nReturn the epoch of the proposed configuration so it can be polled asynchronously.",
+        "description": "This is a required first step towards expunging a sled\n\nThe sled may be identified either by its ID or by its baseboard. Only the latter works for a sled that has no database record.\n\nReturn the epoch of the proposed configuration so it can be polled asynchronously.",
         "operationId": "trust_quorum_remove_sled",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "sled",
-            "description": "ID of the sled",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrustQuorumSledSelector"
+              }
             }
-          }
-        ],
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "successful operation",
@@ -9926,6 +9924,47 @@
           "unacked",
           "prepared",
           "committed"
+        ]
+      },
+      "TrustQuorumSledSelector": {
+        "description": "Identifies a sled to remove from the trust quorum.\n\nSelecting by baseboard is necessary to remove a sled that has no database record, since in that case there is no sled ID to resolve to a baseboard.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "sled_id"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/SledUuid"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "baseboard"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
         ]
       },
       "TufRepoVersion": {

--- a/openapi/nexus-lockstep.json
+++ b/openapi/nexus-lockstep.json
@@ -1539,16 +1539,27 @@
         }
       }
     },
-    "/trust-quorum/remove": {
+    "/trust-quorum/remove/{rack_id}": {
       "post": {
         "summary": "Remove a sled from the trust quorum",
-        "description": "This is a required first step towards expunging a sled\n\nThe sled may be identified either by its ID or by its baseboard. Only the latter works for a sled that has no database record.\n\nReturn the epoch of the proposed configuration so it can be polled asynchronously.",
+        "description": "This is a required first step towards expunging a sled\n\nThe sled is identified by its baseboard, since trust quorum membership is tracked by baseboard and the sled may have no database record.\n\nReturn the epoch of the proposed configuration so it can be polled asynchronously.",
         "operationId": "trust_quorum_remove_sled",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rack_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TrustQuorumSledSelector"
+                "$ref": "#/components/schemas/BaseboardId"
               }
             }
           },
@@ -9924,47 +9935,6 @@
           "unacked",
           "prepared",
           "committed"
-        ]
-      },
-      "TrustQuorumSledSelector": {
-        "description": "Identifies a sled to remove from the trust quorum.\n\nSelecting by baseboard is necessary to remove a sled that has no database record, since in that case there is no sled ID to resolve to a baseboard.",
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "sled_id"
-                ]
-              },
-              "value": {
-                "$ref": "#/components/schemas/SledUuid"
-              }
-            },
-            "required": [
-              "type",
-              "value"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "baseboard"
-                ]
-              },
-              "value": {
-                "$ref": "#/components/schemas/BaseboardId"
-              }
-            },
-            "required": [
-              "type",
-              "value"
-            ]
-          }
         ]
       },
       "TufRepoVersion": {


### PR DESCRIPTION
This commit allows a sled to be removed from a trust quorum configuration via omdb by either SledId or BaseboardId.

Fixes #11030