### PR TITLE
stock dev/test environment cannot run the planner

### DIFF
--- a/nexus/test-utils-macros/src/lib.rs
+++ b/nexus/test-utils-macros/src/lib.rs
@@ -14,6 +14,7 @@ use syn::{ItemFn, Token, parse_macro_input};
 pub(crate) enum NexusTestArg {
     ServerUnderTest(syn::Path),
     ExtraSledAgents(u16),
+    ConfigureSecondNexus(bool),
 }
 
 impl syn::parse::Parse for NexusTestArg {
@@ -30,6 +31,11 @@ impl syn::parse::Parse for NexusTestArg {
             let value: syn::LitInt = input.parse()?;
             let value = value.base10_parse::<u16>()?;
             return Ok(Self::ExtraSledAgents(value));
+        }
+
+        if name.is_ident("configure_second_nexus") {
+            let value: syn::LitBool = input.parse()?;
+            return Ok(Self::ConfigureSecondNexus(value.value()));
         }
 
         Err(syn::Error::new(name.span(), "unrecognized argument to nexus_test"))
@@ -96,6 +102,7 @@ pub fn nexus_test(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let mut which_nexus =
         syn::parse_str::<syn::Path>("::omicron_nexus::Server").unwrap();
     let mut extra_sled_agents: u16 = 0;
+    let mut configure_second_nexus: bool = false;
 
     for arg in nexus_test_args.0 {
         match arg {
@@ -105,6 +112,10 @@ pub fn nexus_test(attrs: TokenStream, input: TokenStream) -> TokenStream {
 
             NexusTestArg::ExtraSledAgents(value) => {
                 extra_sled_agents = value;
+            }
+
+            NexusTestArg::ConfigureSecondNexus(value) => {
+                configure_second_nexus = value;
             }
         }
     }
@@ -134,6 +145,7 @@ pub fn nexus_test(attrs: TokenStream, input: TokenStream) -> TokenStream {
                 #func_ident_string,
             )
             .with_extra_sled_agents(#extra_sled_agents)
+            .with_second_nexus_configured(#configure_second_nexus)
             .start::<#which_nexus>()
             .await;
             #func_ident(&ctx).await;

--- a/nexus/test-utils/src/nexus_test.rs
+++ b/nexus/test-utils/src/nexus_test.rs
@@ -48,6 +48,7 @@ pub struct ControlPlaneBuilder<'a> {
     nextra_sled_agents: u16,
     tls_cert: Option<Certificate>,
     nexus_config: NexusConfig,
+    configure_second_nexus: bool,
 }
 
 impl<'a> ControlPlaneBuilder<'a> {
@@ -57,6 +58,7 @@ impl<'a> ControlPlaneBuilder<'a> {
             nextra_sled_agents: 0,
             tls_cert: None,
             nexus_config: load_test_config(),
+            configure_second_nexus: false,
         }
     }
 
@@ -67,6 +69,11 @@ impl<'a> ControlPlaneBuilder<'a> {
 
     pub fn with_tls_cert(mut self, tls_cert: Option<Certificate>) -> Self {
         self.tls_cert = tls_cert;
+        self
+    }
+
+    pub fn with_second_nexus_configured(mut self, do_configure: bool) -> Self {
+        self.configure_second_nexus = do_configure;
         self
     }
 
@@ -89,7 +96,7 @@ impl<'a> ControlPlaneBuilder<'a> {
             self.tls_cert,
             self.nextra_sled_agents,
             DEFAULT_SP_SIM_CONFIG.into(),
-            false,
+            self.configure_second_nexus,
         )
         .await
     }

--- a/nexus/test-utils/src/starter.rs
+++ b/nexus/test-utils/src/starter.rs
@@ -66,6 +66,7 @@ use omicron_common::address::DNS_OPTE_IPV4_SUBNET;
 use omicron_common::address::DNS_OPTE_IPV6_SUBNET;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::NEXUS_OPTE_IPV4_SUBNET;
+use omicron_common::address::NEXUS_OPTE_IPV6_SUBNET;
 use omicron_common::address::NTP_OPTE_IPV4_SUBNET;
 use omicron_common::address::NTP_PORT;
 use omicron_common::api::external::Generation;
@@ -693,13 +694,28 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
             .mac_addrs
             .next()
             .expect("ran out of MAC addresses");
-        let ip_config = PrivateIpConfig::new_ipv4(
-            NEXUS_OPTE_IPV4_SUBNET
-                .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES + 1 + which)
+        let ip_config =
+            match config.deployment.dropshot_external.dropshot.bind_address {
+                SocketAddr::V4(_) => PrivateIpConfig::new_ipv4(
+                    NEXUS_OPTE_IPV4_SUBNET
+                        .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES + 1 + which)
+                        .unwrap(),
+                    *NEXUS_OPTE_IPV4_SUBNET,
+                )
                 .unwrap(),
-            *NEXUS_OPTE_IPV4_SUBNET,
-        )
-        .unwrap();
+                SocketAddr::V6(_) => PrivateIpConfig::new_ipv6(
+                    NEXUS_OPTE_IPV6_SUBNET
+                        .nth(
+                            u128::try_from(
+                                NUM_INITIAL_RESERVED_IP_ADDRESSES + 1 + which,
+                            )
+                            .unwrap(),
+                        )
+                        .unwrap(),
+                    *NEXUS_OPTE_IPV6_SUBNET,
+                )
+                .unwrap(),
+            };
         self.blueprint_zones.push(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id,

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -32,6 +32,7 @@ use tufaceous::edit::{Ed25519Key, RepositoryEditor, Root};
 use tufaceous_artifact::{Artifact, ArtifactSet, KnownArtifactTags, SpTags};
 
 use crate::integration_tests::target_release::set_target_release_for_mupdate_recovery_with_expected_status;
+use slog_error_chain::InlineErrorChain;
 
 const TRUST_ROOTS_URL: &str = "/v1/system/update/trust-roots";
 
@@ -1052,4 +1053,19 @@ async fn test_request_without_api_version(cptestctx: &ControlPlaneTestContext) {
         NexusRequest::new(req_builder).authn_as(AuthnMode::PrivilegedUser);
     let status: update::UpdateStatus = req.execute_and_parse_unwrap().await;
     assert_eq!(status.target_release.0, None);
+}
+
+/// Test that in a stock test environment, one can run the planner and get a new
+/// blueprint.
+#[nexus_test(configure_second_nexus = true)]
+async fn test_stock_planner(cptestctx: &ControlPlaneTestContext) {
+    let nexus_client = cptestctx.lockstep_client();
+    let _blueprint =
+        nexus_client.blueprint_regenerate().await.unwrap_or_else(|error| {
+            panic!(
+                "unexpectedly failed to generate new blueprint in stock test \
+                 environment: {}",
+                InlineErrorChain::new(&error)
+            );
+        });
 }


### PR DESCRIPTION
I found that when running `cargo xtask omicron-dev run-all` and then running `omdb nexus blueprints regenerate` (which runs the planner to generate a new blueprint), it failed with a 500:

```
2026-08-20 23:24:13.524Z INFO 913233fe-92a8-4635-9572-183f495429c4/3289 (dropshot_lockstep) on ivanova: request completed
    error_message_external = Internal Server Error
    error_message_internal = assembling planning_input: unexpectedly failed to add Omicron zone NIC to planning input: the Omicron zone a4ef738a-1fb0-47b1-9da2-4919c7ec7c7f with NIC 808886c6-b4b8-48d7-8a8a-69eec349bf80 has no private IP address for the external IP 100::1
    latency_us = 298647
    local_addr = 127.0.0.1:33701
    method = POST
    remote_addr = 127.0.0.1:34676
    req_id = aea37fcc-be7c-4c02-a805-ecb9a9ac072a
    response_code = 500
    uri = /deployment/blueprints/regenerate
```

I expected that the same would happen in a stock `nexus_test`, since `omicron-dev run-all` was built to _be_ an interactive `nexus_test` environment.  But this problem it turns out is specific to the `nexus_test` mode where a second Nexus instance is configured (but not started).  `omicron-dev run-all` does that, but the normal test environment does not.

In this PR:

- The first commit adds a test that using the lockstep API to run the planner works in the test environment even when a second Nexus is configured.  (This involved augmenting the `nexus_test` macro to accept a `configure_second_nexus` argument.)
- The second commit fixes the bug.