### PR TITLE
[nexus] slightly better error types for blueprint planning

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -1513,6 +1513,14 @@ fn print_task_blueprint_planner(details: &serde_json::Value) {
         BlueprintPlannerStatus::Disabled => {
             println!("    blueprint planning explicitly disabled by config!");
         }
+        BlueprintPlannerStatus::Skipped(reason) => {
+            println!("    blueprint planning skipped: {reason}");
+            println!(
+                "    (this resolves once the \"{}\" task loads a value; check \
+                 that task if it persists)",
+                reason.loader_task_name(),
+            );
+        }
         BlueprintPlannerStatus::LimitReached { limit, report } => {
             println!(
                 "    blueprint auto-planning disabled because \
@@ -1526,12 +1534,12 @@ fn print_task_blueprint_planner(details: &serde_json::Value) {
             println!("    task did not complete successfully: {error}");
         }
         BlueprintPlannerStatus::Unchanged {
-            parent_blueprint_id,
+            parent,
             report,
             blueprint_count,
             limit,
         } => {
-            println!("    plan unchanged from parent {parent_blueprint_id}");
+            println!("    plan unchanged from parent {}", parent.target_id);
             println!(
                 "    note: {}/{} blueprints in database",
                 blueprint_count, limit
@@ -1539,15 +1547,16 @@ fn print_task_blueprint_planner(details: &serde_json::Value) {
             println!("{report}");
         }
         BlueprintPlannerStatus::Planned {
-            parent_blueprint_id,
+            parent,
             error,
             report,
             blueprint_count,
             limit,
         } => {
             println!(
-                "    planned new blueprint from parent {parent_blueprint_id}, \
-                     but could not make it the target: {error}"
+                "    planned new blueprint from parent {}, but could not make \
+                 it the target: {error}",
+                parent.target_id,
             );
             println!(
                 "    note: {}/{} blueprints in database",
@@ -1556,15 +1565,20 @@ fn print_task_blueprint_planner(details: &serde_json::Value) {
             println!("{report}");
         }
         BlueprintPlannerStatus::Targeted {
-            parent_blueprint_id: _,
-            blueprint_id,
+            parent: _,
+            target,
             report,
             blueprint_count,
             limit,
         } => {
             println!(
-                "    planned new blueprint {blueprint_id}, \
-                     and made it the current target"
+                "    planned new blueprint {}, and made it the current target \
+                 (execution {}, at {})",
+                target.target_id,
+                if target.enabled { "enabled" } else { "disabled" },
+                humantime::format_rfc3339_millis(
+                    target.time_made_target.into()
+                ),
             );
             println!(
                 "    note: {}/{} blueprints in database",

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -85,6 +85,7 @@ use nexus_types::deployment::BlueprintSingleMeasurement;
 use nexus_types::deployment::BlueprintSledConfig;
 use nexus_types::deployment::BlueprintSource;
 use nexus_types::deployment::BlueprintTarget;
+use nexus_types::deployment::BlueprintTargetSetError;
 use nexus_types::deployment::ClickhouseClusterConfig;
 use nexus_types::deployment::CockroachDbPreserveDowngrade;
 use nexus_types::deployment::ExpectedVersion;
@@ -102,7 +103,6 @@ use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupType;
-use omicron_common::api::external::ResourceType;
 use omicron_common::bail_unless;
 use omicron_generation_kinds::Generation;
 use omicron_uuid_kinds::BlueprintKind;
@@ -2134,7 +2134,7 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         target: BlueprintTarget,
-    ) -> Result<(), Error> {
+    ) -> Result<(), BlueprintTargetSetError> {
         let conn = self.pool_connection_authorized(opctx).await?;
         Self::blueprint_target_set_current_on_connection(&conn, opctx, target)
             .await
@@ -2146,7 +2146,7 @@ impl DataStore {
         conn: &async_bb8_diesel::Connection<DbConnection>,
         opctx: &OpContext,
         target: BlueprintTarget,
-    ) -> Result<(), Error> {
+    ) -> Result<(), BlueprintTargetSetError> {
         opctx
             .authorize(authz::Action::Modify, &authz::BLUEPRINT_CONFIG)
             .await?;
@@ -2158,9 +2158,7 @@ impl DataStore {
         )
         .execute_async(conn)
         .await
-        .map_err(|e| {
-            Error::from(decode_target_insert_error(target.target_id, e))
-        })?;
+        .map_err(|e| decode_target_insert_error(target.target_id, e))?;
 
         Ok(())
     }
@@ -2906,38 +2904,6 @@ fn authz_blueprint_from_id(blueprint_id: BlueprintUuid) -> authz::Blueprint {
     )
 }
 
-/// Errors related to inserting a target blueprint
-#[derive(Debug)]
-enum InsertTargetError {
-    /// The requested target blueprint ID does not exist in the blueprint table.
-    NoSuchBlueprint(BlueprintUuid),
-    /// The requested target blueprint's parent does not match the current
-    /// target.
-    ParentNotTarget(BlueprintUuid),
-    /// Any other error
-    Other(DieselError),
-}
-
-impl From<InsertTargetError> for Error {
-    fn from(value: InsertTargetError) -> Self {
-        match value {
-            InsertTargetError::NoSuchBlueprint(id) => Error::not_found_by_id(
-                ResourceType::Blueprint,
-                id.as_untyped_uuid(),
-            ),
-            InsertTargetError::ParentNotTarget(id) => {
-                Error::invalid_request(format!(
-                    "Blueprint {id}'s parent blueprint is not the current \
-                     target blueprint"
-                ))
-            }
-            InsertTargetError::Other(e) => {
-                public_error_from_diesel(e, ErrorHandler::Server)
-            }
-        }
-    }
-}
-
 // Uncastable sentinel used to detect we attempt to make a blueprint the target
 // when it does not exist in the blueprint table.
 const NO_SUCH_BLUEPRINT_SENTINEL: &str = "no-such-blueprint";
@@ -2955,19 +2921,22 @@ const PARENT_NOT_TARGET_ERROR_MESSAGE: &str = "could not parse \"parent-not-targ
 fn decode_target_insert_error(
     target_id: BlueprintUuid,
     err: DieselError,
-) -> InsertTargetError {
+) -> BlueprintTargetSetError {
     match err {
         DieselError::DatabaseError(DatabaseErrorKind::Unknown, info)
             if info.message() == NO_SUCH_BLUEPRINT_ERROR_MESSAGE =>
         {
-            InsertTargetError::NoSuchBlueprint(target_id)
+            BlueprintTargetSetError::NoSuchBlueprint { blueprint_id: target_id }
         }
         DieselError::DatabaseError(DatabaseErrorKind::Unknown, info)
             if info.message() == PARENT_NOT_TARGET_ERROR_MESSAGE =>
         {
-            InsertTargetError::ParentNotTarget(target_id)
+            BlueprintTargetSetError::ParentNotTarget { blueprint_id: target_id }
         }
-        other => InsertTargetError::Other(other),
+        other => BlueprintTargetSetError::Other(public_error_from_diesel(
+            other,
+            ErrorHandler::Server,
+        )),
     }
 }
 
@@ -4187,9 +4156,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err,
-            Error::from(InsertTargetError::NoSuchBlueprint(
-                nonexistent_blueprint_id
-            ))
+            BlueprintTargetSetError::NoSuchBlueprint {
+                blueprint_id: nonexistent_blueprint_id
+            }
         );
 
         // There should be no current target; this is never expected in a real
@@ -4256,7 +4225,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err,
-            Error::from(InsertTargetError::ParentNotTarget(blueprint2.id))
+            BlueprintTargetSetError::ParentNotTarget {
+                blueprint_id: blueprint2.id
+            }
         );
 
         // There should be no current target; this is never expected in a real
@@ -4299,7 +4270,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err,
-            Error::from(InsertTargetError::ParentNotTarget(blueprint1.id))
+            BlueprintTargetSetError::ParentNotTarget {
+                blueprint_id: blueprint1.id
+            }
         );
         let err = datastore
             .blueprint_target_set_current(&opctx, bp2_target)
@@ -4307,7 +4280,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err,
-            Error::from(InsertTargetError::ParentNotTarget(blueprint2.id))
+            BlueprintTargetSetError::ParentNotTarget {
+                blueprint_id: blueprint2.id
+            }
         );
 
         // Create a child of blueprint3, and ensure when we set it as the target

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -858,7 +858,8 @@ impl DataStore {
                              as target";
                             &e,
                         );
-                        err.set(RackInitError::BlueprintTargetSet(e)).unwrap();
+                        err.set(RackInitError::BlueprintTargetSet(e.into()))
+                            .unwrap();
                         DieselError::RollbackTransaction
                     })?;
 

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -9,20 +9,22 @@ use crate::app::BlueprintDebugAction;
 use crate::app::background::BackgroundTask;
 use crate::app::background::tasks::blueprint_load::LoadedTargetBlueprint;
 use crate::app::deployment::SetTargetDebugWriter;
-use chrono::Utc;
 use futures::future::BoxFuture;
 use iddqd::IdOrdMap;
 use nexus_auth::authz;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
 use nexus_db_queries::db::DataStore;
+use nexus_inventory::now_db_precision;
 use nexus_reconfigurator_planning::planner::Planner;
 use nexus_reconfigurator_planning::planner::PlannerRng;
 use nexus_reconfigurator_preparation::PlanningInputFromDb;
 use nexus_reconfigurator_preparation::reconfigurator_state_assemble;
 use nexus_types::deployment::BlueprintSource;
 use nexus_types::deployment::BlueprintTarget;
+use nexus_types::deployment::BlueprintTargetSetError;
 use nexus_types::deployment::PlanningReport;
+use nexus_types::internal_api::background::BlueprintPlannerSkipReason;
 use nexus_types::internal_api::background::BlueprintPlannerStatus;
 use nexus_types::inventory::Collection;
 use omicron_common::api::external::Error;
@@ -39,10 +41,8 @@ use tokio::sync::watch::{self, Receiver, Sender};
 #[derive(Debug, thiserror::Error)]
 enum PlanError {
     // Warning-level problems
-    #[error("no target blueprint available")]
-    NoTargetBlueprint,
-    #[error("no inventory collection available")]
-    NoInventoryCollection,
+    #[error(transparent)]
+    Skipped(BlueprintPlannerSkipReason),
 
     // Error-level problems
     #[error("failed to assemble planning input")]
@@ -137,14 +137,14 @@ impl BlueprintPlanner {
             Ok(status) => status,
             Err(plan_error) => {
                 let error = InlineErrorChain::new(&plan_error);
-                match &plan_error {
-                    PlanError::NoTargetBlueprint
-                    | PlanError::NoInventoryCollection => {
+                match plan_error {
+                    PlanError::Skipped(reason) => {
                         warn!(
                             &opctx.log,
                             "blueprint planning skipped";
                             &error,
                         );
+                        BlueprintPlannerStatus::Skipped(reason)
                     }
                     PlanError::AssemblePlanningInput(_)
                     | PlanError::MakePlanner { .. }
@@ -155,9 +155,9 @@ impl BlueprintPlanner {
                             "blueprint planning failed";
                             &error,
                         );
+                        BlueprintPlannerStatus::Error(error.to_string())
                     }
                 }
-                BlueprintPlannerStatus::Error(error.to_string())
             }
         }
     }
@@ -186,10 +186,14 @@ impl BlueprintPlanner {
 
         // Get the current target blueprint to use as a parent.
         // Cloned so that we don't block the channel.
-        let Some(LoadedTargetBlueprint { target, blueprint: parent }) =
-            self.rx_blueprint.borrow_and_update().clone()
+        let Some(LoadedTargetBlueprint {
+            target: parent_target,
+            blueprint: parent,
+        }) = self.rx_blueprint.borrow_and_update().clone()
         else {
-            return Err(PlanError::NoTargetBlueprint);
+            return Err(PlanError::Skipped(
+                BlueprintPlannerSkipReason::NoTargetBlueprint,
+            ));
         };
         let parent_blueprint_id = parent.id;
 
@@ -199,7 +203,9 @@ impl BlueprintPlanner {
         let Some(collection) =
             self.rx_inventory.borrow_and_update().as_ref().map(Arc::clone)
         else {
-            return Err(PlanError::NoInventoryCollection);
+            return Err(PlanError::Skipped(
+                BlueprintPlannerSkipReason::NoInventoryCollection,
+            ));
         };
 
         // Assemble the planning context.
@@ -271,7 +277,7 @@ impl BlueprintPlanner {
                     "parent_blueprint_id" => %parent_blueprint_id,
                 );
                 return Ok(BlueprintPlannerStatus::Unchanged {
-                    parent_blueprint_id,
+                    parent: parent_target,
                     report,
                     blueprint_count,
                     limit: self.blueprint_limit,
@@ -305,7 +311,7 @@ impl BlueprintPlanner {
             input,
             IdOrdMap::from_iter([(*collection).clone()]),
             IdOrdMap::from_iter([(*parent).clone(), blueprint.clone()]),
-            target,
+            parent_target,
             Some(blueprint_id),
         )
         .await;
@@ -320,18 +326,40 @@ impl BlueprintPlanner {
         // Try to make it the current target.
         let target = BlueprintTarget {
             target_id: blueprint_id,
-            enabled: target.enabled, // copy previous `enabled` flag
-            time_made_target: Utc::now(),
+            enabled: parent_target.enabled, // copy previous `enabled` flag
+            time_made_target: now_db_precision(),
         };
         match self.datastore.blueprint_target_set_current(opctx, target).await {
             Ok(()) => (),
             Err(error) => {
-                warn!(
-                    &opctx.log,
-                    "can't make blueprint the current target, deleting it";
-                    "error" => %error,
-                    "blueprint_id" => %blueprint_id
-                );
+                match &error {
+                    BlueprintTargetSetError::ParentNotTarget { .. } => {
+                        // Either the loader hasn't caught up with a target set
+                        // by someone else, or another Nexus instance's planner
+                        // beat us to it. Neither of these are error conditions.
+                        warn!(
+                            &opctx.log,
+                            "can't make blueprint the current target, \
+                             deleting it";
+                            &error,
+                            "blueprint_id" => %blueprint_id,
+                        );
+                    }
+                    BlueprintTargetSetError::NoSuchBlueprint { .. }
+                    | BlueprintTargetSetError::Other(_) => {
+                        // We inserted this blueprint moments ago, so it not
+                        // existing is an invariant violation, and any other
+                        // failure is a database or authorization problem. These
+                        // are both error conditions.
+                        error!(
+                            &opctx.log,
+                            "can't make blueprint the current target, \
+                             deleting it";
+                            &error,
+                            "blueprint_id" => %blueprint_id,
+                        );
+                    }
+                }
 
                 // Try to cancel the dropbox deposit since the information is
                 // useless now.
@@ -359,8 +387,8 @@ impl BlueprintPlanner {
                     }
                 }
                 return Ok(BlueprintPlannerStatus::Planned {
-                    parent_blueprint_id,
-                    error: format!("{error}"),
+                    parent: parent_target,
+                    error,
                     report,
                     blueprint_count,
                     limit: self.blueprint_limit,
@@ -379,8 +407,8 @@ impl BlueprintPlanner {
 
         self.tx_planned.send_replace(Some(blueprint.id));
         Ok(BlueprintPlannerStatus::Targeted {
-            parent_blueprint_id,
-            blueprint_id,
+            parent: parent_target,
+            target,
             report,
             // A new blueprint was added, so increment the count by 1.
             blueprint_count: blueprint_count + 1,
@@ -583,15 +611,15 @@ mod test {
         .expect("can't activate planner");
         let blueprint_id = match status {
             BlueprintPlannerStatus::Targeted {
-                parent_blueprint_id,
-                blueprint_id,
+                parent,
+                target,
                 report: _,
                 blueprint_count: _,
                 limit: _,
-            } if parent_blueprint_id == initial_blueprint.id
-                && blueprint_id != initial_blueprint.id =>
+            } if parent.target_id == initial_blueprint.id
+                && target.target_id != initial_blueprint.id =>
             {
-                blueprint_id
+                target.target_id
             }
             other => panic!("expected new target blueprint, found {other:?}"),
         };
@@ -623,11 +651,11 @@ mod test {
         assert_matches!(
             status,
             BlueprintPlannerStatus::Unchanged {
-                parent_blueprint_id,
+                parent,
                 report: _,
                 blueprint_count: _,
                 limit: _,
-            } if parent_blueprint_id == parent_blueprint_id
+            } if parent.target_id == blueprint_id
         );
 
         // Enable execution.
@@ -694,11 +722,11 @@ mod test {
         assert_matches!(
             status,
             BlueprintPlannerStatus::Unchanged {
-                parent_blueprint_id,
+                parent,
                 report: _,
                 blueprint_count: _,
                 limit: _,
-            } if parent_blueprint_id == blueprint_id
+            } if parent.target_id == blueprint_id
         );
     }
 

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -11,6 +11,7 @@ use iddqd::IdOrdMap;
 use nexus_db_model::TargetReleaseSource;
 use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;
+use nexus_inventory::now_db_precision;
 use nexus_reconfigurator_planning::planner::Planner;
 use nexus_reconfigurator_planning::planner::PlannerRng;
 use nexus_reconfigurator_preparation::PlanningInputFromDb;
@@ -153,7 +154,7 @@ impl super::Nexus {
         let new_target = BlueprintTarget {
             target_id: params.target_id,
             enabled: params.enabled,
-            time_made_target: chrono::Utc::now(),
+            time_made_target: now_db_precision(),
         };
 
         // Use `SetTargetDebugWriter` to write out debugging files related to
@@ -174,7 +175,7 @@ impl super::Nexus {
             // Try to cancel the dropbox deposit.  This information is
             // useless now.  It's not a problem if this doesn't work.
             debug_dropbox_writer.cancel().await;
-            return Err(error);
+            return Err(error.into());
         }
 
         // We've got a new target.
@@ -201,7 +202,7 @@ impl super::Nexus {
         let new_target = BlueprintTarget {
             target_id: params.target_id,
             enabled: params.enabled,
-            time_made_target: chrono::Utc::now(),
+            time_made_target: now_db_precision(),
         };
 
         // We don't need to create or archive a Reconfigurator state file here

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -34,6 +34,7 @@ use omicron_common::address::SLED_PREFIX_LENGTH;
 use omicron_common::address::SLED_RESERVED_ADDRESSES;
 use omicron_common::address::get_sled_address;
 use omicron_common::api::external::ByteCount;
+use omicron_common::api::external::ResourceType;
 use omicron_common::api::internal::shared::DatasetKind;
 use omicron_common::disk::DatasetName;
 use omicron_generation_kinds::{
@@ -42,6 +43,7 @@ use omicron_generation_kinds::{
 };
 use omicron_uuid_kinds::BlueprintUuid;
 use omicron_uuid_kinds::DatasetUuid;
+use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::MupdateOverrideUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
@@ -69,6 +71,7 @@ use sled_agent_types_versions::latest::inventory::OmicronZoneConfig;
 use sled_agent_types_versions::latest::inventory::OmicronZoneImageSource;
 use sled_agent_types_versions::latest::inventory::ZoneKind;
 use slog::Key;
+use slog_error_chain::SlogInlineError;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt;
@@ -78,6 +81,7 @@ use std::net::Ipv6Addr;
 use std::net::SocketAddrV6;
 use std::sync::Arc;
 use strum::EnumIter;
+use thiserror::Error;
 use tufaceous_artifact::Artifact;
 use tufaceous_artifact::ArtifactHash;
 use tufaceous_artifact::ArtifactVersion;
@@ -3472,6 +3476,47 @@ pub struct BlueprintTarget {
     pub enabled: bool,
     /// when this blueprint was made the target
     pub time_made_target: chrono::DateTime<chrono::Utc>,
+}
+
+/// Errors from making a blueprint the current target.
+#[derive(
+    Debug, Clone, PartialEq, Serialize, Deserialize, Error, SlogInlineError,
+)]
+pub enum BlueprintTargetSetError {
+    /// The target blueprint does not exist in the blueprint table.
+    #[error("blueprint {blueprint_id} does not exist")]
+    NoSuchBlueprint { blueprint_id: BlueprintUuid },
+    /// The requested target blueprint's parent is not the current target.
+    #[error(
+        "blueprint {blueprint_id}'s parent blueprint is not the current \
+         target blueprint"
+    )]
+    ParentNotTarget { blueprint_id: BlueprintUuid },
+    /// Any other error, including authorization and database connection
+    /// failures.
+    #[error(transparent)]
+    Other(#[from] Error),
+}
+
+/// Converts to the public error type:
+///
+/// * `NoSuchBlueprint` is a 404
+/// * `ParentNotTarget` is a 400
+impl From<BlueprintTargetSetError> for Error {
+    fn from(value: BlueprintTargetSetError) -> Self {
+        match value {
+            BlueprintTargetSetError::NoSuchBlueprint { blueprint_id } => {
+                Error::not_found_by_id(
+                    ResourceType::Blueprint,
+                    blueprint_id.as_untyped_uuid(),
+                )
+            }
+            BlueprintTargetSetError::ParentNotTarget { .. } => {
+                Error::invalid_request(value.to_string())
+            }
+            BlueprintTargetSetError::Other(error) => error,
+        }
+    }
 }
 
 /// Specifies what blueprint, if any, the system should be working toward

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::deployment::BlueprintTarget;
+use crate::deployment::BlueprintTargetSetError;
 use crate::deployment::PlanningReport;
 use crate::external_api::alert;
 use chrono::DateTime;
@@ -842,11 +844,19 @@ pub enum InventoryLoadStatus {
 }
 
 /// The status of a `blueprint_planner` background task activation.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum BlueprintPlannerStatus {
     /// Automatic blueprint planning has been explicitly disabled
     /// by the config file.
     Disabled,
+
+    /// Planning was skipped because an input it depends on isn't available yet.
+    ///
+    /// This only happens before the task that loads that input (see
+    /// [`BlueprintPlannerSkipReason`]) has loaded its first value -- normally,
+    /// shortly after Nexus startup -- and resolves once it does. If it
+    /// persists, check that task's status.
+    Skipped(BlueprintPlannerSkipReason),
 
     /// The blueprint limit was reached, so automatic blueprint planning was
     /// disabled.
@@ -860,7 +870,8 @@ pub enum BlueprintPlannerStatus {
     /// Planning produced a blueprint identital to the current target,
     /// so we threw it away and did nothing.
     Unchanged {
-        parent_blueprint_id: BlueprintUuid,
+        /// The target the blueprint was planned from.
+        parent: BlueprintTarget,
         report: Arc<PlanningReport>,
         blueprint_count: u64,
         limit: u64,
@@ -869,8 +880,9 @@ pub enum BlueprintPlannerStatus {
     /// Planning produced a new blueprint, but we failed to make it
     /// the current target and so deleted it.
     Planned {
-        parent_blueprint_id: BlueprintUuid,
-        error: String,
+        /// The target the blueprint was planned from.
+        parent: BlueprintTarget,
+        error: BlueprintTargetSetError,
         report: Arc<PlanningReport>,
         blueprint_count: u64,
         limit: u64,
@@ -879,12 +891,41 @@ pub enum BlueprintPlannerStatus {
     /// Planing succeeded, and we saved and made the new blueprint the
     /// current target.
     Targeted {
-        parent_blueprint_id: BlueprintUuid,
-        blueprint_id: BlueprintUuid,
+        /// The target the blueprint was planned from.
+        parent: BlueprintTarget,
+        /// The new target.
+        target: BlueprintTarget,
         report: Arc<PlanningReport>,
         blueprint_count: u64,
         limit: u64,
     },
+}
+
+/// The reason the blueprint planner skipped planning.
+#[derive(
+    Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, thiserror::Error,
+)]
+pub enum BlueprintPlannerSkipReason {
+    /// The blueprint loader hasn't loaded a target blueprint yet.
+    #[error("no target blueprint available")]
+    NoTargetBlueprint,
+    /// The inventory loader hasn't loaded a collection yet.
+    #[error("no inventory collection available")]
+    NoInventoryCollection,
+}
+
+impl BlueprintPlannerSkipReason {
+    /// The name of the background task that loads the missing input.
+    ///
+    /// If planning keeps being skipped, that task's status says why.
+    pub fn loader_task_name(&self) -> &'static str {
+        match self {
+            BlueprintPlannerSkipReason::NoTargetBlueprint => "blueprint_loader",
+            BlueprintPlannerSkipReason::NoInventoryCollection => {
+                "inventory_loader"
+            }
+        }
+    }
 }
 
 /// The status of a `alert_dispatcher` background task activation.


### PR DESCRIPTION
Going to match on what was previously stringly-typed in an upcoming commit.

Also fix a tautological `parent_blueprint_id == parent_blueprint_id` guard in `test_blueprint_planner`.