### PR TITLE
Reconfigurator: Propagate update disposition down to `OmicronSledConfig`

### DIFF
--- a/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
@@ -1681,6 +1681,7 @@ sled 2eb69596-f081-4e2d-9425-9994926e0832 (role = Gimlet, serial serial1)
 LEDGERED SLED CONFIG
     generation: 2
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 3
@@ -1834,6 +1835,7 @@ sled 32d8d836-4d8a-4e54-8fa9-f31d79c42646 (role = Gimlet, serial serial2)
 LEDGERED SLED CONFIG
     generation: 2
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 3
@@ -2047,6 +2049,7 @@ sled 89d02b1b-478c-401a-8e28-7a26f74fa41b (role = Gimlet, serial serial0)
 LEDGERED SLED CONFIG
     generation: 2
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 3

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -235,6 +235,7 @@ sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (role = Gimlet, serial serial1)
 LEDGERED SLED CONFIG
     generation: 2
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 1
@@ -363,6 +364,7 @@ sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
 LEDGERED SLED CONFIG
     generation: 5
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: artifact 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
     desired host phase 2 slot b: artifact 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
     DISKS: 1
@@ -501,6 +503,7 @@ sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (role = Gimlet, serial serial2)
 LEDGERED SLED CONFIG
     generation: 2
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 1

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
@@ -636,6 +636,7 @@ sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (role = Gimlet, serial serial1)
 LEDGERED SLED CONFIG
     generation: 3
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: artifact c2a8af75d6907ef138d033dc3be1fcbf7d7a78a87aee04796caf283a6bb0952d
     desired host phase 2 slot b: keep current contents
     DISKS: 3
@@ -836,6 +837,7 @@ sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
 LEDGERED SLED CONFIG
     generation: 3
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: artifact c2a8af75d6907ef138d033dc3be1fcbf7d7a78a87aee04796caf283a6bb0952d
     desired host phase 2 slot b: keep current contents
     DISKS: 3
@@ -1033,6 +1035,7 @@ sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (role = Gimlet, serial serial2)
 LEDGERED SLED CONFIG
     generation: 3
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: artifact c2a8af75d6907ef138d033dc3be1fcbf7d7a78a87aee04796caf283a6bb0952d
     desired host phase 2 slot b: keep current contents
     DISKS: 3

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-update-disposition-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-update-disposition-stdout
@@ -24,7 +24,7 @@ to:   blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
 
  MODIFIED SLEDS:
 
-  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2):
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2 -> 3):
 *   update disposition:   available -> evacuating (live-migrate or terminate) (generation 1 -> 2)
 
     measurements:
@@ -117,7 +117,7 @@ to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
 
  MODIFIED SLEDS:
 
-  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2):
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 3 -> 4):
 *   update disposition:   evacuating (live-migrate or terminate) -> evacuating (live-migrate only) (generation 2 -> 3)
 
     measurements:
@@ -209,7 +209,7 @@ to:   blueprint af934083-59b5-4bf6-8966-6fb5292c29e1
 
  MODIFIED SLEDS:
 
-  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2):
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 4 -> 5):
 *   update disposition:   evacuating (live-migrate only) -> available (generation 3 -> 4)
 
     measurements:
@@ -398,7 +398,7 @@ parent:    af934083-59b5-4bf6-8966-6fb5292c29e1
   sled: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
     state::::::::::::::   active
     update disposition:   available (generation 4)
-    config generation::   2
+    config generation::   5
     subnet:::::::::::::   fd00:1122:3344:101::/64
     last allocated IP::   fd00:1122:3344:101::7
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
@@ -616,6 +616,7 @@ sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (role = Gimlet, serial serial1)
 LEDGERED SLED CONFIG
     generation: 3
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 3
@@ -816,6 +817,7 @@ sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
 LEDGERED SLED CONFIG
     generation: 3
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 3
@@ -1013,6 +1015,7 @@ sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (role = Gimlet, serial serial2)
 LEDGERED SLED CONFIG
     generation: 3
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 3

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
@@ -670,6 +670,7 @@ sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (role = Gimlet, serial serial1)
 LEDGERED SLED CONFIG
     generation: 3
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 3
@@ -870,6 +871,7 @@ sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
 LEDGERED SLED CONFIG
     generation: 3
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 3
@@ -1067,6 +1069,7 @@ sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (role = Gimlet, serial serial2)
 LEDGERED SLED CONFIG
     generation: 3
     remove_mupdate_override: None
+    update_disposition: Available
     desired host phase 2 slot a: keep current contents
     desired host phase 2 slot b: keep current contents
     DISKS: 3

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -104,6 +104,7 @@ use sled_agent_types::inventory::MupdateOverrideNonBootInventory;
 use sled_agent_types::inventory::NetworkInterface;
 use sled_agent_types::inventory::OmicronFileSourceResolverInventory;
 use sled_agent_types::inventory::OmicronSingleMeasurement;
+use sled_agent_types::inventory::OmicronSledUpdateDisposition;
 use sled_agent_types::inventory::OrphanedDataset;
 use sled_agent_types::inventory::RemoveMupdateOverrideBootSuccessInventory;
 use sled_agent_types::inventory::RemoveMupdateOverrideInventory;
@@ -2709,6 +2710,43 @@ impl From<InvDataset> for nexus_types::inventory::Dataset {
     }
 }
 
+impl_enum_type!(
+    InvSledUpdateDispositionEnum:
+
+    /// Database representation of the availability half of a sled's
+    /// `update_disposition`.
+    #[derive(
+        Copy,
+        Clone,
+        Debug,
+        PartialEq,
+        AsExpression,
+        FromSqlRow,
+    )]
+    pub enum DbInvSledUpdateDisposition;
+
+    Available => b"available"
+    Evacuating => b"evacuating"
+);
+
+impl From<OmicronSledUpdateDisposition> for DbInvSledUpdateDisposition {
+    fn from(value: OmicronSledUpdateDisposition) -> Self {
+        match value {
+            OmicronSledUpdateDisposition::Available => Self::Available,
+            OmicronSledUpdateDisposition::Evacuating => Self::Evacuating,
+        }
+    }
+}
+
+impl From<DbInvSledUpdateDisposition> for OmicronSledUpdateDisposition {
+    fn from(value: DbInvSledUpdateDisposition) -> Self {
+        match value {
+            DbInvSledUpdateDisposition::Available => Self::Available,
+            DbInvSledUpdateDisposition::Evacuating => Self::Evacuating,
+        }
+    }
+}
+
 /// Top-level information contained in an [`OmicronSledConfig`].
 #[derive(Queryable, Clone, Debug, Selectable, Insertable)]
 #[diesel(table_name = inv_omicron_sled_config)]
@@ -2722,6 +2760,8 @@ pub struct InvOmicronSledConfig {
     pub host_phase_2: DbHostPhase2DesiredSlots,
     #[diesel(embed)]
     pub measurements: DbOmicronMeasurements,
+
+    pub update_disposition: DbInvSledUpdateDisposition,
 }
 
 impl InvOmicronSledConfig {
@@ -2732,6 +2772,7 @@ impl InvOmicronSledConfig {
         remove_mupdate_override: Option<MupdateOverrideUuid>,
         host_phase_2: HostPhase2DesiredSlots,
         measurements: BTreeSet<OmicronSingleMeasurement>,
+        update_disposition: OmicronSledUpdateDisposition,
     ) -> Self {
         Self {
             inv_collection_id: inv_collection_id.into(),
@@ -2740,6 +2781,7 @@ impl InvOmicronSledConfig {
             remove_mupdate_override: remove_mupdate_override.map(From::from),
             host_phase_2: host_phase_2.into(),
             measurements: measurements.into(),
+            update_disposition: update_disposition.into(),
         }
     }
 }

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -2713,8 +2713,7 @@ impl From<InvDataset> for nexus_types::inventory::Dataset {
 impl_enum_type!(
     InvSledUpdateDispositionEnum:
 
-    /// Database representation of the availability half of a sled's
-    /// `update_disposition`.
+    /// Database representation of a sled's `update_disposition`.
     #[derive(
         Copy,
         Clone,

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(294, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(295, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ pub static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(295, "add-inv-sled-update-disposition"),
         KnownVersion::new(294, "external-service-ip-pool"),
         KnownVersion::new(293, "add-rendezvous-sled-bp-availability"),
         KnownVersion::new(292, "allow-ddm-traffic"),

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -3737,8 +3737,9 @@ impl DataStore {
                                 zones: IdOrdMap::default(),
                                 host_phase_2: sled_config.host_phase_2.into(),
                                 measurements: sled_config.measurements.into(),
-                                // TODO-john FIX THIS
-                                update_disposition: sled_agent_types::inventory::OmicronSledUpdateDisposition::Available,
+                                update_disposition: sled_config
+                                    .update_disposition
+                                    .into(),
                             },
                         })
                         .map_err(|e| {
@@ -5311,6 +5312,7 @@ impl ConfigReconcilerRows {
             config.remove_mupdate_override,
             config.host_phase_2.clone(),
             config.measurements.clone(),
+            config.update_disposition,
         ));
         self.disks.extend(config.disks.iter().map(|disk| {
             InvOmicronSledConfigDisk::new(

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -3737,6 +3737,8 @@ impl DataStore {
                                 zones: IdOrdMap::default(),
                                 host_phase_2: sled_config.host_phase_2.into(),
                                 measurements: sled_config.measurements.into(),
+                                // TODO-john FIX THIS
+                                update_disposition: sled_agent_types::inventory::OmicronSledUpdateDisposition::Available,
                             },
                         })
                         .map_err(|e| {

--- a/nexus/db-schema/src/enums.rs
+++ b/nexus/db-schema/src/enums.rs
@@ -73,6 +73,7 @@ define_enums! {
     InstanceStateEnum => "instance_state_v2",
     InstanceIntendedStateEnum => "instance_intended_state",
     InvConfigReconcilerStatusKindEnum => "inv_config_reconciler_status_kind",
+    InvSledUpdateDispositionEnum => "inv_sled_update_disposition",
     InvSvcEnabledNotOnlineStateEnum => "inv_svc_enabled_not_online_state",
     InvZoneImageSourceEnum => "inv_zone_image_source",
     InvZoneManifestSourceEnum => "inv_zone_manifest_source",

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -2133,6 +2133,7 @@ table! {
         host_phase_2_desired_slot_a -> Nullable<Text>,
         host_phase_2_desired_slot_b -> Nullable<Text>,
         measurements -> Nullable<Array<Text>>,
+        update_disposition -> crate::enums::InvSledUpdateDispositionEnum,
     }
 }
 

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -725,6 +725,7 @@ mod test {
     use sled_agent_types::inventory::ConfigReconcilerInventoryStatus;
     use sled_agent_types::inventory::HostPhase2DesiredSlots;
     use sled_agent_types::inventory::OmicronSledConfig;
+    use sled_agent_types::inventory::OmicronSledUpdateDisposition;
     use sled_agent_types::inventory::OmicronZoneConfig;
     use sled_agent_types::inventory::OmicronZoneImageSource;
     use sled_agent_types::inventory::OmicronZoneType;
@@ -748,6 +749,7 @@ mod test {
             remove_mupdate_override,
             host_phase_2,
             measurements,
+            update_disposition,
         } = config;
 
         swriteln!(s, "        generation: {generation}");
@@ -755,6 +757,7 @@ mod test {
             s,
             "        remove_mupdate_override: {remove_mupdate_override:?}"
         );
+        swriteln!(s, "        update_disposition: {update_disposition:?}");
         {
             let HostPhase2DesiredSlots { slot_a, slot_b } = host_phase_2;
             swriteln!(s, "        host_phase_2.slot_a: {slot_a:?}");
@@ -1007,6 +1010,7 @@ mod test {
                 remove_mupdate_override: None,
                 host_phase_2: HostPhase2DesiredSlots::current_contents(),
                 measurements: BTreeSet::new(),
+                update_disposition: OmicronSledUpdateDisposition::Available,
             })
             .await
             .expect("failed to write initial zone version to fake sled agent");

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -434,7 +434,7 @@ pub fn representative() -> Representative {
         remove_mupdate_override: None,
         host_phase_2: HostPhase2DesiredSlots::current_contents(),
         measurements: Default::default(),
-        update_disposition: OmicronSledUpdateDisposition::Available,
+        update_disposition: OmicronSledUpdateDisposition::Evacuating,
     };
 
     // Create iterator producing fixed IDs.

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -59,6 +59,7 @@ use sled_agent_types::inventory::InventoryDisk;
 use sled_agent_types::inventory::InventoryZpool;
 use sled_agent_types::inventory::OmicronFileSourceResolverInventory;
 use sled_agent_types::inventory::OmicronSledConfig;
+use sled_agent_types::inventory::OmicronSledUpdateDisposition;
 use sled_agent_types::inventory::OmicronZonesConfig;
 use sled_agent_types::inventory::OrphanedDataset;
 use sled_agent_types::inventory::SingleMeasurementInventory;
@@ -413,6 +414,7 @@ pub fn representative() -> Representative {
         remove_mupdate_override: None,
         host_phase_2: HostPhase2DesiredSlots::current_contents(),
         measurements: Default::default(),
+        update_disposition: OmicronSledUpdateDisposition::Available,
     };
     let sled16 = OmicronSledConfig {
         generation: sled16.generation,
@@ -422,6 +424,7 @@ pub fn representative() -> Representative {
         remove_mupdate_override: None,
         host_phase_2: HostPhase2DesiredSlots::current_contents(),
         measurements: Default::default(),
+        update_disposition: OmicronSledUpdateDisposition::Available,
     };
     let sled17 = OmicronSledConfig {
         generation: sled17.generation,
@@ -431,6 +434,7 @@ pub fn representative() -> Representative {
         remove_mupdate_override: None,
         host_phase_2: HostPhase2DesiredSlots::current_contents(),
         measurements: Default::default(),
+        update_disposition: OmicronSledUpdateDisposition::Available,
     };
 
     // Create iterator producing fixed IDs.

--- a/nexus/inventory/tests/output/collector_basic.txt
+++ b/nexus/inventory/tests/output/collector_basic.txt
@@ -88,6 +88,7 @@ sled agents found:
     ledgered sled config:
         generation: 3
         remove_mupdate_override: None
+        update_disposition: Available
         host_phase_2.slot_a: CurrentContents
         host_phase_2.slot_b: CurrentContents
         zone 8b88a56f-3eb6-4d80-ba42-75d867bc427d type oximeter
@@ -96,6 +97,7 @@ sled agents found:
     last reconciled config:
         generation: 3
         remove_mupdate_override: None
+        update_disposition: Available
         host_phase_2.slot_a: CurrentContents
         host_phase_2.slot_b: CurrentContents
         zone 8b88a56f-3eb6-4d80-ba42-75d867bc427d type oximeter
@@ -108,6 +110,7 @@ sled agents found:
     ledgered sled config:
         generation: 3
         remove_mupdate_override: None
+        update_disposition: Available
         host_phase_2.slot_a: CurrentContents
         host_phase_2.slot_b: CurrentContents
         zone 5125277f-0988-490b-ac01-3bba20cc8f07 type oximeter
@@ -116,6 +119,7 @@ sled agents found:
     last reconciled config:
         generation: 3
         remove_mupdate_override: None
+        update_disposition: Available
         host_phase_2.slot_a: CurrentContents
         host_phase_2.slot_b: CurrentContents
         zone 5125277f-0988-490b-ac01-3bba20cc8f07 type oximeter

--- a/nexus/inventory/tests/output/collector_sled_agent_errors.txt
+++ b/nexus/inventory/tests/output/collector_sled_agent_errors.txt
@@ -87,6 +87,7 @@ sled agents found:
     ledgered sled config:
         generation: 3
         remove_mupdate_override: None
+        update_disposition: Available
         host_phase_2.slot_a: CurrentContents
         host_phase_2.slot_b: CurrentContents
         zone 5125277f-0988-490b-ac01-3bba20cc8f07 type oximeter
@@ -95,6 +96,7 @@ sled agents found:
     last reconciled config:
         generation: 3
         remove_mupdate_override: None
+        update_disposition: Available
         host_phase_2.slot_a: CurrentContents
         host_phase_2.slot_b: CurrentContents
         zone 5125277f-0988-490b-ac01-3bba20cc8f07 type oximeter

--- a/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
+++ b/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
@@ -250,6 +250,7 @@ mod api_impl {
     use sled_agent_types::inventory::MupdateOverrideInventory;
     use sled_agent_types::inventory::OmicronFileSourceResolverInventory;
     use sled_agent_types::inventory::OmicronSledConfig;
+    use sled_agent_types::inventory::OmicronSledUpdateDisposition;
     use sled_agent_types::inventory::SledCpuFamily;
     use sled_agent_types::inventory::SledRole;
     use sled_agent_types::inventory::SvcsEnabledNotOnlineResult;
@@ -355,6 +356,7 @@ mod api_impl {
                     slot_b: HostPhase2DesiredContents::CurrentContents,
                 },
                 measurements: BTreeSet::new(),
+                update_disposition: OmicronSledUpdateDisposition::Available,
             };
 
             Ok(HttpResponseOk(Inventory {

--- a/nexus/reconfigurator/execution/src/omicron_sled_config.rs
+++ b/nexus/reconfigurator/execution/src/omicron_sled_config.rs
@@ -89,11 +89,13 @@ mod tests {
     use nexus_types::deployment::BlueprintPhysicalDiskConfig;
     use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
     use nexus_types::deployment::BlueprintSledUpdateDisposition;
+    use nexus_types::deployment::BlueprintSledUpdateDispositionKind;
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
     use nexus_types::deployment::BlueprintZoneImageSource;
     use nexus_types::deployment::BlueprintZoneType;
     use nexus_types::deployment::LastAllocatedSubnetIpOffset;
+    use nexus_types::deployment::ReconfiguratorDisruptionPolicy;
     use nexus_types::deployment::blueprint_zone_type;
     use nexus_types::external_api::sled::SledPolicy;
     use nexus_types::external_api::sled::SledProvisionPolicy;
@@ -262,7 +264,12 @@ mod tests {
 
         let sled_config = BlueprintSledConfig {
             state: SledState::Active,
-            update_disposition: BlueprintSledUpdateDisposition::initial(),
+            update_disposition: BlueprintSledUpdateDisposition {
+                generation: Generation::new().next(),
+                kind: BlueprintSledUpdateDispositionKind::Evacuating {
+                    policy: ReconfiguratorDisruptionPolicy::Terminate,
+                },
+            },
             subnet: Ipv6Subnet::new(Ipv6Addr::LOCALHOST),
             last_allocated_ip_subnet_offset:
                 LastAllocatedSubnetIpOffset::initial(),

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -168,10 +168,6 @@ pub enum EnsureMupdateOverrideError {
 pub struct SledEditor {
     underlay_ip_allocator: SledUnderlayIpAllocator,
     incoming_sled_agent_generation: Generation,
-    // Note that the update disposition is purely an internal planner decision
-    // and is not part of the `OmicronSledConfig` sent to sled-agent, so a
-    // change to it should result in an update_disposition_generation bump but
-    // not a sled_agent_generation bump.
     incoming_update_disposition_generation: Generation,
     update_disposition_kind: ScalarEditor<BlueprintSledUpdateDispositionKind>,
     zones: ZonesEditor,
@@ -292,8 +288,6 @@ impl SledEditor {
         };
 
         // Bump the generation if we made any changes of concern to sled-agent.
-        // Note that the update disposition is deliberately excluded, since it
-        // is never part of the `OmicronSledConfig` sent to sled-agent.
         if self.debug_force_generation_bump
             || disks_counts.has_nonzero_counts()
             || datasets_counts.has_nonzero_counts()
@@ -301,6 +295,7 @@ impl SledEditor {
             || remove_mupdate_override_is_modified
             || changed_host_phase_2
             || measurement_counts.has_nonzero_counts()
+            || update_disposition_is_modified
         {
             sled_agent_generation = sled_agent_generation.next();
         }
@@ -1087,8 +1082,8 @@ mod tests {
         assert!(edited.scalar_edits.update_disposition);
         assert_eq!(
             edited.config.sled_agent_generation,
-            Generation::new(),
-            "disposition change must not bump sled_agent_generation",
+            Generation::new().next(),
+            "sled_agent_generation also bumped exactly once",
         );
 
         // Setting the kind and then back to the incoming value is a no-op: the
@@ -1105,5 +1100,10 @@ mod tests {
             "edits that cancel out leave the disposition unchanged",
         );
         assert!(!edited.scalar_edits.update_disposition);
+        assert_eq!(
+            edited.config.sled_agent_generation,
+            Generation::new(),
+            "sled_agent_generation was not bumped - no visible change",
+        );
     }
 }

--- a/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
@@ -39,6 +39,7 @@ use sled_agent_types::inventory::HostPhase2DesiredSlots;
 use sled_agent_types::inventory::Inventory;
 use sled_agent_types::inventory::OmicronFileSourceResolverInventory;
 use sled_agent_types::inventory::OmicronSledConfig;
+use sled_agent_types::inventory::OmicronSledUpdateDisposition;
 use sled_agent_types::inventory::SledCpuFamily;
 use sled_agent_types::inventory::SledRole;
 use sled_agent_types::inventory::SvcsEnabledNotOnlineResult;
@@ -1254,6 +1255,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
                     remove_mupdate_override: None,
                     host_phase_2: HostPhase2DesiredSlots::current_contents(),
                     measurements: BTreeSet::new(),
+                    update_disposition: OmicronSledUpdateDisposition::Available,
                 };
 
                 // The only sled-agent fields that matter for the purposes of

--- a/nexus/test-utils/src/starter.rs
+++ b/nexus/test-utils/src/starter.rs
@@ -103,6 +103,7 @@ use sled_agent_types::inventory::HostPhase2DesiredSlots;
 use sled_agent_types::inventory::NetworkInterface;
 use sled_agent_types::inventory::NetworkInterfaceKind;
 use sled_agent_types::inventory::OmicronSledConfig;
+use sled_agent_types::inventory::OmicronSledUpdateDisposition;
 use sled_agent_types::inventory::OmicronZoneDataset;
 use sled_agent_types::inventory::SledCpuFamily;
 use sled_agent_types::inventory::SourceNatConfigGeneric;
@@ -1023,6 +1024,7 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
                     remove_mupdate_override: None,
                     host_phase_2: HostPhase2DesiredSlots::current_contents(),
                     measurements: BTreeSet::new(),
+                    update_disposition: OmicronSledUpdateDisposition::Available,
                 })
                 .await
                 .expect("Failed to configure sled agent {sled_id} with zones");

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -53,6 +53,7 @@ use sled_agent_types::disk::DiskIdentity;
 use sled_agent_types::disk::M2Slot;
 use sled_agent_types::disk::OmicronPhysicalDiskConfig;
 use sled_agent_types::disk::SharedDatasetConfig;
+use sled_agent_types::inventory::OmicronSledUpdateDisposition;
 use sled_agent_types::system_networking::ServiceZoneNatEntries;
 use sled_agent_types::system_networking::ServiceZoneNatEntriesError;
 use sled_agent_types::system_networking::ServiceZoneNatEntry;
@@ -1686,6 +1687,22 @@ impl fmt::Display for BlueprintSledUpdateDisposition {
     }
 }
 
+impl From<BlueprintSledUpdateDisposition> for OmicronSledUpdateDisposition {
+    fn from(value: BlueprintSledUpdateDisposition) -> Self {
+        // sled-agent only cares about the disposition itself, not the
+        // generation
+        let BlueprintSledUpdateDisposition { generation: _, kind } = value;
+        match kind {
+            BlueprintSledUpdateDispositionKind::Available => Self::Available,
+            BlueprintSledUpdateDispositionKind::Evacuating {
+                // similarly, sled-agent doesn't care about the policy, only
+                // that it should be evacuating
+                policy: _,
+            } => Self::Evacuating,
+        }
+    }
+}
+
 /// The content of a sled's update disposition: whether the sled is available
 /// for provisioning, and if being evacuated, which disruption policy applies.
 ///
@@ -1787,6 +1804,7 @@ impl BlueprintSledConfig {
             remove_mupdate_override: self.remove_mupdate_override,
             host_phase_2: self.host_phase_2.into(),
             measurements: self.measurements.into(),
+            update_disposition: self.update_disposition.into(),
         }
     }
 

--- a/nexus/types/src/inventory/display.rs
+++ b/nexus/types/src/inventory/display.rs
@@ -1201,6 +1201,7 @@ fn display_sled_config(
         remove_mupdate_override,
         host_phase_2,
         measurements,
+        update_disposition,
     } = config;
 
     writeln!(f, "\n{label} SLED CONFIG")?;
@@ -1208,6 +1209,7 @@ fn display_sled_config(
 
     writeln!(indented, "generation: {}", generation)?;
     writeln!(indented, "remove_mupdate_override: {remove_mupdate_override:?}")?;
+    writeln!(indented, "update_disposition: {update_disposition:?}")?;
 
     let display_host_phase_2_desired = |desired| match desired {
         HostPhase2DesiredContents::CurrentContents => {

--- a/openapi/sled-agent/sled-agent-48.0.0-808ec1.json.gitstub
+++ b/openapi/sled-agent/sled-agent-48.0.0-808ec1.json.gitstub
@@ -1,0 +1,1 @@
+7beb2dd346a8644059a9c20cd4889ab6b8b415d1:openapi/sled-agent/sled-agent-48.0.0-808ec1.json

--- a/openapi/sled-agent/sled-agent-49.0.0-63a60d.json
+++ b/openapi/sled-agent/sled-agent-49.0.0-63a60d.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "48.0.0"
+    "version": "49.0.0"
   },
   "paths": {
     "/artifacts": {
@@ -7610,6 +7610,9 @@
               }
             ]
           },
+          "update_disposition": {
+            "$ref": "#/components/schemas/OmicronSledUpdateDisposition"
+          },
           "zones": {
             "title": "IdOrdMapAsMap",
             "x-rust-type": {
@@ -7633,7 +7636,16 @@
           "disks",
           "generation",
           "measurements",
+          "update_disposition",
           "zones"
+        ]
+      },
+      "OmicronSledUpdateDisposition": {
+        "description": "Controls a sled's availability for VMM provisioning.\n\nThis is a simplified version of `BlueprintSledUpdateDisposition`. The blueprint version of this type includes information describing _how_ the sled should be evacuated as well as blueprint-specific metadata. From sled-agent itself, we only need to know the high-level state; we use this to determine whether or not to accept new VMM registration requests.",
+        "type": "string",
+        "enum": [
+          "available",
+          "evacuating"
         ]
       },
       "OmicronZoneConfig": {

--- a/openapi/sled-agent/sled-agent-49.0.0-b9a55b.json
+++ b/openapi/sled-agent/sled-agent-49.0.0-b9a55b.json
@@ -7544,7 +7544,7 @@
         "type": "object",
         "properties": {
           "datasets": {
-            "title": "IdOrdMapAsMap",
+            "title": "IdOrdMap",
             "x-rust-type": {
               "crate": "iddqd",
               "parameters": [
@@ -7555,13 +7555,14 @@
               "path": "iddqd::IdOrdMap",
               "version": "*"
             },
-            "type": "object",
-            "additionalProperties": {
+            "type": "array",
+            "items": {
               "$ref": "#/components/schemas/DatasetConfig"
-            }
+            },
+            "uniqueItems": true
           },
           "disks": {
-            "title": "IdOrdMapAsMap",
+            "title": "IdOrdMap",
             "x-rust-type": {
               "crate": "iddqd",
               "parameters": [
@@ -7572,28 +7573,17 @@
               "path": "iddqd::IdOrdMap",
               "version": "*"
             },
-            "type": "object",
-            "additionalProperties": {
+            "type": "array",
+            "items": {
               "$ref": "#/components/schemas/OmicronPhysicalDiskConfig"
-            }
+            },
+            "uniqueItems": true
           },
           "generation": {
             "$ref": "#/components/schemas/Generation"
           },
           "host_phase_2": {
-            "default": {
-              "slot_a": {
-                "type": "current_contents"
-              },
-              "slot_b": {
-                "type": "current_contents"
-              }
-            },
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/HostPhase2DesiredSlots"
-              }
-            ]
+            "$ref": "#/components/schemas/HostPhase2DesiredSlots"
           },
           "measurements": {
             "type": "array",
@@ -7614,7 +7604,7 @@
             "$ref": "#/components/schemas/OmicronSledUpdateDisposition"
           },
           "zones": {
-            "title": "IdOrdMapAsMap",
+            "title": "IdOrdMap",
             "x-rust-type": {
               "crate": "iddqd",
               "parameters": [
@@ -7625,16 +7615,18 @@
               "path": "iddqd::IdOrdMap",
               "version": "*"
             },
-            "type": "object",
-            "additionalProperties": {
+            "type": "array",
+            "items": {
               "$ref": "#/components/schemas/OmicronZoneConfig"
-            }
+            },
+            "uniqueItems": true
           }
         },
         "required": [
           "datasets",
           "disks",
           "generation",
+          "host_phase_2",
           "measurements",
           "update_disposition",
           "zones"

--- a/openapi/sled-agent/sled-agent-latest.json
+++ b/openapi/sled-agent/sled-agent-latest.json
@@ -1,1 +1,1 @@
-sled-agent-49.0.0-63a60d.json
+sled-agent-49.0.0-b9a55b.json

--- a/openapi/sled-agent/sled-agent-latest.json
+++ b/openapi/sled-agent/sled-agent-latest.json
@@ -1,1 +1,1 @@
-sled-agent-48.0.0-808ec1.json
+sled-agent-49.0.0-63a60d.json

--- a/schema/crdb/add-inv-sled-update-disposition/up1.sql
+++ b/schema/crdb/add-inv-sled-update-disposition/up1.sql
@@ -1,0 +1,4 @@
+CREATE TYPE IF NOT EXISTS omicron.public.inv_sled_update_disposition AS ENUM (
+    'available',
+    'evacuating'
+);

--- a/schema/crdb/add-inv-sled-update-disposition/up2.sql
+++ b/schema/crdb/add-inv-sled-update-disposition/up2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.inv_omicron_sled_config
+    ADD COLUMN IF NOT EXISTS update_disposition omicron.public.inv_sled_update_disposition NOT NULL DEFAULT 'available';

--- a/schema/crdb/add-inv-sled-update-disposition/up3.sql
+++ b/schema/crdb/add-inv-sled-update-disposition/up3.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.inv_omicron_sled_config
+    ALTER COLUMN update_disposition DROP DEFAULT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4865,10 +4865,10 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_dataset (
 
 -- A sled's update disposition in inventory.
 --
--- TODO-john This is the same as `sled_update_availability`. Should we reuse
--- that, or is it better to keep these separate since that one is only one part
--- of the larger blueprint update disposition enum? OmicronSledConfig only cares
--- about these two states.
+-- This is analogous to the `sled_update_availability` enum used as a part of
+-- storing update disposition in blueprints. We use a separate enum (despite
+-- currently having identical variants) because there are separate Rust
+-- types, and it allows the two to evolve independently.
 CREATE TYPE IF NOT EXISTS omicron.public.inv_sled_update_disposition AS ENUM (
     -- Available for use for all provisions.
     'available',

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4863,6 +4863,19 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_dataset (
     PRIMARY KEY (inv_collection_id, sled_id, name)
 );
 
+-- A sled's update disposition in inventory.
+--
+-- TODO-john This is the same as `sled_update_availability`. Should we reuse
+-- that, or is it better to keep these separate since that one is only one part
+-- of the larger blueprint update disposition enum? OmicronSledConfig only cares
+-- about these two states.
+CREATE TYPE IF NOT EXISTS omicron.public.inv_sled_update_disposition AS ENUM (
+    -- Available for use for all provisions.
+    'available',
+    -- Disallowed for all use + migratable instances are being evacuated.
+    'evacuating'
+);
+
 CREATE TABLE IF NOT EXISTS omicron.public.inv_omicron_sled_config (
     -- where this observation came from
     -- (foreign key into `inv_collection` table)
@@ -4886,6 +4899,10 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_omicron_sled_config (
 
     -- the set of artifact hashes used with trust quorum, can be empty
     measurements STRING(64)[],
+
+    -- current update disposition, controlling whether new VMM registrations are
+    -- accepted
+    update_disposition omicron.public.inv_sled_update_disposition NOT NULL,
 
     PRIMARY KEY (inv_collection_id, id)
 );

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -9404,7 +9404,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '294.0.0', NULL)
+    (TRUE, NOW(), NOW(), '295.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -22,7 +22,7 @@ use omicron_common::api::internal::{
 use sled_agent_types_versions::{
     latest, v1, v4, v6, v7, v9, v10, v11, v12, v14, v16, v17, v18, v20, v22,
     v24, v25, v26, v28, v29, v30, v31, v32, v33, v34, v37, v39, v40, v41, v42,
-    v43, v47, v48,
+    v43, v46, v47, v48,
 };
 use sled_diagnostics::SledDiagnosticsQueryOutput;
 use slog_error_chain::InlineErrorChain;
@@ -39,6 +39,7 @@ api_versions!([
     // |  example for the next person.
     // v
     // (next_int, IDENT),
+    (49, ADD_UPDATE_DISPOSITION),
     (48, ALLOW_DDM_TRAFFIC),
     (47, BGP_PEER_SRC_ADDR),
     (46, MODIFY_SVC_STATE_ENUM),
@@ -373,12 +374,26 @@ pub trait SledAgentApi {
     #[endpoint {
         method = PUT,
         path = "/omicron-config",
-        versions = VERSION_MEASUREMENTS..,
+        versions = VERSION_ADD_UPDATE_DISPOSITION..,
     }]
     async fn omicron_config_put(
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<latest::inventory::OmicronSledConfig>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
+
+    #[endpoint {
+        operation_id = "omicron_config_put",
+        method = PUT,
+        path = "/omicron-config",
+        versions = VERSION_MEASUREMENTS..VERSION_ADD_UPDATE_DISPOSITION,
+    }]
+    async fn omicron_config_put_v14(
+        rqctx: RequestContext<Self::Context>,
+        body: TypedBody<v14::inventory::OmicronSledConfig>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let body = body.map(latest::inventory::OmicronSledConfig::from);
+        Self::omicron_config_put(rqctx, body).await
+    }
 
     #[endpoint {
         operation_id = "omicron_config_put",
@@ -391,9 +406,8 @@ pub trait SledAgentApi {
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<v11::inventory::OmicronSledConfig>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        let body =
-            body.try_map(latest::inventory::OmicronSledConfig::try_from)?;
-        Self::omicron_config_put(rqctx, body).await
+        let body = body.try_map(v14::inventory::OmicronSledConfig::try_from)?;
+        Self::omicron_config_put_v14(rqctx, body).await
     }
 
     #[endpoint {
@@ -1160,11 +1174,25 @@ pub trait SledAgentApi {
     #[endpoint {
         method = GET,
         path = "/inventory",
-        versions = VERSION_MODIFY_SVC_STATE_ENUM..,
+        versions = VERSION_ADD_UPDATE_DISPOSITION..,
     }]
     async fn inventory(
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<latest::inventory::Inventory>, HttpError>;
+
+    /// Fetch basic information about this sled
+    #[endpoint {
+        operation_id = "inventory",
+        method = GET,
+        path = "/inventory",
+        versions = VERSION_MODIFY_SVC_STATE_ENUM..VERSION_ADD_UPDATE_DISPOSITION,
+    }]
+    async fn inventory_v46(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<v46::inventory::Inventory>, HttpError> {
+        let HttpResponseOk(inventory) = Self::inventory(rqctx).await?;
+        Ok(HttpResponseOk(inventory.into()))
+    }
 
     /// Fetch basic information about this sled
     #[endpoint {
@@ -1176,7 +1204,7 @@ pub trait SledAgentApi {
     async fn inventory_v43(
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<v43::inventory::Inventory>, HttpError> {
-        let HttpResponseOk(inventory) = Self::inventory(rqctx).await?;
+        let HttpResponseOk(inventory) = Self::inventory_v46(rqctx).await?;
         inventory.try_into().map_err(HttpError::from).map(HttpResponseOk)
     }
 

--- a/sled-agent/config-reconciler/expectorate/v49-sled-config.json
+++ b/sled-agent/config-reconciler/expectorate/v49-sled-config.json
@@ -1,7 +1,7 @@
 {
   "generation": 351,
-  "disks": {
-    "10fec275-f937-40f7-9c25-616079ef3816": {
+  "disks": [
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -10,7 +10,7 @@
       "id": "10fec275-f937-40f7-9c25-616079ef3816",
       "pool_id": "6340805e-c5af-418d-8bd1-fc0085667f33"
     },
-    "883b970b-2b70-4771-bb0e-aed2765c3e6a": {
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -19,7 +19,7 @@
       "id": "883b970b-2b70-4771-bb0e-aed2765c3e6a",
       "pool_id": "414e235b-55c3-4dc1-a568-8adf4ea1a052"
     },
-    "9272fa96-eef8-43ed-8658-12ccf722bec2": {
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -28,7 +28,7 @@
       "id": "9272fa96-eef8-43ed-8658-12ccf722bec2",
       "pool_id": "7b24095a-72df-45e3-984f-2b795e052ac7"
     },
-    "b20f225f-fef6-4ef5-a474-bd818013fceb": {
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -37,7 +37,7 @@
       "id": "b20f225f-fef6-4ef5-a474-bd818013fceb",
       "pool_id": "b93f880e-c55b-4d6c-9a16-939d84b628fc"
     },
-    "b483c693-700f-4630-92bb-9659e735648b": {
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -46,7 +46,7 @@
       "id": "b483c693-700f-4630-92bb-9659e735648b",
       "pool_id": "cf940e15-dbc5-481b-866a-4de4b018898e"
     },
-    "c9bd1b35-c87a-4acf-bf52-06ed624e3be0": {
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -55,7 +55,7 @@
       "id": "c9bd1b35-c87a-4acf-bf52-06ed624e3be0",
       "pool_id": "8a199f12-4f5c-483a-8aca-f97856658a35"
     },
-    "d45fb895-f500-473f-9bdb-3d1f15464055": {
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -64,7 +64,7 @@
       "id": "d45fb895-f500-473f-9bdb-3d1f15464055",
       "pool_id": "26e698bb-006d-4208-94b9-d1bc279111fa"
     },
-    "d9fb1545-4051-4710-bcfd-8d33115bb022": {
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -73,7 +73,7 @@
       "id": "d9fb1545-4051-4710-bcfd-8d33115bb022",
       "pool_id": "e126ddcc-8bee-46ba-8199-2a74df0ba040"
     },
-    "e1bfe0a7-e848-4907-9068-22e02bad03ca": {
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -82,7 +82,7 @@
       "id": "e1bfe0a7-e848-4907-9068-22e02bad03ca",
       "pool_id": "2115b084-be0f-4fba-941b-33a659798a9e"
     },
-    "f6d26664-f32e-46c4-a3f3-74d55dae7fac": {
+    {
       "identity": {
         "vendor": "1b96",
         "model": "WUS4C6432DSP3X3",
@@ -91,9 +91,9 @@
       "id": "f6d26664-f32e-46c4-a3f3-74d55dae7fac",
       "pool_id": "bf428719-1b16-4503-99f4-ad95846d916f"
     }
-  },
-  "datasets": {
-    "01f93020-7e7d-4185-93fb-6ca234056c82": {
+  ],
+  "datasets": [
+    {
       "id": "01f93020-7e7d-4185-93fb-6ca234056c82",
       "name": {
         "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
@@ -105,7 +105,7 @@
       "quota": null,
       "reservation": null
     },
-    "01ffd316-ea25-4287-95aa-01bf6b036a16": {
+    {
       "id": "01ffd316-ea25-4287-95aa-01bf6b036a16",
       "name": {
         "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
@@ -117,7 +117,7 @@
       "quota": null,
       "reservation": null
     },
-    "02a5be47-df19-4159-b793-98a888603200": {
+    {
       "id": "02a5be47-df19-4159-b793-98a888603200",
       "name": {
         "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
@@ -130,7 +130,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "072fdae8-2adf-4fd2-94ce-e9b0663b91e7": {
+    {
       "id": "072fdae8-2adf-4fd2-94ce-e9b0663b91e7",
       "name": {
         "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
@@ -142,7 +142,7 @@
       "quota": null,
       "reservation": null
     },
-    "088ff0e3-9b7e-4798-901c-fe88cf7aca52": {
+    {
       "id": "088ff0e3-9b7e-4798-901c-fe88cf7aca52",
       "name": {
         "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
@@ -154,7 +154,7 @@
       "quota": null,
       "reservation": null
     },
-    "0b41c560-3b20-42f4-82ad-92f5bb575d6b": {
+    {
       "id": "0b41c560-3b20-42f4-82ad-92f5bb575d6b",
       "name": {
         "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
@@ -166,7 +166,7 @@
       "quota": null,
       "reservation": null
     },
-    "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9": {
+    {
       "id": "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9",
       "name": {
         "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
@@ -178,7 +178,7 @@
       "quota": null,
       "reservation": null
     },
-    "14b70f75-89e1-4ded-a7c4-dcf49ebd87ba": {
+    {
       "id": "14b70f75-89e1-4ded-a7c4-dcf49ebd87ba",
       "name": {
         "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
@@ -190,7 +190,7 @@
       "quota": null,
       "reservation": null
     },
-    "1a00597c-8225-4324-9530-aaad3d7a9138": {
+    {
       "id": "1a00597c-8225-4324-9530-aaad3d7a9138",
       "name": {
         "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
@@ -202,7 +202,7 @@
       "quota": null,
       "reservation": null
     },
-    "257d5c91-5bd5-4a13-802b-0995f76df671": {
+    {
       "id": "257d5c91-5bd5-4a13-802b-0995f76df671",
       "name": {
         "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
@@ -214,7 +214,7 @@
       "quota": null,
       "reservation": null
     },
-    "27bb57f7-abc6-4550-b1c6-5a18c7356748": {
+    {
       "id": "27bb57f7-abc6-4550-b1c6-5a18c7356748",
       "name": {
         "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
@@ -227,7 +227,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "2bd226bd-edce-488c-bbe8-e0b301664de0": {
+    {
       "id": "2bd226bd-edce-488c-bbe8-e0b301664de0",
       "name": {
         "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
@@ -239,7 +239,7 @@
       "quota": null,
       "reservation": null
     },
-    "2c260613-a7bc-401e-ab73-cde4069ef09a": {
+    {
       "id": "2c260613-a7bc-401e-ab73-cde4069ef09a",
       "name": {
         "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
@@ -252,7 +252,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "2fa20fca-7b61-4e56-8dbf-f56171bf35e1": {
+    {
       "id": "2fa20fca-7b61-4e56-8dbf-f56171bf35e1",
       "name": {
         "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
@@ -265,7 +265,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "34007214-81f0-4768-804d-d090695f1f09": {
+    {
       "id": "34007214-81f0-4768-804d-d090695f1f09",
       "name": {
         "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
@@ -277,7 +277,7 @@
       "quota": null,
       "reservation": null
     },
-    "46596dcd-4bea-4878-b498-1b9da4437aff": {
+    {
       "id": "46596dcd-4bea-4878-b498-1b9da4437aff",
       "name": {
         "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
@@ -290,7 +290,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "468152ab-b771-4caf-9ca2-8abbd6fc5bec": {
+    {
       "id": "468152ab-b771-4caf-9ca2-8abbd6fc5bec",
       "name": {
         "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
@@ -303,7 +303,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "46c13daf-0808-496a-b0f8-9eca75fcfa84": {
+    {
       "id": "46c13daf-0808-496a-b0f8-9eca75fcfa84",
       "name": {
         "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
@@ -316,7 +316,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "4b771fc2-312a-4abf-9eef-ae9ff3853a13": {
+    {
       "id": "4b771fc2-312a-4abf-9eef-ae9ff3853a13",
       "name": {
         "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
@@ -328,7 +328,7 @@
       "quota": null,
       "reservation": null
     },
-    "4e3b3938-ad72-4443-9d96-4d6ba8ab19fb": {
+    {
       "id": "4e3b3938-ad72-4443-9d96-4d6ba8ab19fb",
       "name": {
         "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
@@ -340,7 +340,7 @@
       "quota": null,
       "reservation": null
     },
-    "50b12371-0120-4210-89c7-2ecd58bea4d3": {
+    {
       "id": "50b12371-0120-4210-89c7-2ecd58bea4d3",
       "name": {
         "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
@@ -352,7 +352,7 @@
       "quota": null,
       "reservation": null
     },
-    "5171b6ba-b282-4e71-917e-f253c7b2eb22": {
+    {
       "id": "5171b6ba-b282-4e71-917e-f253c7b2eb22",
       "name": {
         "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
@@ -364,7 +364,7 @@
       "quota": null,
       "reservation": null
     },
-    "5625f171-927d-4e4a-b009-be250ac92bc3": {
+    {
       "id": "5625f171-927d-4e4a-b009-be250ac92bc3",
       "name": {
         "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
@@ -376,7 +376,7 @@
       "quota": null,
       "reservation": null
     },
-    "56b0119a-f49d-45d7-a93e-d4a4e1d76559": {
+    {
       "id": "56b0119a-f49d-45d7-a93e-d4a4e1d76559",
       "name": {
         "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
@@ -388,7 +388,7 @@
       "quota": null,
       "reservation": null
     },
-    "585cd8c5-c41e-4be4-beb8-bfbef9b53856": {
+    {
       "id": "585cd8c5-c41e-4be4-beb8-bfbef9b53856",
       "name": {
         "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
@@ -400,7 +400,7 @@
       "quota": null,
       "reservation": null
     },
-    "5b0bc0d3-24c6-4f9c-937b-f38e8ccee03c": {
+    {
       "id": "5b0bc0d3-24c6-4f9c-937b-f38e8ccee03c",
       "name": {
         "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
@@ -412,7 +412,7 @@
       "quota": null,
       "reservation": null
     },
-    "5c4e9d03-f202-46dd-ba50-179b2b84f849": {
+    {
       "id": "5c4e9d03-f202-46dd-ba50-179b2b84f849",
       "name": {
         "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
@@ -424,7 +424,7 @@
       "quota": null,
       "reservation": null
     },
-    "69794309-1082-410b-a2a1-8b97588efa16": {
+    {
       "id": "69794309-1082-410b-a2a1-8b97588efa16",
       "name": {
         "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
@@ -436,7 +436,7 @@
       "quota": null,
       "reservation": null
     },
-    "69a6412f-8438-4a0d-9c6e-a2e766750b2c": {
+    {
       "id": "69a6412f-8438-4a0d-9c6e-a2e766750b2c",
       "name": {
         "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
@@ -448,7 +448,7 @@
       "quota": null,
       "reservation": null
     },
-    "7153983f-8fd7-4fb9-92ac-0f07a07798b4": {
+    {
       "id": "7153983f-8fd7-4fb9-92ac-0f07a07798b4",
       "name": {
         "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
@@ -460,7 +460,7 @@
       "quota": null,
       "reservation": null
     },
-    "77906e4e-1bbc-49c9-a7ee-f581de5552c4": {
+    {
       "id": "77906e4e-1bbc-49c9-a7ee-f581de5552c4",
       "name": {
         "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
@@ -472,7 +472,7 @@
       "quota": null,
       "reservation": null
     },
-    "7d44ba36-4a69-490a-bc40-f6f90a4208d4": {
+    {
       "id": "7d44ba36-4a69-490a-bc40-f6f90a4208d4",
       "name": {
         "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
@@ -484,7 +484,7 @@
       "quota": null,
       "reservation": null
     },
-    "8bce1ea9-5d2f-451a-87fd-db9140e07420": {
+    {
       "id": "8bce1ea9-5d2f-451a-87fd-db9140e07420",
       "name": {
         "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
@@ -496,7 +496,7 @@
       "quota": null,
       "reservation": null
     },
-    "8f50c2e8-d091-4440-b9cc-0c6c3e62b8b8": {
+    {
       "id": "8f50c2e8-d091-4440-b9cc-0c6c3e62b8b8",
       "name": {
         "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
@@ -508,7 +508,7 @@
       "quota": null,
       "reservation": null
     },
-    "9721d822-c80a-4856-a715-02c9c0c89184": {
+    {
       "id": "9721d822-c80a-4856-a715-02c9c0c89184",
       "name": {
         "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
@@ -520,7 +520,7 @@
       "quota": null,
       "reservation": null
     },
-    "978354d3-17cb-40ce-815d-b4edaad79f11": {
+    {
       "id": "978354d3-17cb-40ce-815d-b4edaad79f11",
       "name": {
         "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
@@ -532,7 +532,7 @@
       "quota": null,
       "reservation": null
     },
-    "9bf9e7bd-269b-4925-ba99-a0cdb8138fb8": {
+    {
       "id": "9bf9e7bd-269b-4925-ba99-a0cdb8138fb8",
       "name": {
         "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
@@ -544,7 +544,7 @@
       "quota": null,
       "reservation": null
     },
-    "a2d0f801-bf2d-44a3-b39b-bbfb3b387a4a": {
+    {
       "id": "a2d0f801-bf2d-44a3-b39b-bbfb3b387a4a",
       "name": {
         "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
@@ -557,7 +557,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "a6ba8273-0320-4dab-b801-281f041b0c50": {
+    {
       "id": "a6ba8273-0320-4dab-b801-281f041b0c50",
       "name": {
         "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
@@ -569,7 +569,7 @@
       "quota": null,
       "reservation": null
     },
-    "a6cbbb5d-f7b3-4d91-b54e-c3cf55762adc": {
+    {
       "id": "a6cbbb5d-f7b3-4d91-b54e-c3cf55762adc",
       "name": {
         "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
@@ -581,7 +581,7 @@
       "quota": null,
       "reservation": null
     },
-    "a724aab1-2fdc-45aa-8fa2-2f0a272aae62": {
+    {
       "id": "a724aab1-2fdc-45aa-8fa2-2f0a272aae62",
       "name": {
         "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
@@ -593,7 +593,7 @@
       "quota": null,
       "reservation": null
     },
-    "aa44f101-8502-4480-bec8-9c48d3f4106b": {
+    {
       "id": "aa44f101-8502-4480-bec8-9c48d3f4106b",
       "name": {
         "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
@@ -605,7 +605,7 @@
       "quota": null,
       "reservation": null
     },
-    "adb8db9b-2cd7-45b7-bb9f-adf094c4ccca": {
+    {
       "id": "adb8db9b-2cd7-45b7-bb9f-adf094c4ccca",
       "name": {
         "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
@@ -618,7 +618,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "b156677f-cafa-4d73-9719-6b0d16dad722": {
+    {
       "id": "b156677f-cafa-4d73-9719-6b0d16dad722",
       "name": {
         "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
@@ -630,7 +630,7 @@
       "quota": null,
       "reservation": null
     },
-    "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4": {
+    {
       "id": "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4",
       "name": {
         "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
@@ -642,7 +642,7 @@
       "quota": null,
       "reservation": null
     },
-    "c5e4bd8a-d323-48ec-a641-5c7dbecf3252": {
+    {
       "id": "c5e4bd8a-d323-48ec-a641-5c7dbecf3252",
       "name": {
         "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
@@ -654,7 +654,7 @@
       "quota": null,
       "reservation": null
     },
-    "c9c7a527-d432-490d-86b3-658da7b555cc": {
+    {
       "id": "c9c7a527-d432-490d-86b3-658da7b555cc",
       "name": {
         "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
@@ -666,7 +666,7 @@
       "quota": null,
       "reservation": null
     },
-    "d8b3ba09-1267-43af-9734-1fdc3e22b23e": {
+    {
       "id": "d8b3ba09-1267-43af-9734-1fdc3e22b23e",
       "name": {
         "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
@@ -678,7 +678,7 @@
       "quota": null,
       "reservation": null
     },
-    "dee3ca8e-c6f5-4e12-aa0d-74ed9a6245a3": {
+    {
       "id": "dee3ca8e-c6f5-4e12-aa0d-74ed9a6245a3",
       "name": {
         "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
@@ -690,7 +690,7 @@
       "quota": null,
       "reservation": null
     },
-    "e1c7ecae-faed-4d02-b446-2dd3478dc27d": {
+    {
       "id": "e1c7ecae-faed-4d02-b446-2dd3478dc27d",
       "name": {
         "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
@@ -703,7 +703,7 @@
       "quota": 107374182400,
       "reservation": null
     },
-    "e238116d-e5cc-43d4-9c8a-6f138ae8a15d": {
+    {
       "id": "e238116d-e5cc-43d4-9c8a-6f138ae8a15d",
       "name": {
         "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
@@ -715,7 +715,7 @@
       "quota": null,
       "reservation": null
     },
-    "e3d07396-5ab6-4008-b590-df8b5794f9e1": {
+    {
       "id": "e3d07396-5ab6-4008-b590-df8b5794f9e1",
       "name": {
         "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
@@ -727,7 +727,7 @@
       "quota": null,
       "reservation": null
     },
-    "e7d578b0-2c40-4e1f-a1c2-2dc2a6f9f5d8": {
+    {
       "id": "e7d578b0-2c40-4e1f-a1c2-2dc2a6f9f5d8",
       "name": {
         "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
@@ -739,7 +739,7 @@
       "quota": null,
       "reservation": null
     },
-    "fb307365-fd47-4112-9a88-519ee5cf6445": {
+    {
       "id": "fb307365-fd47-4112-9a88-519ee5cf6445",
       "name": {
         "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
@@ -751,9 +751,9 @@
       "quota": null,
       "reservation": null
     }
-  },
-  "zones": {
-    "01f93020-7e7d-4185-93fb-6ca234056c82": {
+  ],
+  "zones": [
+    {
       "id": "01f93020-7e7d-4185-93fb-6ca234056c82",
       "filesystem_pool": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
       "zone_type": {
@@ -768,7 +768,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     },
-    "072fdae8-2adf-4fd2-94ce-e9b0663b91e7": {
+    {
       "id": "072fdae8-2adf-4fd2-94ce-e9b0663b91e7",
       "filesystem_pool": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
       "zone_type": {
@@ -783,7 +783,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     },
-    "0b41c560-3b20-42f4-82ad-92f5bb575d6b": {
+    {
       "id": "0b41c560-3b20-42f4-82ad-92f5bb575d6b",
       "filesystem_pool": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
       "zone_type": {
@@ -798,7 +798,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     },
-    "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9": {
+    {
       "id": "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9",
       "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
       "zone_type": {
@@ -813,7 +813,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     },
-    "470fbf4d-0178-45ee-a422-136fa5f4a158": {
+    {
       "id": "470fbf4d-0178-45ee-a422-136fa5f4a158",
       "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
       "zone_type": {
@@ -852,7 +852,7 @@
         "hash": "1ae3b88364f311ce588ac802cb8177c4806b76da0ce42e39aab0b0d8bb04c197"
       }
     },
-    "585cd8c5-c41e-4be4-beb8-bfbef9b53856": {
+    {
       "id": "585cd8c5-c41e-4be4-beb8-bfbef9b53856",
       "filesystem_pool": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
       "zone_type": {
@@ -867,7 +867,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     },
-    "5c97418b-8318-4427-8f65-14f3e3362d13": {
+    {
       "id": "5c97418b-8318-4427-8f65-14f3e3362d13",
       "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
       "zone_type": {
@@ -903,7 +903,7 @@
         "hash": "389335a28c7bb548e68537df4bf5be5df7f2f54db1fba6b1cba3ad36ad48e625"
       }
     },
-    "7153983f-8fd7-4fb9-92ac-0f07a07798b4": {
+    {
       "id": "7153983f-8fd7-4fb9-92ac-0f07a07798b4",
       "filesystem_pool": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
       "zone_type": {
@@ -918,7 +918,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     },
-    "7d44ba36-4a69-490a-bc40-f6f90a4208d4": {
+    {
       "id": "7d44ba36-4a69-490a-bc40-f6f90a4208d4",
       "filesystem_pool": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
       "zone_type": {
@@ -933,7 +933,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     },
-    "a6ba8273-0320-4dab-b801-281f041b0c50": {
+    {
       "id": "a6ba8273-0320-4dab-b801-281f041b0c50",
       "filesystem_pool": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
       "zone_type": {
@@ -948,7 +948,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     },
-    "a700528f-f600-4908-94ac-9c06442ef6b4": {
+    {
       "id": "a700528f-f600-4908-94ac-9c06442ef6b4",
       "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
       "zone_type": {
@@ -960,7 +960,7 @@
         "hash": "2b0988a6122b34391f3310ce1ade733c175316331f408cf1e40329c419318142"
       }
     },
-    "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4": {
+    {
       "id": "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4",
       "filesystem_pool": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
       "zone_type": {
@@ -975,7 +975,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     },
-    "e238116d-e5cc-43d4-9c8a-6f138ae8a15d": {
+    {
       "id": "e238116d-e5cc-43d4-9c8a-6f138ae8a15d",
       "filesystem_pool": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
       "zone_type": {
@@ -990,7 +990,7 @@
         "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
       }
     }
-  },
+  ],
   "remove_mupdate_override": null,
   "host_phase_2": {
     "slot_a": {

--- a/sled-agent/config-reconciler/expectorate/v49-sled-config.json
+++ b/sled-agent/config-reconciler/expectorate/v49-sled-config.json
@@ -1003,5 +1003,5 @@
     }
   },
   "measurements": [],
-  "update_disposition": "Available"
+  "update_disposition": "available"
 }

--- a/sled-agent/config-reconciler/expectorate/v49-sled-config.json
+++ b/sled-agent/config-reconciler/expectorate/v49-sled-config.json
@@ -1,0 +1,1007 @@
+{
+  "generation": 351,
+  "disks": {
+    "10fec275-f937-40f7-9c25-616079ef3816": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A5E3"
+      },
+      "id": "10fec275-f937-40f7-9c25-616079ef3816",
+      "pool_id": "6340805e-c5af-418d-8bd1-fc0085667f33"
+    },
+    "883b970b-2b70-4771-bb0e-aed2765c3e6a": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A79D"
+      },
+      "id": "883b970b-2b70-4771-bb0e-aed2765c3e6a",
+      "pool_id": "414e235b-55c3-4dc1-a568-8adf4ea1a052"
+    },
+    "9272fa96-eef8-43ed-8658-12ccf722bec2": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A61D"
+      },
+      "id": "9272fa96-eef8-43ed-8658-12ccf722bec2",
+      "pool_id": "7b24095a-72df-45e3-984f-2b795e052ac7"
+    },
+    "b20f225f-fef6-4ef5-a474-bd818013fceb": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A7EE"
+      },
+      "id": "b20f225f-fef6-4ef5-a474-bd818013fceb",
+      "pool_id": "b93f880e-c55b-4d6c-9a16-939d84b628fc"
+    },
+    "b483c693-700f-4630-92bb-9659e735648b": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A67C"
+      },
+      "id": "b483c693-700f-4630-92bb-9659e735648b",
+      "pool_id": "cf940e15-dbc5-481b-866a-4de4b018898e"
+    },
+    "c9bd1b35-c87a-4acf-bf52-06ed624e3be0": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A6F3"
+      },
+      "id": "c9bd1b35-c87a-4acf-bf52-06ed624e3be0",
+      "pool_id": "8a199f12-4f5c-483a-8aca-f97856658a35"
+    },
+    "d45fb895-f500-473f-9bdb-3d1f15464055": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A5C3"
+      },
+      "id": "d45fb895-f500-473f-9bdb-3d1f15464055",
+      "pool_id": "26e698bb-006d-4208-94b9-d1bc279111fa"
+    },
+    "d9fb1545-4051-4710-bcfd-8d33115bb022": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A7BE"
+      },
+      "id": "d9fb1545-4051-4710-bcfd-8d33115bb022",
+      "pool_id": "e126ddcc-8bee-46ba-8199-2a74df0ba040"
+    },
+    "e1bfe0a7-e848-4907-9068-22e02bad03ca": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A7DA"
+      },
+      "id": "e1bfe0a7-e848-4907-9068-22e02bad03ca",
+      "pool_id": "2115b084-be0f-4fba-941b-33a659798a9e"
+    },
+    "f6d26664-f32e-46c4-a3f3-74d55dae7fac": {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A75D"
+      },
+      "id": "f6d26664-f32e-46c4-a3f3-74d55dae7fac",
+      "pool_id": "bf428719-1b16-4503-99f4-ad95846d916f"
+    }
+  },
+  "datasets": {
+    "01f93020-7e7d-4185-93fb-6ca234056c82": {
+      "id": "01f93020-7e7d-4185-93fb-6ca234056c82",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "01ffd316-ea25-4287-95aa-01bf6b036a16": {
+      "id": "01ffd316-ea25-4287-95aa-01bf6b036a16",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "zone/oxz_crucible_01f93020-7e7d-4185-93fb-6ca234056c82"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "02a5be47-df19-4159-b793-98a888603200": {
+      "id": "02a5be47-df19-4159-b793-98a888603200",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "072fdae8-2adf-4fd2-94ce-e9b0663b91e7": {
+      "id": "072fdae8-2adf-4fd2-94ce-e9b0663b91e7",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "088ff0e3-9b7e-4798-901c-fe88cf7aca52": {
+      "id": "088ff0e3-9b7e-4798-901c-fe88cf7aca52",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "0b41c560-3b20-42f4-82ad-92f5bb575d6b": {
+      "id": "0b41c560-3b20-42f4-82ad-92f5bb575d6b",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9": {
+      "id": "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "14b70f75-89e1-4ded-a7c4-dcf49ebd87ba": {
+      "id": "14b70f75-89e1-4ded-a7c4-dcf49ebd87ba",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "zone/oxz_crucible_0b41c560-3b20-42f4-82ad-92f5bb575d6b"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "1a00597c-8225-4324-9530-aaad3d7a9138": {
+      "id": "1a00597c-8225-4324-9530-aaad3d7a9138",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "zone/oxz_crucible_7d44ba36-4a69-490a-bc40-f6f90a4208d4"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "257d5c91-5bd5-4a13-802b-0995f76df671": {
+      "id": "257d5c91-5bd5-4a13-802b-0995f76df671",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone/oxz_nexus_470fbf4d-0178-45ee-a422-136fa5f4a158"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "27bb57f7-abc6-4550-b1c6-5a18c7356748": {
+      "id": "27bb57f7-abc6-4550-b1c6-5a18c7356748",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "2bd226bd-edce-488c-bbe8-e0b301664de0": {
+      "id": "2bd226bd-edce-488c-bbe8-e0b301664de0",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "2c260613-a7bc-401e-ab73-cde4069ef09a": {
+      "id": "2c260613-a7bc-401e-ab73-cde4069ef09a",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "2fa20fca-7b61-4e56-8dbf-f56171bf35e1": {
+      "id": "2fa20fca-7b61-4e56-8dbf-f56171bf35e1",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "34007214-81f0-4768-804d-d090695f1f09": {
+      "id": "34007214-81f0-4768-804d-d090695f1f09",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "external_dns"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "46596dcd-4bea-4878-b498-1b9da4437aff": {
+      "id": "46596dcd-4bea-4878-b498-1b9da4437aff",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "468152ab-b771-4caf-9ca2-8abbd6fc5bec": {
+      "id": "468152ab-b771-4caf-9ca2-8abbd6fc5bec",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "46c13daf-0808-496a-b0f8-9eca75fcfa84": {
+      "id": "46c13daf-0808-496a-b0f8-9eca75fcfa84",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "4b771fc2-312a-4abf-9eef-ae9ff3853a13": {
+      "id": "4b771fc2-312a-4abf-9eef-ae9ff3853a13",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "4e3b3938-ad72-4443-9d96-4d6ba8ab19fb": {
+      "id": "4e3b3938-ad72-4443-9d96-4d6ba8ab19fb",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "zone/oxz_crucible_585cd8c5-c41e-4be4-beb8-bfbef9b53856"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "50b12371-0120-4210-89c7-2ecd58bea4d3": {
+      "id": "50b12371-0120-4210-89c7-2ecd58bea4d3",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "5171b6ba-b282-4e71-917e-f253c7b2eb22": {
+      "id": "5171b6ba-b282-4e71-917e-f253c7b2eb22",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "5625f171-927d-4e4a-b009-be250ac92bc3": {
+      "id": "5625f171-927d-4e4a-b009-be250ac92bc3",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "56b0119a-f49d-45d7-a93e-d4a4e1d76559": {
+      "id": "56b0119a-f49d-45d7-a93e-d4a4e1d76559",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "585cd8c5-c41e-4be4-beb8-bfbef9b53856": {
+      "id": "585cd8c5-c41e-4be4-beb8-bfbef9b53856",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "5b0bc0d3-24c6-4f9c-937b-f38e8ccee03c": {
+      "id": "5b0bc0d3-24c6-4f9c-937b-f38e8ccee03c",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "5c4e9d03-f202-46dd-ba50-179b2b84f849": {
+      "id": "5c4e9d03-f202-46dd-ba50-179b2b84f849",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "zone/oxz_crucible_7153983f-8fd7-4fb9-92ac-0f07a07798b4"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "69794309-1082-410b-a2a1-8b97588efa16": {
+      "id": "69794309-1082-410b-a2a1-8b97588efa16",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "69a6412f-8438-4a0d-9c6e-a2e766750b2c": {
+      "id": "69a6412f-8438-4a0d-9c6e-a2e766750b2c",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone/oxz_external_dns_5c97418b-8318-4427-8f65-14f3e3362d13"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "7153983f-8fd7-4fb9-92ac-0f07a07798b4": {
+      "id": "7153983f-8fd7-4fb9-92ac-0f07a07798b4",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "77906e4e-1bbc-49c9-a7ee-f581de5552c4": {
+      "id": "77906e4e-1bbc-49c9-a7ee-f581de5552c4",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "zone/oxz_crucible_e238116d-e5cc-43d4-9c8a-6f138ae8a15d"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "7d44ba36-4a69-490a-bc40-f6f90a4208d4": {
+      "id": "7d44ba36-4a69-490a-bc40-f6f90a4208d4",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "8bce1ea9-5d2f-451a-87fd-db9140e07420": {
+      "id": "8bce1ea9-5d2f-451a-87fd-db9140e07420",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "zone/oxz_crucible_a6ba8273-0320-4dab-b801-281f041b0c50"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "8f50c2e8-d091-4440-b9cc-0c6c3e62b8b8": {
+      "id": "8f50c2e8-d091-4440-b9cc-0c6c3e62b8b8",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone/oxz_crucible_0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "9721d822-c80a-4856-a715-02c9c0c89184": {
+      "id": "9721d822-c80a-4856-a715-02c9c0c89184",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "978354d3-17cb-40ce-815d-b4edaad79f11": {
+      "id": "978354d3-17cb-40ce-815d-b4edaad79f11",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "9bf9e7bd-269b-4925-ba99-a0cdb8138fb8": {
+      "id": "9bf9e7bd-269b-4925-ba99-a0cdb8138fb8",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "a2d0f801-bf2d-44a3-b39b-bbfb3b387a4a": {
+      "id": "a2d0f801-bf2d-44a3-b39b-bbfb3b387a4a",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "a6ba8273-0320-4dab-b801-281f041b0c50": {
+      "id": "a6ba8273-0320-4dab-b801-281f041b0c50",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "a6cbbb5d-f7b3-4d91-b54e-c3cf55762adc": {
+      "id": "a6cbbb5d-f7b3-4d91-b54e-c3cf55762adc",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "a724aab1-2fdc-45aa-8fa2-2f0a272aae62": {
+      "id": "a724aab1-2fdc-45aa-8fa2-2f0a272aae62",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "aa44f101-8502-4480-bec8-9c48d3f4106b": {
+      "id": "aa44f101-8502-4480-bec8-9c48d3f4106b",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "adb8db9b-2cd7-45b7-bb9f-adf094c4ccca": {
+      "id": "adb8db9b-2cd7-45b7-bb9f-adf094c4ccca",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "b156677f-cafa-4d73-9719-6b0d16dad722": {
+      "id": "b156677f-cafa-4d73-9719-6b0d16dad722",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4": {
+      "id": "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "c5e4bd8a-d323-48ec-a641-5c7dbecf3252": {
+      "id": "c5e4bd8a-d323-48ec-a641-5c7dbecf3252",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "c9c7a527-d432-490d-86b3-658da7b555cc": {
+      "id": "c9c7a527-d432-490d-86b3-658da7b555cc",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "zone/oxz_crucible_072fdae8-2adf-4fd2-94ce-e9b0663b91e7"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "d8b3ba09-1267-43af-9734-1fdc3e22b23e": {
+      "id": "d8b3ba09-1267-43af-9734-1fdc3e22b23e",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "zone/oxz_crucible_b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "dee3ca8e-c6f5-4e12-aa0d-74ed9a6245a3": {
+      "id": "dee3ca8e-c6f5-4e12-aa0d-74ed9a6245a3",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone/oxz_ntp_a700528f-f600-4908-94ac-9c06442ef6b4"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "e1c7ecae-faed-4d02-b446-2dd3478dc27d": {
+      "id": "e1c7ecae-faed-4d02-b446-2dd3478dc27d",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    "e238116d-e5cc-43d4-9c8a-6f138ae8a15d": {
+      "id": "e238116d-e5cc-43d4-9c8a-6f138ae8a15d",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "e3d07396-5ab6-4008-b590-df8b5794f9e1": {
+      "id": "e3d07396-5ab6-4008-b590-df8b5794f9e1",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "e7d578b0-2c40-4e1f-a1c2-2dc2a6f9f5d8": {
+      "id": "e7d578b0-2c40-4e1f-a1c2-2dc2a6f9f5d8",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    "fb307365-fd47-4112-9a88-519ee5cf6445": {
+      "id": "fb307365-fd47-4112-9a88-519ee5cf6445",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    }
+  },
+  "zones": {
+    "01f93020-7e7d-4185-93fb-6ca234056c82": {
+      "id": "01f93020-7e7d-4185-93fb-6ca234056c82",
+      "filesystem_pool": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::5]:32345",
+        "dataset": {
+          "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    "072fdae8-2adf-4fd2-94ce-e9b0663b91e7": {
+      "id": "072fdae8-2adf-4fd2-94ce-e9b0663b91e7",
+      "filesystem_pool": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::b]:32345",
+        "dataset": {
+          "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    "0b41c560-3b20-42f4-82ad-92f5bb575d6b": {
+      "id": "0b41c560-3b20-42f4-82ad-92f5bb575d6b",
+      "filesystem_pool": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::9]:32345",
+        "dataset": {
+          "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9": {
+      "id": "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9",
+      "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::d]:32345",
+        "dataset": {
+          "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    "470fbf4d-0178-45ee-a422-136fa5f4a158": {
+      "id": "470fbf4d-0178-45ee-a422-136fa5f4a158",
+      "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+      "zone_type": {
+        "type": "nexus",
+        "internal_address": "[fd00:1122:3344:103::47]:12221",
+        "lockstep_port": 12232,
+        "external_ip": "172.20.26.8",
+        "nic": {
+          "id": "98d2e08e-a3a6-43ed-a2a0-7cf52fd211f8",
+          "kind": {
+            "type": "service",
+            "id": "470fbf4d-0178-45ee-a422-136fa5f4a158"
+          },
+          "name": "nexus-470fbf4d-0178-45ee-a422-136fa5f4a158",
+          "ip_config": {
+            "type": "v4",
+            "value": {
+              "ip": "172.30.2.9",
+              "subnet": "172.30.2.0/24",
+              "transit_ips": []
+            }
+          },
+          "mac": "A8:40:25:FF:80:05",
+          "vni": 100,
+          "primary": true,
+          "slot": 0
+        },
+        "external_tls": true,
+        "external_dns_servers": [
+          "1.1.1.1",
+          "9.9.9.9"
+        ]
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "1ae3b88364f311ce588ac802cb8177c4806b76da0ce42e39aab0b0d8bb04c197"
+      }
+    },
+    "585cd8c5-c41e-4be4-beb8-bfbef9b53856": {
+      "id": "585cd8c5-c41e-4be4-beb8-bfbef9b53856",
+      "filesystem_pool": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::7]:32345",
+        "dataset": {
+          "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    "5c97418b-8318-4427-8f65-14f3e3362d13": {
+      "id": "5c97418b-8318-4427-8f65-14f3e3362d13",
+      "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+      "zone_type": {
+        "type": "external_dns",
+        "dataset": {
+          "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e"
+        },
+        "http_address": "[fd00:1122:3344:103::46]:5353",
+        "dns_address": "172.20.26.2:53",
+        "nic": {
+          "id": "9e5b3233-1bb2-4d10-a99a-6884d6ab4d7d",
+          "kind": {
+            "type": "service",
+            "id": "5c97418b-8318-4427-8f65-14f3e3362d13"
+          },
+          "name": "external-dns-5c97418b-8318-4427-8f65-14f3e3362d13",
+          "ip_config": {
+            "type": "v4",
+            "value": {
+              "ip": "172.30.1.6",
+              "subnet": "172.30.1.0/24",
+              "transit_ips": []
+            }
+          },
+          "mac": "A8:40:25:FF:80:01",
+          "vni": 100,
+          "primary": true,
+          "slot": 0
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "389335a28c7bb548e68537df4bf5be5df7f2f54db1fba6b1cba3ad36ad48e625"
+      }
+    },
+    "7153983f-8fd7-4fb9-92ac-0f07a07798b4": {
+      "id": "7153983f-8fd7-4fb9-92ac-0f07a07798b4",
+      "filesystem_pool": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::a]:32345",
+        "dataset": {
+          "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    "7d44ba36-4a69-490a-bc40-f6f90a4208d4": {
+      "id": "7d44ba36-4a69-490a-bc40-f6f90a4208d4",
+      "filesystem_pool": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::c]:32345",
+        "dataset": {
+          "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    "a6ba8273-0320-4dab-b801-281f041b0c50": {
+      "id": "a6ba8273-0320-4dab-b801-281f041b0c50",
+      "filesystem_pool": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::4]:32345",
+        "dataset": {
+          "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    "a700528f-f600-4908-94ac-9c06442ef6b4": {
+      "id": "a700528f-f600-4908-94ac-9c06442ef6b4",
+      "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+      "zone_type": {
+        "type": "internal_ntp",
+        "address": "[fd00:1122:3344:103::45]:123"
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "2b0988a6122b34391f3310ce1ade733c175316331f408cf1e40329c419318142"
+      }
+    },
+    "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4": {
+      "id": "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4",
+      "filesystem_pool": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::8]:32345",
+        "dataset": {
+          "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    "e238116d-e5cc-43d4-9c8a-6f138ae8a15d": {
+      "id": "e238116d-e5cc-43d4-9c8a-6f138ae8a15d",
+      "filesystem_pool": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::6]:32345",
+        "dataset": {
+          "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    }
+  },
+  "remove_mupdate_override": null,
+  "host_phase_2": {
+    "slot_a": {
+      "type": "artifact",
+      "hash": "8234c10964ef7f62880772caaf96f449234bad8428b2a6a09e623d383550bfdf"
+    },
+    "slot_b": {
+      "type": "artifact",
+      "hash": "8234c10964ef7f62880772caaf96f449234bad8428b2a6a09e623d383550bfdf"
+    }
+  },
+  "measurements": [],
+  "update_disposition": "Available"
+}

--- a/sled-agent/config-reconciler/src/ledger.rs
+++ b/sled-agent/config-reconciler/src/ledger.rs
@@ -692,6 +692,7 @@ mod tests {
     use sled_agent_types::disk::OmicronPhysicalDiskConfig;
     use sled_agent_types::inventory::HostPhase2DesiredContents;
     use sled_agent_types::inventory::HostPhase2DesiredSlots;
+    use sled_agent_types::inventory::OmicronSledUpdateDisposition;
     use sled_agent_types::inventory::OmicronZoneConfig;
     use sled_agent_types::inventory::OmicronZoneImageSource;
     use sled_agent_types::inventory::OmicronZoneType;
@@ -888,6 +889,7 @@ mod tests {
             remove_mupdate_override: None,
             host_phase_2: HostPhase2DesiredSlots::current_contents(),
             measurements: BTreeSet::new(),
+            update_disposition: OmicronSledUpdateDisposition::Available,
         }
     }
 
@@ -1091,6 +1093,7 @@ mod tests {
             remove_mupdate_override: None,
             host_phase_2: HostPhase2DesiredSlots::current_contents(),
             measurements: BTreeSet::new(),
+            update_disposition: OmicronSledUpdateDisposition::Available,
         };
 
         // The ledger task should reject this config due to a missing artifact.

--- a/sled-agent/config-reconciler/src/ledger/ledgered_sled_config_versioning.rs
+++ b/sled-agent/config-reconciler/src/ledger/ledgered_sled_config_versioning.rs
@@ -14,6 +14,7 @@ use sled_agent_types_versions::v4;
 use sled_agent_types_versions::v10;
 use sled_agent_types_versions::v11;
 use sled_agent_types_versions::v14;
+use sled_agent_types_versions::v49;
 use slog::Logger;
 use slog::info;
 use slog::warn;
@@ -65,6 +66,7 @@ macro_rules! version_conversion_chain {
 // attempt to parse the ledgered config. Add new versions to the top of the
 // list.
 version_conversion_chain!(
+    v49::inventory::OmicronSledConfig,
     v14::inventory::OmicronSledConfig,
     v11::inventory::OmicronSledConfig,
     v10::inventory::OmicronSledConfig,
@@ -272,6 +274,8 @@ pub(super) mod tests {
         "expectorate/v11-sled-config.json";
     const EXPECTORATE_V14_CONFIG_PATH: &str =
         "expectorate/v14-sled-config.json";
+    const EXPECTORATE_V49_CONFIG_PATH: &str =
+        "expectorate/v49-sled-config.json";
 
     // This is solely an expectorate test to guarantee:
     //
@@ -300,6 +304,7 @@ pub(super) mod tests {
             .expect("converted from v10");
         let v14 = v14::inventory::OmicronSledConfig::try_from(v11.clone())
             .expect("converted from v11");
+        let v49 = v49::inventory::OmicronSledConfig::from(v14.clone());
 
         expectorate::assert_contents(
             EXPECTORATE_V10_CONFIG_PATH,
@@ -312,6 +317,10 @@ pub(super) mod tests {
         expectorate::assert_contents(
             EXPECTORATE_V14_CONFIG_PATH,
             &serde_json::to_string_pretty(&v14).unwrap(),
+        );
+        expectorate::assert_contents(
+            EXPECTORATE_V49_CONFIG_PATH,
+            &serde_json::to_string_pretty(&v49).unwrap(),
         );
         logctx.cleanup_successful();
     }
@@ -327,8 +336,8 @@ pub(super) mod tests {
         // compilation error if the latest version changes. Bump the
         // version here and add the new version's path to the array of ledger
         // paths below.
-        let latest_version_path = EXPECTORATE_V14_CONFIG_PATH;
-        let expected_config = v14::inventory::OmicronSledConfig::read_from(
+        let latest_version_path = EXPECTORATE_V49_CONFIG_PATH;
+        let expected_config = v49::inventory::OmicronSledConfig::read_from(
             log,
             latest_version_path.into(),
         )
@@ -357,6 +366,7 @@ pub(super) mod tests {
             EXPECTORATE_V10_CONFIG_PATH,
             EXPECTORATE_V11_CONFIG_PATH,
             EXPECTORATE_V14_CONFIG_PATH,
+            EXPECTORATE_V49_CONFIG_PATH,
         ] {
             // Copy the ledger into `my-ledger.json`
             let dst_ledger_path = tempdir.child("my-ledger.json");

--- a/sled-agent/config-reconciler/src/ledger/ledgered_sled_config_versioning.rs
+++ b/sled-agent/config-reconciler/src/ledger/ledgered_sled_config_versioning.rs
@@ -342,7 +342,7 @@ pub(super) mod tests {
             latest_version_path.into(),
         )
         .await
-        .expect("read v14 config");
+        .expect("read expected config");
 
         // Reading old configs should rewrite the file to match the newest
         // version.

--- a/sled-agent/rack-setup/src/service.rs
+++ b/sled-agent/rack-setup/src/service.rs
@@ -109,6 +109,7 @@ use sled_agent_client::{
     Client as SledAgentClient, Error as SledAgentError, types as SledAgentTypes,
 };
 use sled_agent_types::early_networking::EarlyNetworkConfigEnvelope;
+use sled_agent_types::inventory::OmicronSledUpdateDisposition;
 use sled_agent_types::inventory::{
     ConfigReconcilerInventoryResult, HostPhase2DesiredSlots, OmicronSledConfig,
     OmicronZoneConfig, OmicronZoneType, OmicronZonesConfig,
@@ -578,6 +579,7 @@ impl ServiceInner {
                     remove_mupdate_override: None,
                     host_phase_2: HostPhase2DesiredSlots::current_contents(),
                     measurements: Default::default(),
+                    update_disposition: OmicronSledUpdateDisposition::Available,
                 };
 
                 self.set_config_on_sled(*sled_address, sled_config).await?;

--- a/sled-agent/types/versions/src/add_update_disposition/inventory.rs
+++ b/sled-agent/types/versions/src/add_update_disposition/inventory.rs
@@ -6,7 +6,7 @@
 //!
 //! * Add [`OmicronSledUpdateDisposition`] type
 //! * Add `update_disposition` to [`OmicronSledConfig`]
-//! * New definitions of types that include directly or transitively include
+//! * New definitions of types that directly or transitively include
 //!   `OmicronSledConfig`:
 //!     * [`ConfigReconcilerInventory`]
 //!     * [`ConfigReconcilerInventoryStatus`]
@@ -59,7 +59,9 @@ use std::time::Duration;
 /// sled should be evacuated as well as blueprint-specific metadata. From
 /// sled-agent itself, we only need to know the high-level state; we use this to
 /// determine whether or not to accept new VMM registration requests.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum OmicronSledUpdateDisposition {
     Available,
@@ -83,10 +85,7 @@ pub struct OmicronSledConfig {
     pub remove_mupdate_override: Option<MupdateOverrideUuid>,
     #[serde(default = "HostPhase2DesiredSlots::current_contents")]
     pub host_phase_2: HostPhase2DesiredSlots,
-    // We purposely skip a serde default here to work around some ledger
-    // versioning quirks
     pub measurements: BTreeSet<OmicronSingleMeasurement>,
-
     pub update_disposition: OmicronSledUpdateDisposition,
 }
 
@@ -170,14 +169,24 @@ impl From<ConfigReconcilerInventory>
     for crate::v16::inventory::ConfigReconcilerInventory
 {
     fn from(value: ConfigReconcilerInventory) -> Self {
+        let ConfigReconcilerInventory {
+            last_reconciled_config,
+            external_disks,
+            datasets,
+            orphaned_datasets,
+            zones,
+            boot_partitions,
+            remove_mupdate_override,
+        } = value;
+
         Self {
-            last_reconciled_config: value.last_reconciled_config.into(),
-            external_disks: value.external_disks,
-            datasets: value.datasets,
-            orphaned_datasets: value.orphaned_datasets,
-            zones: value.zones,
-            boot_partitions: value.boot_partitions,
-            remove_mupdate_override: value.remove_mupdate_override,
+            last_reconciled_config: last_reconciled_config.into(),
+            external_disks,
+            datasets,
+            orphaned_datasets,
+            zones,
+            boot_partitions,
+            remove_mupdate_override,
         }
     }
 }
@@ -255,26 +264,46 @@ pub struct Inventory {
 
 impl From<Inventory> for crate::v46::inventory::Inventory {
     fn from(value: Inventory) -> Self {
+        let Inventory {
+            sled_id,
+            sled_agent_address,
+            sled_role,
+            baseboard_id,
+            usable_hardware_threads,
+            usable_physical_ram,
+            cpu_family,
+            reservoir_size,
+            disks,
+            zpools,
+            datasets,
+            ledgered_sled_config,
+            reconciler_status,
+            last_reconciliation,
+            file_source_resolver,
+            smf_services_enabled_not_online,
+            reference_measurements,
+            fmd,
+        } = value;
+
         Self {
-            sled_id: value.sled_id,
-            sled_agent_address: value.sled_agent_address,
-            sled_role: value.sled_role,
-            baseboard_id: value.baseboard_id,
-            usable_hardware_threads: value.usable_hardware_threads,
-            usable_physical_ram: value.usable_physical_ram,
-            cpu_family: value.cpu_family,
-            reservoir_size: value.reservoir_size,
-            disks: value.disks,
-            zpools: value.zpools,
-            datasets: value.datasets,
-            ledgered_sled_config: value.ledgered_sled_config.map(From::from),
-            reconciler_status: value.reconciler_status.into(),
-            last_reconciliation: value.last_reconciliation.map(From::from),
-            file_source_resolver: value.file_source_resolver,
-            smf_services_enabled_not_online: value
-                .smf_services_enabled_not_online,
-            reference_measurements: value.reference_measurements,
-            fmd: value.fmd,
+            sled_id,
+            sled_agent_address,
+            sled_role,
+            baseboard_id,
+            usable_hardware_threads,
+            usable_physical_ram,
+            cpu_family,
+            reservoir_size,
+            disks,
+            zpools,
+            datasets,
+            ledgered_sled_config: ledgered_sled_config.map(From::from),
+            reconciler_status: reconciler_status.into(),
+            last_reconciliation: last_reconciliation.map(From::from),
+            file_source_resolver,
+            smf_services_enabled_not_online,
+            reference_measurements,
+            fmd,
         }
     }
 }

--- a/sled-agent/types/versions/src/add_update_disposition/inventory.rs
+++ b/sled-agent/types/versions/src/add_update_disposition/inventory.rs
@@ -72,18 +72,10 @@ pub enum OmicronSledUpdateDisposition {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct OmicronSledConfig {
     pub generation: Generation,
-    // Serialize and deserialize disks, datasets, and zones as maps for
-    // backwards compatibility. Newer IdOrdMaps should not use IdOrdMapAsMap.
-    #[serde(
-        with = "iddqd::id_ord_map::IdOrdMapAsMap::<OmicronPhysicalDiskConfig>"
-    )]
     pub disks: IdOrdMap<OmicronPhysicalDiskConfig>,
-    #[serde(with = "iddqd::id_ord_map::IdOrdMapAsMap::<DatasetConfig>")]
     pub datasets: IdOrdMap<DatasetConfig>,
-    #[serde(with = "iddqd::id_ord_map::IdOrdMapAsMap::<OmicronZoneConfig>")]
     pub zones: IdOrdMap<OmicronZoneConfig>,
     pub remove_mupdate_override: Option<MupdateOverrideUuid>,
-    #[serde(default = "HostPhase2DesiredSlots::current_contents")]
     pub host_phase_2: HostPhase2DesiredSlots,
     pub measurements: BTreeSet<OmicronSingleMeasurement>,
     pub update_disposition: OmicronSledUpdateDisposition,

--- a/sled-agent/types/versions/src/add_update_disposition/inventory.rs
+++ b/sled-agent/types/versions/src/add_update_disposition/inventory.rs
@@ -59,7 +59,7 @@ use std::time::Duration;
 /// sled should be evacuated as well as blueprint-specific metadata. From
 /// sled-agent itself, we only need to know the high-level state; we use this to
 /// determine whether or not to accept new VMM registration requests.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum OmicronSledUpdateDisposition {
     Available,

--- a/sled-agent/types/versions/src/add_update_disposition/inventory.rs
+++ b/sled-agent/types/versions/src/add_update_disposition/inventory.rs
@@ -1,0 +1,280 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Changes in this version:
+//!
+//! * Add [`OmicronSledUpdateDisposition`] type
+//! * Add `update_disposition` to [`OmicronSledConfig`]
+//! * New definitions of types that include directly or transitively include
+//!   `OmicronSledConfig`:
+//!     * [`ConfigReconcilerInventory`]
+//!     * [`ConfigReconcilerInventoryStatus`]
+//!     * [`Inventory`]
+
+use crate::v1::disk::DatasetConfig;
+use crate::v1::disk::OmicronPhysicalDiskConfig;
+use crate::v1::inventory::BootPartitionContents;
+use crate::v1::inventory::ConfigReconcilerInventoryResult;
+use crate::v1::inventory::HostPhase2DesiredSlots;
+use crate::v1::inventory::InventoryDataset;
+use crate::v1::inventory::InventoryDisk;
+use crate::v1::inventory::OrphanedDataset;
+use crate::v1::inventory::RemoveMupdateOverrideInventory;
+use crate::v1::inventory::SledCpuFamily;
+use crate::v1::inventory::SledRole;
+use crate::v11::inventory::OmicronZoneConfig;
+use crate::v14::inventory::OmicronFileSourceResolverInventory;
+use crate::v14::inventory::OmicronSingleMeasurement;
+use crate::v16::inventory::SingleMeasurementInventory;
+use crate::v24::inventory::InventoryZpool;
+use crate::v40::inventory::FmdInventory;
+use crate::v40::inventory::FmdInventoryError;
+use crate::v46::inventory::SvcsEnabledNotOnlineResult;
+use chrono::DateTime;
+use chrono::Utc;
+use iddqd::IdOrdMap;
+use omicron_common::api::external::ByteCount;
+use omicron_common::api::external::Generation;
+use omicron_common::snake_case_result;
+use omicron_common::snake_case_result::SnakeCaseResult;
+use omicron_ledger::Ledgerable;
+use omicron_uuid_kinds::DatasetUuid;
+use omicron_uuid_kinds::MupdateOverrideUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::PhysicalDiskUuid;
+use omicron_uuid_kinds::SledUuid;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sled_hardware_types::BaseboardId;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::net::SocketAddrV6;
+use std::time::Duration;
+
+/// Controls a sled's availability for VMM provisioning.
+///
+/// This is a simplified version of `BlueprintSledUpdateDisposition`. The
+/// blueprint version of this type includes information describing _how_ the
+/// sled should be evacuated as well as blueprint-specific metadata. From
+/// sled-agent itself, we only need to know the high-level state; we use this to
+/// determine whether or not to accept new VMM registration requests.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OmicronSledUpdateDisposition {
+    Available,
+    Evacuating,
+}
+
+/// Describes the set of Reconfigurator-managed configuration elements of a sled
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct OmicronSledConfig {
+    pub generation: Generation,
+    // Serialize and deserialize disks, datasets, and zones as maps for
+    // backwards compatibility. Newer IdOrdMaps should not use IdOrdMapAsMap.
+    #[serde(
+        with = "iddqd::id_ord_map::IdOrdMapAsMap::<OmicronPhysicalDiskConfig>"
+    )]
+    pub disks: IdOrdMap<OmicronPhysicalDiskConfig>,
+    #[serde(with = "iddqd::id_ord_map::IdOrdMapAsMap::<DatasetConfig>")]
+    pub datasets: IdOrdMap<DatasetConfig>,
+    #[serde(with = "iddqd::id_ord_map::IdOrdMapAsMap::<OmicronZoneConfig>")]
+    pub zones: IdOrdMap<OmicronZoneConfig>,
+    pub remove_mupdate_override: Option<MupdateOverrideUuid>,
+    #[serde(default = "HostPhase2DesiredSlots::current_contents")]
+    pub host_phase_2: HostPhase2DesiredSlots,
+    // We purposely skip a serde default here to work around some ledger
+    // versioning quirks
+    pub measurements: BTreeSet<OmicronSingleMeasurement>,
+
+    pub update_disposition: OmicronSledUpdateDisposition,
+}
+
+impl From<crate::v14::inventory::OmicronSledConfig> for OmicronSledConfig {
+    fn from(value: crate::v14::inventory::OmicronSledConfig) -> Self {
+        // Old versions had no `update_disposition` and were always implicitly
+        // `Available`.
+        let update_disposition = OmicronSledUpdateDisposition::Available;
+
+        Self {
+            generation: value.generation,
+            disks: value.disks,
+            datasets: value.datasets,
+            zones: value.zones,
+            remove_mupdate_override: value.remove_mupdate_override,
+            host_phase_2: value.host_phase_2,
+            measurements: value.measurements,
+            update_disposition,
+        }
+    }
+}
+
+impl From<OmicronSledConfig> for crate::v14::inventory::OmicronSledConfig {
+    fn from(value: OmicronSledConfig) -> Self {
+        // Converting in this direction drops the new `update_disposition` field;
+        // this allows old Nexus to request our inventory after sled-agent is
+        // updated.
+        Self {
+            generation: value.generation,
+            disks: value.disks,
+            datasets: value.datasets,
+            zones: value.zones,
+            remove_mupdate_override: value.remove_mupdate_override,
+            host_phase_2: value.host_phase_2,
+            measurements: value.measurements,
+        }
+    }
+}
+
+// NOTE: Most trait impls live in the `impls` module of this crate and are only
+// implemented for the `latest` version of each type. However,
+// `OmicronSledConfig` is special: it's not only used in the sled-agent API
+// (which would only require trait impls on `latest`); it's also ledgered to
+// disk to support cold boot of the rack. In the ledgering case, we have to be
+// able to handle reading older versions, which means all the old versions we
+// support also need to implement `Ledgerable`. Therefore, we implement this
+// trait for this specific version (and do so for every other version of
+// `OmicronSledConfig` too).
+impl Ledgerable for OmicronSledConfig {
+    fn is_newer_than(&self, other: &Self) -> bool {
+        self.generation > other.generation
+    }
+
+    fn generation_bump(&mut self) {
+        // DO NOTHING!
+        //
+        // Generation bumps must only ever come from nexus and will be encoded
+        // in the struct itself
+    }
+}
+
+/// Describes the last attempt made by the sled-agent-config-reconciler to
+/// reconcile the current sled config against the actual state of the sled.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ConfigReconcilerInventory {
+    pub last_reconciled_config: OmicronSledConfig,
+    pub external_disks:
+        BTreeMap<PhysicalDiskUuid, ConfigReconcilerInventoryResult>,
+    pub datasets: BTreeMap<DatasetUuid, ConfigReconcilerInventoryResult>,
+    pub orphaned_datasets: IdOrdMap<OrphanedDataset>,
+    pub zones: BTreeMap<OmicronZoneUuid, ConfigReconcilerInventoryResult>,
+    pub boot_partitions: BootPartitionContents,
+    /// The result of removing the mupdate override file on disk.
+    ///
+    /// `None` if `remove_mupdate_override` was not provided in the sled config.
+    pub remove_mupdate_override: Option<RemoveMupdateOverrideInventory>,
+}
+
+impl From<ConfigReconcilerInventory>
+    for crate::v16::inventory::ConfigReconcilerInventory
+{
+    fn from(value: ConfigReconcilerInventory) -> Self {
+        Self {
+            last_reconciled_config: value.last_reconciled_config.into(),
+            external_disks: value.external_disks,
+            datasets: value.datasets,
+            orphaned_datasets: value.orphaned_datasets,
+            zones: value.zones,
+            boot_partitions: value.boot_partitions,
+            remove_mupdate_override: value.remove_mupdate_override,
+        }
+    }
+}
+
+/// Status of the sled-agent-config-reconciler task.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ConfigReconcilerInventoryStatus {
+    /// The reconciler task has not yet run for the first time since sled-agent
+    /// started.
+    NotYetRun,
+    /// The reconciler task is actively running.
+    Running {
+        config: Box<OmicronSledConfig>,
+        started_at: DateTime<Utc>,
+        running_for: Duration,
+    },
+    /// The reconciler task is currently idle, but previously did complete a
+    /// reconciliation attempt.
+    ///
+    /// This variant does not include the `OmicronSledConfig` used in the last
+    /// attempt, because that's always available via
+    /// [`ConfigReconcilerInventory::last_reconciled_config`].
+    Idle { completed_at: DateTime<Utc>, ran_for: Duration },
+}
+
+impl From<ConfigReconcilerInventoryStatus>
+    for crate::v14::inventory::ConfigReconcilerInventoryStatus
+{
+    fn from(value: ConfigReconcilerInventoryStatus) -> Self {
+        match value {
+            ConfigReconcilerInventoryStatus::NotYetRun => Self::NotYetRun,
+            ConfigReconcilerInventoryStatus::Running {
+                config,
+                started_at,
+                running_for,
+            } => Self::Running {
+                config: Box::new((*config).into()),
+                started_at,
+                running_for,
+            },
+            ConfigReconcilerInventoryStatus::Idle { completed_at, ran_for } => {
+                Self::Idle { completed_at, ran_for }
+            }
+        }
+    }
+}
+
+/// Identity and basic status information about this sled agent
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+pub struct Inventory {
+    pub sled_id: SledUuid,
+    pub sled_agent_address: SocketAddrV6,
+    pub sled_role: SledRole,
+    pub baseboard_id: BaseboardId,
+    pub usable_hardware_threads: u32,
+    pub usable_physical_ram: ByteCount,
+    pub cpu_family: SledCpuFamily,
+    pub reservoir_size: ByteCount,
+    pub disks: Vec<InventoryDisk>,
+    pub zpools: Vec<InventoryZpool>,
+    pub datasets: Vec<InventoryDataset>,
+    pub ledgered_sled_config: Option<OmicronSledConfig>,
+    pub reconciler_status: ConfigReconcilerInventoryStatus,
+    pub last_reconciliation: Option<ConfigReconcilerInventory>,
+    pub file_source_resolver: OmicronFileSourceResolverInventory,
+    pub smf_services_enabled_not_online: SvcsEnabledNotOnlineResult,
+    pub reference_measurements: IdOrdMap<SingleMeasurementInventory>,
+    #[serde(with = "snake_case_result")]
+    #[schemars(
+        schema_with = "SnakeCaseResult::<FmdInventory, FmdInventoryError>::json_schema"
+    )]
+    pub fmd: Result<FmdInventory, FmdInventoryError>,
+}
+
+impl From<Inventory> for crate::v46::inventory::Inventory {
+    fn from(value: Inventory) -> Self {
+        Self {
+            sled_id: value.sled_id,
+            sled_agent_address: value.sled_agent_address,
+            sled_role: value.sled_role,
+            baseboard_id: value.baseboard_id,
+            usable_hardware_threads: value.usable_hardware_threads,
+            usable_physical_ram: value.usable_physical_ram,
+            cpu_family: value.cpu_family,
+            reservoir_size: value.reservoir_size,
+            disks: value.disks,
+            zpools: value.zpools,
+            datasets: value.datasets,
+            ledgered_sled_config: value.ledgered_sled_config.map(From::from),
+            reconciler_status: value.reconciler_status.into(),
+            last_reconciliation: value.last_reconciliation.map(From::from),
+            file_source_resolver: value.file_source_resolver,
+            smf_services_enabled_not_online: value
+                .smf_services_enabled_not_online,
+            reference_measurements: value.reference_measurements,
+            fmd: value.fmd,
+        }
+    }
+}

--- a/sled-agent/types/versions/src/add_update_disposition/mod.rs
+++ b/sled-agent/types/versions/src/add_update_disposition/mod.rs
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Version `ADD_UPDATE_DISPOSITION` of the Sled Agent API.
+
+pub mod inventory;

--- a/sled-agent/types/versions/src/impls/inventory.rs
+++ b/sled-agent/types/versions/src/impls/inventory.rs
@@ -28,11 +28,11 @@ use crate::latest::inventory::{
     ManifestNonBootInventory, MupdateOverrideBootInventory,
     MupdateOverrideInventory, MupdateOverrideNonBootInventory,
     NetworkInterface, OmicronFileSourceResolverInventory, OmicronSledConfig,
-    OmicronZoneConfig, OmicronZoneImageSource, OmicronZoneType,
-    OmicronZonesConfig, RemoveMupdateOverrideBootSuccessInventory,
-    RemoveMupdateOverrideInventory, SingleMeasurementInventory,
-    SourceNatConfig, SourceNatConfigGeneric, SourceNatConfigV4,
-    SourceNatConfigV6, SvcEnabledNotOnlineState, SvcState,
+    OmicronSledUpdateDisposition, OmicronZoneConfig, OmicronZoneImageSource,
+    OmicronZoneType, OmicronZonesConfig,
+    RemoveMupdateOverrideBootSuccessInventory, RemoveMupdateOverrideInventory,
+    SingleMeasurementInventory, SourceNatConfig, SourceNatConfigGeneric,
+    SourceNatConfigV4, SourceNatConfigV6, SvcEnabledNotOnlineState, SvcState,
     SvcsEnabledNotOnline, ZoneArtifactInventory, ZoneKind, ZpoolHealth,
 };
 
@@ -878,6 +878,7 @@ impl Default for OmicronSledConfig {
             remove_mupdate_override: None,
             host_phase_2: HostPhase2DesiredSlots::current_contents(),
             measurements: BTreeSet::new(),
+            update_disposition: OmicronSledUpdateDisposition::Available,
         }
     }
 }

--- a/sled-agent/types/versions/src/latest.rs
+++ b/sled-agent/types/versions/src/latest.rs
@@ -175,13 +175,10 @@ pub mod inventory {
 
     pub use crate::v12::inventory::HealthMonitorInventory;
 
-    pub use crate::v14::inventory::ConfigReconcilerInventoryStatus;
     pub use crate::v14::inventory::OmicronFileSourceResolverInventory;
     pub use crate::v14::inventory::OmicronSingleMeasurement;
-    pub use crate::v14::inventory::OmicronSledConfig;
     pub use crate::v14::inventory::ReconciledSingleMeasurement;
 
-    pub use crate::v16::inventory::ConfigReconcilerInventory;
     pub use crate::v16::inventory::SingleMeasurementInventory;
 
     pub use crate::v24::inventory::InventoryZpool;
@@ -197,13 +194,18 @@ pub mod inventory {
     pub use crate::v40::inventory::FmdInventoryErrorKind;
     pub use crate::v40::inventory::FmdResource;
 
-    pub use crate::v46::inventory::Inventory;
     pub use crate::v46::inventory::Svc;
     pub use crate::v46::inventory::SvcEnabledNotOnline;
     pub use crate::v46::inventory::SvcEnabledNotOnlineState;
     pub use crate::v46::inventory::SvcState;
     pub use crate::v46::inventory::SvcsEnabledNotOnline;
     pub use crate::v46::inventory::SvcsEnabledNotOnlineResult;
+
+    pub use crate::v49::inventory::ConfigReconcilerInventory;
+    pub use crate::v49::inventory::ConfigReconcilerInventoryStatus;
+    pub use crate::v49::inventory::Inventory;
+    pub use crate::v49::inventory::OmicronSledConfig;
+    pub use crate::v49::inventory::OmicronSledUpdateDisposition;
 
     pub use crate::impls::inventory::FmdHostCaseDisplay;
     pub use crate::impls::inventory::FmdInventoryDisplay;

--- a/sled-agent/types/versions/src/lib.rs
+++ b/sled-agent/types/versions/src/lib.rs
@@ -101,6 +101,8 @@ pub mod v46;
 pub mod v47;
 #[path = "allow_ddm_traffic/mod.rs"]
 pub mod v48;
+#[path = "add_update_disposition/mod.rs"]
+pub mod v49;
 #[path = "add_probe_put_endpoint/mod.rs"]
 pub mod v6;
 #[path = "multicast_support/mod.rs"]


### PR DESCRIPTION
This is the first part of #11121 - sled-agent needs to know when it's in the `Evacuating` disposition so it can reject incoming VMM registrations.

The changes here are much smaller than the git diff implies - over 1000 lines of this is in a new expectorate file for the sled config format bump, and another ~250ish lines are boilerplate copy/pasting type definitions for a new sled-agent API version.

There are a couple minor judgment calls I'll point out in comments below that could use gut checks.