### PR TITLE
Report reservoir size on error if possible

### DIFF
--- a/illumos-utils/src/vmm_reservoir.rs
+++ b/illumos-utils/src/vmm_reservoir.rs
@@ -30,8 +30,11 @@ pub enum Error {
     #[error("Reservoir size must be aligned to 2 MiB: {0}")]
     InvalidSize(ByteCount),
 
-    #[error("Failed to resize reservoir")]
-    ReservoirError(#[from] std::io::Error),
+    #[error("Failed to open vmm ctl fd")]
+    VmCtlOpen(#[source] std::io::Error),
+
+    #[error("Failed to resize reservoir: {error}")]
+    ReservoirError { error: std::io::Error, current_size: Option<ByteCount> },
 }
 
 /// Controls the size of the memory reservoir
@@ -46,12 +49,19 @@ impl ReservoirControl {
             return Err(Error::InvalidSize(size));
         }
 
-        let ctl = bhyve_api::VmmCtlFd::open()?;
+        let ctl =
+            bhyve_api::VmmCtlFd::open().map_err(|e| Error::VmCtlOpen(e))?;
         ctl.reservoir_resize(
             size.to_bytes().try_into().map_err(|_| Error::InvalidSize(size))?,
             RESERVOIR_CHUNK_SZ,
         )
-        .map_err(std::io::Error::from)?;
+        .map_err(|e| Error::ReservoirError {
+            error: e.into(),
+            current_size: ctl.reservoir_query().ok().and_then(|v| {
+                ByteCount::try_from((v.vrq_free_sz + v.vrq_alloc_sz) as u64)
+                    .ok()
+            }),
+        })?;
 
         Ok(())
     }

--- a/illumos-utils/src/vmm_reservoir.rs
+++ b/illumos-utils/src/vmm_reservoir.rs
@@ -33,8 +33,12 @@ pub enum Error {
     #[error("Failed to open vmm ctl fd")]
     VmCtlOpen(#[source] std::io::Error),
 
-    #[error("Failed to resize reservoir: {error}")]
-    ReservoirError { error: std::io::Error, current_size: Option<ByteCount> },
+    #[error("Failed to resize reservoir")]
+    ReservoirError {
+        #[source]
+        error: std::io::Error,
+        current_size: Option<ByteCount>,
+    },
 }
 
 /// Controls the size of the memory reservoir

--- a/sled-agent/src/vmm_reservoir.rs
+++ b/sled-agent/src/vmm_reservoir.rs
@@ -264,12 +264,32 @@ impl VmmReservoirManager {
             );
         }
         info!(self.log, "Setting reservoir size to {reservoir_size} bytes");
-        vmm_reservoir::ReservoirControl::set(reservoir_size)?;
 
-        self.reservoir_size.store(reservoir_size.to_bytes(), Ordering::SeqCst);
+        let actual_size = match vmm_reservoir::ReservoirControl::set(
+            reservoir_size,
+        ) {
+            Ok(()) => reservoir_size,
+            Err(vmm_reservoir::Error::ReservoirError {
+                error,
+                current_size: Some(size),
+            }) => {
+                // TODO: When we hit this error condition we really would like
+                // to keep retrying in the background to get to our intended
+                // size.
+                warn!(
+                    self.log,
+                    "Reservoir resize failed but reservoir is currently at {size} bytes";
+                    "error" => &error,
+                );
+                size
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        self.reservoir_size.store(actual_size.to_bytes(), Ordering::SeqCst);
         info!(
             self.log,
-            "Finished setting reservoir size to {reservoir_size} bytes"
+            "Finished setting reservoir size to {actual_size} bytes"
         );
         self.size_updated_tx.send(()).unwrap();
 

--- a/sled-agent/src/vmm_reservoir.rs
+++ b/sled-agent/src/vmm_reservoir.rs
@@ -7,7 +7,7 @@
 use illumos_utils::vmm_reservoir;
 use omicron_common::api::external::ByteCount;
 use slog::Logger;
-use slog_error_chain::SlogInlineError;
+use slog_error_chain::{InlineErrorChain, SlogInlineError};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
@@ -279,7 +279,7 @@ impl VmmReservoirManager {
                 warn!(
                     self.log,
                     "Reservoir resize failed but reservoir is currently at {size} bytes";
-                    "error" => &error,
+                    InlineErrorChain::new(&error),
                 );
                 size
             }


### PR DESCRIPTION
When we fail to set the reservoir size, say due to an ENOMEM, we record a zero for reservoir_size in
crdb. It's much better if we report how much memory we were actually able stuff in the reservoir so
that instances could still land on the sled.