### PR TITLE
fix flake in test_stock_planner

### DIFF
--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -1060,6 +1060,12 @@ async fn test_request_without_api_version(cptestctx: &ControlPlaneTestContext) {
 #[nexus_test(configure_second_nexus = true)]
 async fn test_stock_planner(cptestctx: &ControlPlaneTestContext) {
     let nexus_client = cptestctx.lockstep_client();
+    // We need an inventory collection available to do this.
+    cptestctx
+        .wait_for_at_least_one_inventory_collection(
+            std::time::Duration::from_secs(60),
+        )
+        .await;
     let _blueprint =
         nexus_client.blueprint_regenerate().await.unwrap_or_else(|error| {
             panic!(


### PR DESCRIPTION
I noticed this flake here, on #10306:
https://buildomat.eng.oxide.computer/wg/0/details/01M0TM6BRDPZCN7X8Q9BJ1AJMG/z4VAQxja8lQ5mthfbbg38dZrz7GDnVE5PV1BJgu0E9SHH8xs/01M0TM6V85QSKX27VD5R7KWBG0

[Failure](https://buildomat.eng.oxide.computer/wg/0/details/01M0TM6BRDPZCN7X8Q9BJ1AJMG/z4VAQxja8lQ5mthfbbg38dZrz7GDnVE5PV1BJgu0E9SHH8xs/01M0TM6V85QSKX27VD5R7KWBG0#S8104):

```
  TRY 1 FAIL [  14.854s] (─────────) omicron-nexus::test_all integration_tests::updates::test_stock_planner
  stdout ───
    running 1 test
    test integration_tests::updates::test_stock_planner ... FAILED
    failures:
    failures:
        integration_tests::updates::test_stock_planner
    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 576 filtered out; finished in 14.32s
    
  stderr ───
    log file: /var/tmp/omicron_tmp/test_all-f9b1c6affd8efe33-test_stock_planner.24373.0.log
    note: configured to log to "/var/tmp/omicron_tmp/test_all-f9b1c6affd8efe33-test_stock_planner.24373.0.log"
    DB URL: postgresql://root@[::1]:35578/omicron?sslmode=disable
    DB address: [::1]:35578
    log file: /var/tmp/omicron_tmp/test_all-f9b1c6affd8efe33-test_stock_planner.24373.2.log
    note: configured to log to "/var/tmp/omicron_tmp/test_all-f9b1c6affd8efe33-test_stock_planner.24373.2.log"
    Dendrite address: [::1]:62263 (dpd backend: [::1]:54734)
    thread 'integration_tests::updates::test_stock_planner' (2) panicked at nexus/tests/integration_tests/updates.rs:1281:13:
    unexpectedly failed to generate new blueprint in stock test environment: Error Response: status: 500 Internal Server Error; headers: {"content-type": "application/json", "x-request-id": "fae6a37c-8cf9-45a2-b7dd-f6f4cc11b228", "content-length": "124", "date": "Mon, 24 Aug 2026 19:59:58 GMT"}; value: Error { error_code: Some("Internal"), message: "Internal Server Error", request_id: "fae6a37c-8cf9-45a2-b7dd-f6f4cc11b228" }
```

The [request](https://buildomat.eng.oxide.computer/wg/0/artefact/01M0TM6BRDPZCN7X8Q9BJ1AJMG/z4VAQxja8lQ5mthfbbg38dZrz7GDnVE5PV1BJgu0E9SHH8xs/01M0TM6V85QSKX27VD5R7KWBG0/01M0TNXNVA524T5S205821Y1B9/test_all-f9b1c6affd8efe33-test_stock_planner.24373.0.log?format=x-bunyan#L4012):

```
2026-08-24T19:59:58.524Z	INFO	test_stock_planner (dropshot_lockstep): request completed
    error_message_external = Internal Server Error
    error_message_internal = no recent inventory collection found
    latency_us = 768424
    local_addr = 127.0.0.1:46477
    method = POST
    remote_addr = 127.0.0.1:61032
    req_id = fae6a37c-8cf9-45a2-b7dd-f6f4cc11b228
    response_code = 500
    uri = /deployment/blueprints/regenerate
```

We've seen this kind of flake a lot.  We need to use the helper to wait for an inventory collection to be present.