### PR TITLE
possibly fix test flake #11059

### DIFF
--- a/nexus/test-utils/src/starter.rs
+++ b/nexus/test-utils/src/starter.rs
@@ -1462,6 +1462,7 @@ impl ControlPlaneTestContextSledAgent {
 
     pub async fn teardown(self) {
         self.server.http_server.close().await.unwrap();
+        self.server.sled_agent.repo_depot.app_private().stop_writers().await;
     }
 }
 

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -267,7 +267,7 @@ async fn test_repo_upload() -> Result<()> {
 
     // Wait for all the copy requests to complete.
     futures::future::join_all(cptestctx.sled_agents.iter().map(|sled_agent| {
-        sled_agent.sled_agent().artifact_store().wait_for_copy_tasks()
+        sled_agent.sled_agent().artifact_store().wait_for_writers()
     }))
     .await;
 

--- a/sled-agent/src/artifact_store.rs
+++ b/sled-agent/src/artifact_store.rs
@@ -17,6 +17,7 @@
 //! Operations that list or modify artifacts or the configuration are called by
 //! Nexus and handled by the Sled Agent API.
 
+use std::convert::Infallible;
 use std::future::Future;
 use std::io::{ErrorKind, Write};
 use std::net::SocketAddrV6;
@@ -231,7 +232,10 @@ macro_rules! log_and_store {
     };
 }
 
-impl<T: DatasetsManager> ArtifactStore<T> {
+impl<T: DatasetsManager> ArtifactStore<T>
+where
+    Error: From<T::PermitError>,
+{
     /// Get the current [`ArtifactConfig`].
     pub(crate) fn get_config(&self) -> Option<ArtifactConfig> {
         self.config.borrow().clone()
@@ -371,6 +375,7 @@ impl<T: DatasetsManager> ArtifactStore<T> {
         let mut writer = ArtifactWriter::new(self.log.clone(), sha256);
         let mut last_error = None;
         for mountpoint in self.storage.artifact_storage_paths().await {
+            let write_permit = self.storage.write_permit().await?;
             let temp_dir = mountpoint.join(TEMP_SUBDIR);
             if let Err(err) = tokio::fs::create_dir(&temp_dir).await {
                 if err.kind() != ErrorKind::AlreadyExists {
@@ -380,7 +385,7 @@ impl<T: DatasetsManager> ArtifactStore<T> {
                     continue;
                 }
             }
-            writer.add_path(mountpoint, temp_dir);
+            writer.add_path(mountpoint, temp_dir, write_permit);
         }
         if writer.write_tasks.is_empty() {
             Err(last_error.unwrap_or(Error::NoUpdateDataset))
@@ -411,7 +416,6 @@ impl<T: DatasetsManager> ArtifactStore<T> {
     ) -> Result<(), Error> {
         // Check that there's no conflict before we send the upstream request.
         let writer = self.writer(sha256, generation).await?;
-        let permit = self.storage.copy_permit().await;
 
         let client = repo_depot_client::Client::new_with_client(
             depot_base_url,
@@ -433,7 +437,6 @@ impl<T: DatasetsManager> ArtifactStore<T> {
         let log = self.log.clone();
         let base_url = depot_base_url.to_owned();
         tokio::task::spawn(async move {
-            let _permit = permit;
             let stream = response.into_inner().into_inner().map_err(|err| {
                 Error::DepotCopy {
                     sha256,
@@ -599,19 +602,25 @@ async fn delete_reconciler<T: DatasetsManager>(
 /// simulated sled agent, and this module's unit tests have different ways of
 /// keeping track of the datasets on the system.
 pub trait DatasetsManager: Clone + Send + Sync + 'static {
+    type PermitError;
+
     fn artifact_storage_paths(
         &self,
     ) -> impl Future<Output = impl Iterator<Item = Utf8PathBuf> + Send + '_> + Send;
 
     #[expect(async_fn_in_trait)]
-    async fn copy_permit(&self) -> Option<OwnedSemaphorePermit> {
-        None
+    async fn write_permit(
+        &self,
+    ) -> Result<Option<OwnedSemaphorePermit>, Self::PermitError> {
+        Ok(None)
     }
 
     fn signal_delete_done(&self, _generation: Generation) {}
 }
 
 impl DatasetsManager for InternalDisksReceiver {
+    type PermitError = Infallible;
+
     async fn artifact_storage_paths(
         &self,
     ) -> impl Iterator<Item = Utf8PathBuf> + '_ {
@@ -638,7 +647,12 @@ impl ArtifactWriter {
         }
     }
 
-    fn add_path(&mut self, mountpoint: Utf8PathBuf, temp_dir: Utf8PathBuf) {
+    fn add_path(
+        &mut self,
+        mountpoint: Utf8PathBuf,
+        temp_dir: Utf8PathBuf,
+        write_permit: Option<OwnedSemaphorePermit>,
+    ) {
         let log = self.log.clone();
         let path = mountpoint.join(self.sha256.to_string());
         let atomic_file = AtomicFile::new_with_tmpdir(
@@ -650,6 +664,7 @@ impl ArtifactWriter {
         let expected = self.sha256;
         self.senders.push(tx);
         self.write_tasks.spawn_blocking(move || {
+            let _write_permit = write_permit;
             let moved_path = path.clone();
             atomic_file
                 .write(|file| {
@@ -856,6 +871,12 @@ pub enum Error {
     NotInConfig { sha256: ArtifactHash, generation: Generation },
 }
 
+impl From<Infallible> for Error {
+    fn from(source: Infallible) -> Self {
+        match source {}
+    }
+}
+
 impl From<Error> for HttpError {
     fn from(err: Error) -> HttpError {
         let message = InlineErrorChain::new(&err).to_string();
@@ -897,6 +918,7 @@ impl From<Error> for HttpError {
 #[cfg(test)]
 mod test {
     use std::collections::BTreeSet;
+    use std::convert::Infallible;
     use std::sync::Arc;
 
     use bytes::Bytes;
@@ -945,6 +967,8 @@ mod test {
     }
 
     impl DatasetsManager for TestBackend {
+        type PermitError = Infallible;
+
         async fn artifact_storage_paths(
             &self,
         ) -> impl Iterator<Item = camino::Utf8PathBuf> + '_ {

--- a/sled-agent/src/sim/artifact_store.rs
+++ b/sled-agent/src/sim/artifact_store.rs
@@ -43,10 +43,12 @@ pub struct SimArtifactStorage {
 impl SimArtifactStorage {
     pub(super) fn new() -> SimArtifactStorage {
         SimArtifactStorage {
-            dirs: Arc::new([
-                camino_tempfile::tempdir().unwrap(),
-                camino_tempfile::tempdir().unwrap(),
-            ]),
+            dirs: Arc::new(std::array::from_fn(|_| {
+                camino_tempfile::Builder::new()
+                    .prefix("artifact-store")
+                    .tempdir()
+                    .unwrap()
+            })),
             write_semaphore: Arc::new(
                 const { Semaphore::const_new(MAX_PERMITS as usize) },
             ),

--- a/sled-agent/src/sim/artifact_store.rs
+++ b/sled-agent/src/sim/artifact_store.rs
@@ -15,9 +15,9 @@ use dropshot::{
 };
 use omicron_common::api::external::Generation;
 use repo_depot_api::*;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore, watch};
+use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore, watch};
 
-use crate::artifact_store::{ArtifactStore, DatasetsManager};
+use crate::artifact_store::{ArtifactStore, DatasetsManager, Error};
 
 // Semaphore mostly uses usize but in `acquire_many` it unfortunately uses u32.
 const MAX_PERMITS: u32 = u32::MAX >> 3;
@@ -27,9 +27,13 @@ pub struct SimArtifactStorage {
     // We simulate the two M.2s with two separate temporary directories.
     dirs: Arc<[Utf8TempDir; 2]>,
 
-    // Semaphore to keep track of how many copy requests are in flight, and to
-    // be able to await on their completion. Used in integration tests.
-    copy_semaphore: Arc<Semaphore>,
+    // Semaphore to keep track of how many writes are in flight, and to be
+    // able to await on their completion. Used to wait for copies to complete
+    // in integration tests and to wait for writes to complete finish before
+    // dropping sled-agent, to avoid a race condition where files are moved
+    // to their final path while the drop implementation for `Utf8TempDir` is
+    // running.
+    write_semaphore: Arc<Semaphore>,
 
     // Watch channel to be able to await on the delete reconciler completing in
     // integration tests.
@@ -43,7 +47,7 @@ impl SimArtifactStorage {
                 camino_tempfile::tempdir().unwrap(),
                 camino_tempfile::tempdir().unwrap(),
             ]),
-            copy_semaphore: Arc::new(
+            write_semaphore: Arc::new(
                 const { Semaphore::const_new(MAX_PERMITS as usize) },
             ),
             delete_done: watch::Sender::new(0u32.into()),
@@ -52,14 +56,26 @@ impl SimArtifactStorage {
 }
 
 impl DatasetsManager for SimArtifactStorage {
+    type PermitError = Error;
+
     async fn artifact_storage_paths(
         &self,
     ) -> impl Iterator<Item = camino::Utf8PathBuf> + '_ {
         self.dirs.iter().map(|tempdir| tempdir.path().to_owned())
     }
 
-    async fn copy_permit(&self) -> Option<OwnedSemaphorePermit> {
-        Some(self.copy_semaphore.clone().acquire_owned().await.unwrap())
+    async fn write_permit(
+        &self,
+    ) -> Result<Option<OwnedSemaphorePermit>, Error> {
+        match self.write_semaphore.clone().acquire_owned().await {
+            Ok(permit) => Ok(Some(permit)),
+            Err(err) => {
+                let _err: AcquireError = err;
+                // `ArtifactStore::stop_writers` was called and the semaphore is
+                // closed, so claim that no update datasets are available.
+                Err(Error::NoUpdateDataset)
+            }
+        }
     }
 
     fn signal_delete_done(&self, generation: Generation) {
@@ -98,15 +114,28 @@ impl ArtifactStore<SimArtifactStorage> {
         self.storage.dirs.iter().map(|p| p.path())
     }
 
-    pub async fn wait_for_copy_tasks(&self) {
-        // Acquire a permit for MAX_PERMITS, which requires that all copy tasks
+    pub async fn wait_for_writers(&self) {
+        // Acquire a permit for MAX_PERMITS, which requires that all write tasks
         // have dropped their permits. Then immediately drop it.
         let _permit = self
             .storage
-            .copy_semaphore
+            .write_semaphore
             .acquire_many(MAX_PERMITS)
             .await
             .unwrap();
+    }
+
+    pub async fn stop_writers(&self) {
+        // Acquire a permit for MAX_PERMITS, which requires that all write
+        // tasks have dropped their permits. While holding the permit, close the
+        // semaphore to prevent any new write tasks from starting.
+        let _permit = self
+            .storage
+            .write_semaphore
+            .acquire_many(MAX_PERMITS)
+            .await
+            .unwrap();
+        self.storage.write_semaphore.close();
     }
 
     pub fn subscribe_delete_done(&self) -> watch::Receiver<Generation> {

--- a/sled-agent/src/sim/artifact_store.rs
+++ b/sled-agent/src/sim/artifact_store.rs
@@ -49,9 +49,7 @@ impl SimArtifactStorage {
                     .tempdir()
                     .unwrap()
             })),
-            write_semaphore: Arc::new(
-                const { Semaphore::const_new(MAX_PERMITS as usize) },
-            ),
+            write_semaphore: Arc::new(Semaphore::new(MAX_PERMITS as usize)),
             delete_done: watch::Sender::new(0u32.into()),
         }
     }
@@ -119,24 +117,21 @@ impl ArtifactStore<SimArtifactStorage> {
     pub async fn wait_for_writers(&self) {
         // Acquire a permit for MAX_PERMITS, which requires that all write tasks
         // have dropped their permits. Then immediately drop it.
-        let _permit = self
-            .storage
-            .write_semaphore
-            .acquire_many(MAX_PERMITS)
-            .await
-            .unwrap();
+        let _permit_or_closed =
+            self.storage.write_semaphore.acquire_many(MAX_PERMITS).await;
     }
 
+    /// Waits for all current writers to complete, then closes the semaphore to
+    /// disallow any new writers from starting.
+    ///
+    /// This cannot take an owned `self` because it would require moving this
+    /// struct out of an `Arc`.
     pub async fn stop_writers(&self) {
         // Acquire a permit for MAX_PERMITS, which requires that all write
         // tasks have dropped their permits. While holding the permit, close the
         // semaphore to prevent any new write tasks from starting.
-        let _permit = self
-            .storage
-            .write_semaphore
-            .acquire_many(MAX_PERMITS)
-            .await
-            .unwrap();
+        let _permit_or_closed =
+            self.storage.write_semaphore.acquire_many(MAX_PERMITS).await;
         self.storage.write_semaphore.close();
     }
 

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -112,8 +112,7 @@ pub struct SledAgent {
     /// counter and return 503 Service Unavailable.
     local_storage_error_count: AtomicU32,
     pub bootstore_network_config: Mutex<bootstore::NetworkConfig>,
-    pub(super) repo_depot:
-        dropshot::HttpServer<ArtifactStore<SimArtifactStorage>>,
+    pub repo_depot: dropshot::HttpServer<ArtifactStore<SimArtifactStorage>>,
     pub log: Logger,
     health_monitor: HealthMonitorHandle,
 }


### PR DESCRIPTION
#11059 describes a test flake where some hex filenames are found leftover from temporary directories. I intuited that these are likely from the artifact store implementation and that, perhaps, artifacts are being persisted into the temporary directories that belong to `SimArtifactStore` during the drop implementation of its two `Utf8TempDir`s, in the window of time after `readdir` has reached the end of directory but before `unlink` is called on the hopefully-empty directory. This closes that theoretical race condition, hoping that it is the actual race condition.

@jgallagher noted that #10921 added an integration test which uploads a TUF repo but does not wait for the artifact replication machinery at all. This is probably not the first test that does this but it likely exacerbated this possible race. (Tests that wait for the artifact replication machinery will essentially synchronize on all of the write tasks completing before the simulated artifact store is dropped.)

In the simulated artifact store we already have a `Semaphore` set up to allow synchronizing after copy-from-sled requests are finished. I've extended this to be used for _any_ write task, and wired up a method to `cptestctx.teardown().await` to wait for all current writers to complete and then stop any new writers by closing the semaphore.

If this doesn't fix it, I've also labeled the simulated artifact store's storage tempdirs so we have a better idea of whether this code is even involved.