### PR TITLE
Support multiple external IPs for services in blueprint tables

### DIFF
--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -1162,7 +1162,7 @@ impl BpOmicronZone {
 
 /// A single external IP address of a blueprint zone.
 ///
-/// Each zone with external networking has one or row in the
+/// Each zone with external networking has one or more rows in the
 /// `bp_omicron_zone_external_ip` table. Each EIP here is an _allocated_
 /// external IP, so it carries the `external_ip_id` as an FK into the
 /// `external_ip` table. The kind is inferred from the owning zone and which of

--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -23,11 +23,12 @@ use nexus_db_schema::schema::{
     blueprint, bp_clickhouse_cluster_config,
     bp_clickhouse_keeper_zone_id_to_node_id,
     bp_clickhouse_server_zone_id_to_node_id, bp_omicron_dataset,
-    bp_omicron_physical_disk, bp_omicron_zone, bp_omicron_zone_nic,
-    bp_oximeter_read_policy, bp_pending_mgs_update_host_phase_1,
-    bp_pending_mgs_update_rot, bp_pending_mgs_update_rot_bootloader,
-    bp_pending_mgs_update_sp, bp_single_measurements, bp_sled_metadata,
-    bp_target, debug_log_blueprint_planning,
+    bp_omicron_physical_disk, bp_omicron_zone, bp_omicron_zone_external_ip,
+    bp_omicron_zone_nic, bp_oximeter_read_policy,
+    bp_pending_mgs_update_host_phase_1, bp_pending_mgs_update_rot,
+    bp_pending_mgs_update_rot_bootloader, bp_pending_mgs_update_sp,
+    bp_single_measurements, bp_sled_metadata, bp_target,
+    debug_log_blueprint_planning,
 };
 use nexus_types::deployment::BlueprintMeasurements;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
@@ -70,16 +71,16 @@ use omicron_generation_kinds::{
     UpdateDispositionGenerationKind,
 };
 use omicron_uuid_kinds::{
-    BlueprintKind, BlueprintUuid, DatasetKind, ExternalIpKind, ExternalIpUuid,
-    GenericUuid, MupdateOverrideKind, OmicronZoneKind, OmicronZoneUuid,
-    PhysicalDiskKind, SledKind, SledUuid, ZpoolKind, ZpoolUuid,
+    BlueprintKind, BlueprintUuid, DatasetKind, ExternalIpKind, GenericUuid,
+    MupdateOverrideKind, OmicronZoneKind, OmicronZoneUuid, PhysicalDiskKind,
+    SledKind, SledUuid, ZpoolKind, ZpoolUuid,
 };
 use sled_agent_types::disk::DiskIdentity;
 use sled_agent_types::inventory::NetworkInterface;
 use sled_agent_types::inventory::OmicronZoneDataset;
 use sled_agent_types::inventory::SourceNatConfigGeneric;
 use sled_hardware_types::BaseboardId;
-use std::net::{IpAddr, SocketAddrV6};
+use std::net::{IpAddr, SocketAddr, SocketAddrV6};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -710,16 +711,12 @@ pub struct BpOmicronZone {
     pub ntp_domain: Option<String>,
     pub nexus_external_tls: Option<bool>,
     pub nexus_external_dns_servers: Option<Vec<IpNetwork>>,
-    pub snat_ip: Option<IpNetwork>,
-    pub snat_first_port: Option<SqlU16>,
-    pub snat_last_port: Option<SqlU16>,
 
     disposition: DbBpZoneDisposition,
     disposition_expunged_as_of_generation:
         Option<DbTypedGeneration<SledConfigGenerationKind>>,
     disposition_expunged_ready_for_cleanup: bool,
 
-    pub external_ip_id: Option<DbTypedUuid<ExternalIpKind>>,
     pub filesystem_pool: DbTypedUuid<ZpoolKind>,
 
     pub image_source: DbBpZoneImageSource,
@@ -734,11 +731,6 @@ impl BpOmicronZone {
         sled_id: SledUuid,
         blueprint_zone: &BlueprintZoneConfig,
     ) -> anyhow::Result<Self> {
-        let external_ip_id = blueprint_zone
-            .zone_type
-            .external_networking()
-            .map(|(ip, _)| ip.id().into());
-
         let DbBpZoneDispositionColumns {
             disposition,
             expunged_as_of_generation: disposition_expunged_as_of_generation,
@@ -755,7 +747,6 @@ impl BpOmicronZone {
             blueprint_id: blueprint_id.into(),
             sled_id: sled_id.into(),
             id: blueprint_zone.id.into(),
-            external_ip_id,
             filesystem_pool: blueprint_zone.filesystem_pool.id().into(),
             disposition,
             disposition_expunged_as_of_generation,
@@ -784,9 +775,6 @@ impl BpOmicronZone {
             ntp_domain: None,
             nexus_external_tls: None,
             nexus_external_dns_servers: None,
-            snat_ip: None,
-            snat_first_port: None,
-            snat_last_port: None,
             nexus_generation: None,
             nexus_lockstep_port: None,
         };
@@ -799,15 +787,15 @@ impl BpOmicronZone {
                     dns_servers,
                     domain,
                     nic,
-                    external_ip,
+                    // The SNAT external IP is stored in the
+                    // `bp_omicron_zone_external_ip` table, not here.
+                    external_ip: _,
                 },
             ) => {
                 // Set the common fields
                 bp_omicron_zone.set_primary_service_ip_and_port(address);
 
                 // Set the zone specific fields
-                let snat_cfg = external_ip.snat_cfg;
-                let (first_port, last_port) = snat_cfg.port_range_raw();
                 bp_omicron_zone.ntp_ntp_servers = Some(ntp_servers.clone());
                 bp_omicron_zone.ntp_dns_servers = Some(
                     dns_servers
@@ -817,10 +805,6 @@ impl BpOmicronZone {
                         .collect(),
                 );
                 bp_omicron_zone.ntp_domain.clone_from(domain);
-                bp_omicron_zone.snat_ip = Some(IpNetwork::from(snat_cfg.ip));
-                bp_omicron_zone.snat_first_port =
-                    Some(SqlU16::from(first_port));
-                bp_omicron_zone.snat_last_port = Some(SqlU16::from(last_port));
                 bp_omicron_zone.bp_nic_id = Some(nic.id);
             }
             BlueprintZoneType::Clickhouse(
@@ -869,7 +853,9 @@ impl BpOmicronZone {
                 blueprint_zone_type::ExternalDns {
                     dataset,
                     http_address,
-                    dns_address,
+                    // The external DNS address is stored in the
+                    // `bp_omicron_zone_external_ip` table, not here.
+                    dns_address: _,
                     nic,
                 },
             ) => {
@@ -879,10 +865,6 @@ impl BpOmicronZone {
 
                 // Set the zone specific fields
                 bp_omicron_zone.bp_nic_id = Some(nic.id);
-                bp_omicron_zone.second_service_ip =
-                    Some(IpNetwork::from(dns_address.addr.ip()));
-                bp_omicron_zone.second_service_port =
-                    Some(SqlU16::from(dns_address.addr.port()));
             }
             BlueprintZoneType::InternalDns(
                 blueprint_zone_type::InternalDns {
@@ -917,7 +899,9 @@ impl BpOmicronZone {
             BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
                 internal_address,
                 lockstep_port,
-                external_ip,
+                // The external IP is stored in the
+                // `bp_omicron_zone_external_ip` table, not here.
+                external_ip: _,
                 nic,
                 external_tls,
                 external_dns_servers,
@@ -929,8 +913,6 @@ impl BpOmicronZone {
 
                 // Set the zone specific fields
                 bp_omicron_zone.bp_nic_id = Some(nic.id);
-                bp_omicron_zone.second_service_ip =
-                    Some(IpNetwork::from(external_ip.ip));
                 bp_omicron_zone.nexus_lockstep_port =
                     Some(SqlU16::from(*lockstep_port));
                 bp_omicron_zone.nexus_external_tls = Some(*external_tls);
@@ -965,20 +947,12 @@ impl BpOmicronZone {
     fn set_zpool_name(&mut self, dataset: &OmicronZoneDataset) {
         self.dataset_zpool_name = Some(dataset.pool_name.to_string());
     }
-    /// Convert an external ip from a `BpOmicronZone` to a `BlueprintZoneType`
-    /// representation.
-    fn external_ip_to_blueprint_zone_type(
-        external_ip: Option<DbTypedUuid<ExternalIpKind>>,
-    ) -> anyhow::Result<ExternalIpUuid> {
-        external_ip
-            .map(Into::into)
-            .ok_or_else(|| anyhow!("expected an external IP ID"))
-    }
 
     pub fn into_blueprint_zone_config(
         self,
         nic_row: Option<BpOmicronZoneNic>,
         image_artifact_row: Option<TufArtifactFile>,
+        external_ip_rows: Vec<BpOmicronZoneExternalIp>,
     ) -> anyhow::Result<BlueprintZoneConfig> {
         // Build up a set of common fields for our `BlueprintZoneType`s
         //
@@ -1004,9 +978,22 @@ impl BpOmicronZone {
             nic_row.map(Into::into),
         )?;
 
-        let external_ip_id =
-            Self::external_ip_to_blueprint_zone_type(self.external_ip_id);
+        // The external IP(s) for this zone live in the
+        // `bp_omicron_zone_external_ip` table. Until `BlueprintZoneType` can
+        // handle multiple IPs (#9288), we need zero or exactly one row here,
+        // for the zone types that have external networking.
+        //
+        // NOTE: This returns an error if `external_ip_rows` is empty. That's
+        // fine if the zone doesn't need external networking, so we only
+        // ?-propagate this inside the zone-specific code below.
+        let external_ip = BpOmicronZoneExternalIp::into_single(
+            external_ip_rows,
+            self.id.into(),
+        );
 
+        // NOTE: this is the *internal* DNS underlay address, held in
+        // `second_service_ip` / `second_service_port`. External DNS's external
+        // address comes from `external_ip` above.
         let dns_address =
             omicron_zone_config::secondary_ip_and_port_to_dns_address(
                 self.second_service_ip,
@@ -1024,24 +1011,8 @@ impl BpOmicronZone {
 
         let zone_type = match self.zone_type {
             ZoneType::BoundaryNtp => {
-                let snat_cfg = match (
-                    self.snat_ip,
-                    self.snat_first_port,
-                    self.snat_last_port,
-                ) {
-                    (Some(ip), Some(first_port), Some(last_port)) => {
-                        SourceNatConfigGeneric::new(
-                            ip.ip(),
-                            *first_port,
-                            *last_port,
-                        )
-                        .context("bad SNAT config for boundary NTP")?
-                    }
-                    _ => bail!(
-                        "expected non-NULL snat properties, \
-                         found at least one NULL"
-                    ),
-                };
+                let external_ip = external_ip?;
+                let snat_cfg = external_ip.to_snat_config()?;
                 BlueprintZoneType::BoundaryNtp(
                     blueprint_zone_type::BoundaryNtp {
                         address: primary_address,
@@ -1050,7 +1021,7 @@ impl BpOmicronZone {
                         domain: self.ntp_domain,
                         nic: nic?,
                         external_ip: OmicronZoneExternalSnatIp {
-                            id: external_ip_id?,
+                            id: external_ip.external_ip_id.into(),
                             snat_cfg,
                         },
                     },
@@ -1092,17 +1063,20 @@ impl BpOmicronZone {
                     address: primary_address,
                 },
             ),
-            ZoneType::ExternalDns => BlueprintZoneType::ExternalDns(
-                blueprint_zone_type::ExternalDns {
-                    dataset: dataset?,
-                    http_address: primary_address,
-                    dns_address: OmicronZoneExternalFloatingAddr {
-                        id: external_ip_id?,
-                        addr: dns_address?,
+            ZoneType::ExternalDns => {
+                let external_ip = external_ip?;
+                BlueprintZoneType::ExternalDns(
+                    blueprint_zone_type::ExternalDns {
+                        dataset: dataset?,
+                        http_address: primary_address,
+                        dns_address: OmicronZoneExternalFloatingAddr {
+                            id: external_ip.external_ip_id.into(),
+                            addr: external_ip.to_floating_addr()?,
+                        },
+                        nic: nic?,
                     },
-                    nic: nic?,
-                },
-            ),
+                )
+            }
             ZoneType::InternalDns => BlueprintZoneType::InternalDns(
                 blueprint_zone_type::InternalDns {
                     dataset: dataset?,
@@ -1125,19 +1099,15 @@ impl BpOmicronZone {
                 blueprint_zone_type::InternalNtp { address: primary_address },
             ),
             ZoneType::Nexus => {
+                let external_ip = external_ip?;
                 BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
                     internal_address: primary_address,
                     lockstep_port: *self.nexus_lockstep_port.ok_or_else(
                         || anyhow!("expected 'nexus_lockstep_port'"),
                     )?,
                     external_ip: OmicronZoneExternalFloatingIp {
-                        id: external_ip_id?,
-                        ip: self
-                            .second_service_ip
-                            .ok_or_else(|| {
-                                anyhow!("expected second service IP")
-                            })?
-                            .ip(),
+                        id: external_ip.external_ip_id.into(),
+                        ip: external_ip.ip.ip(),
                     },
                     nic: nic?,
                     external_tls: self
@@ -1187,6 +1157,140 @@ impl BpOmicronZone {
             zone_type,
             image_source: image_source_cols.try_into()?,
         })
+    }
+}
+
+/// A single external IP address of a blueprint zone.
+///
+/// Each zone with external networking has one or row in the
+/// `bp_omicron_zone_external_ip` table. Each EIP here is an _allocated_
+/// external IP, so it carries the `external_ip_id` as an FK into the
+/// `external_ip` table. The kind is inferred from the owning zone and which of
+/// the port columns are set:
+///
+///  - Nexus:        a floating IP (`ip` only).
+///  - External DNS: a floating IP with a port (`ip` + `port`).
+///  - Boundary NTP: a source-NAT IP (`ip` + `snat_first_port`/`snat_last_port`).
+#[derive(Queryable, Clone, Debug, Selectable, Insertable)]
+#[diesel(table_name = bp_omicron_zone_external_ip)]
+pub struct BpOmicronZoneExternalIp {
+    pub blueprint_id: DbTypedUuid<BlueprintKind>,
+    pub zone_id: DbTypedUuid<OmicronZoneKind>,
+    pub external_ip_id: DbTypedUuid<ExternalIpKind>,
+    pub ip: IpNetwork,
+    pub port: Option<SqlU16>,
+    pub snat_first_port: Option<SqlU16>,
+    pub snat_last_port: Option<SqlU16>,
+}
+
+impl BpOmicronZoneExternalIp {
+    /// Build the external IP child rows for a blueprint zone.
+    ///
+    /// Returns one row per external IP. Today the in-memory `BlueprintZoneType`
+    /// only ever has at most one external IP per zone, so this returns at most
+    /// one row. In general though, the `bp_omicron_zone_external_ip` table can
+    /// store any number of rows per zone, so we're returning an array.
+    pub fn for_zone(
+        blueprint_id: BlueprintUuid,
+        blueprint_zone: &BlueprintZoneConfig,
+    ) -> Vec<Self> {
+        let blueprint_id = blueprint_id.into();
+        let zone_id = blueprint_zone.id.into();
+        match &blueprint_zone.zone_type {
+            BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
+                external_ip,
+                ..
+            }) => vec![Self {
+                blueprint_id,
+                zone_id,
+                external_ip_id: external_ip.id.into(),
+                ip: IpNetwork::from(external_ip.ip),
+                port: None,
+                snat_first_port: None,
+                snat_last_port: None,
+            }],
+            BlueprintZoneType::ExternalDns(
+                blueprint_zone_type::ExternalDns { dns_address, .. },
+            ) => vec![Self {
+                blueprint_id,
+                zone_id,
+                external_ip_id: dns_address.id.into(),
+                ip: IpNetwork::from(dns_address.addr.ip()),
+                port: Some(SqlU16::from(dns_address.addr.port())),
+                snat_first_port: None,
+                snat_last_port: None,
+            }],
+            BlueprintZoneType::BoundaryNtp(
+                blueprint_zone_type::BoundaryNtp { external_ip, .. },
+            ) => {
+                let (first_port, last_port) =
+                    external_ip.snat_cfg.port_range_raw();
+                vec![Self {
+                    blueprint_id,
+                    zone_id,
+                    external_ip_id: external_ip.id.into(),
+                    ip: IpNetwork::from(external_ip.snat_cfg.ip),
+                    port: None,
+                    snat_first_port: Some(SqlU16::from(first_port)),
+                    snat_last_port: Some(SqlU16::from(last_port)),
+                }]
+            }
+            BlueprintZoneType::Clickhouse(_)
+            | BlueprintZoneType::ClickhouseKeeper(_)
+            | BlueprintZoneType::ClickhouseServer(_)
+            | BlueprintZoneType::CockroachDb(_)
+            | BlueprintZoneType::Crucible(_)
+            | BlueprintZoneType::CruciblePantry(_)
+            | BlueprintZoneType::InternalDns(_)
+            | BlueprintZoneType::InternalNtp(_)
+            | BlueprintZoneType::Oximeter(_) => vec![],
+        }
+    }
+
+    /// Collapse the external IP rows for a zone into exactly one.
+    ///
+    /// NOTE: This is a temporary method until the `BlueprintZoneType` variants
+    /// with external addresses can handle more than one EIP. Until then, these
+    /// zones must have exactly one external IP. This returns that single
+    /// address, or an error if there is any other number of rows.
+    fn into_single(
+        mut rows: Vec<Self>,
+        zone_id: OmicronZoneUuid,
+    ) -> anyhow::Result<Self> {
+        match rows.len() {
+            1 => Ok(rows.pop().expect("length checked to be 1")),
+            0 => bail!(
+                "zone {zone_id} has no external IP, \
+                 but its type requires one"
+            ),
+            n => bail!(
+                "zone {zone_id} has {n} external IPs, but only one is \
+                 supported until the in-memory blueprint type is widened \
+                 (#9288)"
+            ),
+        }
+    }
+
+    /// Interpret this row as a boundary NTP source-NAT configuration.
+    fn to_snat_config(&self) -> anyhow::Result<SourceNatConfigGeneric> {
+        let (Some(first_port), Some(last_port)) =
+            (self.snat_first_port, self.snat_last_port)
+        else {
+            bail!(
+                "expected non-NULL SNAT ports for boundary NTP external IP, \
+                 found at least one NULL"
+            );
+        };
+        SourceNatConfigGeneric::new(self.ip.ip(), *first_port, *last_port)
+            .context("bad SNAT config for boundary NTP")
+    }
+
+    /// Interpret this row as an external DNS floating address (IP + port).
+    fn to_floating_addr(&self) -> anyhow::Result<SocketAddr> {
+        let port = self.port.ok_or_else(|| {
+            anyhow!("expected a port for external DNS external IP")
+        })?;
+        Ok(SocketAddr::new(self.ip.ip(), *port))
     }
 }
 

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(297, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(298, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ pub static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(298, "blueprint-zone-multiple-external-ips"),
         KnownVersion::new(297, "inventory-zone-multiple-external-ips"),
         KnownVersion::new(296, "vmm-stop-for-update-disposition-generation"),
         KnownVersion::new(295, "add-inv-sled-update-disposition"),

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -50,6 +50,7 @@ use nexus_db_model::BpClickhouseServerZoneIdToNodeId;
 use nexus_db_model::BpOmicronDataset;
 use nexus_db_model::BpOmicronPhysicalDisk;
 use nexus_db_model::BpOmicronZone;
+use nexus_db_model::BpOmicronZoneExternalIp;
 use nexus_db_model::BpOmicronZoneNic;
 use nexus_db_model::BpOximeterReadPolicy;
 use nexus_db_model::BpPendingMgsUpdateComponent;
@@ -344,6 +345,15 @@ impl DataStore {
                 })
             })
             .collect::<Result<Vec<BpOmicronZoneNic>, _>>()?;
+        let omicron_zone_external_ips = blueprint
+            .sleds
+            .values()
+            .flat_map(|sled| {
+                sled.zones.iter().flat_map(|zone| {
+                    BpOmicronZoneExternalIp::for_zone(blueprint_id, zone)
+                })
+            })
+            .collect::<Vec<BpOmicronZoneExternalIp>>();
 
         let clickhouse_tables: Option<(_, _, _)> = if let Some(config) =
             &blueprint.clickhouse_cluster_config
@@ -495,6 +505,20 @@ impl DataStore {
                         omicron_zone_nic::bp_omicron_zone_nic,
                     )
                     .values(omicron_zone_nics)
+                    .execute_async(&conn)
+                    .await?;
+                }
+
+                {
+                    // Skip formatting this line to prevent rustfmt bailing out.
+                    #[rustfmt::skip]
+                    use nexus_db_schema::schema::
+                        bp_omicron_zone_external_ip::dsl
+                        as omicron_zone_external_ip;
+                    let _ = diesel::insert_into(
+                        omicron_zone_external_ip::bp_omicron_zone_external_ip,
+                    )
+                    .values(omicron_zone_external_ips)
                     .execute_async(&conn)
                     .await?;
                 }
@@ -786,6 +810,35 @@ impl DataStore {
                 })?;
 
                 paginator = p.found_batch(&batch, &|n| n.id);
+                rows.extend(batch);
+            }
+            rows
+        };
+
+        // Load zone external IP rows
+        let raw_zone_external_ips: Vec<BpOmicronZoneExternalIp> = {
+            use nexus_db_schema::schema::bp_omicron_zone_external_ip::dsl;
+
+            let mut rows = Vec::new();
+            let mut paginator = Paginator::new(
+                SQL_BATCH_SIZE,
+                dropshot::PaginationOrder::Ascending,
+            );
+            while let Some(p) = paginator.next() {
+                let batch = paginated(
+                    dsl::bp_omicron_zone_external_ip,
+                    dsl::external_ip_id,
+                    &p.current_pagparams(),
+                )
+                .filter(dsl::blueprint_id.eq(to_db_typed_uuid(blueprint_id)))
+                .select(BpOmicronZoneExternalIp::as_select())
+                .load_async(&*conn)
+                .await
+                .map_err(|e| {
+                    public_error_from_diesel(e, ErrorHandler::Server)
+                })?;
+
+                paginator = p.found_batch(&batch, &|r| r.external_ip_id);
                 rows.extend(batch);
             }
             rows
@@ -1338,6 +1391,16 @@ impl DataStore {
             );
         }
 
+        // Assemble a mutable map of all the external IPs found, grouped by zone
+        // id.  A zone may have more than one, so we collect them into a `Vec`.
+        // As we match these up with each zone below, we remove entries, so we
+        // can tell if any external IP references a zone that doesn't exist.
+        let mut omicron_zone_external_ips: BTreeMap<_, Vec<_>> =
+            BTreeMap::new();
+        for ip in raw_zone_external_ips {
+            omicron_zone_external_ips.entry(ip.zone_id).or_default().push(ip);
+        }
+
         // Process zones: match NICs, validate sled references, parse
         for (z, artifact) in raw_zones {
             let nic_row = z
@@ -1360,6 +1423,8 @@ impl DataStore {
                 .transpose()?;
             let sled_id = SledUuid::from(z.sled_id);
             let zone_id = z.id;
+            let external_ip_rows =
+                omicron_zone_external_ips.remove(&zone_id).unwrap_or_default();
             let sled_config =
                 sled_configs.get_mut(&sled_id).ok_or_else(|| {
                     // This error means that we found a row in
@@ -1372,11 +1437,9 @@ impl DataStore {
                     ))
                 })?;
             let zone = z
-                .into_blueprint_zone_config(nic_row, artifact)
+                .into_blueprint_zone_config(nic_row, artifact, external_ip_rows)
                 .with_context(|| format!("zone {zone_id}: parse from database"))
-                .map_err(|e| {
-                    Error::internal_error(&format!("{:#}", e.to_string()))
-                })?;
+                .map_err(|e| Error::internal_error(&format!("{e:#}")))?;
             sled_config.zones.insert_unique(zone).map_err(|e| {
                 Error::internal_error(&format!(
                     "duplicate zone ID found, but \
@@ -1391,6 +1454,13 @@ impl DataStore {
             omicron_zone_nics.is_empty(),
             "found extra Omicron zone NICs: {:?}",
             omicron_zone_nics.keys()
+        );
+
+        // Validate no external IPs remain
+        bail_unless!(
+            omicron_zone_external_ips.is_empty(),
+            "found external IPs for unknown Omicron zones: {:?}",
+            omicron_zone_external_ips.keys()
         );
 
         // Process disks: validate sled references, parse
@@ -1652,6 +1722,7 @@ impl DataStore {
             ndatasets: usize,
             nzones: usize,
             nnics: usize,
+            nexternal_ips: usize,
             nclickhouse_cluster_configs: usize,
             nclickhouse_keepers: usize,
             nclickhouse_servers: usize,
@@ -1670,6 +1741,7 @@ impl DataStore {
             ndatasets,
             nzones,
             nnics,
+            nexternal_ips,
             nclickhouse_cluster_configs,
             nclickhouse_keepers,
             nclickhouse_servers,
@@ -1791,6 +1863,21 @@ impl DataStore {
                             bp_omicron_zone_nic::dsl;
                         diesel::delete(
                             dsl::bp_omicron_zone_nic.filter(
+                                dsl::blueprint_id
+                                    .eq(to_db_typed_uuid(blueprint_id)),
+                            ),
+                        )
+                        .execute_async(&conn)
+                        .await?
+                    };
+
+                    let nexternal_ips = {
+                        // Skip rustfmt because it bails out on this long line.
+                        #[rustfmt::skip]
+                        use nexus_db_schema::schema::
+                            bp_omicron_zone_external_ip::dsl;
+                        diesel::delete(
+                            dsl::bp_omicron_zone_external_ip.filter(
                                 dsl::blueprint_id
                                     .eq(to_db_typed_uuid(blueprint_id)),
                             ),
@@ -1943,6 +2030,7 @@ impl DataStore {
                         ndatasets,
                         nzones,
                         nnics,
+                        nexternal_ips,
                         nclickhouse_cluster_configs,
                         nclickhouse_keepers,
                         nclickhouse_servers,
@@ -1969,6 +2057,7 @@ impl DataStore {
             "ndatasets" => ndatasets,
             "nzones" => nzones,
             "nnics" => nnics,
+            "nexternal_ips" => nexternal_ips,
             "nclickhouse_cluster_configs" => nclickhouse_cluster_configs,
             "nclickhouse_keepers" => nclickhouse_keepers,
             "nclickhouse_servers" => nclickhouse_servers,
@@ -3357,6 +3446,77 @@ mod tests {
         // on other tests to check blueprint deletion.
 
         // Clean up.
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    // A zone with more than one external IP is not yet representable in the
+    // in-memory `BlueprintZoneType` (#9288). But the tables for its EIPs can
+    // store multiple rows per zone, so we have to check that we fail when
+    // reading a blueprint with more than one row. We'll adjust this to ensure
+    // we _can_ read such a blueprint when the zone-type enum is expanded.
+    #[tokio::test]
+    async fn test_blueprint_zone_requires_exactly_one_external_ip() {
+        let logctx = dev::test_setup_log(
+            "test_blueprint_zone_requires_exactly_one_external_ip",
+        );
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let (_collection, _planning_input, blueprint) = representative(
+            &logctx.log,
+            "test_blueprint_zone_requires_exactly_one_external_ip",
+        );
+        let authz_blueprint = authz_blueprint_from_id(blueprint.id);
+
+        // Find a Nexus zone, and ensure we can write / read it with one IP.
+        let nexus_zone_id = blueprint
+            .sleds
+            .values()
+            .flat_map(|sled| sled.zones.iter())
+            .find(|zone| zone.zone_type.is_nexus())
+            .expect("representative blueprint has a Nexus zone")
+            .id;
+
+        datastore
+            .blueprint_insert(&opctx, &blueprint)
+            .await
+            .expect("failed to insert blueprint");
+
+        // With exactly one external IP per zone, the blueprint round-trips.
+        let blueprint_read = datastore
+            .blueprint_read(&opctx, &authz_blueprint)
+            .await
+            .expect("failed to read blueprint back");
+        assert_eq!(blueprint, blueprint_read);
+
+        // Inject a second external IP row for the Nexus zone. We should fail
+        // when reading this, because we can't represent it in the zone-type
+        // enum.
+        const SECOND_EXTERNAL_IP_ID: &str =
+            "b3f7d6c2-9a1e-4c8b-8d2f-0a1b2c3d4e5f";
+        let conn = datastore.pool_connection_for_tests().await.unwrap();
+        let sql = format!(
+            "INSERT INTO omicron.public.bp_omicron_zone_external_ip \
+             (blueprint_id, zone_id, external_ip_id, ip, port, \
+              snat_first_port, snat_last_port) \
+             VALUES ('{}', '{}', '{SECOND_EXTERNAL_IP_ID}', \
+              '192.0.2.222', NULL, NULL, NULL)",
+            blueprint.id, nexus_zone_id,
+        );
+        conn.batch_execute_async(&sql)
+            .await
+            .expect("injected a second external IP row");
+        let err = datastore
+            .blueprint_read(&opctx, &authz_blueprint)
+            .await
+            .expect_err("a zone with two external IPs must fail to read back");
+        let msg = InlineErrorChain::new(&err).to_string();
+        assert!(
+            msg.contains("external IPs"),
+            "expected an exactly-one-external-IP error, got: {msg}",
+        );
+
         db.terminate().await;
         logctx.cleanup_successful();
     }
@@ -4820,6 +4980,7 @@ mod tests {
                 query_count!(bp_omicron_physical_disk, blueprint_id),
                 query_count!(bp_omicron_zone, blueprint_id),
                 query_count!(bp_omicron_zone_nic, blueprint_id),
+                query_count!(bp_omicron_zone_external_ip, blueprint_id),
                 query_count!(bp_clickhouse_cluster_config, blueprint_id),
                 query_count!(
                     bp_clickhouse_keeper_zone_id_to_node_id,

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -2409,10 +2409,6 @@ table! {
         ntp_domain -> Nullable<Text>,
         nexus_external_tls -> Nullable<Bool>,
         nexus_external_dns_servers -> Nullable<Array<Inet>>,
-        snat_ip -> Nullable<Inet>,
-        snat_first_port -> Nullable<Int4>,
-        snat_last_port -> Nullable<Int4>,
-        external_ip_id -> Nullable<Uuid>,
         filesystem_pool -> Uuid,
         disposition -> crate::enums::BpZoneDispositionEnum,
         disposition_expunged_as_of_generation -> Nullable<Int8>,
@@ -2442,6 +2438,18 @@ table! {
         slot -> Int2,
         ipv6 -> Nullable<Inet>,
         ipv6_subnet -> Nullable<Inet>,
+    }
+}
+
+table! {
+    bp_omicron_zone_external_ip (blueprint_id, zone_id, external_ip_id) {
+        blueprint_id -> Uuid,
+        zone_id -> Uuid,
+        external_ip_id -> Uuid,
+        ip -> Inet,
+        port -> Nullable<Int4>,
+        snat_first_port -> Nullable<Int4>,
+        snat_last_port -> Nullable<Int4>,
     }
 }
 

--- a/nexus/tests/integration_tests/data_migrations/blueprint_zone_multiple_external_ips.rs
+++ b/nexus/tests/integration_tests/data_migrations/blueprint_zone_multiple_external_ips.rs
@@ -23,9 +23,12 @@ const NTP_ZONE_ID: &str = "1af903af-131a-463c-b086-c7aded7fb2c1";
 const INTERNAL_DNS_ZONE_ID: &str = "675dc9cb-2d77-4d67-9ca2-cec939fa797c";
 const CRUCIBLE_ZONE_ID: &str = "8639e2e7-9499-46a7-9927-ea6e6a81b1d3";
 
-// The allocated external IP IDs for the three external-networking zones.
+// The allocated external IPs and IDs for the three external-networking zones.
+const NEXUS_EIP: &str = "192.0.2.1";
 const NEXUS_EIP_ID: &str = "3c2b1a09-8f7e-4d6c-5b4a-3928170615a4";
+const DNS_EIP: &str = "192.0.2.2";
 const DNS_EIP_ID: &str = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+const NTP_EIP: &str = "192.0.2.3";
 const NTP_EIP_ID: &str = "d4c3b2a1-f6e5-4b7a-9d8c-5d4c3b2a1f6e";
 
 // The internal DNS zone's underlay `dns_address`, which stays in
@@ -64,15 +67,15 @@ async fn before_impl(ctx: &MigrationContext<'_>) {
             image_source, nexus_generation, nexus_lockstep_port
         ) VALUES
         ('{BLUEPRINT_ID}', '{SLED_ID}', '{NEXUS_ZONE_ID}', 'nexus',
-         '::1', 12345, '192.0.2.1', NULL, NULL, NULL, NULL,
+         '::1', 12345, '{NEXUS_EIP}', NULL, NULL, NULL, NULL,
          '{NEXUS_EIP_ID}', '{FILESYSTEM_POOL}',
          'in_service', FALSE, 'install_dataset', 1, 12346),
         ('{BLUEPRINT_ID}', '{SLED_ID}', '{DNS_ZONE_ID}', 'external_dns',
-         '::1', 5353, '192.0.2.2', 53, NULL, NULL, NULL,
+         '::1', 5353, '{DNS_EIP}', 53, NULL, NULL, NULL,
          '{DNS_EIP_ID}', '{FILESYSTEM_POOL}',
          'in_service', FALSE, 'install_dataset', NULL, NULL),
         ('{BLUEPRINT_ID}', '{SLED_ID}', '{NTP_ZONE_ID}', 'boundary_ntp',
-         '::1', 123, NULL, NULL, '192.0.2.3', 0, 16383,
+         '::1', 123, NULL, NULL, '{NTP_EIP}', 0, 16383,
          '{NTP_EIP_ID}', '{FILESYSTEM_POOL}',
          'in_service', FALSE, 'install_dataset', NULL, NULL),
         ('{BLUEPRINT_ID}', '{SLED_ID}', '{INTERNAL_DNS_ZONE_ID}', \
@@ -147,7 +150,7 @@ async fn after_impl(ctx: &MigrationContext<'_>) {
         by_zone.get(&nexus),
         Some(&(
             NEXUS_EIP_ID.parse().unwrap(),
-            "192.0.2.1".to_string(),
+            NEXUS_EIP.to_string(),
             None,
             None,
             None,
@@ -160,7 +163,7 @@ async fn after_impl(ctx: &MigrationContext<'_>) {
         by_zone.get(&dns),
         Some(&(
             DNS_EIP_ID.parse().unwrap(),
-            "192.0.2.2".to_string(),
+            DNS_EIP.to_string(),
             Some(53),
             None,
             None,
@@ -173,7 +176,7 @@ async fn after_impl(ctx: &MigrationContext<'_>) {
         by_zone.get(&ntp),
         Some(&(
             NTP_EIP_ID.parse().unwrap(),
-            "192.0.2.3".to_string(),
+            NTP_EIP.to_string(),
             None,
             Some(0),
             Some(16383),

--- a/nexus/tests/integration_tests/data_migrations/blueprint_zone_multiple_external_ips.rs
+++ b/nexus/tests/integration_tests/data_migrations/blueprint_zone_multiple_external_ips.rs
@@ -1,0 +1,243 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Data migration test for moving blueprint zone external IPs from inline
+//! columns on `bp_omicron_zone` into the new `bp_omicron_zone_external_ip`
+//! child table.
+
+use crate::integration_tests::schema::DataMigrationFns;
+use crate::integration_tests::schema::MigrationContext;
+use futures::FutureExt as _;
+use futures::future::BoxFuture;
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+// IDs for the inserted rows.
+const BLUEPRINT_ID: &str = "6b7e5a1a-8f1c-4a1b-9b6d-2f6b0e7c1a2b";
+const SLED_ID: &str = "0b6f1a3c-2e4d-4a5b-8c9d-1e2f3a4b5c6d";
+const FILESYSTEM_POOL: &str = "9d8c7b6a-5e4f-3a2b-1c0d-9e8f7a6b5c4d";
+const NEXUS_ZONE_ID: &str = "ab1d1dc9-2737-4c60-8aeb-f1da4ac92d93";
+const DNS_ZONE_ID: &str = "55b704d9-0118-4f34-974a-87a27186d564";
+const NTP_ZONE_ID: &str = "1af903af-131a-463c-b086-c7aded7fb2c1";
+const INTERNAL_DNS_ZONE_ID: &str = "675dc9cb-2d77-4d67-9ca2-cec939fa797c";
+const CRUCIBLE_ZONE_ID: &str = "8639e2e7-9499-46a7-9927-ea6e6a81b1d3";
+
+// The allocated external IP IDs for the three external-networking zones.
+const NEXUS_EIP_ID: &str = "3c2b1a09-8f7e-4d6c-5b4a-3928170615a4";
+const DNS_EIP_ID: &str = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+const NTP_EIP_ID: &str = "d4c3b2a1-f6e5-4b7a-9d8c-5d4c3b2a1f6e";
+
+// The internal DNS zone's underlay `dns_address`, which stays in
+// `second_service_ip` / `second_service_port` columns. This is to check that
+// the migration doesn't remove these, since they aren't external IPs.
+const INTERNAL_DNS_IP: &str = "fd00::1";
+const INTERNAL_DNS_PORT: i32 = 53;
+
+pub(super) fn checks() -> DataMigrationFns {
+    DataMigrationFns::new().before(before).after(after)
+}
+
+fn before<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
+    before_impl(ctx).boxed()
+}
+
+async fn before_impl(ctx: &MigrationContext<'_>) {
+    // Insert blueprint zone rows with the old, inlined external IPs directly in
+    // the row. The zones are:
+    //
+    // - Nexus: external IP but no ports at all
+    // - External DNS: external IP and one port, but no SNAT first / last.
+    // - NTP: external IP, no `port`, and an SNAT first / last port.
+    //
+    // Also insert an _internal_ DNS zone, which reuses the `second_service_ip`
+    // column for its _underlay_ address, and a Crucible zone, which has no
+    // secondary or external IPs at all.
+    let sql = format!(
+        "INSERT INTO omicron.public.bp_omicron_zone (
+            blueprint_id, sled_id, id, zone_type,
+            primary_service_ip, primary_service_port,
+            second_service_ip, second_service_port,
+            snat_ip, snat_first_port, snat_last_port,
+            external_ip_id, filesystem_pool,
+            disposition, disposition_expunged_ready_for_cleanup,
+            image_source, nexus_generation, nexus_lockstep_port
+        ) VALUES
+        ('{BLUEPRINT_ID}', '{SLED_ID}', '{NEXUS_ZONE_ID}', 'nexus',
+         '::1', 12345, '192.0.2.1', NULL, NULL, NULL, NULL,
+         '{NEXUS_EIP_ID}', '{FILESYSTEM_POOL}',
+         'in_service', FALSE, 'install_dataset', 1, 12346),
+        ('{BLUEPRINT_ID}', '{SLED_ID}', '{DNS_ZONE_ID}', 'external_dns',
+         '::1', 5353, '192.0.2.2', 53, NULL, NULL, NULL,
+         '{DNS_EIP_ID}', '{FILESYSTEM_POOL}',
+         'in_service', FALSE, 'install_dataset', NULL, NULL),
+        ('{BLUEPRINT_ID}', '{SLED_ID}', '{NTP_ZONE_ID}', 'boundary_ntp',
+         '::1', 123, NULL, NULL, '192.0.2.3', 0, 16383,
+         '{NTP_EIP_ID}', '{FILESYSTEM_POOL}',
+         'in_service', FALSE, 'install_dataset', NULL, NULL),
+        ('{BLUEPRINT_ID}', '{SLED_ID}', '{INTERNAL_DNS_ZONE_ID}', \
+         'internal_dns',
+         '::1', 5353, '{INTERNAL_DNS_IP}', {INTERNAL_DNS_PORT}, NULL, NULL, \
+         NULL, NULL, '{FILESYSTEM_POOL}',
+         'in_service', FALSE, 'install_dataset', NULL, NULL),
+        ('{BLUEPRINT_ID}', '{SLED_ID}', '{CRUCIBLE_ZONE_ID}', 'crucible',
+         '::1', 32345, NULL, NULL, NULL, NULL, NULL,
+         NULL, '{FILESYSTEM_POOL}',
+         'in_service', FALSE, 'install_dataset', NULL, NULL)",
+    );
+    ctx.client
+        .batch_execute(&sql)
+        .await
+        .expect("inserted old-schema blueprint zone rows");
+}
+
+fn after<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
+    after_impl(ctx).boxed()
+}
+
+async fn after_impl(ctx: &MigrationContext<'_>) {
+    let blueprint_id = Uuid::parse_str(BLUEPRINT_ID).unwrap();
+    let rows = ctx
+        .client
+        .query(
+            "SELECT \
+                zone_id, \
+                external_ip_id, \
+                host(ip) AS ip, \
+                port, \
+                snat_first_port, \
+                snat_last_port \
+            FROM omicron.public.bp_omicron_zone_external_ip \
+            WHERE blueprint_id = $1",
+            &[&blueprint_id],
+        )
+        .await
+        .expect("queried external IP child table");
+
+    let mut by_zone = BTreeMap::new();
+    for row in rows {
+        let zone_id: Uuid = row.get("zone_id");
+        let external_ip_id: Uuid = row.get("external_ip_id");
+        let ip: String = row.get("ip");
+        let port: Option<i32> = row.get("port");
+        let snat_first_port: Option<i32> = row.get("snat_first_port");
+        let snat_last_port: Option<i32> = row.get("snat_last_port");
+        let maybe_old = by_zone.insert(
+            zone_id,
+            (external_ip_id, ip, port, snat_first_port, snat_last_port),
+        );
+        assert!(
+            maybe_old.is_none(),
+            "Duplicate zone ID '{}' when reading EIP rows",
+            zone_id,
+        );
+    }
+
+    // Only the three zones with actual external IPs should have been
+    // backfilled.
+    assert_eq!(
+        by_zone.len(),
+        3,
+        "expected exactly three external IP rows, found {}",
+        by_zone.len(),
+    );
+
+    let nexus = NEXUS_ZONE_ID.parse().unwrap();
+    assert_eq!(
+        by_zone.get(&nexus),
+        Some(&(
+            NEXUS_EIP_ID.parse().unwrap(),
+            "192.0.2.1".to_string(),
+            None,
+            None,
+            None,
+        )),
+        "Nexus external IP should be a floating IP with no ports",
+    );
+
+    let dns = DNS_ZONE_ID.parse().unwrap();
+    assert_eq!(
+        by_zone.get(&dns),
+        Some(&(
+            DNS_EIP_ID.parse().unwrap(),
+            "192.0.2.2".to_string(),
+            Some(53),
+            None,
+            None,
+        )),
+        "external DNS external IP should carry its DNS port",
+    );
+
+    let ntp = NTP_ZONE_ID.parse().unwrap();
+    assert_eq!(
+        by_zone.get(&ntp),
+        Some(&(
+            NTP_EIP_ID.parse().unwrap(),
+            "192.0.2.3".to_string(),
+            None,
+            Some(0),
+            Some(16383),
+        )),
+        "boundary NTP external IP should carry its SNAT port range",
+    );
+
+    // Crucible has only the primary IP and no external IPs.
+    let crucible = CRUCIBLE_ZONE_ID.parse().unwrap();
+    assert!(
+        !by_zone.contains_key(&crucible),
+        "a zone without external networking should have no external IP row",
+    );
+
+    // The moved rows should have had their inline `second_service_ip` /
+    // `second_service_port` cleared, while the internal DNS zone's underlay
+    // address must be preserved.
+    let zone_rows = ctx
+        .client
+        .query(
+            "SELECT \
+                id, \
+                host(second_service_ip) AS second_service_ip, \
+                second_service_port \
+            FROM omicron.public.bp_omicron_zone \
+            WHERE blueprint_id = $1",
+            &[&blueprint_id],
+        )
+        .await
+        .expect("queried blueprint zone rows");
+
+    let mut second_service_by_zone = BTreeMap::new();
+    for row in zone_rows {
+        let id: Uuid = row.get("id");
+        let ip: Option<String> = row.get("second_service_ip");
+        let port: Option<i32> = row.get("second_service_port");
+        let maybe_old = second_service_by_zone.insert(id, (ip, port));
+        assert!(
+            maybe_old.is_none(),
+            "Duplicate zone ID '{}' when reading blueprint rows",
+            id,
+        );
+    }
+
+    assert_eq!(
+        second_service_by_zone.get(&nexus),
+        Some(&(None, None)),
+        "Nexus second_service_ip/port should have been cleared",
+    );
+    assert_eq!(
+        second_service_by_zone.get(&dns),
+        Some(&(None, None)),
+        "External DNS second_service_ip/port should have been cleared",
+    );
+    assert_eq!(
+        second_service_by_zone.get(&ntp),
+        Some(&(None, None)),
+        "Boundary NTP second_service_ip/port should have been cleared",
+    );
+
+    let internal_dns = Uuid::parse_str(INTERNAL_DNS_ZONE_ID).unwrap();
+    assert_eq!(
+        second_service_by_zone.get(&internal_dns),
+        Some(&(Some(INTERNAL_DNS_IP.to_string()), Some(INTERNAL_DNS_PORT))),
+        "internal DNS underlay dns_address must be preserved",
+    );
+}

--- a/nexus/tests/integration_tests/data_migrations/mod.rs
+++ b/nexus/tests/integration_tests/data_migrations/mod.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 mod add_rendezvous_sled_bp_availability;
 mod add_sled_update_disposition;
 mod bgp_unnumbered_peer_cleanup;
+mod blueprint_zone_multiple_external_ips;
 mod delete_nexus_default_allow_firewall_rule;
 mod drop_uninitialized_svc_enabled_not_online_state;
 mod ereport_everyone_gets_a_slot;
@@ -80,6 +81,7 @@ pub(crate) fn get_migration_checks() -> BTreeMap<Version, DataMigrationFns> {
     register!(normalize_service_external_ips);
     register!(add_rendezvous_sled_bp_availability);
     register!(inventory_zone_multiple_external_ips);
+    register!(blueprint_zone_multiple_external_ips);
 
     map
 }

--- a/schema/crdb/blueprint-zone-multiple-external-ips/up01.sql
+++ b/schema/crdb/blueprint-zone-multiple-external-ips/up01.sql
@@ -15,5 +15,5 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_omicron_zone_external_ip (
     CONSTRAINT only_port_or_snat_ports CHECK (
         NOT ((port IS NOT NULL) AND (snat_first_port IS NOT NULL))
     ),
-    PRIMARY KEY (blueprint_id, zone_id, external_ip_id)
+    PRIMARY KEY (blueprint_id, external_ip_id)
 );

--- a/schema/crdb/blueprint-zone-multiple-external-ips/up01.sql
+++ b/schema/crdb/blueprint-zone-multiple-external-ips/up01.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS omicron.public.bp_omicron_zone_external_ip (
+    blueprint_id UUID NOT NULL,
+    zone_id UUID NOT NULL,
+    external_ip_id UUID NOT NULL,
+    ip INET NOT NULL,
+    port INT4
+        CHECK (port IS NULL OR port BETWEEN 0 AND 65535),
+    snat_first_port INT4
+        CHECK (snat_first_port IS NULL OR snat_first_port BETWEEN 0 AND 65535),
+    snat_last_port INT4
+        CHECK (snat_last_port IS NULL OR snat_last_port BETWEEN 0 AND 65535),
+    CONSTRAINT both_snat_ports CHECK (
+        (snat_first_port IS NULL) = (snat_last_port IS NULL)
+    ),
+    CONSTRAINT only_port_or_snat_ports CHECK (
+        NOT ((port IS NOT NULL) AND (snat_first_port IS NOT NULL))
+    ),
+    PRIMARY KEY (blueprint_id, zone_id, external_ip_id)
+);

--- a/schema/crdb/blueprint-zone-multiple-external-ips/up02.sql
+++ b/schema/crdb/blueprint-zone-multiple-external-ips/up02.sql
@@ -1,0 +1,39 @@
+/*
+ * Backfill the new external IP child table from `bp_omicron_zone`.
+ *
+ * These addresses were previously stored inline with the rest of the row. We
+ * need to move them out to allow multiple IPs per zone. Unlike the inventory
+ * equivalent, each blueprint external IP is an *allocated* IP, so we also carry
+ * its `external_ip_id`. From each row we take:
+ *
+ *   - Nexus:        the IP in `second_service_ip` (no port).
+ *   - External DNS: the IP + port in `second_service_ip` /
+ *                   `second_service_port`.
+ *   - Boundary NTP: the IP + port range in `snat_ip` / `snat_first_port` /
+ *                   `snat_last_port`.
+ */
+SET LOCAL disallow_full_table_scans = 'off';
+
+INSERT INTO omicron.public.bp_omicron_zone_external_ip
+    (blueprint_id, zone_id, external_ip_id, ip, port, snat_first_port, snat_last_port)
+SELECT
+    blueprint_id, id, external_ip_id, second_service_ip,
+    NULL::INT4, NULL::INT4, NULL::INT4
+FROM omicron.public.bp_omicron_zone
+WHERE zone_type = 'nexus'
+    AND external_ip_id IS NOT NULL AND second_service_ip IS NOT NULL
+UNION ALL
+SELECT
+    blueprint_id, id, external_ip_id, second_service_ip,
+    second_service_port, NULL::INT4, NULL::INT4
+FROM omicron.public.bp_omicron_zone
+WHERE zone_type = 'external_dns'
+    AND external_ip_id IS NOT NULL AND second_service_ip IS NOT NULL
+UNION ALL
+SELECT
+    blueprint_id, id, external_ip_id, snat_ip,
+    NULL::INT4, snat_first_port, snat_last_port
+FROM omicron.public.bp_omicron_zone
+WHERE zone_type = 'boundary_ntp'
+    AND external_ip_id IS NOT NULL AND snat_ip IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/schema/crdb/blueprint-zone-multiple-external-ips/up03.sql
+++ b/schema/crdb/blueprint-zone-multiple-external-ips/up03.sql
@@ -1,0 +1,14 @@
+/*
+ * Now that the Nexus and external DNS external IPs live in the child table,
+ * clear the inline `second_service_ip` / `second_service_port` columns for
+ * those zones. These columns are no longer for external address information.
+ *
+ * NOTE: We don't need to delete the SNAT-related data for boundary NTP zones,
+ * because we drop those columns wholesale in the following migration files. The
+ * same is true of `external_ip_id`, which we drop below.
+ */
+SET LOCAL disallow_full_table_scans = 'off';
+
+UPDATE omicron.public.bp_omicron_zone
+SET second_service_ip = NULL, second_service_port = NULL
+WHERE zone_type IN ('nexus', 'external_dns');

--- a/schema/crdb/blueprint-zone-multiple-external-ips/up04.sql
+++ b/schema/crdb/blueprint-zone-multiple-external-ips/up04.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.bp_omicron_zone
+    DROP COLUMN IF EXISTS snat_ip;

--- a/schema/crdb/blueprint-zone-multiple-external-ips/up05.sql
+++ b/schema/crdb/blueprint-zone-multiple-external-ips/up05.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.bp_omicron_zone
+    DROP COLUMN IF EXISTS snat_first_port;

--- a/schema/crdb/blueprint-zone-multiple-external-ips/up06.sql
+++ b/schema/crdb/blueprint-zone-multiple-external-ips/up06.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.bp_omicron_zone
+    DROP COLUMN IF EXISTS snat_last_port;

--- a/schema/crdb/blueprint-zone-multiple-external-ips/up07.sql
+++ b/schema/crdb/blueprint-zone-multiple-external-ips/up07.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.bp_omicron_zone
+    DROP COLUMN IF EXISTS external_ip_id;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -6042,7 +6042,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_omicron_zone_external_ip (
         NOT ((port IS NOT NULL) AND (snat_first_port IS NOT NULL))
     ),
 
-    PRIMARY KEY (blueprint_id, zone_id, external_ip_id)
+    PRIMARY KEY (blueprint_id, external_ip_id)
 );
 
 -- Blueprint information related to clickhouse cluster management

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -5881,7 +5881,9 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_omicron_zone (
     -- worthwhile.
 
     -- Some zones have a second service.  Like the primary one, the meaning of
-    -- this is zone-type-dependent.
+    -- this is zone-type-dependent.  This should be used for additional underlay
+    -- IPs, _not_ external IP addresses.  Those are stored in the child table
+    -- `bp_omicron_zone_external_ip` with a reference to this row.
     second_service_ip INET,
     second_service_port INT4
         CHECK (second_service_port IS NULL
@@ -5910,22 +5912,6 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_omicron_zone (
     -- Properties specific to Nexus zones
     nexus_external_tls BOOLEAN,
     nexus_external_dns_servers INET ARRAY,
-
-    -- Source NAT configuration (currently used for boundary NTP only)
-    snat_ip INET,
-    snat_first_port INT4
-        CHECK (snat_first_port IS NULL OR snat_first_port BETWEEN 0 AND 65535),
-    snat_last_port INT4
-        CHECK (snat_last_port IS NULL OR snat_last_port BETWEEN 0 AND 65535),
-
-    -- For some zones, either primary_service_ip or second_service_ip (but not
-    -- both!) is an external IP address. For such zones, this is the ID of that
-    -- external IP. In general this is a foreign key into
-    -- omicron.public.external_ip, though the row many not exist: if this
-    -- blueprint is old, it's possible the IP has been deleted, and if this
-    -- blueprint has not yet been realized, it's possible the IP hasn't been
-    -- created yet.
-    external_ip_id UUID,
 
     filesystem_pool UUID NOT NULL,
 
@@ -6007,6 +5993,56 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_omicron_zone_nic (
         (ip IS NULL) = (subnet IS NULL) AND
         (ipv6 IS NULL) = (ipv6_subnet IS NULL)
     )
+);
+
+-- The external IP addresses of a zone in a `bp_omicron_zone`.
+--
+-- Zones with external networking have one or more external IPs. There is one
+-- row here per external IP. Each blueprint external IP is an *allocated* IP, so it
+-- carries its `external_ip_id` (an FK into `omicron.public.external_ip`,
+-- though the row may not exist: if this blueprint is old, the IP may have been
+-- deleted, and if it has not yet been realized, the IP may not exist yet). The
+-- kind of external IP is inferred from the owning zone's `zone_type` together
+-- with which port columns are set:
+--
+--  - Nexus:        a floating IP (`ip` only).
+--  - External DNS: a floating IP with a port (`ip` + `port`).
+--  - Boundary NTP: a source-NAT IP (`ip` + `snat_first_port`/`snat_last_port`).
+CREATE TABLE IF NOT EXISTS omicron.public.bp_omicron_zone_external_ip (
+    -- foreign key into the `blueprint` table
+    blueprint_id UUID NOT NULL,
+
+    -- foreign key into the `bp_omicron_zone` table
+    zone_id UUID NOT NULL,
+
+    -- ID of the external IP allocation (foreign key into
+    -- `omicron.public.external_ip`)
+    external_ip_id UUID NOT NULL,
+
+    -- the external IP address itself
+    ip INET NOT NULL,
+
+    -- the port for a floating IP with an address (external DNS); NULL otherwise
+    port INT4
+        CHECK (port IS NULL OR port BETWEEN 0 AND 65535),
+
+    -- the source-NAT port range (boundary NTP); NULL otherwise
+    snat_first_port INT4
+        CHECK (snat_first_port IS NULL OR snat_first_port BETWEEN 0 AND 65535),
+    snat_last_port INT4
+        CHECK (snat_last_port IS NULL OR snat_last_port BETWEEN 0 AND 65535),
+
+    -- must provide both SNAT ports
+    CONSTRAINT both_snat_ports CHECK (
+        (snat_first_port IS NULL) = (snat_last_port IS NULL)
+    ),
+
+    -- may not provide _both_ `port` and any SNAT port
+    CONSTRAINT only_port_or_snat_ports CHECK (
+        NOT ((port IS NOT NULL) AND (snat_first_port IS NOT NULL))
+    ),
+
+    PRIMARY KEY (blueprint_id, zone_id, external_ip_id)
 );
 
 -- Blueprint information related to clickhouse cluster management
@@ -9464,7 +9500,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '297.0.0', NULL)
+    (TRUE, NOW(), NOW(), '298.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
- Add a child table of the main blueprint zone, which stores the external IPs for each zone. This supports multiple addresses, each with a reference back to the owning zone.
- Add schema migration and test for the data migration portion of it
- Add test ensuring we currently _fail_ when storing more than one IP for a zone into the new table. This preserves current behavior, since the planner only generates <= 1 IP per zone today.