### PR TITLE
Support multiple external IPs in service NAT entries

### DIFF
--- a/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/nat/tests.rs
+++ b/sled-agent/scrimlet-reconcilers/src/dpd_reconciler/nat/tests.rs
@@ -132,7 +132,8 @@ fn filter_out_overlapping_arbitrary_service_entries(
 ) -> bool {
     let mut entry_ips = BTreeSet::new();
     for entry in entries {
-        if desired_service_nat_entries.contains_key(&entry.zone_id) {
+        let key = (entry.zone_id, entry.kind.external_ip());
+        if desired_service_nat_entries.contains_key(&key) {
             return false;
         }
         if !entry_ips.insert(collapse_ipv4_mapped(entry.kind.external_ip())) {

--- a/sled-agent/types/versions/src/bootstore_service_nat/system_networking.rs
+++ b/sled-agent/types/versions/src/bootstore_service_nat/system_networking.rs
@@ -83,10 +83,10 @@ pub struct ServiceZoneNatEntry {
 }
 
 impl IdOrdItem for ServiceZoneNatEntry {
-    type Key<'a> = OmicronZoneUuid;
+    type Key<'a> = (OmicronZoneUuid, IpAddr);
 
     fn key(&self) -> Self::Key<'_> {
-        self.zone_id
+        (self.zone_id, self.kind.external_ip())
     }
 
     iddqd::id_upcast!();


### PR DESCRIPTION
- Modifies the key-type for the `ServiceNatEntry` type to include the IP address in addition to the zone ID. This lets us support multiple EIPs per-zone. This works without any changes to serialization because the key never appears in the serialized form, only the values. The keys are reconstructed from the values.
- Closes #11162