### PR TITLE
Add `allow_ddm_traffic` to port config in CRDB

### DIFF
--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(291, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(292, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ pub static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(292, "allow-ddm-traffic"),
         KnownVersion::new(291, "bgp-peer-src-addr"),
         KnownVersion::new(290, "saga-abandon-reason-orphaned"),
         KnownVersion::new(289, "normalize-service-external-ips"),

--- a/nexus/db-model/src/switch_port.rs
+++ b/nexus/db-model/src/switch_port.rs
@@ -435,11 +435,17 @@ impl Into<networking_types::SwitchPortSettingsGroup>
 pub struct SwitchPortConfig {
     pub port_settings_id: Uuid,
     pub geometry: SwitchPortGeometry,
+    /// Whether DDM traffic is permitted on this port.
+    pub allow_ddm_traffic: bool,
 }
 
 impl SwitchPortConfig {
-    pub fn new(port_settings_id: Uuid, geometry: SwitchPortGeometry) -> Self {
-        Self { port_settings_id, geometry }
+    pub fn new(
+        port_settings_id: Uuid,
+        geometry: SwitchPortGeometry,
+        allow_ddm_traffic: bool,
+    ) -> Self {
+        Self { port_settings_id, geometry, allow_ddm_traffic }
     }
 }
 

--- a/nexus/db-queries/src/db/datastore/switch_port.rs
+++ b/nexus/db-queries/src/db/datastore/switch_port.rs
@@ -365,6 +365,7 @@ impl DataStore {
         opctx: &OpContext,
         params: &networking::SwitchPortSettingsCreate,
         id: Option<Uuid>,
+        allow_ddm_traffic: bool,
     ) -> CreateResult<SwitchPortSettingsCombinedResult> {
         let err = OptionalError::new();
         let conn = self.pool_connection_authorized(opctx).await?;
@@ -375,7 +376,14 @@ impl DataStore {
             .transaction(&conn, |conn| {
                 let err = err.clone();
                 async move {
-                    do_switch_port_settings_create(&conn, id, params, err).await
+                    do_switch_port_settings_create(
+                        &conn,
+                        id,
+                        params,
+                        allow_ddm_traffic,
+                        err,
+                    )
+                    .await
                 }
             })
             .await
@@ -459,9 +467,32 @@ impl DataStore {
                 let create_err = create_err.clone();
                 let selector = NameOrId::Id(id);
                 async move {
+                    use nexus_db_schema::schema::switch_port_settings_port_config::dsl as port_config_dsl;
+
+                    // Until the rest of multirack is implemented, we don't
+                    // want to expose `allow_ddm_traffic` in the external API.
+                    // It's very possible that the actual external configuration
+                    // will look different. For now, we must just ensure that
+                    // a customer doesn't set this flag to true at RSS time
+                    // as we'll maintain whatever actual value was set during
+                    // RSS below. This allows us to test multirack during
+                    // implementation without making it customer visible.
+                    //
+                    // Since `allow_ddm_traffic` isn't part of the external API
+                    // it's absent from `params`. Read it back before the delete
+                    // and carry it into the recreate. Otherwise an operator
+                    // editing unrelated port settings would silently clear what
+                    // RSS configured.
+                    let allow_ddm_traffic: bool =
+                        port_config_dsl::switch_port_settings_port_config
+                            .filter(port_config_dsl::port_settings_id.eq(id))
+                            .select(port_config_dsl::allow_ddm_traffic)
+                            .get_result_async(&conn)
+                            .await?;
+
                     do_switch_port_settings_delete(&conn, &selector, delete_err).await?;
                     do_switch_port_settings_create(
-                        &conn, Some(id), params, create_err,
+                        &conn, Some(id), params, allow_ddm_traffic, create_err,
                     ).await
                 }
             })
@@ -1566,6 +1597,7 @@ async fn do_switch_port_settings_create(
     conn: &Connection<DTraceConnection<PgConnection>>,
     id: Option<Uuid>,
     params: &networking::SwitchPortSettingsCreate,
+    allow_ddm_traffic: bool,
     err: OptionalError<SwitchPortSettingsCreateError>,
 ) -> Result<SwitchPortSettingsCombinedResult, diesel::result::Error> {
     use nexus_db_schema::schema::{
@@ -1599,8 +1631,11 @@ async fn do_switch_port_settings_create(
     let psid = db_port_settings.identity.id;
 
     // add the port config
-    let port_config =
-        SwitchPortConfig::new(psid, params.port_config.geometry.into());
+    let port_config = SwitchPortConfig::new(
+        psid,
+        params.port_config.geometry.into(),
+        allow_ddm_traffic,
+    );
 
     let db_port_config: SwitchPortConfig =
         diesel::insert_into(port_config_dsl::switch_port_settings_port_config)
@@ -2462,8 +2497,14 @@ mod test {
             addresses: vec![],
         };
 
+        let allow_ddm_traffic = false;
         let settings_result = datastore
-            .switch_port_settings_create(&opctx, &settings, None)
+            .switch_port_settings_create(
+                &opctx,
+                &settings,
+                None,
+                allow_ddm_traffic,
+            )
             .await
             .unwrap();
 
@@ -2833,8 +2874,14 @@ mod test {
             }],
             addresses: vec![],
         };
+        let allow_ddm_traffic = false;
         let settings_result = datastore
-            .switch_port_settings_create(&opctx, &settings, None)
+            .switch_port_settings_create(
+                &opctx,
+                &settings,
+                None,
+                allow_ddm_traffic,
+            )
             .await
             .unwrap();
         datastore
@@ -3045,8 +3092,14 @@ mod test {
             addresses: vec![],
         };
 
+        let allow_ddm_traffic = false;
         let result = datastore
-            .switch_port_settings_create(&opctx, &settings, None)
+            .switch_port_settings_create(
+                &opctx,
+                &settings,
+                None,
+                allow_ddm_traffic,
+            )
             .await
             .expect("created settings");
 

--- a/nexus/db-queries/src/db/datastore/switch_port.rs
+++ b/nexus/db-queries/src/db/datastore/switch_port.rs
@@ -360,6 +360,12 @@ impl DataStore {
             .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
     }
 
+    // Until the rest of multirack is implemented, we don't want to expose
+    // `allow_ddm_traffic` in the external API. That's why it's passed
+    // separately from `params`.
+    //
+    // There is a more detailed comment in `switch_port_settings_update` where
+    // this value gets used.
     pub async fn switch_port_settings_create(
         &self,
         opctx: &OpContext,

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -183,6 +183,7 @@ table! {
     switch_port_settings_port_config (port_settings_id) {
         port_settings_id -> Uuid,
         geometry -> crate::enums::SwitchPortGeometryEnum,
+        allow_ddm_traffic -> Bool,
     }
 }
 

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -603,7 +603,12 @@ impl super::Nexus {
 
             match self
                 .db_datastore
-                .switch_port_settings_create(opctx, &port_settings_params, None)
+                .switch_port_settings_create(
+                    opctx,
+                    &port_settings_params,
+                    None,
+                    uplink_config.allow_ddm_traffic,
+                )
                 .await
             {
                 Ok(_) | Err(Error::ObjectAlreadyExists { .. }) => Ok(()),

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -1337,13 +1337,24 @@ mod test {
             }],
         }];
 
+        let allow_ddm_traffic = false;
         let uplink0_settings = datastore
-            .switch_port_settings_create(&opctx, &uplink0_params, None)
+            .switch_port_settings_create(
+                &opctx,
+                &uplink0_params,
+                None,
+                allow_ddm_traffic,
+            )
             .await
             .expect("should be able to create configuration for uplink0");
 
         let uplink1_settings = datastore
-            .switch_port_settings_create(&opctx, &uplink1_params, None)
+            .switch_port_settings_create(
+                &opctx,
+                &uplink1_params,
+                None,
+                allow_ddm_traffic,
+            )
             .await
             .expect("should be able to create configuration for uplink1");
 

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -2928,13 +2928,24 @@ mod test {
             }],
         }];
 
+        let allow_ddm_traffic = false;
         let uplink0_settings = datastore
-            .switch_port_settings_create(&opctx, &uplink0_params, None)
+            .switch_port_settings_create(
+                &opctx,
+                &uplink0_params,
+                None,
+                allow_ddm_traffic,
+            )
             .await
             .expect("should be able to create configuration for uplink0");
 
         let uplink1_settings = datastore
-            .switch_port_settings_create(&opctx, &uplink1_params, None)
+            .switch_port_settings_create(
+                &opctx,
+                &uplink1_params,
+                None,
+                allow_ddm_traffic,
+            )
             .await
             .expect("should be able to create configuration for uplink1");
 

--- a/nexus/src/app/switch_port.rs
+++ b/nexus/src/app/switch_port.rs
@@ -104,9 +104,15 @@ impl super::Nexus {
         params: networking::SwitchPortSettingsCreate,
         id: Option<Uuid>,
     ) -> CreateResult<SwitchPortSettingsCombinedResult> {
+        // We explicitly do not expose `allow_ddm_traffic` through the external
+        // API. We want to wait until multirack is further along to determine
+        // the shape of exposure. The flag is only set by RSS for testing
+        // purposes. Setting it to false here won't restrict our testing right
+        // now.
+        let allow_ddm_traffic = false;
         let result = self
             .db_datastore
-            .switch_port_settings_create(opctx, &params, id)
+            .switch_port_settings_create(opctx, &params, id, allow_ddm_traffic)
             .await?;
 
         // eagerly propagate changes via rpw

--- a/nexus/switch-config/preparation/src/lib.rs
+++ b/nexus/switch-config/preparation/src/lib.rs
@@ -229,5 +229,6 @@ fn port_input_from_db(
                 post1: c.post1,
             })
             .collect(),
+        allow_ddm_traffic: info.port.allow_ddm_traffic,
     }
 }

--- a/nexus/switch-config/src/lib.rs
+++ b/nexus/switch-config/src/lib.rs
@@ -143,6 +143,8 @@ pub struct PortInput {
     pub lldp: Vec<LldpInput>,
     /// The port's TX-EQ overrides. Only the first entry is used today.
     pub tx_eq: Vec<TxEqConfig>,
+    /// Whether DDM traffic is permitted on this port.
+    pub allow_ddm_traffic: bool,
 }
 
 /// An IP address assigned to a port.
@@ -460,7 +462,7 @@ pub fn build_rack_network_config(
                     management_addrs: c.management_ip.map(|ip| vec![ip]),
                 }),
             tx_eq,
-            allow_ddm_traffic: false,
+            allow_ddm_traffic: port.allow_ddm_traffic,
         };
 
         ports.push(port_config);
@@ -540,6 +542,7 @@ mod tests {
             routes: vec![],
             lldp: vec![],
             tx_eq: vec![],
+            allow_ddm_traffic: false,
         }
     }
 

--- a/schema/crdb/allow-ddm-traffic/up01.sql
+++ b/schema/crdb/allow-ddm-traffic/up01.sql
@@ -1,2 +1,2 @@
 ALTER TABLE omicron.public.switch_port_settings_port_config
-    ADD COLUMN IF NOT EXISTS allow_ddm_traffic BOOL NOT NULL DEFAULT false;
+    ADD COLUMN IF NOT EXISTS allow_ddm_traffic BOOL NOT NULL;

--- a/schema/crdb/allow-ddm-traffic/up01.sql
+++ b/schema/crdb/allow-ddm-traffic/up01.sql
@@ -1,2 +1,2 @@
 ALTER TABLE omicron.public.switch_port_settings_port_config
-    ADD COLUMN IF NOT EXISTS allow_ddm_traffic BOOL NOT NULL;
+    ADD COLUMN IF NOT EXISTS allow_ddm_traffic BOOL NOT NULL DEFAULT FALSE;

--- a/schema/crdb/allow-ddm-traffic/up01.sql
+++ b/schema/crdb/allow-ddm-traffic/up01.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.switch_port_settings_port_config
+    ADD COLUMN IF NOT EXISTS allow_ddm_traffic BOOL NOT NULL DEFAULT false;

--- a/schema/crdb/allow-ddm-traffic/up02.sql
+++ b/schema/crdb/allow-ddm-traffic/up02.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.switch_port_settings_port_config
+    ALTER COLUMN allow_ddm_traffic DROP DEFAULT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3753,7 +3753,7 @@ CREATE TYPE IF NOT EXISTS omicron.public.switch_port_geometry AS ENUM (
 CREATE TABLE IF NOT EXISTS omicron.public.switch_port_settings_port_config (
     port_settings_id UUID PRIMARY KEY,
     geometry omicron.public.switch_port_geometry,
-    allow_ddm_traffic BOOL NOT NULL DEFAULT false
+    allow_ddm_traffic BOOL NOT NULL
 );
 
 CREATE TYPE IF NOT EXISTS omicron.public.switch_link_fec AS ENUM (

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3752,7 +3752,8 @@ CREATE TYPE IF NOT EXISTS omicron.public.switch_port_geometry AS ENUM (
 
 CREATE TABLE IF NOT EXISTS omicron.public.switch_port_settings_port_config (
     port_settings_id UUID PRIMARY KEY,
-    geometry omicron.public.switch_port_geometry
+    geometry omicron.public.switch_port_geometry,
+    allow_ddm_traffic BOOL NOT NULL DEFAULT false
 );
 
 CREATE TYPE IF NOT EXISTS omicron.public.switch_link_fec AS ENUM (
@@ -9261,7 +9262,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '291.0.0', NULL)
+    (TRUE, NOW(), NOW(), '292.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
For multirack testing we need to be able to enable DDM traffic on a front port. We only want to expose this configuraton via RSS now, as the vast majority of multirack is not ready and we only want to do internal testing. We want to leave the external API untouched right now.

However, the `sync_switch_configuration` background task will immediately overwrite the value set in RSS, if we always hard code it to the default of false. Therefore, we had to add code to plumb the value into CRDB from RSS and apply it during the `sync_switch_configuration` background task.

Thanks to @jgallagher for [pointing this out earlier](https://github.com/oxidecomputer/omicron/pull/11091#discussion_r3815988172).