### PR TITLE
nix: configure pq-sys to use nix's libpq

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -442,6 +442,9 @@
             OPENSSL_DIR = "${openssl.dev}";
             OPENSSL_LIB_DIR = "${openssl.out}/lib";
 
+            # Needed so `pq-sys` uses Nix's `libpq` instead of the host's.
+            PQ_LIB_DIR = "${postgresql.lib}/lib";
+
             # Needed by rustfmt-wrapper, see:
             # https://github.com/oxidecomputer/rustfmt-wrapper/blob/main/src/lib.rs
             RUSTFMT = "${rustToolchain}/bin/rustfmt";


### PR DESCRIPTION
When `pg_config` is installed on the host, `pq-sys` can discover it from inside the Nix development shell and link against the host's `libpq` instead of Nix's. On Arch Linux with `postgresql-libs` installed, this produced a binary that failed to run:

```
> cargo xtask omicron-dev run-all
...
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 53s
     Running `target/debug/omicron-dev run-all`
target/debug/omicron-dev: error while loading shared libraries: libgssapi_krb5.so.2: cannot open shared object file: No such file or directory
```

This patch sets `PQ_LIB_DIR` so `pq-sys` links against Nix's `libpq`. `DEP_PQ_LIBDIRS` is kept so Omicron embeds the corresponding runtime search path.