### PR TITLE
Update static route example in rack setup template toml

### DIFF
--- a/wicket/src/cli/rack_setup/config_template.toml
+++ b/wicket/src/cli/rack_setup/config_template.toml
@@ -85,7 +85,7 @@ infra_ip_last = ""
     routes = []
 
     # Addresses associated with this port.
-    # "1.2.3.4/30"
+    # "1.2.3.4/31"
     addresses = []
 
     # `speed40_g`, `speed100_g`, ...

--- a/wicket/src/cli/rack_setup/config_template.toml
+++ b/wicket/src/cli/rack_setup/config_template.toml
@@ -81,11 +81,11 @@ infra_ip_last = ""
 [rack_network_config.switch0.qsfp0]
 
     # Routes associated with this port.
-    # { nexthop = "1.2.3.4", destination = "0.0.0.0/0" }
+    # { nexthop = "1.2.3.5", destination = "0.0.0.0/0" }
     routes = []
 
     # Addresses associated with this port.
-    # "1.2.3.4/24"
+    # "1.2.3.4/30"
     addresses = []
 
     # `speed40_g`, `speed100_g`, ...


### PR DESCRIPTION
The existing example values in the rack setup toml template were incorrect and led to at least two misconfigured racks.  These new values more correctly model what is expected when static routes are used.