### PR TITLE
scrimlet-reconcilers status (PR 2/3): collapse two enum variants

### DIFF
--- a/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/dpd.rs
+++ b/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/dpd.rs
@@ -41,15 +41,8 @@ pub enum DpdPortReconcilerStatus {
     /// plan - this should be impossible absent bugs.
     FailedGeneratingPlan(String),
 
-    /// Reconciliation completed successfully.
-    Success {
-        unchanged: BTreeSet<String>,
-        cleared: BTreeSet<String>,
-        applied: BTreeSet<String>,
-    },
-
-    /// Reconciliation completed but had at least one failure.
-    PartialSuccess {
+    /// Reconciliation completed.
+    Complete {
         unchanged: BTreeSet<String>,
         cleared: BTreeSet<String>,
         clear_failures: Vec<DpdPortOperationFailure>,
@@ -72,21 +65,7 @@ impl slog::KV for DpdPortReconcilerStatus {
             Self::FailedGeneratingPlan(reason) => {
                 serializer.emit_str(skipped_key.into(), reason)
             }
-            Self::Success { unchanged, cleared, applied } => {
-                // Only show a summary count; we have individual log statements
-                // for each clear/apply.
-                for (key, val) in [
-                    ("port-settings-unchanged", unchanged.len()),
-                    ("port-settings-successfully-cleared", cleared.len()),
-                    ("port-settings-failed-to-clear", 0),
-                    ("port-settings-successfully-applied", applied.len()),
-                    ("port-settings-failed-to-apply", 0),
-                ] {
-                    serializer.emit_usize(key.into(), val)?;
-                }
-                Ok(())
-            }
-            Self::PartialSuccess {
+            Self::Complete {
                 unchanged,
                 cleared,
                 clear_failures,

--- a/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/dpd.rs
+++ b/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/dpd.rs
@@ -162,21 +162,8 @@ pub enum DpdNatReconcilerStatus {
     /// combination of entries (e.g., two zones with identical NAT entries).
     InvalidSystemNetworkingConfig(String),
 
-    /// Reconciliation completed successfully.
-    Success {
-        /// Set of zone IDs whose NAT entries were already correct in `dpd` and
-        /// left unchanged.
-        unchanged: BTreeSet<OmicronZoneUuid>,
-
-        /// List of NAT entries removed.
-        removed: Vec<DpdNatReconcilerStatusNatEntry>,
-
-        /// Map of zone NAT entries created.
-        created: BTreeMap<OmicronZoneUuid, DpdNatReconcilerStatusNatEntry>,
-    },
-
-    /// Reconciliation completed but had at least one failure.
-    PartialSuccess {
+    /// Reconciliation completed.
+    Complete {
         /// Set of zone IDs whose NAT entries were already correct in `dpd` and
         /// left unchanged.
         unchanged: BTreeSet<OmicronZoneUuid>,
@@ -216,21 +203,7 @@ impl slog::KV for DpdNatReconcilerStatus {
                     &format_args!("invalid system networking config: {reason}"),
                 )
             }
-            DpdNatReconcilerStatus::Success { unchanged, removed, created } => {
-                // Only show a summary count; we have individual log statements
-                // for each create/remove.
-                for (key, val) in [
-                    ("nat-entries-unchanged", unchanged.len()),
-                    ("nat-entries-successfully-removed", removed.len()),
-                    ("nat-entries-failed-to-remove", 0),
-                    ("nat-entries-successfully-created", created.len()),
-                    ("nat-entries-failed-to-create", 0),
-                ] {
-                    serializer.emit_usize(key.into(), val)?;
-                }
-                Ok(())
-            }
-            DpdNatReconcilerStatus::PartialSuccess {
+            DpdNatReconcilerStatus::Complete {
                 unchanged,
                 removed,
                 remove_failures,

--- a/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/mgd.rs
+++ b/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/mgd.rs
@@ -171,20 +171,11 @@ pub enum MgdBgpReconcilerStatus {
     /// persisted config.
     FailedGeneratingDesiredConfig(String),
 
-    /// Reconciliation completed successfully.
+    /// Reconciliation completed.
     ///
-    /// mgd operations are performed in bulk, so each item here contains the
-    /// count of items involved.
-    Success {
-        counts: MgdBgpReconcilerStatusOpCount,
-        did_change_max_paths: bool,
-    },
-
-    /// Reconciliation completed with at least one failure.
-    ///
-    /// mgd operations are performed in bulk, so each item here contains the
-    /// count of items applied on success.
-    PartialSuccess {
+    /// mgd operations are performed in bulk, so `counts` contains the number of
+    /// items involved.
+    Complete {
         counts: MgdBgpReconcilerStatusOpCount,
         did_change_max_paths: bool,
         errors: Vec<String>,
@@ -203,14 +194,7 @@ impl slog::KV for MgdBgpReconcilerStatus {
             | Self::FailedGeneratingDesiredConfig(reason) => {
                 serializer.emit_str(skipped_key, reason)
             }
-            Self::Success { counts, did_change_max_paths } => {
-                serializer.emit_bool(
-                    "bgp-did-change-max-paths".into(),
-                    *did_change_max_paths,
-                )?;
-                slog::KV::serialize(&counts, record, serializer)
-            }
-            MgdBgpReconcilerStatus::PartialSuccess {
+            MgdBgpReconcilerStatus::Complete {
                 counts,
                 did_change_max_paths,
                 errors,

--- a/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/mgd.rs
+++ b/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/mgd.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeSet;
 use std::net::IpAddr;
 
 /// Description of a failure to perform some mgd operation on a BFD peer.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct MgdBfdOperationFailure {
     pub peer: IpAddr,
     pub error: String,
@@ -24,15 +24,8 @@ pub enum MgdBfdReconcilerStatus {
     /// BFD peers from mgd.
     FailedReadingBfdPeers(String),
 
-    /// Reconciliation completed successfully.
-    Success {
-        unchanged: BTreeSet<IpAddr>,
-        remove_success: Vec<IpAddr>,
-        add_success: Vec<IpAddr>,
-    },
-
-    /// Reconciliation completed but had at least one failure.
-    PartialSuccess {
+    /// Reconciliation completed.
+    Complete {
         unchanged: BTreeSet<IpAddr>,
         remove_success: Vec<IpAddr>,
         remove_failure: Vec<MgdBfdOperationFailure>,
@@ -52,19 +45,7 @@ impl slog::KV for MgdBfdReconcilerStatus {
             Self::FailedReadingBfdPeers(reason) => {
                 serializer.emit_str(skipped_key.into(), reason)
             }
-            Self::Success { unchanged, remove_success, add_success } => {
-                for (key, val) in [
-                    ("bfd-unchanged", unchanged.len()),
-                    ("bfd-successfully-removed", remove_success.len()),
-                    ("bfd-failed-to-remove", 0),
-                    ("bfd-successfully-added", add_success.len()),
-                    ("bfd-failed-to-add", 0),
-                ] {
-                    serializer.emit_usize(key.into(), val)?;
-                }
-                Ok(())
-            }
-            Self::PartialSuccess {
+            Self::Complete {
                 unchanged,
                 remove_success,
                 remove_failure,

--- a/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/mgd.rs
+++ b/sled-agent/bootstrap-agent-lockstep-types/src/scrimlet_reconcilers/mgd.rs
@@ -225,23 +225,12 @@ pub enum MgdStaticRouteReconcilerStatus {
     /// somewhere (either coming from mgd or in the rack network config).
     FailedGeneratingPlan(String),
 
-    /// Reconciliation completed successfully.
+    /// Reconciliation completed.
     ///
     /// mgd operations are performed in bulk, so each item here contains the
-    /// count of items involved.
-    Success {
-        unchanged: usize,
-        deleted_v4: usize,
-        deleted_v6: usize,
-        added_v4: usize,
-        added_v6: usize,
-    },
-
-    /// Reconciliation completed with at least one failure.
-    ///
-    /// mgd operations are performed in bulk. Each successful result contains
-    /// the count of items involved; error results describe the failure.
-    PartialSuccess {
+    /// count of items involved (on success) or the error associated with the
+    /// bulk operation (on failure).
+    Complete {
         unchanged: usize,
         delete_v4_result: Result<usize, String>,
         delete_v6_result: Result<usize, String>,
@@ -264,29 +253,7 @@ impl slog::KV for MgdStaticRouteReconcilerStatus {
             Self::FailedGeneratingPlan(reason) => {
                 serializer.emit_str(skipped_key.into(), reason)
             }
-            Self::Success {
-                unchanged,
-                deleted_v4,
-                deleted_v6,
-                added_v4,
-                added_v6,
-            } => {
-                serializer
-                    .emit_usize("static-routes-unchanged".into(), *unchanged)?;
-                for (key, items) in [
-                    ("static-routes-delete-v4", deleted_v4),
-                    ("static-routes-delete-v6", deleted_v6),
-                    ("static-routes-add-v4", added_v4),
-                    ("static-routes-add-v6", added_v6),
-                ] {
-                    serializer.emit_arguments(
-                        key.into(),
-                        &format_args!("success ({items} routes affected)"),
-                    )?;
-                }
-                Ok(())
-            }
-            Self::PartialSuccess {
+            Self::Complete {
                 unchanged,
                 delete_v4_result,
                 delete_v6_result,

--- a/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/nat.rs
+++ b/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/nat.rs
@@ -178,16 +178,12 @@ async fn apply_plan(
         }
     }
 
-    if remove_failures.is_empty() && create_failures.is_empty() {
-        DpdNatReconcilerStatus::Success { unchanged, removed, created }
-    } else {
-        DpdNatReconcilerStatus::PartialSuccess {
-            unchanged,
-            removed,
-            remove_failures,
-            created,
-            create_failures,
-        }
+    DpdNatReconcilerStatus::Complete {
+        unchanged,
+        removed,
+        remove_failures,
+        created,
+        create_failures,
     }
 }
 

--- a/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/nat/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/nat/tests.rs
@@ -386,11 +386,20 @@ async fn proptest_full_reconciliation() {
         match status {
             DpdNatReconcilerStatus::NoNatEntriesConfig
             | DpdNatReconcilerStatus::FailedReadingCurrentDpdNatEntries(_)
-            | DpdNatReconcilerStatus::InvalidSystemNetworkingConfig(_)
-            | DpdNatReconcilerStatus::PartialSuccess { .. } => {
+            | DpdNatReconcilerStatus::InvalidSystemNetworkingConfig(_) => {
                 panic!("unexpected reconciler status: {status:?}");
             }
-            DpdNatReconcilerStatus::Success { .. } => {
+            DpdNatReconcilerStatus::Complete {
+                // checked by `validate_post_reconciliation()`
+                unchanged: _,
+                removed: _,
+                created: _,
+
+                remove_failures,
+                create_failures,
+            } => {
+                assert_eq!(remove_failures, Vec::new());
+                assert_eq!(create_failures, BTreeMap::new());
                 input
                     .validate_post_reconciliation(&client)
                     .await

--- a/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/port_reconciler.rs
+++ b/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/port_reconciler.rs
@@ -235,16 +235,12 @@ async fn apply_plan(
         }
     }
 
-    if clear_failures.is_empty() && apply_failures.is_empty() {
-        DpdPortReconcilerStatus::Success { unchanged, cleared, applied }
-    } else {
-        DpdPortReconcilerStatus::PartialSuccess {
-            unchanged,
-            cleared,
-            clear_failures,
-            applied,
-            apply_failures,
-        }
+    DpdPortReconcilerStatus::Complete {
+        unchanged,
+        cleared,
+        clear_failures,
+        applied,
+        apply_failures,
     }
 }
 

--- a/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/port_reconciler/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/port_reconciler/tests.rs
@@ -925,15 +925,19 @@ async fn proptest_full_reconciliation() {
 
         match status {
             DpdPortReconcilerStatus::FailedReadingCurrentSettings(_)
-            | DpdPortReconcilerStatus::FailedGeneratingPlan(_)
-            | DpdPortReconcilerStatus::PartialSuccess { .. } => {
+            | DpdPortReconcilerStatus::FailedGeneratingPlan(_) => {
                 panic!("unexpected reconciler status: {status:?}");
             }
-            DpdPortReconcilerStatus::Success {
+            DpdPortReconcilerStatus::Complete {
                 unchanged,
                 cleared,
+                clear_failures,
                 applied,
+                apply_failures,
             } => {
+                assert_eq!(clear_failures, Vec::new());
+                assert_eq!(apply_failures, Vec::new());
+
                 assert_eq!(
                     unchanged,
                     input.expected_unchanged(),

--- a/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bfd_reconciler.rs
+++ b/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bfd_reconciler.rs
@@ -139,20 +139,12 @@ async fn apply_plan(
         }
     }
 
-    if remove_failure.is_empty() && add_failure.is_empty() {
-        MgdBfdReconcilerStatus::Success {
-            unchanged,
-            remove_success,
-            add_success,
-        }
-    } else {
-        MgdBfdReconcilerStatus::PartialSuccess {
-            unchanged,
-            remove_success,
-            remove_failure,
-            add_success,
-            add_failure,
-        }
+    MgdBfdReconcilerStatus::Complete {
+        unchanged,
+        remove_success,
+        remove_failure,
+        add_success,
+        add_failure,
     }
 }
 

--- a/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bfd_reconciler/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bfd_reconciler/tests.rs
@@ -507,7 +507,17 @@ async fn run_one_proptest_input(
     match reconcile(client, &desired_config, ThisSledSwitchSlot::TEST_FAKE, log)
         .await
     {
-        MgdBfdReconcilerStatus::Success { .. } => {}
+        MgdBfdReconcilerStatus::Complete {
+            unchanged: _,
+            remove_success: _,
+            add_success: _,
+
+            remove_failure,
+            add_failure,
+        } => {
+            assert_eq!(remove_failure, Vec::new());
+            assert_eq!(add_failure, Vec::new());
+        }
         status => {
             panic!("unexpected status: {status:?}")
         }

--- a/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler.rs
+++ b/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler.rs
@@ -456,15 +456,7 @@ async fn apply_plan(
     }
 
     let StatusBuilder { counts, did_change_max_paths, errors } = status_builder;
-    if errors.is_empty() {
-        MgdBgpReconcilerStatus::Success { counts, did_change_max_paths }
-    } else {
-        MgdBgpReconcilerStatus::PartialSuccess {
-            counts,
-            did_change_max_paths,
-            errors,
-        }
-    }
+    MgdBgpReconcilerStatus::Complete { counts, did_change_max_paths, errors }
 }
 
 #[derive(Debug)]

--- a/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/bgp_reconciler/tests.rs
@@ -446,7 +446,13 @@ async fn run_one_proptest_input(
     )
     .await
     {
-        MgdBgpReconcilerStatus::Success { .. } => {}
+        MgdBgpReconcilerStatus::Complete {
+            counts: _,
+            did_change_max_paths: _,
+            errors,
+        } => {
+            assert_eq!(errors, Vec::<String>::new());
+        }
         status => {
             panic!("unexpected status: {status:?}")
         }

--- a/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/static_route_reconciler.rs
+++ b/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/static_route_reconciler.rs
@@ -165,24 +165,12 @@ async fn apply_plan(
         )
     };
 
-    match (&add_v4_result, &add_v6_result, &delete_v4_result, &delete_v6_result)
-    {
-        (Ok(added_v4), Ok(added_v6), Ok(deleted_v4), Ok(deleted_v6)) => {
-            MgdStaticRouteReconcilerStatus::Success {
-                unchanged: unchanged_count,
-                deleted_v4: *deleted_v4,
-                deleted_v6: *deleted_v6,
-                added_v4: *added_v4,
-                added_v6: *added_v6,
-            }
-        }
-        _ => MgdStaticRouteReconcilerStatus::PartialSuccess {
-            unchanged: unchanged_count,
-            delete_v4_result,
-            delete_v6_result,
-            add_v4_result,
-            add_v6_result,
-        },
+    MgdStaticRouteReconcilerStatus::Complete {
+        unchanged: unchanged_count,
+        delete_v4_result,
+        delete_v6_result,
+        add_v4_result,
+        add_v6_result,
     }
 }
 

--- a/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/static_route_reconciler/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/mgd_reconciler/static_route_reconciler/tests.rs
@@ -942,12 +942,12 @@ impl TestInput {
             }
         }
 
-        MgdStaticRouteReconcilerStatus::Success {
+        MgdStaticRouteReconcilerStatus::Complete {
             unchanged,
-            deleted_v4,
-            deleted_v6,
-            added_v4,
-            added_v6,
+            delete_v4_result: Ok(deleted_v4),
+            delete_v6_result: Ok(deleted_v6),
+            add_v4_result: Ok(added_v4),
+            add_v6_result: Ok(added_v6),
         }
     }
 }


### PR DESCRIPTION
Each of the reconcilers had both `Success` (no errors in the variant at all) and `PartialSuccess` (guaranteed non-empty sets of errors) variants; this isn't actually useful for status reporting, so this PR collapses those into a single `Complete` (contains errors, but may be empty if reconciliation was successful) variant.