### PR TITLE
Crucible resources must be marked for deletion

### DIFF
--- a/nexus/db-queries/src/db/datastore/region.rs
+++ b/nexus/db-queries/src/db/datastore/region.rs
@@ -289,17 +289,19 @@ impl DataStore {
         Ok(dataset_and_regions)
     }
 
-    /// Deletes a set of regions.
+    /// Hard-deletes a set of regions marked for deletion.
     ///
     /// Also updates the storage usage on their corresponding datasets.
     pub async fn regions_hard_delete(
         &self,
-        _log: &Logger,
+        log: &Logger,
         region_ids: Vec<Uuid>,
     ) -> DeleteResult {
         if region_ids.is_empty() {
             return Ok(());
         }
+
+        use nexus_db_schema::schema::region::dsl;
 
         let conn = self.pool_connection_unauthorized().await?;
 
@@ -308,10 +310,9 @@ impl DataStore {
                 let region_ids = region_ids.clone();
 
                 async move {
-                    use nexus_db_schema::schema::region::dsl;
-
                     let dataset_ids: Vec<Uuid> = diesel::delete(dsl::region)
                         .filter(dsl::id.eq_any(region_ids))
+                        .filter(dsl::deleting.eq(true))
                         .returning(dsl::dataset_id)
                         .get_results_async(&conn)
                         .await?;
@@ -329,7 +330,32 @@ impl DataStore {
                 }
             })
             .await
-            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
+
+        // The DELETE above should have removed all the records - double check
+        // here. Don't do this in the transaction above: we want to free up all
+        // the resources we can with a region delete.
+
+        let non_deleted_regions: Vec<Uuid> = dsl::region
+            .filter(dsl::id.eq_any(region_ids))
+            .select(dsl::id)
+            .get_results_async(&*conn)
+            .await
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
+
+        if !non_deleted_regions.is_empty() {
+            error!(
+                log,
+                "regions not marked for deletion";
+                "non_deleted_regions" => ?non_deleted_regions,
+            );
+
+            return Err(Error::internal_error(format!(
+                "regions not marked for deletion: {non_deleted_regions:?}"
+            )));
+        }
+
+        Ok(())
     }
 
     /// Return the total reserved size for all the regions allocated to a
@@ -544,6 +570,24 @@ impl DataStore {
             .select(Region::as_select())
             .load_async(&*conn)
             .await
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+    }
+
+    pub async fn mark_region_for_deletion(
+        &self,
+        region_id: Uuid,
+    ) -> DeleteResult {
+        use nexus_db_schema::schema::region::dsl;
+
+        let conn = self.pool_connection_unauthorized().await?;
+
+        diesel::update(dsl::region)
+            .filter(dsl::id.eq(region_id))
+            .filter(dsl::deleting.eq(false))
+            .set(dsl::deleting.eq(true))
+            .execute_async(&*conn)
+            .await
+            .map(|_| ())
             .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
     }
 }

--- a/nexus/db-queries/src/db/datastore/region_snapshot.rs
+++ b/nexus/db-queries/src/db/datastore/region_snapshot.rs
@@ -16,8 +16,10 @@ use nexus_db_errors::ErrorHandler;
 use nexus_db_errors::public_error_from_diesel;
 use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::DeleteResult;
+use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupResult;
 use omicron_uuid_kinds::DatasetUuid;
+use slog::Logger;
 use uuid::Uuid;
 
 impl DataStore {
@@ -57,7 +59,7 @@ impl DataStore {
             .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
     }
 
-    pub async fn region_snapshot_remove(
+    pub async fn mark_region_snapshot_for_deletion(
         &self,
         dataset_id: DatasetUuid,
         region_id: Uuid,
@@ -67,14 +69,37 @@ impl DataStore {
 
         let conn = self.pool_connection_unauthorized().await?;
 
-        let result = diesel::delete(dsl::region_snapshot)
+        diesel::update(dsl::region_snapshot)
             .filter(dsl::dataset_id.eq(to_db_typed_uuid(dataset_id)))
             .filter(dsl::region_id.eq(region_id))
             .filter(dsl::snapshot_id.eq(snapshot_id))
+            .filter(dsl::deleting.eq(false))
+            .set(dsl::deleting.eq(true))
             .execute_async(&*conn)
             .await
-            .map(|_rows_deleted| ())
-            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server));
+            .map(|_| ())
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+    }
+
+    pub async fn region_snapshot_remove(
+        &self,
+        log: &Logger,
+        dataset_id: DatasetUuid,
+        region_id: Uuid,
+        snapshot_id: Uuid,
+    ) -> DeleteResult {
+        use nexus_db_schema::schema::region_snapshot::dsl;
+
+        let conn = self.pool_connection_unauthorized().await?;
+
+        diesel::delete(dsl::region_snapshot)
+            .filter(dsl::dataset_id.eq(to_db_typed_uuid(dataset_id)))
+            .filter(dsl::region_id.eq(region_id))
+            .filter(dsl::snapshot_id.eq(snapshot_id))
+            .filter(dsl::deleting.eq(true))
+            .execute_async(&*conn)
+            .await
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
 
         // Whenever a region snapshot is hard-deleted, validate invariants for
         // all volumes
@@ -83,7 +108,34 @@ impl DataStore {
             .await
             .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
 
-        result
+        // The DELETE above should have removed the record - double check here.
+
+        let maybe_region_snapshot = dsl::region_snapshot
+            .filter(dsl::dataset_id.eq(to_db_typed_uuid(dataset_id)))
+            .filter(dsl::region_id.eq(region_id))
+            .filter(dsl::snapshot_id.eq(snapshot_id))
+            .select(RegionSnapshot::as_select())
+            .get_result_async(&*conn)
+            .await
+            .optional()
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
+
+        if maybe_region_snapshot.is_some() {
+            error!(
+                log,
+                "region snapshot not marked for deletion";
+                "dataset_id" => %dataset_id,
+                "region_id" => %region_id,
+                "snapshot_id" => %snapshot_id,
+            );
+
+            return Err(Error::internal_error(format!(
+                "region snapshot not marked for deletion: {dataset_id} \
+                {region_id} {snapshot_id}",
+            )));
+        }
+
+        Ok(())
     }
 
     /// Find region snapshots on expunged disks

--- a/nexus/db-queries/src/db/datastore/volume.rs
+++ b/nexus/db-queries/src/db/datastore/volume.rs
@@ -1183,6 +1183,7 @@ impl DataStore {
         // of in soft_delete_volume_in_txn!) and their associated datasets
         let unfiltered_deleted_regions = region_dsl::region
             .filter(region_dsl::read_only.eq(false))
+            .filter(region_dsl::deleting.eq(true))
             // the volume may be hard deleted, so use a left join here
             .left_join(
                 volume_dsl::volume.on(region_dsl::volume_id.eq(volume_dsl::id)),
@@ -1473,6 +1474,28 @@ impl DataStore {
                     format!("could not find resource for {target}"),
                 )));
             };
+
+            // Mark the region for deletion
+            let region_id = region.id();
+
+            use nexus_db_schema::schema::region::dsl;
+
+            let updated_rows = diesel::update(dsl::region)
+                .filter(dsl::id.eq(region_id))
+                .filter(dsl::read_only.eq(false))
+                .filter(dsl::deleting.eq(false))
+                .set(dsl::deleting.eq(true))
+                .execute_async(conn)
+                .await?;
+
+            if updated_rows != 1 {
+                return Err(err.bail(
+                    SoftDeleteError::UnexpectedDatabaseUpdate(
+                        updated_rows,
+                        "setting deleting (region)".into(),
+                    ),
+                ));
+            }
 
             // Filter out regions that have any region-snapshots
             let region_snapshot_count: i64 = {

--- a/nexus/db-queries/src/db/queries/region_allocation.rs
+++ b/nexus/db-queries/src/db/queries/region_allocation.rs
@@ -1805,10 +1805,17 @@ mod test {
             .expect("allocation should succeed at boundary: extent_count_fits just fits");
 
         // Delete the regions so we can try again with one more extent
-        let region_ids = datasets_and_regions
+        let region_ids: Vec<Uuid> = datasets_and_regions
             .iter()
             .map(|(_dataset, region)| region.id())
             .collect();
+
+        for region_id in &region_ids {
+            datastore
+                .mark_region_for_deletion(*region_id)
+                .await
+                .expect("region cleanup should succeed");
+        }
 
         datastore
             .regions_hard_delete(&logctx.log, region_ids)

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
@@ -614,10 +614,8 @@ mod test {
     ) {
         let nexus = &cptestctx.server.server_context().nexus;
         let datastore = nexus.datastore();
-        let opctx = OpContext::for_tests(
-            cptestctx.logctx.log.clone(),
-            datastore.clone(),
-        );
+        let log = cptestctx.logctx.log.clone();
+        let opctx = OpContext::for_tests(log.clone(), datastore.clone());
 
         let starter = Arc::new(NoopStartSaga::new());
         let mut task = RegionSnapshotReplacementDetector::new(
@@ -768,7 +766,17 @@ mod test {
         // So delete it!
 
         datastore
+            .mark_region_snapshot_for_deletion(
+                region_snapshot_to_delete.dataset_id.into(),
+                region_snapshot_to_delete.region_id,
+                region_snapshot_to_delete.snapshot_id,
+            )
+            .await
+            .unwrap();
+
+        datastore
             .region_snapshot_remove(
+                &log,
                 region_snapshot_to_delete.dataset_id.into(),
                 region_snapshot_to_delete.region_id,
                 region_snapshot_to_delete.snapshot_id,

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -432,7 +432,12 @@ async fn sdc_alloc_regions_undo(
         .map(|(_, region)| region.id())
         .collect::<Vec<Uuid>>();
 
+    for region_id in &region_ids {
+        osagactx.datastore().mark_region_for_deletion(*region_id).await?;
+    }
+
     osagactx.datastore().regions_hard_delete(log, region_ids).await?;
+
     Ok(())
 }
 

--- a/nexus/src/app/sagas/region_replacement_start.rs
+++ b/nexus/src/app/sagas/region_replacement_start.rs
@@ -314,6 +314,9 @@ async fn srrs_alloc_new_region_undo(
     // the case anyway.
     if let Some(dataset_and_region) = maybe_dataset_and_region {
         let (_, region) = dataset_and_region;
+
+        osagactx.datastore().mark_region_for_deletion(region.id()).await?;
+
         osagactx
             .datastore()
             .regions_hard_delete(log, vec![region.id()])

--- a/nexus/src/app/sagas/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/sagas/region_snapshot_replacement_start.rs
@@ -692,6 +692,9 @@ async fn rsrss_alloc_new_region_undo(
     // Guard against the case anyway.
     if let Some(dataset_and_region) = maybe_dataset_and_region {
         let (_, region) = dataset_and_region;
+
+        osagactx.datastore().mark_region_for_deletion(region.id()).await?;
+
         osagactx
             .datastore()
             .regions_hard_delete(log, vec![region.id()])

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -492,7 +492,12 @@ async fn ssc_alloc_regions_undo(
         .map(|(_, region)| region.id())
         .collect::<Vec<Uuid>>();
 
+    for region_id in &region_ids {
+        osagactx.datastore().mark_region_for_deletion(*region_id).await?;
+    }
+
     osagactx.datastore().regions_hard_delete(log, region_ids).await?;
+
     Ok(())
 }
 
@@ -1524,9 +1529,24 @@ async fn ssc_start_running_snapshot_undo(
 
         osagactx
             .datastore()
-            .region_snapshot_remove(dataset.id(), region.id(), snapshot_id)
+            .mark_region_snapshot_for_deletion(
+                dataset.id(),
+                region.id(),
+                snapshot_id,
+            )
+            .await?;
+
+        osagactx
+            .datastore()
+            .region_snapshot_remove(
+                &log,
+                dataset.id(),
+                region.id(),
+                snapshot_id,
+            )
             .await?;
     }
+
     Ok(())
 }
 

--- a/nexus/src/app/sagas/volume_delete.rs
+++ b/nexus/src/app/sagas/volume_delete.rs
@@ -286,6 +286,7 @@ async fn svd_delete_crucible_snapshots(
 async fn svd_delete_crucible_snapshot_records(
     sagactx: NexusActionContext,
 ) -> Result<(), ActionError> {
+    let log = sagactx.user_data().log();
     let osagactx = sagactx.user_data();
 
     let crucible_resources_to_delete =
@@ -294,22 +295,19 @@ async fn svd_delete_crucible_snapshot_records(
     // Remove DB records
     let datasets_and_snapshots = osagactx
         .datastore()
-        .snapshots_to_delete(
-            &crucible_resources_to_delete,
-        )
+        .snapshots_to_delete(&crucible_resources_to_delete)
         .await
         .map_err(|e| {
             saga_action_failed(Error::internal_error(&format!(
-                "failed to get datasets_and_snapshots from crucible resources ({:?}): {:?}",
-                crucible_resources_to_delete,
-                e,
+                "failed to get datasets_and_snapshots from crucible resources \
+                ({crucible_resources_to_delete:?}): {e:?}",
             )))
         })?;
 
     for (_, region_snapshot) in datasets_and_snapshots {
         osagactx
             .datastore()
-            .region_snapshot_remove(
+            .mark_region_snapshot_for_deletion(
                 region_snapshot.dataset_id.into(),
                 region_snapshot.region_id,
                 region_snapshot.snapshot_id,
@@ -317,11 +315,28 @@ async fn svd_delete_crucible_snapshot_records(
             .await
             .map_err(|e| {
                 saga_action_failed(Error::internal_error(&format!(
-                    "failed to region_snapshot_remove {} {} {}: {:?}",
+                    "failed to mark region snapshot {} {} {}: {e:?}",
                     region_snapshot.dataset_id,
                     region_snapshot.region_id,
                     region_snapshot.snapshot_id,
-                    e,
+                )))
+            })?;
+
+        osagactx
+            .datastore()
+            .region_snapshot_remove(
+                log,
+                region_snapshot.dataset_id.into(),
+                region_snapshot.region_id,
+                region_snapshot.snapshot_id,
+            )
+            .await
+            .map_err(|e| {
+                saga_action_failed(Error::internal_error(&format!(
+                    "failed to remove region snapshot {} {} {}: {e:?}",
+                    region_snapshot.dataset_id,
+                    region_snapshot.region_id,
+                    region_snapshot.snapshot_id,
                 )))
             })?;
     }


### PR DESCRIPTION
Return an internal error if Crucible resource records (for regions and region snapshots) are being hard-deleted without being marked for deletion.

This commit was pulled out of the work to delete volumes and local storage in background tasks instead of sagas: that work transitions to a mark and sweep style of resource deletion, and this commit enforces that all resources are properly marked before being deleted.