### PR TITLE
[nexus] Don't watch VMMs that are terminal or belong to deleted instances

### DIFF
--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -2350,6 +2350,88 @@ mod tests {
         authz_instance
     }
 
+    /// Inserts a VMM record in `state` on `sled_id` for an existing
+    /// instance, and updates the instance's runtime state to make it the
+    /// instance's active VMM.
+    async fn set_test_vmm(
+        datastore: &DataStore,
+        opctx: &OpContext,
+        instance_id: InstanceUuid,
+        sled_id: SledUuid,
+        state: VmmState,
+    ) -> Vmm {
+        let failure_reason = if state == VmmState::Failed {
+            Some(VmmFailureReason::FromSledAgent)
+        } else {
+            None
+        };
+        let vmm = datastore
+            .vmm_insert(
+                opctx,
+                Vmm {
+                    id: Uuid::new_v4(),
+                    time_created: Utc::now(),
+                    time_deleted: None,
+                    instance_id: instance_id.into_untyped_uuid(),
+                    sled_id: sled_id.into(),
+                    propolis_ip: "10.1.9.42".parse().unwrap(),
+                    propolis_port: 420.into(),
+                    cpu_platform: VmmCpuPlatform::SledDefault,
+                    time_state_updated: Utc::now(),
+                    generation: Generation::new(),
+                    state,
+                    failure_reason,
+                },
+            )
+            .await
+            .expect("test VMM should insert");
+        let updated = datastore
+            .instance_update_runtime(
+                &instance_id,
+                &InstanceRuntimeState {
+                    time_updated: Utc::now(),
+                    generation: Generation(Generation::new().next()),
+                    nexus_state: InstanceState::Vmm,
+                    propolis_id: Some(vmm.id),
+                    dst_propolis_id: None,
+                    migration_id: None,
+                    time_last_auto_restarted: None,
+                },
+            )
+            .await
+            .expect("instance should be updated");
+        assert!(updated, "instance should be updated");
+        vmm
+    }
+
+    /// Creates a test instance named `instance_name` with an active VMM in
+    /// `state` on `sled_id`.
+    async fn create_test_instance_with_vmm(
+        datastore: &DataStore,
+        opctx: &OpContext,
+        authz_project: &authz::Project,
+        sled_id: SledUuid,
+        instance_name: &str,
+        state: VmmState,
+    ) -> (authz::Instance, Vmm) {
+        let authz_instance = create_test_instance(
+            datastore,
+            opctx,
+            authz_project,
+            instance_name,
+        )
+        .await;
+        let vmm = set_test_vmm(
+            datastore,
+            opctx,
+            InstanceUuid::from_untyped_uuid(authz_instance.id()),
+            sled_id,
+            state,
+        )
+        .await;
+        (authz_instance, vmm)
+    }
+
     #[tokio::test]
     async fn test_instance_updater_acquires_lock() {
         // Setup
@@ -3505,68 +3587,6 @@ mod tests {
             instance_id: Uuid,
         }
 
-        // Creates a test instance with a VMM in `state` on `sled_id`.
-        async fn create_test_instance_with_vmm(
-            datastore: &DataStore,
-            opctx: &OpContext,
-            authz_project: &authz::Project,
-            sled_id: SledUuid,
-            instance_name: &str,
-            state: VmmState,
-        ) -> Ids {
-            let authz_instance = create_test_instance(
-                datastore,
-                opctx,
-                authz_project,
-                instance_name,
-            )
-            .await;
-            let instance_id = authz_instance.id();
-            let failure_reason = if state == VmmState::Failed {
-                Some(VmmFailureReason::FromSledAgent)
-            } else {
-                None
-            };
-            let vmm = datastore
-                .vmm_insert(
-                    opctx,
-                    Vmm {
-                        id: Uuid::new_v4(),
-                        time_created: Utc::now(),
-                        time_deleted: None,
-                        instance_id,
-                        sled_id: sled_id.into(),
-                        propolis_ip: "10.1.9.42".parse().unwrap(),
-                        propolis_port: 420.into(),
-                        cpu_platform: VmmCpuPlatform::SledDefault,
-                        time_state_updated: Utc::now(),
-                        generation: Generation::new(),
-                        state,
-                        failure_reason,
-                    },
-                )
-                .await
-                .expect("test VMM should insert");
-            let vmm_id = vmm.id;
-            let updated = datastore
-                .instance_update_runtime(
-                    &InstanceUuid::from_untyped_uuid(instance_id),
-                    &InstanceRuntimeState {
-                        time_updated: Utc::now(),
-                        generation: Generation(Generation::new().next()),
-                        nexus_state: InstanceState::Vmm,
-                        propolis_id: Some(vmm_id),
-                        dst_propolis_id: None,
-                        migration_id: None,
-                        time_last_auto_restarted: None,
-                    },
-                )
-                .await
-                .expect("instance should be updated");
-            assert!(updated, "instance should be updated");
-            Ids { sled_id, vmm_id, instance_id }
-        }
-
         // Make some sleds, and put some instances and VMMs on those sleds.
         let mut sled_ids = Vec::new();
         for s in 0..2 {
@@ -3580,7 +3600,7 @@ mod tests {
             for i in 0..INSTANCES_PER_SLED {
                 // Make sure the instance has a unique name.
                 let instance_name = format!("s{s}i{i}");
-                let ids = create_test_instance_with_vmm(
+                let (authz_instance, vmm) = create_test_instance_with_vmm(
                     &datastore,
                     &opctx,
                     &authz_project,
@@ -3589,7 +3609,11 @@ mod tests {
                     VmmState::Running,
                 )
                 .await;
-                expected_instances.insert(ids);
+                expected_instances.insert(Ids {
+                    sled_id,
+                    vmm_id: vmm.id,
+                    instance_id: authz_instance.id(),
+                });
             }
         }
 
@@ -3622,7 +3646,7 @@ mod tests {
 
         // A deleted instance whose VMM row still exists should not be listed.
         {
-            let ids = create_test_instance_with_vmm(
+            let (authz_instance, _) = create_test_instance_with_vmm(
                 &datastore,
                 &opctx,
                 &authz_project,
@@ -3633,7 +3657,7 @@ mod tests {
             .await;
             use nexus_db_schema::schema::instance::dsl as instance_dsl;
             diesel::update(instance_dsl::instance)
-                .filter(instance_dsl::id.eq(ids.instance_id))
+                .filter(instance_dsl::id.eq(authz_instance.id()))
                 .set((
                     instance_dsl::state.eq(InstanceState::Destroyed),
                     instance_dsl::active_propolis_id.eq(Option::<Uuid>::None),

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -1022,10 +1022,12 @@ impl DataStore {
             // nothing further about them.
             .filter(vmm_dsl::state.ne_all(VmmState::TERMINAL_STATES));
         // Now, join with the `instance` table on the instance's VMM ID.
-        let query = query.inner_join(
-            instance_dsl::instance
-                .on(instance_dsl::id.eq(vmm_dsl::instance_id)),
-        );
+        let query = query
+            .inner_join(
+                instance_dsl::instance
+                    .on(instance_dsl::id.eq(vmm_dsl::instance_id)),
+            )
+            .filter(instance_dsl::time_deleted.is_null());
         // Finally, join with the `project` table on the instance's project ID,
         // to return the project that each instance belongs to.
         let query = query.inner_join(
@@ -3616,6 +3618,32 @@ mod tests {
                 *state,
             )
             .await;
+        }
+
+        // A deleted instance whose VMM row still exists should not be listed.
+        {
+            let ids = create_test_instance_with_vmm(
+                &datastore,
+                &opctx,
+                &authz_project,
+                sled_ids[0],
+                "deleted",
+                VmmState::Running,
+            )
+            .await;
+            use nexus_db_schema::schema::instance::dsl as instance_dsl;
+            diesel::update(instance_dsl::instance)
+                .filter(instance_dsl::id.eq(ids.instance_id))
+                .set((
+                    instance_dsl::state.eq(InstanceState::Destroyed),
+                    instance_dsl::active_propolis_id.eq(Option::<Uuid>::None),
+                    instance_dsl::time_deleted.eq(Utc::now()),
+                ))
+                .execute_async(
+                    &*datastore.pool_connection_for_tests().await.unwrap(),
+                )
+                .await
+                .expect("instance should be marked deleted");
         }
 
         // Okay, now list instances by sled.

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -1016,7 +1016,11 @@ impl DataStore {
             // sled. Since this query drives instance-watcher health checking,
             // it is not necessary to perform health checks for VMMs that don't
             // actually exist in real life.
-            .filter(vmm_dsl::state.ne_all(VmmState::NONEXISTENT_STATES));
+            .filter(vmm_dsl::state.ne_all(VmmState::NONEXISTENT_STATES))
+            // Also ignore VMMs in terminal states, which will never
+            // transition to another state, so a health check can learn
+            // nothing further about them.
+            .filter(vmm_dsl::state.ne_all(VmmState::TERMINAL_STATES));
         // Now, join with the `instance` table on the instance's VMM ID.
         let query = query.inner_join(
             instance_dsl::instance
@@ -2259,6 +2263,7 @@ mod tests {
     use nexus_db_model::InstanceState;
     use nexus_db_model::Project;
     use nexus_db_model::VmmCpuPlatform;
+    use nexus_db_model::VmmFailureReason;
     use nexus_db_model::VmmState;
     use nexus_types::external_api::instance as instance_types;
     use nexus_types::external_api::project;
@@ -3497,7 +3502,71 @@ mod tests {
             vmm_id: Uuid,
             instance_id: Uuid,
         }
+
+        // Creates a test instance with a VMM in `state` on `sled_id`.
+        async fn create_test_instance_with_vmm(
+            datastore: &DataStore,
+            opctx: &OpContext,
+            authz_project: &authz::Project,
+            sled_id: SledUuid,
+            instance_name: &str,
+            state: VmmState,
+        ) -> Ids {
+            let authz_instance = create_test_instance(
+                datastore,
+                opctx,
+                authz_project,
+                instance_name,
+            )
+            .await;
+            let instance_id = authz_instance.id();
+            let failure_reason = if state == VmmState::Failed {
+                Some(VmmFailureReason::FromSledAgent)
+            } else {
+                None
+            };
+            let vmm = datastore
+                .vmm_insert(
+                    opctx,
+                    Vmm {
+                        id: Uuid::new_v4(),
+                        time_created: Utc::now(),
+                        time_deleted: None,
+                        instance_id,
+                        sled_id: sled_id.into(),
+                        propolis_ip: "10.1.9.42".parse().unwrap(),
+                        propolis_port: 420.into(),
+                        cpu_platform: VmmCpuPlatform::SledDefault,
+                        time_state_updated: Utc::now(),
+                        generation: Generation::new(),
+                        state,
+                        failure_reason,
+                    },
+                )
+                .await
+                .expect("test VMM should insert");
+            let vmm_id = vmm.id;
+            let updated = datastore
+                .instance_update_runtime(
+                    &InstanceUuid::from_untyped_uuid(instance_id),
+                    &InstanceRuntimeState {
+                        time_updated: Utc::now(),
+                        generation: Generation(Generation::new().next()),
+                        nexus_state: InstanceState::Vmm,
+                        propolis_id: Some(vmm_id),
+                        dst_propolis_id: None,
+                        migration_id: None,
+                        time_last_auto_restarted: None,
+                    },
+                )
+                .await
+                .expect("instance should be updated");
+            assert!(updated, "instance should be updated");
+            Ids { sled_id, vmm_id, instance_id }
+        }
+
         // Make some sleds, and put some instances and VMMs on those sleds.
+        let mut sled_ids = Vec::new();
         for s in 0..2 {
             let (sled, updated) = datastore
                 .sled_upsert(sled::test::test_new_sled_update())
@@ -3505,55 +3574,20 @@ mod tests {
                 .unwrap();
             assert!(updated);
             let sled_id = sled.id();
+            sled_ids.push(sled_id);
             for i in 0..INSTANCES_PER_SLED {
                 // Make sure the instance has a unique name.
                 let instance_name = format!("s{s}i{i}");
-                let authz_instance = create_test_instance(
+                let ids = create_test_instance_with_vmm(
                     &datastore,
                     &opctx,
                     &authz_project,
+                    sled_id,
                     &instance_name,
+                    VmmState::Running,
                 )
                 .await;
-                let instance_id = authz_instance.id();
-                let vmm = datastore
-                    .vmm_insert(
-                        &opctx,
-                        Vmm {
-                            id: Uuid::new_v4(),
-                            time_created: Utc::now(),
-                            time_deleted: None,
-                            instance_id,
-                            sled_id: sled_id.into(),
-                            propolis_ip: "10.1.9.42".parse().unwrap(),
-                            propolis_port: 420.into(),
-                            cpu_platform: VmmCpuPlatform::SledDefault,
-                            time_state_updated: Utc::now(),
-                            generation: Generation::new(),
-                            state: VmmState::Running,
-                            failure_reason: None,
-                        },
-                    )
-                    .await
-                    .expect("test VMM should insert");
-                let vmm_id = vmm.id;
-                let updated = datastore
-                    .instance_update_runtime(
-                        &InstanceUuid::from_untyped_uuid(instance_id),
-                        &InstanceRuntimeState {
-                            time_updated: Utc::now(),
-                            generation: Generation(Generation::new().next()),
-                            nexus_state: InstanceState::Vmm,
-                            propolis_id: Some(vmm_id),
-                            dst_propolis_id: None,
-                            migration_id: None,
-                            time_last_auto_restarted: None,
-                        },
-                    )
-                    .await
-                    .expect("instance should be updated");
-                assert!(updated, "instance should be updated");
-                expected_instances.insert(Ids { sled_id, vmm_id, instance_id });
+                expected_instances.insert(ids);
             }
         }
 
@@ -3565,6 +3599,21 @@ mod tests {
                 &opctx,
                 &authz_project,
                 &instance_name,
+            )
+            .await;
+        }
+
+        // Instances with VMMs in terminal states should not be listed, as
+        // there is nothing left to health check.
+        for state in VmmState::TERMINAL_STATES {
+            let instance_name = format!("terminal-{state}");
+            let _ = create_test_instance_with_vmm(
+                &datastore,
+                &opctx,
+                &authz_project,
+                sled_ids[0],
+                &instance_name,
+                *state,
             )
             .await;
         }

--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -249,8 +249,13 @@ impl Check {
                 let instance_state = {
                     // let state = state.state.state.into()! wow!!
                     let db_vmm_state = vmm_state.vmm_state.state.into();
+                    // Compute the state as though this VMM were the
+                    // instance's active VMM, since it may be a migration
+                    // target or no longer linked to the instance, and
+                    // `InstanceStateComputer` asserts on instance/VMM state
+                    // pairs that cannot occur for an active VMM.
                     InstanceStateComputer::compute_state_from(
-                        &instance.nexus_state,
+                        &nexus_db_model::InstanceState::Vmm,
                         instance.migration_id.as_ref(),
                         Some(&db_vmm_state),
                     )

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1991,6 +1991,38 @@ mod test {
             .await
             .unwrap();
 
+        // Mark any remaining VMM records for this instance as destroyed and
+        // deleted. The instance-update saga doesn't unwind changes to VMM
+        // records, and we are about to delete the instance record directly
+        // rather than going through the normal deletion path, which requires
+        // the VMMs to be cleaned up first. If we leave live VMM rows behind
+        // pointing at a deleted instance, the `instance_watcher` background
+        // task may try to health check them and trip debug assertions on the
+        // (deleted instance, live VMM) state pair.
+        {
+            use async_bb8_diesel::AsyncRunQueryDsl;
+            use diesel::prelude::*;
+            use nexus_db_schema::schema::vmm::dsl as vmm_dsl;
+            let datastore = cptestctx.server.server_context().nexus.datastore();
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+            diesel::update(vmm_dsl::vmm)
+                .filter(vmm_dsl::instance_id.eq(instance.id()))
+                .filter(vmm_dsl::time_deleted.is_null())
+                .set((
+                    vmm_dsl::state.eq(db::model::VmmState::Destroyed),
+                    // `failure_reason` must be NULL for any state other than
+                    // `Failed`, per the `failure_reason_iff_failed` CHECK
+                    // constraint.
+                    vmm_dsl::failure_reason
+                        .eq(Option::<db::model::VmmFailureReason>::None),
+                    vmm_dsl::time_state_updated.eq(Utc::now()),
+                    vmm_dsl::time_deleted.eq(Utc::now()),
+                ))
+                .execute_async(&*conn)
+                .await
+                .expect("should be able to mark the test VMMs as deleted");
+        }
+
         test_helpers::instance_delete_by_name(
             cptestctx,
             INSTANCE_NAME,

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1991,14 +1991,14 @@ mod test {
             .await
             .unwrap();
 
-        // Mark any remaining VMM records for this instance as destroyed and
-        // deleted. The instance-update saga doesn't unwind changes to VMM
-        // records, and we are about to delete the instance record directly
-        // rather than going through the normal deletion path, which requires
-        // the VMMs to be cleaned up first. If we leave live VMM rows behind
-        // pointing at a deleted instance, the `instance_watcher` background
-        // task may try to health check them and trip debug assertions on the
-        // (deleted instance, live VMM) state pair.
+        // Hard delete any remaining VMM records for this instance. The
+        // instance-update saga doesn't unwind changes to VMM records, and we
+        // are about to delete the instance record directly rather than going
+        // through the normal deletion path, which requires the VMMs to be
+        // cleaned up first. If we leave live VMM rows behind pointing at a
+        // deleted instance, the `instance_watcher` background task may try to
+        // health check them and trip debug assertions on the (deleted
+        // instance, live VMM) state pair.
         {
             use async_bb8_diesel::AsyncRunQueryDsl;
             use diesel::prelude::*;
@@ -2007,23 +2007,13 @@ mod test {
             let nexus = &cptestctx.server.server_context().nexus;
             let datastore = nexus.datastore();
             let conn = datastore.pool_connection_for_tests().await.unwrap();
-            let vmms: Vec<(Uuid, Uuid)> = diesel::update(vmm_dsl::vmm)
+            let vmms: Vec<(Uuid, Uuid)> = diesel::delete(vmm_dsl::vmm)
                 .filter(vmm_dsl::instance_id.eq(instance.id()))
                 .filter(vmm_dsl::time_deleted.is_null())
-                .set((
-                    vmm_dsl::state.eq(db::model::VmmState::Destroyed),
-                    // `failure_reason` must be NULL for any state other than
-                    // `Failed`, per the `failure_reason_iff_failed` CHECK
-                    // constraint.
-                    vmm_dsl::failure_reason
-                        .eq(Option::<db::model::VmmFailureReason>::None),
-                    vmm_dsl::time_state_updated.eq(Utc::now()),
-                    vmm_dsl::time_deleted.eq(Utc::now()),
-                ))
                 .returning((vmm_dsl::id, vmm_dsl::sled_id))
                 .get_results_async(&*conn)
                 .await
-                .expect("should be able to mark the test VMMs as deleted");
+                .expect("should be able to delete the test VMMs");
 
             // Also unregister the VMMs from their simulated sled-agents, so
             // that the sim agents' state stays consistent with the database.

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -2003,9 +2003,11 @@ mod test {
             use async_bb8_diesel::AsyncRunQueryDsl;
             use diesel::prelude::*;
             use nexus_db_schema::schema::vmm::dsl as vmm_dsl;
-            let datastore = cptestctx.server.server_context().nexus.datastore();
+            use omicron_uuid_kinds::SledUuid;
+            let nexus = &cptestctx.server.server_context().nexus;
+            let datastore = nexus.datastore();
             let conn = datastore.pool_connection_for_tests().await.unwrap();
-            diesel::update(vmm_dsl::vmm)
+            let vmms: Vec<(Uuid, Uuid)> = diesel::update(vmm_dsl::vmm)
                 .filter(vmm_dsl::instance_id.eq(instance.id()))
                 .filter(vmm_dsl::time_deleted.is_null())
                 .set((
@@ -2018,9 +2020,22 @@ mod test {
                     vmm_dsl::time_state_updated.eq(Utc::now()),
                     vmm_dsl::time_deleted.eq(Utc::now()),
                 ))
-                .execute_async(&*conn)
+                .returning((vmm_dsl::id, vmm_dsl::sled_id))
+                .get_results_async(&*conn)
                 .await
                 .expect("should be able to mark the test VMMs as deleted");
+
+            // Also unregister the VMMs from their simulated sled-agents, so
+            // that the sim agents' state stays consistent with the database.
+            for (vmm_id, sled_id) in vmms {
+                nexus
+                    .sled_client(&SledUuid::from_untyped_uuid(sled_id))
+                    .await
+                    .expect("the VMM's sled should exist")
+                    .vmm_unregister(&PropolisUuid::from_untyped_uuid(vmm_id))
+                    .await
+                    .expect("should be able to unregister the VMM");
+            }
         }
 
         test_helpers::instance_delete_by_name(


### PR DESCRIPTION
The `instance_watcher` background task's query could return a live VMM row paired with a deleted instance record. Monitoring such a VMM trips debug assertions in `InstanceStateComputer::compute_state_from`, which expects a deleted instance to have no VMM state, causing the test flake in #8755.

These fixes include:
- The instance-update unwinding tests now clean up their VMM records before deleting the test instance, instead of leaving live VMM rows behind pointing at a deleted instance. This commit changes test cleanup only; it is exercised by the existing unwinding tests, including the formerly flaky `test_migration_source_failed_destroyed_can_unwind`.
- The watcher query now skips VMMs in terminal states (`Failed`, `Destroyed`), which will never transition again, so a request to monitor can learn nothing further about them. This commit extends `test_instance_and_vmm_list_by_sled_agent` with an instance in each terminal VMM state and asserts that neither is listed.
- The watcher query now filters out deleted instances when joining the `vmm` table with the `instance` table. This commit extends the same test with a deleted instance whose VMM row still exists, again asserting it is not listed. Additionally, it always passes `InstanceState::Vmm` to the `InstanceStateComputer`, to avoid src/dst issues during migration that can cause the `InstanceState` machine to panic. This avoids panicking the test demonstrated in https://github.com/oxidecomputer/omicron/pull/11101

Fixes #8755.