### PR TITLE
[5/n gen] [sled-agent/nexus] add typed SledConfigGeneration

### DIFF
--- a/generation-kinds/src/lib.rs
+++ b/generation-kinds/src/lib.rs
@@ -42,6 +42,7 @@ impl_typed_generation_kinds! {
         Alert = {},
         SagaAdopt = {},
         SagaReassignment = {},
+        SledConfig = {},
         SupportBundle = {},
         TargetRelease = {},
     },

--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -65,7 +65,9 @@ use nexus_types::deployment::{
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::zpool_name::ZpoolName;
-use omicron_generation_kinds::TargetReleaseGenerationKind;
+use omicron_generation_kinds::{
+    SledConfigGenerationKind, TargetReleaseGenerationKind,
+};
 use omicron_uuid_kinds::{
     BlueprintKind, BlueprintUuid, DatasetKind, ExternalIpKind, ExternalIpUuid,
     GenericUuid, MupdateOverrideKind, OmicronZoneKind, OmicronZoneUuid,
@@ -253,7 +255,7 @@ pub struct BpSledMetadata {
     pub blueprint_id: DbTypedUuid<BlueprintKind>,
     pub sled_id: DbTypedUuid<SledKind>,
     pub sled_state: SledState,
-    pub sled_agent_generation: Generation,
+    pub sled_agent_generation: DbTypedGeneration<SledConfigGenerationKind>,
     pub remove_mupdate_override: Option<DbTypedUuid<MupdateOverrideKind>>,
     pub host_phase_2_desired_slot_a: Option<ArtifactHash>,
     pub host_phase_2_desired_slot_b: Option<ArtifactHash>,
@@ -428,7 +430,8 @@ impl_enum_type!(
 
 struct DbBpPhysicalDiskDispositionColumns {
     disposition: DbBpPhysicalDiskDisposition,
-    expunged_as_of_generation: Option<Generation>,
+    expunged_as_of_generation:
+        Option<DbTypedGeneration<SledConfigGenerationKind>>,
     expunged_ready_for_cleanup: bool,
 }
 
@@ -449,7 +452,7 @@ impl From<BlueprintPhysicalDiskDisposition>
                 ready_for_cleanup,
             } => (
                 DbBpPhysicalDiskDisposition::Expunged,
-                Some(Generation(as_of_generation)),
+                Some(as_of_generation.into()),
                 ready_for_cleanup,
             ),
         };
@@ -475,7 +478,7 @@ impl TryFrom<DbBpPhysicalDiskDispositionColumns>
             }
             (DbBpPhysicalDiskDisposition::Expunged, Some(as_of_generation)) => {
                 Ok(Self::Expunged {
-                    as_of_generation: *as_of_generation,
+                    as_of_generation: as_of_generation.into(),
                     ready_for_cleanup: value.expunged_ready_for_cleanup,
                 })
             }
@@ -505,7 +508,8 @@ pub struct BpOmicronPhysicalDisk {
     pub pool_id: Uuid,
 
     disposition: DbBpPhysicalDiskDisposition,
-    disposition_expunged_as_of_generation: Option<Generation>,
+    disposition_expunged_as_of_generation:
+        Option<DbTypedGeneration<SledConfigGenerationKind>>,
     disposition_expunged_ready_for_cleanup: bool,
 }
 
@@ -709,7 +713,8 @@ pub struct BpOmicronZone {
     pub snat_last_port: Option<SqlU16>,
 
     disposition: DbBpZoneDisposition,
-    disposition_expunged_as_of_generation: Option<Generation>,
+    disposition_expunged_as_of_generation:
+        Option<DbTypedGeneration<SledConfigGenerationKind>>,
     disposition_expunged_ready_for_cleanup: bool,
 
     pub external_ip_id: Option<DbTypedUuid<ExternalIpKind>>,
@@ -1201,7 +1206,8 @@ impl_enum_type!(
 
 struct DbBpZoneDispositionColumns {
     disposition: DbBpZoneDisposition,
-    expunged_as_of_generation: Option<Generation>,
+    expunged_as_of_generation:
+        Option<DbTypedGeneration<SledConfigGenerationKind>>,
     expunged_ready_for_cleanup: bool,
 }
 
@@ -1220,7 +1226,7 @@ impl From<BlueprintZoneDisposition> for DbBpZoneDispositionColumns {
                 ready_for_cleanup,
             } => (
                 DbBpZoneDisposition::Expunged,
-                Some(Generation(as_of_generation)),
+                Some(as_of_generation.into()),
                 ready_for_cleanup,
             ),
         };
@@ -1242,7 +1248,7 @@ impl TryFrom<DbBpZoneDispositionColumns> for BlueprintZoneDisposition {
             (DbBpZoneDisposition::InService, None) => Ok(Self::InService),
             (DbBpZoneDisposition::Expunged, Some(as_of_generation)) => {
                 Ok(Self::Expunged {
-                    as_of_generation: *as_of_generation,
+                    as_of_generation: as_of_generation.into(),
                     ready_for_cleanup: value.expunged_ready_for_cleanup,
                 })
             }

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -10,6 +10,7 @@ use crate::PhysicalDiskKind;
 use crate::omicron_zone_config::{self, OmicronZoneNic};
 use crate::sled_cpu_family::SledCpuFamily;
 use crate::to_db_typed_uuid;
+use crate::typed_generation::DbTypedGeneration;
 use crate::typed_uuid::DbTypedUuid;
 use crate::{
     ByteCount, MacAddr, Name, ServiceKind, SqlU8, SqlU16, SqlU32,
@@ -58,6 +59,9 @@ use nexus_types::inventory::{
 use omicron_common::disk::DatasetName;
 use omicron_common::update::OmicronInstallManifestSource;
 use omicron_common::zpool_name::ZpoolName;
+use omicron_generation_kinds::{
+    SledConfigGeneration, SledConfigGenerationKind,
+};
 use omicron_uuid_kinds::DatasetKind;
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::FmdHostCaseKind;
@@ -2751,7 +2755,7 @@ impl From<DbInvSledUpdateDisposition> for OmicronSledUpdateDisposition {
 pub struct InvOmicronSledConfig {
     pub inv_collection_id: DbTypedUuid<CollectionKind>,
     pub id: DbTypedUuid<OmicronSledConfigKind>,
-    pub generation: Generation,
+    pub generation: DbTypedGeneration<SledConfigGenerationKind>,
     pub remove_mupdate_override: Option<DbTypedUuid<MupdateOverrideKind>>,
 
     #[diesel(embed)]
@@ -2766,7 +2770,7 @@ impl InvOmicronSledConfig {
     pub fn new(
         inv_collection_id: CollectionUuid,
         id: OmicronSledConfigUuid,
-        generation: omicron_generation_kinds::Generation,
+        generation: SledConfigGeneration,
         remove_mupdate_override: Option<MupdateOverrideUuid>,
         host_phase_2: HostPhase2DesiredSlots,
         measurements: BTreeSet<OmicronSingleMeasurement>,
@@ -2775,7 +2779,7 @@ impl InvOmicronSledConfig {
         Self {
             inv_collection_id: inv_collection_id.into(),
             id: id.into(),
-            generation: Generation(generation),
+            generation: generation.into(),
             remove_mupdate_override: remove_mupdate_override.map(From::from),
             host_phase_2: host_phase_2.into(),
             measurements: measurements.into(),

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -1304,7 +1304,7 @@ impl DataStore {
                 state: s.sled_state.into(),
                 update_disposition,
                 subnet,
-                sled_agent_generation: *s.sled_agent_generation,
+                sled_agent_generation: s.sled_agent_generation.into(),
                 last_allocated_ip_subnet_offset,
                 disks: IdOrdMap::new(),
                 datasets: IdOrdMap::new(),

--- a/nexus/db-queries/src/db/datastore/support_bundle.rs
+++ b/nexus/db-queries/src/db/datastore/support_bundle.rs
@@ -970,7 +970,7 @@ mod test {
     use omicron_common::api::external::ByteCount;
     use omicron_common::api::external::LookupType;
     use omicron_common::api::internal::shared::DatasetKind::Debug as DebugDatasetKind;
-    use omicron_generation_kinds::AlertGeneration;
+    use omicron_generation_kinds::{AlertGeneration, SledConfigGeneration};
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::BlueprintUuid;
     use omicron_uuid_kinds::DatasetUuid;
@@ -1599,7 +1599,7 @@ mod test {
             for mut zone in &mut sled.zones {
                 if zone.id == bundle.assigned_nexus.unwrap().into() {
                     zone.disposition = BlueprintZoneDisposition::Expunged {
-                        as_of_generation: *Generation::new(),
+                        as_of_generation: SledConfigGeneration::new(),
                         ready_for_cleanup: true,
                     };
                 }

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -2986,7 +2986,7 @@ mod tests {
     use nexus_types::external_api::vpc;
     use nexus_types::identity::Asset;
     use omicron_common::api::external;
-    use omicron_generation_kinds::Generation;
+    use omicron_generation_kinds::SledConfigGeneration;
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::BlueprintUuid;
     use omicron_uuid_kinds::GenericUuid;
@@ -3521,7 +3521,7 @@ mod tests {
                 bp4.sleds.get_mut(&sled_ids[3]).expect("config for sled");
             sled3.zones.iter_mut().next().unwrap().disposition =
                 BlueprintZoneDisposition::Expunged {
-                    as_of_generation: Generation::new(),
+                    as_of_generation: SledConfigGeneration::new(),
                     ready_for_cleanup: false,
                 };
             sled3.sled_agent_generation = sled3.sled_agent_generation.next();

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -717,7 +717,7 @@ mod test {
     use nexus_types::inventory::Collection;
     use omicron_cockroach_metrics::CockroachClusterAdminClient;
     use omicron_common::zpool_name::ZpoolName;
-    use omicron_generation_kinds::Generation;
+    use omicron_generation_kinds::SledConfigGeneration;
     use omicron_sled_agent::sim;
     use omicron_uuid_kinds::OmicronZoneUuid;
     use omicron_uuid_kinds::SledUuid;
@@ -999,7 +999,7 @@ mod test {
         let zone_address = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 123, 0, 0);
         client
             .omicron_config_put(&OmicronSledConfig {
-                generation: Generation::from(3),
+                generation: SledConfigGeneration::from_u32(3),
                 disks: IdOrdMap::default(),
                 datasets: IdOrdMap::default(),
                 zones: id_ord_map! {

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -27,6 +27,7 @@ use omicron_cockroach_metrics::PrometheusMetrics;
 use omicron_common::api::external::ByteCount;
 use omicron_common::disk::DatasetKind;
 use omicron_common::disk::DatasetName;
+use omicron_generation_kinds::{GenericGeneration, SledConfigGeneration};
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::SledUuid;
@@ -407,7 +408,9 @@ pub fn representative() -> Representative {
     // Convert these to `OmicronSledConfig`s. We'll start with empty disks and
     // datasets for now, and add to them below for sled14.
     let mut sled14 = OmicronSledConfig {
-        generation: sled14.generation,
+        generation: SledConfigGeneration::from_untyped_generation(
+            sled14.generation,
+        ),
         disks: Default::default(),
         datasets: Default::default(),
         zones: sled14.zones.into_iter().collect(),
@@ -417,7 +420,9 @@ pub fn representative() -> Representative {
         update_disposition: OmicronSledUpdateDisposition::Available,
     };
     let sled16 = OmicronSledConfig {
-        generation: sled16.generation,
+        generation: SledConfigGeneration::from_untyped_generation(
+            sled16.generation,
+        ),
         disks: Default::default(),
         datasets: Default::default(),
         zones: sled16.zones.into_iter().collect(),
@@ -427,7 +432,9 @@ pub fn representative() -> Representative {
         update_disposition: OmicronSledUpdateDisposition::Available,
     };
     let sled17 = OmicronSledConfig {
-        generation: sled17.generation,
+        generation: SledConfigGeneration::from_untyped_generation(
+            sled17.generation,
+        ),
         disks: Default::default(),
         datasets: Default::default(),
         zones: sled17.zones.into_iter().collect(),

--- a/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
+++ b/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
@@ -207,7 +207,7 @@ mod api_impl {
     use omicron_common::api::internal::shared::{
         ResolvedVpcRouteSet, ResolvedVpcRouteState,
     };
-    use omicron_generation_kinds::Generation;
+    use omicron_generation_kinds::SledConfigGeneration;
     use sled_agent_types::artifact::ArtifactConfig;
     use sled_agent_types::artifact::ArtifactCopyFromDepotBody;
     use sled_agent_types::artifact::ArtifactCopyFromDepotResponse;
@@ -346,7 +346,7 @@ mod api_impl {
             // The rest of the inventory fields are irrelevant; fill them in
             // with something quasi-reasonable (or empty, if we can).
             let config = OmicronSledConfig {
-                generation: Generation::new(),
+                generation: SledConfigGeneration::new(),
                 disks: IdOrdMap::new(),
                 datasets: IdOrdMap::new(),
                 zones: IdOrdMap::new(),

--- a/nexus/reconfigurator/execution/src/database.rs
+++ b/nexus/reconfigurator/execution/src/database.rs
@@ -92,7 +92,9 @@ mod test {
     use omicron_common::api::external::Vni;
     use omicron_common::api::internal::shared::PrivateIpConfig;
     use omicron_common::zpool_name::ZpoolName;
-    use omicron_generation_kinds::{Generation, TargetReleaseGeneration};
+    use omicron_generation_kinds::{
+        Generation, SledConfigGeneration, TargetReleaseGeneration,
+    };
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::BlueprintUuid;
     use omicron_uuid_kinds::ExternalIpUuid;
@@ -170,7 +172,7 @@ mod test {
                 subnet: Ipv6Subnet::new(Ipv6Addr::LOCALHOST),
                 last_allocated_ip_subnet_offset:
                     LastAllocatedSubnetIpOffset::initial(),
-                sled_agent_generation: Generation::new(),
+                sled_agent_generation: SledConfigGeneration::new(),
                 zones,
                 disks: IdOrdMap::new(),
                 datasets: IdOrdMap::new(),
@@ -261,7 +263,7 @@ mod test {
                 (
                     expunged_nexus,
                     BlueprintZoneDisposition::Expunged {
-                        as_of_generation: Generation::new(),
+                        as_of_generation: SledConfigGeneration::new(),
                         ready_for_cleanup: true,
                     },
                     Generation::new(),

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -357,7 +357,9 @@ mod test {
     use omicron_common::address::get_switch_zone_address;
     use omicron_common::api::external::IdentityMetadataCreateParams;
     use omicron_common::zpool_name::ZpoolName;
-    use omicron_generation_kinds::{Generation, TargetReleaseGeneration};
+    use omicron_generation_kinds::{
+        Generation, SledConfigGeneration, TargetReleaseGeneration,
+    };
     use omicron_test_utils::dev::test_setup_log;
     use omicron_uuid_kinds::BlueprintUuid;
     use omicron_uuid_kinds::ExternalIpUuid;
@@ -733,7 +735,7 @@ mod test {
             .zones
             .insert_unique(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::Expunged {
-                    as_of_generation: Generation::new(),
+                    as_of_generation: SledConfigGeneration::new(),
                     ready_for_cleanup: false,
                 },
                 id: out_of_service_id,
@@ -1180,7 +1182,7 @@ mod test {
             .find(|z| z.zone_type.is_nexus())
             .unwrap();
         nexus_zone.disposition = BlueprintZoneDisposition::Expunged {
-            as_of_generation: Generation::new(),
+            as_of_generation: SledConfigGeneration::new(),
             ready_for_cleanup: false,
         };
         mem::drop(nexus_zone);

--- a/nexus/reconfigurator/execution/src/omicron_sled_config.rs
+++ b/nexus/reconfigurator/execution/src/omicron_sled_config.rs
@@ -104,7 +104,7 @@ mod tests {
     use omicron_common::address::REPO_DEPOT_PORT;
     use omicron_common::api::internal::shared::DatasetKind;
     use omicron_common::zpool_name::ZpoolName;
-    use omicron_generation_kinds::Generation;
+    use omicron_generation_kinds::{Generation, SledConfigGeneration};
     use omicron_uuid_kinds::DatasetUuid;
     use omicron_uuid_kinds::OmicronZoneUuid;
     use omicron_uuid_kinds::PhysicalDiskUuid;
@@ -135,7 +135,7 @@ mod tests {
         let sim_sled_agent = &cptestctx.sled_agents[0].sled_agent();
         let sim_sled_agent_config_generation = sim_sled_agent
             .omicron_sled_config()
-            .map_or(Generation::new(), |config| config.generation);
+            .map_or(SledConfigGeneration::new(), |config| config.generation);
 
         let sleds_by_id = id_ord_map! {
             Sled::new(
@@ -178,7 +178,7 @@ mod tests {
         disks
             .insert_unique(BlueprintPhysicalDiskConfig {
                 disposition: BlueprintPhysicalDiskDisposition::Expunged {
-                    as_of_generation: Generation::new(),
+                    as_of_generation: SledConfigGeneration::new(),
                     ready_for_cleanup: false,
                 },
                 identity: DiskIdentity {
@@ -248,7 +248,7 @@ mod tests {
         zones
             .insert_unique(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::Expunged {
-                    as_of_generation: Generation::new(),
+                    as_of_generation: SledConfigGeneration::new(),
                     ready_for_cleanup: false,
                 },
                 id: OmicronZoneUuid::new_v4(),

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -339,7 +339,7 @@ mod test {
         BlueprintZoneImageSource, BlueprintZoneType, blueprint_zone_type,
     };
     use omicron_common::zpool_name::ZpoolName;
-    use omicron_generation_kinds::Generation;
+    use omicron_generation_kinds::SledConfigGeneration;
     use omicron_uuid_kinds::OmicronZoneUuid;
     use omicron_uuid_kinds::ZpoolUuid;
     use sled_agent_types::inventory::OmicronZoneDataset;
@@ -363,7 +363,7 @@ mod test {
         // Construct the cockroach zone we're going to try to clean up.
         let crdb_zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::Expunged {
-                as_of_generation: Generation::new(),
+                as_of_generation: SledConfigGeneration::new(),
                 ready_for_cleanup: true,
             },
             id: OmicronZoneUuid::new_v4(),

--- a/nexus/reconfigurator/execution/src/sagas.rs
+++ b/nexus/reconfigurator/execution/src/sagas.rs
@@ -231,7 +231,9 @@ mod test {
     use omicron_common::api::external::Vni;
     use omicron_common::api::internal::shared::PrivateIpConfig;
     use omicron_common::zpool_name::ZpoolName;
-    use omicron_generation_kinds::{Generation, TargetReleaseGeneration};
+    use omicron_generation_kinds::{
+        Generation, SledConfigGeneration, TargetReleaseGeneration,
+    };
     use omicron_test_utils::dev::test_setup_log;
     use omicron_uuid_kinds::BlueprintUuid;
     use omicron_uuid_kinds::ExternalIpUuid;
@@ -311,7 +313,7 @@ mod test {
                 subnet: Ipv6Subnet::new(Ipv6Addr::LOCALHOST),
                 last_allocated_ip_subnet_offset:
                     LastAllocatedSubnetIpOffset::initial(),
-                sled_agent_generation: Generation::new(),
+                sled_agent_generation: SledConfigGeneration::new(),
                 zones,
                 disks: IdOrdMap::new(),
                 datasets: IdOrdMap::new(),
@@ -566,6 +568,8 @@ mod test {
         // g1 is older than the current generation g2.
         let g1 = Generation::new();
         let g2 = g1.next();
+        let sled_g1 = SledConfigGeneration::new();
+        let sled_g2 = sled_g1.next();
 
         // Build a blueprint with different Nexus states across two generations:
         //
@@ -591,7 +595,7 @@ mod test {
                 (
                     g1_expunged_a,
                     BlueprintZoneDisposition::Expunged {
-                        as_of_generation: g1,
+                        as_of_generation: sled_g1,
                         ready_for_cleanup: true,
                     },
                     g1,
@@ -599,7 +603,7 @@ mod test {
                 (
                     g1_expunged_b,
                     BlueprintZoneDisposition::Expunged {
-                        as_of_generation: g1,
+                        as_of_generation: sled_g1,
                         ready_for_cleanup: true,
                     },
                     g1,
@@ -609,7 +613,7 @@ mod test {
                 (
                     g2_expunged_ready,
                     BlueprintZoneDisposition::Expunged {
-                        as_of_generation: g2,
+                        as_of_generation: sled_g2,
                         ready_for_cleanup: true,
                     },
                     g2,
@@ -617,7 +621,7 @@ mod test {
                 (
                     g2_expunged_not_ready,
                     BlueprintZoneDisposition::Expunged {
-                        as_of_generation: g2,
+                        as_of_generation: sled_g2,
                         ready_for_cleanup: false,
                     },
                     g2,
@@ -704,6 +708,8 @@ mod test {
         // Generations: g1 is older than the live generation g2.
         let g1 = Generation::new();
         let g2 = g1.next();
+        let sled_g1 = SledConfigGeneration::new();
+        let sled_g2 = sled_g1.next();
 
         // Build a blueprint with:
         // - an in-service Nexus at the live generation (g2)
@@ -723,7 +729,7 @@ mod test {
                 (
                     expunged_same_gen_zone,
                     BlueprintZoneDisposition::Expunged {
-                        as_of_generation: g2,
+                        as_of_generation: sled_g2,
                         ready_for_cleanup: true,
                     },
                     g2,
@@ -731,7 +737,7 @@ mod test {
                 (
                     orphan_zone,
                     BlueprintZoneDisposition::Expunged {
-                        as_of_generation: g1,
+                        as_of_generation: sled_g1,
                         ready_for_cleanup: true,
                     },
                     g1,

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -65,7 +65,9 @@ use omicron_common::address::NTP_PORT;
 use omicron_common::address::ReservedRackSubnet;
 use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::api::external::Vni;
-use omicron_generation_kinds::{Generation, TargetReleaseGeneration};
+use omicron_generation_kinds::{
+    Generation, SledConfigGeneration, TargetReleaseGeneration,
+};
 use omicron_uuid_kinds::BlueprintUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::MupdateOverrideUuid;
@@ -893,7 +895,7 @@ impl<'a> BlueprintBuilder<'a> {
     pub fn current_sled_incoming_sled_agent_generation(
         &self,
         sled_id: SledUuid,
-    ) -> Result<Generation, Error> {
+    ) -> Result<SledConfigGeneration, Error> {
         let editor = self.sled_editors.get(&sled_id).ok_or_else(|| {
             Error::Planner(anyhow!(
                 "tried to get incoming generation for unknown sled {sled_id}"
@@ -2704,7 +2706,10 @@ pub(crate) enum BpMupdateOverrideNotSetReason {
     /// The sled's inventory is stale relative to the parent blueprint, so we
     /// can't trust an override observed in inventory to reflect current
     /// reality.
-    InventoryStale { parent_bp_gen: Generation, inventory_gen: Generation },
+    InventoryStale {
+        parent_bp_gen: SledConfigGeneration,
+        inventory_gen: SledConfigGeneration,
+    },
     /// The sled has not yet successfully reconciled any config, so we have no
     /// generation to compare against.
     NoLastReconciliation,
@@ -2920,7 +2925,7 @@ pub mod test {
             summary.diff.sleds.added.first_key_value().unwrap();
         assert_eq!(*sled_id, new_sled_id);
         // The generation number should be newer than the initial default.
-        assert!(new_sled.sled_agent_generation > Generation::new());
+        assert!(new_sled.sled_agent_generation > SledConfigGeneration::new());
 
         // All zones' underlay addresses ought to be on the sled's subnet.
         for z in &new_sled.zones {
@@ -3005,7 +3010,7 @@ pub mod test {
 
             for mut zone in &mut sled_config.zones {
                 zone.disposition = BlueprintZoneDisposition::Expunged {
-                    as_of_generation: Generation::new(),
+                    as_of_generation: SledConfigGeneration::new(),
                     ready_for_cleanup: false,
                 };
             }
@@ -3014,7 +3019,7 @@ pub mod test {
             }
             for mut disk in &mut sled_config.disks {
                 disk.disposition = BlueprintPhysicalDiskDisposition::Expunged {
-                    as_of_generation: Generation::new(),
+                    as_of_generation: SledConfigGeneration::new(),
                     ready_for_cleanup: false,
                 };
             }
@@ -3059,7 +3064,7 @@ pub mod test {
             &mut blueprint2.sleds.get_mut(&decommision_sled_id).unwrap().zones
         {
             z.disposition = BlueprintZoneDisposition::Expunged {
-                as_of_generation: Generation::new(),
+                as_of_generation: SledConfigGeneration::new(),
                 ready_for_cleanup: false,
             };
         }

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -43,7 +43,7 @@ use nexus_types::external_api::sled::SledState;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::disk::DatasetKind;
-use omicron_generation_kinds::Generation;
+use omicron_generation_kinds::{Generation, SledConfigGeneration};
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::MupdateOverrideUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -167,7 +167,7 @@ pub enum EnsureMupdateOverrideError {
 #[derive(Debug)]
 pub struct SledEditor {
     underlay_ip_allocator: SledUnderlayIpAllocator,
-    incoming_sled_agent_generation: Generation,
+    incoming_sled_agent_generation: SledConfigGeneration,
     incoming_update_disposition_generation: Generation,
     update_disposition_kind: ScalarEditor<BlueprintSledUpdateDispositionKind>,
     zones: ZonesEditor,
@@ -241,7 +241,7 @@ impl SledEditor {
                 subnet,
                 LastAllocatedSubnetIpOffset::initial(),
             ),
-            incoming_sled_agent_generation: Generation::new(),
+            incoming_sled_agent_generation: SledConfigGeneration::new(),
             incoming_update_disposition_generation: Generation::new(),
             update_disposition_kind: ScalarEditor::new(
                 BlueprintSledUpdateDispositionKind::Available,
@@ -419,7 +419,7 @@ impl SledEditor {
         self.zones.all_in_service_and_expunged_zones(reason)
     }
 
-    pub fn incoming_sled_agent_generation(&self) -> Generation {
+    pub fn incoming_sled_agent_generation(&self) -> SledConfigGeneration {
         self.incoming_sled_agent_generation
     }
 
@@ -1082,7 +1082,7 @@ mod tests {
         assert!(edited.scalar_edits.update_disposition);
         assert_eq!(
             edited.config.sled_agent_generation,
-            Generation::new().next(),
+            SledConfigGeneration::new().next(),
             "sled_agent_generation also bumped exactly once",
         );
 
@@ -1102,7 +1102,7 @@ mod tests {
         assert!(!edited.scalar_edits.update_disposition);
         assert_eq!(
             edited.config.sled_agent_generation,
-            Generation::new(),
+            SledConfigGeneration::new(),
             "sled_agent_generation was not bumped - no visible change",
         );
     }

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/disks.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/disks.rs
@@ -7,7 +7,7 @@ use iddqd::IdOrdMap;
 use iddqd::id_ord_map::Entry;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
-use omicron_generation_kinds::Generation;
+use omicron_generation_kinds::SledConfigGeneration;
 use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 
@@ -25,14 +25,14 @@ pub enum DisksEditError {
 
 #[derive(Debug)]
 pub(super) struct DisksEditor {
-    incoming_sled_agent_generation: Generation,
+    incoming_sled_agent_generation: SledConfigGeneration,
     disks: IdOrdMap<BlueprintPhysicalDiskConfig>,
     counts: EditCounts,
 }
 
 impl DisksEditor {
     pub fn new(
-        incoming_sled_agent_generation: Generation,
+        incoming_sled_agent_generation: SledConfigGeneration,
         disks: IdOrdMap<BlueprintPhysicalDiskConfig>,
     ) -> Self {
         Self {
@@ -44,7 +44,7 @@ impl DisksEditor {
 
     pub fn empty() -> Self {
         Self {
-            incoming_sled_agent_generation: Generation::new(),
+            incoming_sled_agent_generation: SledConfigGeneration::new(),
             disks: IdOrdMap::new(),
             counts: EditCounts::zeroes(),
         }

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -9,7 +9,7 @@ use nexus_types::deployment::BlueprintExpungedZoneAccessReason;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneImageSource;
-use omicron_generation_kinds::Generation;
+use omicron_generation_kinds::SledConfigGeneration;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use sled_agent_types::inventory::ZoneKind;
@@ -37,14 +37,14 @@ pub enum ZonesEditError {
 
 #[derive(Debug)]
 pub(super) struct ZonesEditor {
-    incoming_sled_agent_generation: Generation,
+    incoming_sled_agent_generation: SledConfigGeneration,
     zones: IdOrdMap<BlueprintZoneConfig>,
     counts: EditCounts,
 }
 
 impl ZonesEditor {
     pub fn new(
-        incoming_sled_agent_generation: Generation,
+        incoming_sled_agent_generation: SledConfigGeneration,
         zones: IdOrdMap<BlueprintZoneConfig>,
     ) -> Self {
         Self {
@@ -56,7 +56,7 @@ impl ZonesEditor {
 
     pub fn empty() -> Self {
         Self {
-            incoming_sled_agent_generation: Generation::new(),
+            incoming_sled_agent_generation: SledConfigGeneration::new(),
             zones: IdOrdMap::new(),
             counts: EditCounts::zeroes(),
         }
@@ -247,7 +247,7 @@ impl ZonesEditor {
     fn expunge_impl(
         config: &mut BlueprintZoneConfig,
         counts: &mut EditCounts,
-        current_generation: Generation,
+        current_generation: SledConfigGeneration,
     ) -> bool {
         match config.disposition {
             BlueprintZoneDisposition::InService => {

--- a/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
@@ -26,7 +26,7 @@ use nexus_types::inventory::CabooseWhich;
 use nexus_types::inventory::Collection;
 use nexus_types::inventory::SpType;
 use nexus_types::tuf_repo::TufRepoDescription;
-use omicron_generation_kinds::Generation;
+use omicron_generation_kinds::SledConfigGeneration;
 use omicron_uuid_kinds::SledUuid;
 use sled_agent_types::disk::M2Slot;
 use sled_agent_types::inventory::BootImageHeader;
@@ -1248,7 +1248,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
                     )
                     .unwrap();
                 let fake_sled_config = OmicronSledConfig {
-                    generation: Generation::new(),
+                    generation: SledConfigGeneration::new(),
                     disks: IdOrdMap::new(),
                     datasets: IdOrdMap::new(),
                     zones: IdOrdMap::new(),

--- a/nexus/reconfigurator/planning/src/planner/image_source.rs
+++ b/nexus/reconfigurator/planning/src/planner/image_source.rs
@@ -19,7 +19,7 @@ use nexus_types::{
     },
     inventory::Collection,
 };
-use omicron_generation_kinds::Generation;
+use omicron_generation_kinds::SledConfigGeneration;
 use omicron_uuid_kinds::{MupdateOverrideUuid, OmicronZoneUuid, SledUuid};
 use sled_agent_types::inventory::{
     BootPartitionContents, BootPartitionDetails, ManifestBootInventory,
@@ -498,7 +498,10 @@ pub(crate) enum NoopConvertSledIneligibleReason {
 
     /// The inventory is stale, as indicated by its generation number: it has an
     /// older generation for this sled than the parent blueprint.
-    InventoryStale { parent_bp_gen: Generation, inventory_gen: Generation },
+    InventoryStale {
+        parent_bp_gen: SledConfigGeneration,
+        inventory_gen: SledConfigGeneration,
+    },
 
     /// An error occurred retrieving the sled's install dataset zone manifest.
     ManifestError { message: String },

--- a/nexus/reconfigurator/planning/tests/integration_tests/planner.rs
+++ b/nexus/reconfigurator/planning/tests/integration_tests/planner.rs
@@ -68,7 +68,7 @@ use omicron_deployment_graph::DagEdge;
 use omicron_deployment_graph::DagEdgesFile;
 use omicron_deployment_graph::DeploymentUnitName;
 use omicron_deployment_graph::OMICRON_LS_APIS_PATH;
-use omicron_generation_kinds::Generation;
+use omicron_generation_kinds::{Generation, SledConfigGeneration};
 use omicron_test_utils::dev::test_setup_log;
 use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -272,7 +272,7 @@ fn test_basic_add_sled() {
     // We have defined elsewhere that the first generation contains no
     // zones.  So the first one with zones must be newer.  See
     // OmicronZonesConfig::INITIAL_GENERATION.
-    assert!(sled_added.sled_agent_generation > Generation::new());
+    assert!(sled_added.sled_agent_generation > SledConfigGeneration::new());
     assert_eq!(*sled_id, new_sled_id);
     assert_eq!(sled_added.zones.len(), 1);
     assert!(matches!(
@@ -1080,7 +1080,10 @@ fn test_disk_add_expunge_decommission() {
 
     // The initial blueprint configuration has generation 2
     let (sled_id, sled_config) = blueprint1.sleds.first_key_value().unwrap();
-    assert_eq!(sled_config.sled_agent_generation, Generation::from_u32(2));
+    assert_eq!(
+        sled_config.sled_agent_generation,
+        SledConfigGeneration::from_u32(2)
+    );
 
     // All disks should have an `InService` disposition and `Active` state
     for disk in &sled_config.disks {
@@ -1118,7 +1121,10 @@ fn test_disk_add_expunge_decommission() {
     let sled_config = &blueprint2.sleds.first_key_value().unwrap().1;
 
     // The generation goes from 2 -> 3
-    assert_eq!(sled_config.sled_agent_generation, Generation::from_u32(3));
+    assert_eq!(
+        sled_config.sled_agent_generation,
+        SledConfigGeneration::from_u32(3)
+    );
     // One disk should have it's disposition set to
     // `Expunged{ready_for_cleanup: false, ..}`.
     for disk in &sled_config.disks {
@@ -1159,7 +1165,10 @@ fn test_disk_add_expunge_decommission() {
     // The reason for this is because the generation is there primarily to
     // inform the sled-agent that it has work to do, but decommissioning
     // doesn't trigger any sled-agent changes.
-    assert_eq!(sled_config.sled_agent_generation, Generation::from_u32(3));
+    assert_eq!(
+        sled_config.sled_agent_generation,
+        SledConfigGeneration::from_u32(3)
+    );
     // One disk should have its disposition set to
     // `Expunged{ready_for_cleanup: true, ..}`.
     for disk in &sled_config.disks {
@@ -1200,7 +1209,10 @@ fn test_disk_add_expunge_decommission() {
     let sled_config = &blueprint4.sleds.first_key_value().unwrap().1;
 
     // The config generation goes from 3 -> 4
-    assert_eq!(sled_config.sled_agent_generation, Generation::from_u32(4));
+    assert_eq!(
+        sled_config.sled_agent_generation,
+        SledConfigGeneration::from_u32(4)
+    );
     // We should still have 10 disks
     assert_eq!(sled_config.disks.len(), 10);
     // All disks should have their disposition set to
@@ -1729,7 +1741,7 @@ fn test_nexus_allocation_skips_nonprovisionable_sleds() {
             match next {
                 NextCrucibleMutate::Modify => {
                     zone.disposition = BlueprintZoneDisposition::Expunged {
-                        as_of_generation: Generation::new(),
+                        as_of_generation: SledConfigGeneration::new(),
                         ready_for_cleanup: false,
                     };
                     next = NextCrucibleMutate::Remove;
@@ -4980,7 +4992,7 @@ fn test_simple_measurements() {
                 // 4 because we plan a zone update
                 assert_eq!(
                     sled_config.sled_agent_generation,
-                    Generation::from_u32(4)
+                    SledConfigGeneration::from_u32(4)
                 );
                 println!("converted after {i} iterations");
                 logctx.cleanup_successful();

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -252,7 +252,9 @@ mod test {
     use omicron_common::address::Ipv6Subnet;
     use omicron_common::api::external;
     use omicron_common::zpool_name::ZpoolName;
-    use omicron_generation_kinds::{Generation, TargetReleaseGeneration};
+    use omicron_generation_kinds::{
+        Generation, SledConfigGeneration, TargetReleaseGeneration,
+    };
     use omicron_uuid_kinds::BlueprintUuid;
     use omicron_uuid_kinds::OmicronZoneUuid;
     use omicron_uuid_kinds::PhysicalDiskUuid;
@@ -292,7 +294,8 @@ mod test {
                         subnet: Ipv6Subnet::new(Ipv6Addr::LOCALHOST),
                         last_allocated_ip_subnet_offset:
                             LastAllocatedSubnetIpOffset::initial(),
-                        sled_agent_generation: Generation::new().next(),
+                        sled_agent_generation: SledConfigGeneration::new()
+                            .next(),
                         disks: IdOrdMap::new(),
                         datasets: IdOrdMap::new(),
                         zones,

--- a/nexus/src/app/background/tasks/crdb_node_id_collector.rs
+++ b/nexus/src/app/background/tasks/crdb_node_id_collector.rs
@@ -242,7 +242,7 @@ mod tests {
     use nexus_types::deployment::BlueprintTarget;
     use nexus_types::deployment::BlueprintZoneDisposition;
     use nexus_types::deployment::BlueprintZoneImageSource;
-    use omicron_generation_kinds::Generation;
+    use omicron_generation_kinds::SledConfigGeneration;
     use omicron_test_utils::dev;
     use std::collections::BTreeMap;
     use std::collections::BTreeSet;
@@ -313,7 +313,7 @@ mod tests {
                 expected.insert((zone.id, addr));
             } else {
                 zone.disposition = BlueprintZoneDisposition::Expunged {
-                    as_of_generation: Generation::new(),
+                    as_of_generation: SledConfigGeneration::new(),
                     ready_for_cleanup: false,
                 };
             }

--- a/nexus/test-utils/src/starter.rs
+++ b/nexus/test-utils/src/starter.rs
@@ -80,7 +80,9 @@ use omicron_common::api::internal::shared::DatasetKind;
 use omicron_common::api::internal::shared::PrivateIpConfig;
 use omicron_common::zpool_name::ZpoolName;
 use omicron_debug_dropbox::DebugDropbox;
-use omicron_generation_kinds::{Generation, TargetReleaseGeneration};
+use omicron_generation_kinds::{
+    Generation, SledConfigGeneration, TargetReleaseGeneration,
+};
 use omicron_sled_agent::sim;
 use omicron_test_utils::dev;
 use omicron_test_utils::dev::TestTempDir;
@@ -1015,7 +1017,7 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
         // Send the sled-agents their new configurations.
         // This generation number should match the one in
         // `make_sled_configs`.
-        let generation = Generation::from_u32(2);
+        let generation = SledConfigGeneration::from_u32(2);
 
         for (sled_agent, sled_zones) in zip(self.sled_agents.iter(), zones) {
             let sled_id = sled_agent.sled_agent_id();
@@ -1377,7 +1379,7 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
         // The generation number that the sled-agents' configuration
         // will have when this blueprint is executed. Should match
         // the one in `configure_sled_agents`.
-        let sled_agent_generation = Generation::from_u32(2);
+        let sled_agent_generation = SledConfigGeneration::from_u32(2);
 
         for (sled_agent, maybe_zones) in
             zip(self.sled_agents.iter(), maybe_zones)

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -36,7 +36,9 @@ use omicron_common::address::get_sled_address;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::internal::shared::DatasetKind;
 use omicron_common::disk::DatasetName;
-use omicron_generation_kinds::{Generation, TargetReleaseGeneration};
+use omicron_generation_kinds::{
+    Generation, SledConfigGeneration, TargetReleaseGeneration,
+};
 use omicron_uuid_kinds::BlueprintUuid;
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::MupdateOverrideUuid;
@@ -1632,7 +1634,7 @@ pub struct BlueprintSledConfig {
     /// `state` from `Active` to `Decommissioned` would not require a bump to
     /// `sled_agent_generation`, because a `Decommissioned` sled will never be
     /// sent an `OmicronSledConfig`.
-    pub sled_agent_generation: Generation,
+    pub sled_agent_generation: SledConfigGeneration,
 
     pub disks: IdOrdMap<BlueprintPhysicalDiskConfig>,
     pub datasets: IdOrdMap<BlueprintDatasetConfig>,
@@ -2012,7 +2014,7 @@ pub enum BlueprintZoneDisposition {
     /// The zone is permanently gone.
     Expunged {
         /// Generation of the parent config in which this zone became expunged.
-        as_of_generation: Generation,
+        as_of_generation: SledConfigGeneration,
 
         /// True if Reconfiguration knows that this zone has been shut down and
         /// will not be restarted.
@@ -3172,7 +3174,7 @@ pub enum BlueprintPhysicalDiskDisposition {
     /// The physical disk is permanently gone.
     Expunged {
         /// Generation of the parent config in which this disk became expunged.
-        as_of_generation: Generation,
+        as_of_generation: SledConfigGeneration,
 
         /// True if Reconfiguration knows that this disk has been expunged.
         ///
@@ -3222,7 +3224,7 @@ impl BlueprintPhysicalDiskDisposition {
 
     /// Return the generation when a disk was expunged or `None` if the disk
     /// was not expunged.
-    pub fn expunged_as_of_generation(&self) -> Option<Generation> {
+    pub fn expunged_as_of_generation(&self) -> Option<SledConfigGeneration> {
         match self {
             BlueprintPhysicalDiskDisposition::Expunged {
                 as_of_generation,

--- a/openapi/nexus-lockstep.json
+++ b/openapi/nexus-lockstep.json
@@ -2592,7 +2592,7 @@
                 "description": "Generation of the parent config in which this disk became expunged.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/Generation"
+                    "$ref": "#/components/schemas/SledConfigGeneration"
                   }
                 ]
               },
@@ -2695,7 +2695,7 @@
             "description": "Generation number used when this type is converted into an `OmicronSledConfig` for use by sled-agent.\n\nThis field is explicitly named `sled_agent_generation` to indicate that it is only required to cover information that changes what Reconfigurator sends to sled agent. For example, changing the sled `state` from `Active` to `Decommissioned` would not require a bump to `sled_agent_generation`, because a `Decommissioned` sled will never be sent an `OmicronSledConfig`.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/Generation"
+                "$ref": "#/components/schemas/SledConfigGeneration"
               }
             ]
           },
@@ -3047,7 +3047,7 @@
                 "description": "Generation of the parent config in which this zone became expunged.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/Generation"
+                    "$ref": "#/components/schemas/SledConfigGeneration"
                   }
                 ]
               },
@@ -9583,6 +9583,17 @@
           "sled_id",
           "zones"
         ]
+      },
+      "SledConfigGeneration": {
+        "description": "Generation numbers stored in the database, used for optimistic concurrency control",
+        "x-rust-type": {
+          "crate": "omicron-generation-kinds",
+          "path": "omicron_generation_kinds::SledConfigGeneration",
+          "version": "*"
+        },
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0
       },
       "SledPolicy": {
         "description": "The operator-defined policy of a sled.",

--- a/openapi/sled-agent/sled-agent-49.0.0-b9a55b.json.gitstub
+++ b/openapi/sled-agent/sled-agent-49.0.0-b9a55b.json.gitstub
@@ -1,0 +1,1 @@
+f8e9052b768e1fa9c3fc16ef033fcab9ede3b806:openapi/sled-agent/sled-agent-49.0.0-b9a55b.json

--- a/openapi/sled-agent/sled-agent-50.0.0-240307.json
+++ b/openapi/sled-agent/sled-agent-50.0.0-240307.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "49.0.0"
+    "version": "50.0.0"
   },
   "paths": {
     "/artifacts": {
@@ -7580,7 +7580,7 @@
             "uniqueItems": true
           },
           "generation": {
-            "$ref": "#/components/schemas/Generation"
+            "$ref": "#/components/schemas/SledConfigGeneration"
           },
           "host_phase_2": {
             "$ref": "#/components/schemas/HostPhase2DesiredSlots"
@@ -9385,6 +9385,17 @@
           "path",
           "result"
         ]
+      },
+      "SledConfigGeneration": {
+        "description": "Generation numbers stored in the database, used for optimistic concurrency control",
+        "x-rust-type": {
+          "crate": "omicron-generation-kinds",
+          "path": "omicron_generation_kinds::SledConfigGeneration",
+          "version": "*"
+        },
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0
       },
       "SledCpuFamily": {
         "description": "Identifies the kind of CPU present on a sled, determined by reading CPUID.\n\nThis is intended to broadly support the control plane answering the question \"can I run this instance on that sled?\" given an instance with either no or some CPU platform requirement. It is not enough information for more precise placement questions - for example, is a CPU a high-frequency part or many-core part? We don't include Genoa here, but in that CPU family there are high frequency parts, many-core parts, and large-cache parts. To support those questions (or satisfactorily answer #8730) we would need to collect additional information and send it along.",

--- a/openapi/sled-agent/sled-agent-latest.json
+++ b/openapi/sled-agent/sled-agent-latest.json
@@ -1,1 +1,1 @@
-sled-agent-49.0.0-b9a55b.json
+sled-agent-50.0.0-240307.json

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -22,7 +22,7 @@ use omicron_common::api::internal::{
 use sled_agent_types_versions::{
     latest, v1, v4, v6, v7, v9, v10, v11, v12, v14, v16, v17, v18, v20, v22,
     v24, v25, v26, v28, v29, v30, v31, v32, v33, v34, v37, v39, v40, v41, v42,
-    v43, v46, v47, v48,
+    v43, v46, v47, v48, v49,
 };
 use sled_diagnostics::SledDiagnosticsQueryOutput;
 use slog_error_chain::InlineErrorChain;
@@ -39,6 +39,7 @@ api_versions!([
     // |  example for the next person.
     // v
     // (next_int, IDENT),
+    (50, TYPED_SLED_CONFIG_GENERATION),
     (49, ADD_UPDATE_DISPOSITION),
     (48, ALLOW_DDM_TRAFFIC),
     (47, BGP_PEER_SRC_ADDR),
@@ -374,12 +375,25 @@ pub trait SledAgentApi {
     #[endpoint {
         method = PUT,
         path = "/omicron-config",
-        versions = VERSION_ADD_UPDATE_DISPOSITION..,
+        versions = VERSION_TYPED_SLED_CONFIG_GENERATION..,
     }]
     async fn omicron_config_put(
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<latest::inventory::OmicronSledConfig>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
+
+    #[endpoint {
+        operation_id = "omicron_config_put",
+        method = PUT,
+        path = "/omicron-config",
+        versions = VERSION_ADD_UPDATE_DISPOSITION..VERSION_TYPED_SLED_CONFIG_GENERATION,
+    }]
+    async fn omicron_config_put_v49(
+        rqctx: RequestContext<Self::Context>,
+        body: TypedBody<v49::inventory::OmicronSledConfig>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        Self::omicron_config_put(rqctx, body.map(Into::into)).await
+    }
 
     #[endpoint {
         operation_id = "omicron_config_put",
@@ -391,8 +405,7 @@ pub trait SledAgentApi {
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<v14::inventory::OmicronSledConfig>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        let body = body.map(latest::inventory::OmicronSledConfig::from);
-        Self::omicron_config_put(rqctx, body).await
+        Self::omicron_config_put_v49(rqctx, body.map(Into::into)).await
     }
 
     #[endpoint {
@@ -1174,11 +1187,26 @@ pub trait SledAgentApi {
     #[endpoint {
         method = GET,
         path = "/inventory",
-        versions = VERSION_ADD_UPDATE_DISPOSITION..,
+        versions = VERSION_TYPED_SLED_CONFIG_GENERATION..,
     }]
     async fn inventory(
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<latest::inventory::Inventory>, HttpError>;
+
+    /// Fetch basic information about this sled
+    #[endpoint {
+        operation_id = "inventory",
+        method = GET,
+        path = "/inventory",
+        versions = VERSION_ADD_UPDATE_DISPOSITION..VERSION_TYPED_SLED_CONFIG_GENERATION,
+    }]
+    async fn inventory_v49(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<v49::inventory::Inventory>, HttpError> {
+        Self::inventory(rqctx).await.map(|HttpResponseOk(inv)| {
+            HttpResponseOk(v49::inventory::Inventory::from(inv))
+        })
+    }
 
     /// Fetch basic information about this sled
     #[endpoint {
@@ -1190,8 +1218,9 @@ pub trait SledAgentApi {
     async fn inventory_v46(
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<v46::inventory::Inventory>, HttpError> {
-        let HttpResponseOk(inventory) = Self::inventory(rqctx).await?;
-        Ok(HttpResponseOk(inventory.into()))
+        Self::inventory_v49(rqctx).await.map(|HttpResponseOk(inv)| {
+            HttpResponseOk(v46::inventory::Inventory::from(inv))
+        })
     }
 
     /// Fetch basic information about this sled

--- a/sled-agent/config-reconciler/expectorate/v50-sled-config.json
+++ b/sled-agent/config-reconciler/expectorate/v50-sled-config.json
@@ -1,0 +1,1007 @@
+{
+  "generation": 351,
+  "disks": [
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A5E3"
+      },
+      "id": "10fec275-f937-40f7-9c25-616079ef3816",
+      "pool_id": "6340805e-c5af-418d-8bd1-fc0085667f33"
+    },
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A79D"
+      },
+      "id": "883b970b-2b70-4771-bb0e-aed2765c3e6a",
+      "pool_id": "414e235b-55c3-4dc1-a568-8adf4ea1a052"
+    },
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A61D"
+      },
+      "id": "9272fa96-eef8-43ed-8658-12ccf722bec2",
+      "pool_id": "7b24095a-72df-45e3-984f-2b795e052ac7"
+    },
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A7EE"
+      },
+      "id": "b20f225f-fef6-4ef5-a474-bd818013fceb",
+      "pool_id": "b93f880e-c55b-4d6c-9a16-939d84b628fc"
+    },
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A67C"
+      },
+      "id": "b483c693-700f-4630-92bb-9659e735648b",
+      "pool_id": "cf940e15-dbc5-481b-866a-4de4b018898e"
+    },
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A6F3"
+      },
+      "id": "c9bd1b35-c87a-4acf-bf52-06ed624e3be0",
+      "pool_id": "8a199f12-4f5c-483a-8aca-f97856658a35"
+    },
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A5C3"
+      },
+      "id": "d45fb895-f500-473f-9bdb-3d1f15464055",
+      "pool_id": "26e698bb-006d-4208-94b9-d1bc279111fa"
+    },
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A7BE"
+      },
+      "id": "d9fb1545-4051-4710-bcfd-8d33115bb022",
+      "pool_id": "e126ddcc-8bee-46ba-8199-2a74df0ba040"
+    },
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A7DA"
+      },
+      "id": "e1bfe0a7-e848-4907-9068-22e02bad03ca",
+      "pool_id": "2115b084-be0f-4fba-941b-33a659798a9e"
+    },
+    {
+      "identity": {
+        "vendor": "1b96",
+        "model": "WUS4C6432DSP3X3",
+        "serial": "A084A75D"
+      },
+      "id": "f6d26664-f32e-46c4-a3f3-74d55dae7fac",
+      "pool_id": "bf428719-1b16-4503-99f4-ad95846d916f"
+    }
+  ],
+  "datasets": [
+    {
+      "id": "01f93020-7e7d-4185-93fb-6ca234056c82",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "01ffd316-ea25-4287-95aa-01bf6b036a16",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "zone/oxz_crucible_01f93020-7e7d-4185-93fb-6ca234056c82"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "02a5be47-df19-4159-b793-98a888603200",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "072fdae8-2adf-4fd2-94ce-e9b0663b91e7",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "088ff0e3-9b7e-4798-901c-fe88cf7aca52",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "0b41c560-3b20-42f4-82ad-92f5bb575d6b",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "14b70f75-89e1-4ded-a7c4-dcf49ebd87ba",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "zone/oxz_crucible_0b41c560-3b20-42f4-82ad-92f5bb575d6b"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "1a00597c-8225-4324-9530-aaad3d7a9138",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "zone/oxz_crucible_7d44ba36-4a69-490a-bc40-f6f90a4208d4"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "257d5c91-5bd5-4a13-802b-0995f76df671",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone/oxz_nexus_470fbf4d-0178-45ee-a422-136fa5f4a158"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "27bb57f7-abc6-4550-b1c6-5a18c7356748",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "2bd226bd-edce-488c-bbe8-e0b301664de0",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "2c260613-a7bc-401e-ab73-cde4069ef09a",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "2fa20fca-7b61-4e56-8dbf-f56171bf35e1",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "34007214-81f0-4768-804d-d090695f1f09",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "external_dns"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "46596dcd-4bea-4878-b498-1b9da4437aff",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "468152ab-b771-4caf-9ca2-8abbd6fc5bec",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "46c13daf-0808-496a-b0f8-9eca75fcfa84",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "4b771fc2-312a-4abf-9eef-ae9ff3853a13",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "4e3b3938-ad72-4443-9d96-4d6ba8ab19fb",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "zone/oxz_crucible_585cd8c5-c41e-4be4-beb8-bfbef9b53856"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "50b12371-0120-4210-89c7-2ecd58bea4d3",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "5171b6ba-b282-4e71-917e-f253c7b2eb22",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "5625f171-927d-4e4a-b009-be250ac92bc3",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "56b0119a-f49d-45d7-a93e-d4a4e1d76559",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "585cd8c5-c41e-4be4-beb8-bfbef9b53856",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "5b0bc0d3-24c6-4f9c-937b-f38e8ccee03c",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "5c4e9d03-f202-46dd-ba50-179b2b84f849",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "zone/oxz_crucible_7153983f-8fd7-4fb9-92ac-0f07a07798b4"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "69794309-1082-410b-a2a1-8b97588efa16",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "69a6412f-8438-4a0d-9c6e-a2e766750b2c",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone/oxz_external_dns_5c97418b-8318-4427-8f65-14f3e3362d13"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "7153983f-8fd7-4fb9-92ac-0f07a07798b4",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "77906e4e-1bbc-49c9-a7ee-f581de5552c4",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "zone/oxz_crucible_e238116d-e5cc-43d4-9c8a-6f138ae8a15d"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "7d44ba36-4a69-490a-bc40-f6f90a4208d4",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "8bce1ea9-5d2f-451a-87fd-db9140e07420",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "zone/oxz_crucible_a6ba8273-0320-4dab-b801-281f041b0c50"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "8f50c2e8-d091-4440-b9cc-0c6c3e62b8b8",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone/oxz_crucible_0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "9721d822-c80a-4856-a715-02c9c0c89184",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "978354d3-17cb-40ce-815d-b4edaad79f11",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "9bf9e7bd-269b-4925-ba99-a0cdb8138fb8",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "a2d0f801-bf2d-44a3-b39b-bbfb3b387a4a",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "a6ba8273-0320-4dab-b801-281f041b0c50",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "a6cbbb5d-f7b3-4d91-b54e-c3cf55762adc",
+      "name": {
+        "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "a724aab1-2fdc-45aa-8fa2-2f0a272aae62",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "aa44f101-8502-4480-bec8-9c48d3f4106b",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "adb8db9b-2cd7-45b7-bb9f-adf094c4ccca",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "b156677f-cafa-4d73-9719-6b0d16dad722",
+      "name": {
+        "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "c5e4bd8a-d323-48ec-a641-5c7dbecf3252",
+      "name": {
+        "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "c9c7a527-d432-490d-86b3-658da7b555cc",
+      "name": {
+        "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+        "kind": "zone/oxz_crucible_072fdae8-2adf-4fd2-94ce-e9b0663b91e7"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "d8b3ba09-1267-43af-9734-1fdc3e22b23e",
+      "name": {
+        "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+        "kind": "zone/oxz_crucible_b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "dee3ca8e-c6f5-4e12-aa0d-74ed9a6245a3",
+      "name": {
+        "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+        "kind": "zone/oxz_ntp_a700528f-f600-4908-94ac-9c06442ef6b4"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "e1c7ecae-faed-4d02-b446-2dd3478dc27d",
+      "name": {
+        "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+        "kind": "debug"
+      },
+      "compression": {
+        "type": "gzip_n",
+        "level": 9
+      },
+      "quota": 107374182400,
+      "reservation": null
+    },
+    {
+      "id": "e238116d-e5cc-43d4-9c8a-6f138ae8a15d",
+      "name": {
+        "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+        "kind": "crucible"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "e3d07396-5ab6-4008-b590-df8b5794f9e1",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "local_storage"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "e7d578b0-2c40-4e1f-a1c2-2dc2a6f9f5d8",
+      "name": {
+        "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    },
+    {
+      "id": "fb307365-fd47-4112-9a88-519ee5cf6445",
+      "name": {
+        "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+        "kind": "zone"
+      },
+      "compression": {
+        "type": "off"
+      },
+      "quota": null,
+      "reservation": null
+    }
+  ],
+  "zones": [
+    {
+      "id": "01f93020-7e7d-4185-93fb-6ca234056c82",
+      "filesystem_pool": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::5]:32345",
+        "dataset": {
+          "pool_name": "oxp_7b24095a-72df-45e3-984f-2b795e052ac7"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    {
+      "id": "072fdae8-2adf-4fd2-94ce-e9b0663b91e7",
+      "filesystem_pool": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::b]:32345",
+        "dataset": {
+          "pool_name": "oxp_26e698bb-006d-4208-94b9-d1bc279111fa"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    {
+      "id": "0b41c560-3b20-42f4-82ad-92f5bb575d6b",
+      "filesystem_pool": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::9]:32345",
+        "dataset": {
+          "pool_name": "oxp_b93f880e-c55b-4d6c-9a16-939d84b628fc"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    {
+      "id": "0ccf27c0-e32d-4b52-a2c5-6db0c64a26f9",
+      "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::d]:32345",
+        "dataset": {
+          "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    {
+      "id": "470fbf4d-0178-45ee-a422-136fa5f4a158",
+      "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+      "zone_type": {
+        "type": "nexus",
+        "internal_address": "[fd00:1122:3344:103::47]:12221",
+        "lockstep_port": 12232,
+        "external_ip": "172.20.26.8",
+        "nic": {
+          "id": "98d2e08e-a3a6-43ed-a2a0-7cf52fd211f8",
+          "kind": {
+            "type": "service",
+            "id": "470fbf4d-0178-45ee-a422-136fa5f4a158"
+          },
+          "name": "nexus-470fbf4d-0178-45ee-a422-136fa5f4a158",
+          "ip_config": {
+            "type": "v4",
+            "value": {
+              "ip": "172.30.2.9",
+              "subnet": "172.30.2.0/24",
+              "transit_ips": []
+            }
+          },
+          "mac": "A8:40:25:FF:80:05",
+          "vni": 100,
+          "primary": true,
+          "slot": 0
+        },
+        "external_tls": true,
+        "external_dns_servers": [
+          "1.1.1.1",
+          "9.9.9.9"
+        ]
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "1ae3b88364f311ce588ac802cb8177c4806b76da0ce42e39aab0b0d8bb04c197"
+      }
+    },
+    {
+      "id": "585cd8c5-c41e-4be4-beb8-bfbef9b53856",
+      "filesystem_pool": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::7]:32345",
+        "dataset": {
+          "pool_name": "oxp_6340805e-c5af-418d-8bd1-fc0085667f33"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    {
+      "id": "5c97418b-8318-4427-8f65-14f3e3362d13",
+      "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+      "zone_type": {
+        "type": "external_dns",
+        "dataset": {
+          "pool_name": "oxp_2115b084-be0f-4fba-941b-33a659798a9e"
+        },
+        "http_address": "[fd00:1122:3344:103::46]:5353",
+        "dns_address": "172.20.26.2:53",
+        "nic": {
+          "id": "9e5b3233-1bb2-4d10-a99a-6884d6ab4d7d",
+          "kind": {
+            "type": "service",
+            "id": "5c97418b-8318-4427-8f65-14f3e3362d13"
+          },
+          "name": "external-dns-5c97418b-8318-4427-8f65-14f3e3362d13",
+          "ip_config": {
+            "type": "v4",
+            "value": {
+              "ip": "172.30.1.6",
+              "subnet": "172.30.1.0/24",
+              "transit_ips": []
+            }
+          },
+          "mac": "A8:40:25:FF:80:01",
+          "vni": 100,
+          "primary": true,
+          "slot": 0
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "389335a28c7bb548e68537df4bf5be5df7f2f54db1fba6b1cba3ad36ad48e625"
+      }
+    },
+    {
+      "id": "7153983f-8fd7-4fb9-92ac-0f07a07798b4",
+      "filesystem_pool": "oxp_bf428719-1b16-4503-99f4-ad95846d916f",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::a]:32345",
+        "dataset": {
+          "pool_name": "oxp_bf428719-1b16-4503-99f4-ad95846d916f"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    {
+      "id": "7d44ba36-4a69-490a-bc40-f6f90a4208d4",
+      "filesystem_pool": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::c]:32345",
+        "dataset": {
+          "pool_name": "oxp_414e235b-55c3-4dc1-a568-8adf4ea1a052"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    {
+      "id": "a6ba8273-0320-4dab-b801-281f041b0c50",
+      "filesystem_pool": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::4]:32345",
+        "dataset": {
+          "pool_name": "oxp_8a199f12-4f5c-483a-8aca-f97856658a35"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    {
+      "id": "a700528f-f600-4908-94ac-9c06442ef6b4",
+      "filesystem_pool": "oxp_2115b084-be0f-4fba-941b-33a659798a9e",
+      "zone_type": {
+        "type": "internal_ntp",
+        "address": "[fd00:1122:3344:103::45]:123"
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "2b0988a6122b34391f3310ce1ade733c175316331f408cf1e40329c419318142"
+      }
+    },
+    {
+      "id": "b9b7b4c2-284a-4ec1-80ea-75b7a43b71c4",
+      "filesystem_pool": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::8]:32345",
+        "dataset": {
+          "pool_name": "oxp_cf940e15-dbc5-481b-866a-4de4b018898e"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    },
+    {
+      "id": "e238116d-e5cc-43d4-9c8a-6f138ae8a15d",
+      "filesystem_pool": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040",
+      "zone_type": {
+        "type": "crucible",
+        "address": "[fd00:1122:3344:103::6]:32345",
+        "dataset": {
+          "pool_name": "oxp_e126ddcc-8bee-46ba-8199-2a74df0ba040"
+        }
+      },
+      "image_source": {
+        "type": "artifact",
+        "hash": "988cab6ea184b7912350e5af151bd18152ee2702bad7dc0b977d414eb8062e27"
+      }
+    }
+  ],
+  "remove_mupdate_override": null,
+  "host_phase_2": {
+    "slot_a": {
+      "type": "artifact",
+      "hash": "8234c10964ef7f62880772caaf96f449234bad8428b2a6a09e623d383550bfdf"
+    },
+    "slot_b": {
+      "type": "artifact",
+      "hash": "8234c10964ef7f62880772caaf96f449234bad8428b2a6a09e623d383550bfdf"
+    }
+  },
+  "measurements": [],
+  "update_disposition": "available"
+}

--- a/sled-agent/config-reconciler/src/ledger.rs
+++ b/sled-agent/config-reconciler/src/ledger.rs
@@ -6,7 +6,7 @@
 
 use camino::Utf8PathBuf;
 use dropshot::HttpError;
-use omicron_generation_kinds::Generation;
+use omicron_generation_kinds::SledConfigGeneration;
 use omicron_ledger as ledger;
 use omicron_ledger::Ledger;
 use sled_agent_types::artifact::ArtifactConfig;
@@ -64,9 +64,12 @@ pub enum LedgerNewConfigError {
     #[error(
         "sled config generation out of date (got {requested}, have {current})"
     )]
-    GenerationOutdated { current: Generation, requested: Generation },
+    GenerationOutdated {
+        current: SledConfigGeneration,
+        requested: SledConfigGeneration,
+    },
     #[error("sled config changed with the same generation ({generation})")]
-    ConfigurationChanged { generation: Generation },
+    ConfigurationChanged { generation: SledConfigGeneration },
     #[error("failed to commit sled config to ledger")]
     LedgerCommitFailed(#[source] ledger::Error),
     #[error("sled config is invalid: {0}")]
@@ -681,6 +684,7 @@ mod tests {
     use camino_tempfile::tempfile;
     use iddqd::IdOrdMap;
     use illumos_utils::zpool::ZpoolName;
+    use omicron_generation_kinds::Generation;
     use omicron_test_utils::dev;
     use omicron_test_utils::dev::poll::wait_for_watch_channel_condition;
     use omicron_uuid_kinds::InternalZpoolUuid;
@@ -880,7 +884,7 @@ mod tests {
     // particular contents.
     fn make_nonempty_sled_config() -> OmicronSledConfig {
         OmicronSledConfig {
-            generation: Generation::new().next(),
+            generation: SledConfigGeneration::new().next(),
             disks: [make_dummy_disk_config("test-serial")]
                 .into_iter()
                 .collect(),
@@ -1009,16 +1013,17 @@ mod tests {
         let logctx = dev::test_setup_log("reject_old_config_generation");
 
         // Set up the ledger task with an initial config (with a generation >
-        // `Generation::new()`, so we can test sending a lower generation).
+        // `SledConfigGeneration::new()`, so we can test sending a lower
+        // generation).
         let mut sled_config = make_nonempty_sled_config();
-        assert!(sled_config.generation > Generation::new());
+        assert!(sled_config.generation > SledConfigGeneration::new());
 
         let test_harness =
             TestHarness::with_initial_config(logctx.log.clone(), &sled_config)
                 .await;
 
         // Try to send a lower generation; the task should reject this.
-        sled_config.generation = Generation::new();
+        sled_config.generation = SledConfigGeneration::new();
         let err = test_harness
             .task_handle
             .set_new_config(sled_config)
@@ -1082,7 +1087,7 @@ mod tests {
         // Create a config that references a zone with a different artifact
         // hash.
         let mut config = OmicronSledConfig {
-            generation: Generation::new().next(),
+            generation: SledConfigGeneration::new().next(),
             disks: IdOrdMap::new(),
             datasets: IdOrdMap::new(),
             zones: [make_dummy_zone_config_using_artifact_hash(

--- a/sled-agent/config-reconciler/src/ledger/ledgered_sled_config_versioning.rs
+++ b/sled-agent/config-reconciler/src/ledger/ledgered_sled_config_versioning.rs
@@ -15,6 +15,7 @@ use sled_agent_types_versions::v10;
 use sled_agent_types_versions::v11;
 use sled_agent_types_versions::v14;
 use sled_agent_types_versions::v49;
+use sled_agent_types_versions::v50;
 use slog::Logger;
 use slog::info;
 use slog::warn;
@@ -66,6 +67,7 @@ macro_rules! version_conversion_chain {
 // attempt to parse the ledgered config. Add new versions to the top of the
 // list.
 version_conversion_chain!(
+    v50::inventory::OmicronSledConfig,
     v49::inventory::OmicronSledConfig,
     v14::inventory::OmicronSledConfig,
     v11::inventory::OmicronSledConfig,
@@ -276,6 +278,8 @@ pub(super) mod tests {
         "expectorate/v14-sled-config.json";
     const EXPECTORATE_V49_CONFIG_PATH: &str =
         "expectorate/v49-sled-config.json";
+    const EXPECTORATE_V50_CONFIG_PATH: &str =
+        "expectorate/v50-sled-config.json";
 
     // This is solely an expectorate test to guarantee:
     //
@@ -305,6 +309,7 @@ pub(super) mod tests {
         let v14 = v14::inventory::OmicronSledConfig::try_from(v11.clone())
             .expect("converted from v11");
         let v49 = v49::inventory::OmicronSledConfig::from(v14.clone());
+        let v50 = v50::inventory::OmicronSledConfig::from(v49.clone());
 
         expectorate::assert_contents(
             EXPECTORATE_V10_CONFIG_PATH,
@@ -322,6 +327,10 @@ pub(super) mod tests {
             EXPECTORATE_V49_CONFIG_PATH,
             &serde_json::to_string_pretty(&v49).unwrap(),
         );
+        expectorate::assert_contents(
+            EXPECTORATE_V50_CONFIG_PATH,
+            &serde_json::to_string_pretty(&v50).unwrap(),
+        );
         logctx.cleanup_successful();
     }
 
@@ -336,28 +345,25 @@ pub(super) mod tests {
         // compilation error if the latest version changes. Bump the
         // version here and add the new version's path to the array of ledger
         // paths below.
-        let latest_version_path = EXPECTORATE_V49_CONFIG_PATH;
-        let expected_config = v49::inventory::OmicronSledConfig::read_from(
-            log,
-            latest_version_path.into(),
-        )
-        .await
-        .expect("read expected config");
+        type LatestConfig = v50::inventory::OmicronSledConfig;
+        let latest_version_path = EXPECTORATE_V50_CONFIG_PATH;
+        let expected_config =
+            LatestConfig::read_from(log, latest_version_path.into())
+                .await
+                .expect("read expected config");
 
         // Reading old configs should rewrite the file to match the newest
         // version.
         let expected_rewritten =
             serde_json::to_string(&expected_config).expect("serialized config");
 
-        // If no conversion was necessary, we should keep the same contents.
-        // This is semantically equivalent to `expected_rewritten` but may be
-        // formatted differently (e.g., our expectorate files are written
-        // pretty-printed, but ledgered files generally aren't).
-        let expected_unchanged = tokio::fs::read_to_string(latest_version_path)
-            .await
-            .expect("read latest version");
-
         let tempdir = Utf8TempDir::new().unwrap();
+
+        // Guard against every fixture silently taking one branch (e.g. after a
+        // wire-compatible bump or a forgotten array entry) by counting both
+        // branches and asserting that both of them were > 0.
+        let mut converted_count = 0usize;
+        let mut unchanged_count = 0usize;
 
         // For each older version, confirm we can read a ledger of that version
         // and that it's converted to the current version.
@@ -367,14 +373,52 @@ pub(super) mod tests {
             EXPECTORATE_V11_CONFIG_PATH,
             EXPECTORATE_V14_CONFIG_PATH,
             EXPECTORATE_V49_CONFIG_PATH,
+            EXPECTORATE_V50_CONFIG_PATH,
         ] {
             // Copy the ledger into `my-ledger.json`
             let dst_ledger_path = tempdir.child("my-ledger.json");
             dst_ledger_path.write_file(src_ledger_path.into()).unwrap();
 
+            // Read the fixture contents. This is expected to be a
+            // pretty-printed JSON file.
+            let fixture_contents = tokio::fs::read_to_string(src_ledger_path)
+                .await
+                .expect("read source ledger");
+
+            // Does this fixture need conversion (does it parse directly as the
+            // latest version?)
+            //
+            // A source can also parse successfully as the latest version
+            // without being the latest expectorate file, e.g. when a version
+            // bump introduces a transparent newtype.
+            //
+            // Ledger::<LatestConfig>::new is (effectively) the first step of
+            // read_ledgered_sled_config, so the test matches the SUT if a
+            // version ever overrides Ledgerable::deserialize.
+            let parses_as_latest = Ledger::<LatestConfig>::new(
+                log,
+                vec![dst_ledger_path.to_path_buf()],
+            )
+            .await
+            .is_some();
+            if src_ledger_path == V4_CONFIG_PATH {
+                assert!(
+                    !parses_as_latest,
+                    "{src_ledger_path} is the oldest supported version \
+                     and must not parse as the latest version"
+                );
+            }
+            if src_ledger_path == latest_version_path {
+                assert!(
+                    parses_as_latest,
+                    "{src_ledger_path} is the latest version \
+                     and must parse as such"
+                );
+            }
+
             // Attempt to read `my-ledger.json`; this should give us back a
-            // current-version `OmicronSledConfig` and also have rewritten the
-            // config.
+            // current-version `OmicronSledConfig` and, if a conversion was
+            // needed, also have rewritten the config.
             let converted_config = read_ledgered_sled_config(
                 log,
                 vec![dst_ledger_path.to_path_buf()],
@@ -383,16 +427,57 @@ pub(super) mod tests {
             .expect("read and converted ledger");
             assert_eq!(expected_config, converted_config);
 
-            // We should only rewrite the file if we converted it.
             let data = tokio::fs::read_to_string(&dst_ledger_path)
                 .await
                 .expect("read tempdir ledger");
-            if data != expected_unchanged {
-                // The data changed - we must have done a conversion. Assert it
-                // matches what we expect.
-                assert_eq!(data, expected_rewritten);
+            if parses_as_latest {
+                unchanged_count += 1;
+                // Ensure that the fixture contents are *not* byte-identical to
+                // the serialized JSON that a rewrite would produce (fixtures
+                // are pretty-printed while ledgered data is stored as compact
+                // JSON).
+                //
+                // Why? In the assert_eq! below, we depend on the fact that
+                // these two are not the same.
+                //
+                // * The expected behavior here is "if the data is successfully
+                //   parsed as the latest version, the file isn't changed, even
+                //   if what it would serialize to differs from the input".
+                // * If the two were the same, and if we accidentally changed the
+                //   SUT to always rewrite the file, then data == fixture_contents
+                //   would be true even though the SUT had unexpected behavior.
+                assert_ne!(
+                    fixture_contents, expected_rewritten,
+                    "{src_ledger_path} is byte-identical to its compact \
+                     rewrite, so a spurious rewrite would be undetectable"
+                );
+
+                assert_eq!(
+                    data, fixture_contents,
+                    "{src_ledger_path} parses as the latest version \
+                     and must not be rewritten"
+                );
+            } else {
+                converted_count += 1;
+                // We couldn't parse as the latest version, so the file must
+                // have been rewritten in the latest format.
+                assert_eq!(
+                    data, expected_rewritten,
+                    "{src_ledger_path} required conversion \
+                     and must be rewritten"
+                );
             }
         }
+
+        assert!(
+            converted_count > 0,
+            "no fixture required conversion; the conversion chain is untested"
+        );
+        assert!(
+            unchanged_count > 0,
+            "no fixture parsed as the latest version; \
+             the no-conversion path is untested"
+        );
 
         logctx.cleanup_successful();
     }

--- a/sled-agent/config-reconciler/src/ledger/ledgered_sled_config_versioning.rs
+++ b/sled-agent/config-reconciler/src/ledger/ledgered_sled_config_versioning.rs
@@ -336,28 +336,25 @@ pub(super) mod tests {
         // compilation error if the latest version changes. Bump the
         // version here and add the new version's path to the array of ledger
         // paths below.
+        type LatestConfig = v49::inventory::OmicronSledConfig;
         let latest_version_path = EXPECTORATE_V49_CONFIG_PATH;
-        let expected_config = v49::inventory::OmicronSledConfig::read_from(
-            log,
-            latest_version_path.into(),
-        )
-        .await
-        .expect("read expected config");
+        let expected_config =
+            LatestConfig::read_from(log, latest_version_path.into())
+                .await
+                .expect("read expected config");
 
         // Reading old configs should rewrite the file to match the newest
         // version.
         let expected_rewritten =
             serde_json::to_string(&expected_config).expect("serialized config");
 
-        // If no conversion was necessary, we should keep the same contents.
-        // This is semantically equivalent to `expected_rewritten` but may be
-        // formatted differently (e.g., our expectorate files are written
-        // pretty-printed, but ledgered files generally aren't).
-        let expected_unchanged = tokio::fs::read_to_string(latest_version_path)
-            .await
-            .expect("read latest version");
-
         let tempdir = Utf8TempDir::new().unwrap();
+
+        // Guard against every fixture silently taking one branch (e.g. after a
+        // wire-compatible bump or a forgotten array entry) by counting both
+        // branches and asserting that both of them were > 0.
+        let mut converted_count = 0usize;
+        let mut unchanged_count = 0usize;
 
         // For each older version, confirm we can read a ledger of that version
         // and that it's converted to the current version.
@@ -372,9 +369,46 @@ pub(super) mod tests {
             let dst_ledger_path = tempdir.child("my-ledger.json");
             dst_ledger_path.write_file(src_ledger_path.into()).unwrap();
 
+            // Read the fixture contents. This is expected to be a
+            // pretty-printed JSON file.
+            let fixture_contents = tokio::fs::read_to_string(src_ledger_path)
+                .await
+                .expect("read source ledger");
+
+            // Does this fixture need conversion (does it parse directly as the
+            // latest version?)
+            //
+            // A source can also parse successfully as the latest version
+            // without being the latest expectorate file, e.g. when a version
+            // bump introduces a transparent newtype.
+            //
+            // Ledger::<LatestConfig>::new is (effectively) the first step of
+            // read_ledgered_sled_config, so the test matches the SUT if a
+            // version ever overrides Ledgerable::deserialize.
+            let parses_as_latest = Ledger::<LatestConfig>::new(
+                log,
+                vec![dst_ledger_path.to_path_buf()],
+            )
+            .await
+            .is_some();
+            if src_ledger_path == V4_CONFIG_PATH {
+                assert!(
+                    !parses_as_latest,
+                    "{src_ledger_path} is the oldest supported version \
+                     and must not parse as the latest version"
+                );
+            }
+            if src_ledger_path == latest_version_path {
+                assert!(
+                    parses_as_latest,
+                    "{src_ledger_path} is the latest version \
+                     and must parse as such"
+                );
+            }
+
             // Attempt to read `my-ledger.json`; this should give us back a
-            // current-version `OmicronSledConfig` and also have rewritten the
-            // config.
+            // current-version `OmicronSledConfig` and, if a conversion was
+            // needed, also have rewritten the config.
             let converted_config = read_ledgered_sled_config(
                 log,
                 vec![dst_ledger_path.to_path_buf()],
@@ -383,16 +417,57 @@ pub(super) mod tests {
             .expect("read and converted ledger");
             assert_eq!(expected_config, converted_config);
 
-            // We should only rewrite the file if we converted it.
             let data = tokio::fs::read_to_string(&dst_ledger_path)
                 .await
                 .expect("read tempdir ledger");
-            if data != expected_unchanged {
-                // The data changed - we must have done a conversion. Assert it
-                // matches what we expect.
-                assert_eq!(data, expected_rewritten);
+            if parses_as_latest {
+                unchanged_count += 1;
+                // Ensure that the fixture contents are *not* byte-identical to
+                // the serialized JSON that a rewrite would produce (fixtures
+                // are pretty-printed while ledgered data is stored as compact
+                // JSON).
+                //
+                // Why? In the assert_eq! below, we depend on the fact that
+                // these two are not the same.
+                //
+                // * The expected behavior here is "if the data is successfully
+                //   parsed as the latest version, the file isn't changed, even
+                //   if what it would serialize to differs from the input".
+                // * If the two were the same, and if we accidentally changed the
+                //   SUT to always rewrite the file, then data == fixture_contents
+                //   would be true even though the SUT had unexpected behavior.
+                assert_ne!(
+                    fixture_contents, expected_rewritten,
+                    "{src_ledger_path} is byte-identical to its compact \
+                     rewrite, so a spurious rewrite would be undetectable"
+                );
+
+                assert_eq!(
+                    data, fixture_contents,
+                    "{src_ledger_path} parses as the latest version \
+                     and must not be rewritten"
+                );
+            } else {
+                converted_count += 1;
+                // We couldn't parse as the latest version, so the file must
+                // have been rewritten in the latest format.
+                assert_eq!(
+                    data, expected_rewritten,
+                    "{src_ledger_path} required conversion \
+                     and must be rewritten"
+                );
             }
         }
+
+        assert!(
+            converted_count > 0,
+            "no fixture required conversion; the conversion chain is untested"
+        );
+        assert!(
+            unchanged_count > 0,
+            "no fixture parsed as the latest version; \
+             the no-conversion path is untested"
+        );
 
         logctx.cleanup_successful();
     }

--- a/sled-agent/rack-setup/src/plan/service.rs
+++ b/sled-agent/rack-setup/src/plan/service.rs
@@ -50,7 +50,9 @@ use omicron_common::policy::{
     OXIMETER_REDUNDANCY, RESERVED_INTERNAL_DNS_REDUNDANCY,
     SINGLE_NODE_CLICKHOUSE_REDUNDANCY,
 };
-use omicron_generation_kinds::{Generation, TargetReleaseGeneration};
+use omicron_generation_kinds::{
+    Generation, SledConfigGeneration, TargetReleaseGeneration,
+};
 use omicron_uuid_kinds::{
     BlueprintUuid, DatasetUuid, ExternalIpUuid, GenericUuid, OmicronZoneUuid,
     PhysicalDiskUuid, SledUuid, ZpoolUuid,
@@ -911,7 +913,7 @@ impl ServicePlan {
 
     pub fn to_blueprint(
         &self,
-        sled_agent_config_generation: Generation,
+        sled_agent_config_generation: SledConfigGeneration,
     ) -> anyhow::Result<Blueprint> {
         let mut blueprint_sleds = BTreeMap::new();
         for sled_description in &self.all_sleds {

--- a/sled-agent/rack-setup/src/service.rs
+++ b/sled-agent/rack-setup/src/service.rs
@@ -98,7 +98,9 @@ use omicron_common::backoff::{
 };
 use omicron_common::disk::DatasetKind;
 use omicron_ddm_admin_client::DdmError;
-use omicron_generation_kinds::Generation;
+use omicron_generation_kinds::{
+    Generation, GenericGeneration, SledConfigGeneration,
+};
 use omicron_ledger::{self as ledger};
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::RackUuid;
@@ -415,7 +417,7 @@ impl ServiceInner {
     async fn wait_for_config_reconciliation_on_sled(
         &self,
         sled_address: SocketAddrV6,
-        generation: Generation,
+        generation: SledConfigGeneration,
     ) -> Result<(), SetupServiceError> {
         let dur = std::time::Duration::from_secs(60);
         let client = reqwest::ClientBuilder::new()
@@ -566,7 +568,9 @@ impl ServiceInner {
 
                 // We bump the zone generation as we step through phases of
                 // RSS; use that as the overall sled config generation.
-                let generation = zones_config.generation;
+                let generation = SledConfigGeneration::from_untyped_generation(
+                    zones_config.generation,
+                );
                 let sled_config = OmicronSledConfig {
                     generation,
                     disks: config
@@ -1148,7 +1152,9 @@ impl ServiceInner {
                 // `V5_EVERYTHING` (i.e., "don't filter anything out"), so use
                 // that as the generation for all sled configs in the blueprint,
                 // too.
-                DeployStepVersion::V5_EVERYTHING,
+                SledConfigGeneration::from_untyped_generation(
+                    DeployStepVersion::V5_EVERYTHING,
+                ),
             )
             .map_err(SetupServiceError::ConvertPlanToBlueprint)?;
 
@@ -1877,7 +1883,9 @@ mod test {
                 .expect("created service plan");
 
         let blueprint = service_plan
-            .to_blueprint(DeployStepVersion::V5_EVERYTHING)
+            .to_blueprint(SledConfigGeneration::from_untyped_generation(
+                DeployStepVersion::V5_EVERYTHING,
+            ))
             .expect("built blueprint");
 
         let report = Blippy::new_blueprint_only(&blueprint)

--- a/sled-agent/types/versions/src/impls/inventory.rs
+++ b/sled-agent/types/versions/src/impls/inventory.rs
@@ -15,7 +15,7 @@ use omicron_common::address::Ip;
 use omicron_common::address::NUM_SOURCE_NAT_PORTS;
 use omicron_common::disk::{DatasetKind, DatasetName};
 use omicron_common::update::OmicronInstallManifestSource;
-use omicron_generation_kinds::Generation;
+use omicron_generation_kinds::{Generation, SledConfigGeneration};
 use omicron_uuid_kinds::MupdateUuid;
 use tufaceous_artifact::ArtifactHash;
 
@@ -871,7 +871,7 @@ impl HostPhase2DesiredSlots {
 impl Default for OmicronSledConfig {
     fn default() -> Self {
         Self {
-            generation: Generation::new(),
+            generation: SledConfigGeneration::new(),
             disks: IdOrdMap::default(),
             datasets: IdOrdMap::default(),
             zones: IdOrdMap::default(),

--- a/sled-agent/types/versions/src/latest.rs
+++ b/sled-agent/types/versions/src/latest.rs
@@ -201,11 +201,12 @@ pub mod inventory {
     pub use crate::v46::inventory::SvcsEnabledNotOnline;
     pub use crate::v46::inventory::SvcsEnabledNotOnlineResult;
 
-    pub use crate::v49::inventory::ConfigReconcilerInventory;
-    pub use crate::v49::inventory::ConfigReconcilerInventoryStatus;
-    pub use crate::v49::inventory::Inventory;
-    pub use crate::v49::inventory::OmicronSledConfig;
     pub use crate::v49::inventory::OmicronSledUpdateDisposition;
+
+    pub use crate::v50::inventory::ConfigReconcilerInventory;
+    pub use crate::v50::inventory::ConfigReconcilerInventoryStatus;
+    pub use crate::v50::inventory::Inventory;
+    pub use crate::v50::inventory::OmicronSledConfig;
 
     pub use crate::impls::inventory::FmdHostCaseDisplay;
     pub use crate::impls::inventory::FmdInventoryDisplay;

--- a/sled-agent/types/versions/src/lib.rs
+++ b/sled-agent/types/versions/src/lib.rs
@@ -103,6 +103,8 @@ pub mod v47;
 pub mod v48;
 #[path = "add_update_disposition/mod.rs"]
 pub mod v49;
+#[path = "typed_sled_config_generation/mod.rs"]
+pub mod v50;
 #[path = "add_probe_put_endpoint/mod.rs"]
 pub mod v6;
 #[path = "multicast_support/mod.rs"]

--- a/sled-agent/types/versions/src/typed_sled_config_generation/inventory.rs
+++ b/sled-agent/types/versions/src/typed_sled_config_generation/inventory.rs
@@ -1,0 +1,284 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use chrono::{DateTime, Utc};
+use iddqd::IdOrdMap;
+use omicron_common::api::external::ByteCount;
+use omicron_common::snake_case_result;
+use omicron_common::snake_case_result::SnakeCaseResult;
+use omicron_generation_kinds::{GenericGeneration, SledConfigGeneration};
+use omicron_ledger::Ledgerable;
+use omicron_uuid_kinds::{
+    DatasetUuid, MupdateOverrideUuid, OmicronZoneUuid, PhysicalDiskUuid,
+    SledUuid,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sled_hardware_types::{BaseboardId, SledCpuFamily};
+use std::collections::{BTreeMap, BTreeSet};
+use std::net::SocketAddrV6;
+use std::time::Duration;
+
+use crate::v1::disk::{DatasetConfig, OmicronPhysicalDiskConfig};
+use crate::v1::inventory::{
+    BootPartitionContents, ConfigReconcilerInventoryResult,
+    HostPhase2DesiredSlots, InventoryDataset, InventoryDisk, OrphanedDataset,
+    RemoveMupdateOverrideInventory, SledRole,
+};
+use crate::v11::inventory::OmicronZoneConfig;
+use crate::v14::inventory::{
+    OmicronFileSourceResolverInventory, OmicronSingleMeasurement,
+};
+use crate::v16::inventory::SingleMeasurementInventory;
+use crate::v24::inventory::InventoryZpool;
+use crate::v40::inventory::{FmdInventory, FmdInventoryError};
+use crate::v46::inventory::SvcsEnabledNotOnlineResult;
+use crate::v49;
+use crate::v49::inventory::OmicronSledUpdateDisposition;
+
+/// Describes the set of Reconfigurator-managed configuration elements of a sled
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct OmicronSledConfig {
+    pub generation: SledConfigGeneration,
+    pub disks: IdOrdMap<OmicronPhysicalDiskConfig>,
+    pub datasets: IdOrdMap<DatasetConfig>,
+    pub zones: IdOrdMap<OmicronZoneConfig>,
+    pub remove_mupdate_override: Option<MupdateOverrideUuid>,
+    pub host_phase_2: HostPhase2DesiredSlots,
+    pub measurements: BTreeSet<OmicronSingleMeasurement>,
+    pub update_disposition: OmicronSledUpdateDisposition,
+}
+
+// NOTE: Most trait impls live in the `impls` module of this crate and are only
+// implemented for the `latest` version of each type. However,
+// `OmicronSledConfig` is special: it's not only used in the sled-agent API
+// (which would only require trait impls on `latest`); it's also ledgered to
+// disk to support cold boot of the rack. In the ledgering case, we have to be
+// able to handle reading older versions, which means all the old versions we
+// support also need to implement `Ledgerable`. Therefore, we implement this
+// trait for this specific version (and do so for every other version of
+// `OmicronSledConfig` too).
+impl Ledgerable for OmicronSledConfig {
+    fn is_newer_than(&self, other: &Self) -> bool {
+        self.generation > other.generation
+    }
+
+    fn generation_bump(&mut self) {
+        // DO NOTHING!
+        //
+        // Generation bumps must only ever come from nexus and will be encoded
+        // in the struct itself
+    }
+}
+
+impl From<OmicronSledConfig> for v49::inventory::OmicronSledConfig {
+    fn from(value: OmicronSledConfig) -> Self {
+        let OmicronSledConfig {
+            generation,
+            disks,
+            datasets,
+            zones,
+            remove_mupdate_override,
+            host_phase_2,
+            measurements,
+            update_disposition,
+        } = value;
+        Self {
+            generation: generation.into_untyped_generation(),
+            disks,
+            datasets,
+            zones,
+            remove_mupdate_override,
+            host_phase_2,
+            measurements,
+            update_disposition,
+        }
+    }
+}
+
+impl From<v49::inventory::OmicronSledConfig> for OmicronSledConfig {
+    fn from(value: v49::inventory::OmicronSledConfig) -> Self {
+        let v49::inventory::OmicronSledConfig {
+            generation,
+            disks,
+            datasets,
+            zones,
+            remove_mupdate_override,
+            host_phase_2,
+            measurements,
+            update_disposition,
+        } = value;
+        Self {
+            generation: SledConfigGeneration::from_untyped_generation(
+                generation,
+            ),
+            disks,
+            datasets,
+            zones,
+            remove_mupdate_override,
+            host_phase_2,
+            measurements,
+            update_disposition,
+        }
+    }
+}
+
+/// Describes the last attempt made by the sled-agent-config-reconciler to
+/// reconcile the current sled config against the actual state of the sled.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ConfigReconcilerInventory {
+    pub last_reconciled_config: OmicronSledConfig,
+    pub external_disks:
+        BTreeMap<PhysicalDiskUuid, ConfigReconcilerInventoryResult>,
+    pub datasets: BTreeMap<DatasetUuid, ConfigReconcilerInventoryResult>,
+    pub orphaned_datasets: IdOrdMap<OrphanedDataset>,
+    pub zones: BTreeMap<OmicronZoneUuid, ConfigReconcilerInventoryResult>,
+    pub boot_partitions: BootPartitionContents,
+    /// The result of removing the mupdate override file on disk.
+    ///
+    /// `None` if `remove_mupdate_override` was not provided in the sled config.
+    pub remove_mupdate_override: Option<RemoveMupdateOverrideInventory>,
+}
+
+impl From<ConfigReconcilerInventory>
+    for v49::inventory::ConfigReconcilerInventory
+{
+    fn from(value: ConfigReconcilerInventory) -> Self {
+        let ConfigReconcilerInventory {
+            last_reconciled_config,
+            external_disks,
+            datasets,
+            orphaned_datasets,
+            zones,
+            boot_partitions,
+            remove_mupdate_override,
+        } = value;
+        Self {
+            last_reconciled_config: last_reconciled_config.into(),
+            external_disks,
+            datasets,
+            orphaned_datasets,
+            zones,
+            boot_partitions,
+            remove_mupdate_override,
+        }
+    }
+}
+
+/// Status of the sled-agent-config-reconciler task.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ConfigReconcilerInventoryStatus {
+    /// The reconciler task has not yet run for the first time since sled-agent
+    /// started.
+    NotYetRun,
+    /// The reconciler task is actively running.
+    Running {
+        config: Box<OmicronSledConfig>,
+        started_at: DateTime<Utc>,
+        running_for: Duration,
+    },
+    /// The reconciler task is currently idle, but previously did complete a
+    /// reconciliation attempt.
+    ///
+    /// This variant does not include the `OmicronSledConfig` used in the last
+    /// attempt, because that's always available via
+    /// [`ConfigReconcilerInventory::last_reconciled_config`].
+    Idle { completed_at: DateTime<Utc>, ran_for: Duration },
+}
+
+impl From<ConfigReconcilerInventoryStatus>
+    for v49::inventory::ConfigReconcilerInventoryStatus
+{
+    fn from(value: ConfigReconcilerInventoryStatus) -> Self {
+        match value {
+            ConfigReconcilerInventoryStatus::NotYetRun => Self::NotYetRun,
+            ConfigReconcilerInventoryStatus::Running {
+                config,
+                started_at,
+                running_for,
+            } => Self::Running {
+                config: Box::new((*config).into()),
+                started_at,
+                running_for,
+            },
+            ConfigReconcilerInventoryStatus::Idle { completed_at, ran_for } => {
+                Self::Idle { completed_at, ran_for }
+            }
+        }
+    }
+}
+
+/// Identity and basic status information about this sled agent
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+pub struct Inventory {
+    pub sled_id: SledUuid,
+    pub sled_agent_address: SocketAddrV6,
+    pub sled_role: SledRole,
+    pub baseboard_id: BaseboardId,
+    pub usable_hardware_threads: u32,
+    pub usable_physical_ram: ByteCount,
+    pub cpu_family: SledCpuFamily,
+    pub reservoir_size: ByteCount,
+    pub disks: Vec<InventoryDisk>,
+    pub zpools: Vec<InventoryZpool>,
+    pub datasets: Vec<InventoryDataset>,
+    pub ledgered_sled_config: Option<OmicronSledConfig>,
+    pub reconciler_status: ConfigReconcilerInventoryStatus,
+    pub last_reconciliation: Option<ConfigReconcilerInventory>,
+    pub file_source_resolver: OmicronFileSourceResolverInventory,
+    pub smf_services_enabled_not_online: SvcsEnabledNotOnlineResult,
+    pub reference_measurements: IdOrdMap<SingleMeasurementInventory>,
+    #[serde(with = "snake_case_result")]
+    #[schemars(
+        schema_with = "SnakeCaseResult::<FmdInventory, FmdInventoryError>::json_schema"
+    )]
+    pub fmd: Result<FmdInventory, FmdInventoryError>,
+}
+
+impl From<Inventory> for v49::inventory::Inventory {
+    fn from(value: Inventory) -> Self {
+        let Inventory {
+            sled_id,
+            sled_agent_address,
+            sled_role,
+            baseboard_id,
+            usable_hardware_threads,
+            usable_physical_ram,
+            cpu_family,
+            reservoir_size,
+            disks,
+            zpools,
+            datasets,
+            ledgered_sled_config,
+            reconciler_status,
+            last_reconciliation,
+            file_source_resolver,
+            smf_services_enabled_not_online,
+            reference_measurements,
+            fmd,
+        } = value;
+        Self {
+            sled_id,
+            sled_agent_address,
+            sled_role,
+            baseboard_id,
+            usable_hardware_threads,
+            usable_physical_ram,
+            cpu_family,
+            reservoir_size,
+            disks,
+            zpools,
+            datasets,
+            ledgered_sled_config: ledgered_sled_config.map(Into::into),
+            reconciler_status: reconciler_status.into(),
+            last_reconciliation: last_reconciliation.map(Into::into),
+            file_source_resolver,
+            smf_services_enabled_not_online,
+            reference_measurements,
+            fmd,
+        }
+    }
+}

--- a/sled-agent/types/versions/src/typed_sled_config_generation/mod.rs
+++ b/sled-agent/types/versions/src/typed_sled_config_generation/mod.rs
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Version `TYPED_SLED_CONFIG_GENERATION` of the Sled Agent API.
+//!
+//! This version changes the generation number of `OmicronSledConfig` from an
+//! untyped `Generation` to a typed `SledConfigGeneration`.
+
+pub mod inventory;


### PR DESCRIPTION
Requires a sled agent API bump even though this is a wire-compatible change.

Note that ledgered data from the last version is successfully deserialized, so it isn't rewritten. This is fine because there aren't any semantic changes here.

Depends on:

* #11165
