### PR TITLE
[nexus] use `matching_classes` in alert glob reprocessing

### DIFF
--- a/nexus/db-model/src/alert_subscription.rs
+++ b/nexus/db-model/src/alert_subscription.rs
@@ -112,22 +112,7 @@ impl AlertSubscriptionKind {
 
         match self {
             Self::Exact(class) => Ok(Either::Left(std::iter::once(*class))),
-            Self::Glob(glob) => {
-                let regex = regex::Regex::new(&glob.regex).map_err(
-                    |error| Error::InternalError {
-                        internal_message: format!(
-                            "valid alert class glob {:?} produced an invalid \
-                             regular expression: {error}",
-                            glob.glob,
-                        ),
-                    },
-                )?;
-                let iter = AlertClass::ALL_CLASSES
-                    .iter()
-                    .copied()
-                    .filter(move |class| regex.is_match(class.as_str()));
-                Ok(Either::Right(iter))
-            }
+            Self::Glob(glob) => glob.matching_classes().map(Either::Right),
         }
     }
 }
@@ -256,6 +241,25 @@ impl AlertGlob {
         regex.push('$'); // End anchor
 
         Ok(regex)
+    }
+
+    pub fn matching_classes(
+        &self,
+    ) -> Result<impl Iterator<Item = AlertClass>, Error> {
+        let regex = regex::Regex::new(&self.regex).map_err(|error| {
+            Error::InternalError {
+                internal_message: format!(
+                    "valid alert class glob {:?} produced an invalid \
+                     regular expression: {error}",
+                    self.glob,
+                ),
+            }
+        })?;
+        let iter = AlertClass::ALL_CLASSES
+            .iter()
+            .copied()
+            .filter(move |class| regex.is_match(class.as_str()));
+        Ok(iter)
     }
 }
 

--- a/nexus/db-queries/src/db/datastore/alert_rx.rs
+++ b/nexus/db-queries/src/db/datastore/alert_rx.rs
@@ -725,49 +725,31 @@ impl DataStore {
         glob: &AlertRxGlob,
         conn: &async_bb8_diesel::Connection<DbConnection>,
     ) -> Result<usize, TransactionError<Error>> {
-        let regex = match regex::Regex::new(&glob.glob.regex) {
-            Ok(r) => r,
-            Err(error) => {
-                const MSG: &str =
-                    "alert glob subscription regex was not a valid regex";
+        let subscriptions = glob
+            .glob
+            .matching_classes()
+            .map_err(|error| {
                 slog::error!(
                     &opctx.log,
-                    "{MSG}";
+                    "alert glob subscription regex was not a valid regex";
                     "glob" => ?glob.glob.glob,
                     "regex" => ?glob.glob.regex,
                     "error" => %error,
                 );
-                return Err(TransactionError::CustomError(
-                    Error::internal_error(MSG),
-                ));
-            }
-        };
-        let subscriptions = AlertClass::ALL_CLASSES
-            .iter()
-            .filter_map(|class| {
-                if regex.is_match(class.as_str()) {
-                    slog::debug!(
-                        &opctx.log,
-                        "alert glob matches event class";
-                        "rx_id" => ?glob.rx_id,
-                        "glob" => ?glob.glob.glob,
-                        "regex" => ?regex,
-                        "alert_class" => %class,
-                    );
-                    Some(AlertRxSubscription::for_glob(&glob, *class))
-                } else {
-                    slog::trace!(
-                        &opctx.log,
-                        "alert glob does not match event class";
-                        "rx_id" => ?glob.rx_id,
-                        "glob" => ?glob.glob.glob,
-                        "regex" => ?regex,
-                        "alert_class" => %class,
-                    );
-                    None
-                }
+                TransactionError::CustomError(error)
+            })?
+            .map(|class| {
+                slog::debug!(
+                    &opctx.log,
+                    "alert glob matches event class";
+                    "rx_id" => ?glob.rx_id,
+                    "glob" => ?glob.glob.glob,
+                    "regex" => ?glob.glob.regex,
+                    "alert_class" => %class,
+                );
+                AlertRxSubscription::for_glob(&glob, class)
             })
-            .collect::<Vec<_>>();
+            .collect();
         let created = self
             .add_exact_subscription_batch_on_conn(
                 glob.rx_id.into(),
@@ -781,7 +763,7 @@ impl DataStore {
             "created {created} webhook subscriptions for glob";
             "rx_id" => ?glob.rx_id,
             "glob" => ?glob.glob.glob,
-            "regex" => ?regex,
+            "regex" => ?glob.glob.regex,
         );
 
         Ok(created)


### PR DESCRIPTION
Depends on #11072.

This way, the glob reprocessing code and the alert list endpoint use the same underlying logic for matching globs, and it's defined in one place. This should make subsequent changes (such as performance improvements) a bit easier, and ensures that the two will behave identically.