### PR TITLE
[nexus] planner: report "config not yet loaded" as a skipped status

### DIFF
--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -171,11 +171,9 @@ impl BlueprintPlanner {
         // loading task needs to have a chance to check.)
         let config = match &*self.rx_config.borrow_and_update() {
             ReconfiguratorConfigLoaderState::NotYetLoaded => {
-                debug!(
-                    opctx.log,
-                    "reconfigurator config not yet loaded; doing nothing"
-                );
-                return Ok(BlueprintPlannerStatus::Disabled);
+                return Err(PlanError::Skipped(
+                    BlueprintPlannerSkipReason::ConfigNotYetLoaded,
+                ));
             }
             ReconfiguratorConfigLoaderState::Loaded(config) => config.clone(),
         };

--- a/nexus/src/app/background/tasks/reconfigurator_config.rs
+++ b/nexus/src/app/background/tasks/reconfigurator_config.rs
@@ -93,6 +93,7 @@ mod test {
         PlannerConfig, ReconfiguratorConfig, ReconfiguratorConfigParam,
         ReconfiguratorDisruptionPolicy,
     };
+    use nexus_types::internal_api::background::BlueprintPlannerSkipReason;
     use nexus_types::internal_api::background::BlueprintPlannerStatus;
     use nexus_types::internal_api::background::TufRepoPrunerStatus;
     use omicron_test_utils::dev::poll::{CondCheckError, wait_for_condition};
@@ -255,9 +256,7 @@ mod test {
         wait_for_task_status(
             &lockstep_client,
             "blueprint_planner",
-            &|planner_status: &BlueprintPlannerStatus| {
-                matches!(planner_status, BlueprintPlannerStatus::Disabled)
-            },
+            &planner_observed_disabled,
         )
         .await;
         wait_for_task_status(
@@ -290,9 +289,7 @@ mod test {
         wait_for_task_status(
             &lockstep_client,
             "blueprint_planner",
-            &|planner_status: &BlueprintPlannerStatus| {
-                !matches!(planner_status, BlueprintPlannerStatus::Disabled)
-            },
+            &planner_observed_enabled,
         )
         .await;
         wait_for_task_status(
@@ -319,9 +316,7 @@ mod test {
         wait_for_task_status(
             &lockstep_client,
             "blueprint_planner",
-            &|planner_status: &BlueprintPlannerStatus| {
-                matches!(planner_status, BlueprintPlannerStatus::Disabled)
-            },
+            &planner_observed_disabled,
         )
         .await;
         wait_for_task_status(
@@ -332,6 +327,41 @@ mod test {
             },
         )
         .await;
+    }
+
+    /// Return true if the planner has observed a config with planning disabled.
+    fn planner_observed_disabled(status: &BlueprintPlannerStatus) -> bool {
+        match status {
+            BlueprintPlannerStatus::Disabled => true,
+            BlueprintPlannerStatus::Skipped(_)
+            | BlueprintPlannerStatus::LimitReached { .. }
+            | BlueprintPlannerStatus::Error(_)
+            | BlueprintPlannerStatus::Unchanged { .. }
+            | BlueprintPlannerStatus::Planned { .. }
+            | BlueprintPlannerStatus::Targeted { .. } => false,
+        }
+    }
+
+    /// Return true if the planner has observed a config with planning enabled.
+    fn planner_observed_enabled(status: &BlueprintPlannerStatus) -> bool {
+        match status {
+            // For ConfigNotYetLoaded, the planner has not yet observed a config
+            // with planning enabled.
+            BlueprintPlannerStatus::Disabled
+            | BlueprintPlannerStatus::Skipped(
+                BlueprintPlannerSkipReason::ConfigNotYetLoaded,
+            ) => false,
+            // Planning must be enabled to return any of these values.
+            BlueprintPlannerStatus::Skipped(
+                BlueprintPlannerSkipReason::NoTargetBlueprint
+                | BlueprintPlannerSkipReason::NoInventoryCollection,
+            )
+            | BlueprintPlannerStatus::LimitReached { .. }
+            | BlueprintPlannerStatus::Error(_)
+            | BlueprintPlannerStatus::Unchanged { .. }
+            | BlueprintPlannerStatus::Planned { .. }
+            | BlueprintPlannerStatus::Targeted { .. } => true,
+        }
     }
 
     async fn wait_for_task_status<T: DeserializeOwned>(

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -846,8 +846,11 @@ pub enum InventoryLoadStatus {
 /// The status of a `blueprint_planner` background task activation.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum BlueprintPlannerStatus {
-    /// Automatic blueprint planning has been explicitly disabled
-    /// by the config file.
+    /// Automatic blueprint planning is disabled in the reconfigurator config.
+    ///
+    /// Until the config has been loaded at all, the status is
+    /// [`Self::Skipped`] with [`BlueprintPlannerSkipReason::ConfigNotYetLoaded`]
+    /// instead.
     Disabled,
 
     /// Planning was skipped because an input it depends on isn't available yet.
@@ -906,6 +909,11 @@ pub enum BlueprintPlannerStatus {
     Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, thiserror::Error,
 )]
 pub enum BlueprintPlannerSkipReason {
+    /// The reconfigurator config loader hasn't loaded the config yet, so it's
+    /// not known whether planning is enabled. This is treated as planning being
+    /// disabled.
+    #[error("reconfigurator config not yet loaded")]
+    ConfigNotYetLoaded,
     /// The blueprint loader hasn't loaded a target blueprint yet.
     #[error("no target blueprint available")]
     NoTargetBlueprint,
@@ -920,6 +928,9 @@ impl BlueprintPlannerSkipReason {
     /// If planning keeps being skipped, that task's status says why.
     pub fn loader_task_name(&self) -> &'static str {
         match self {
+            BlueprintPlannerSkipReason::ConfigNotYetLoaded => {
+                "reconfigurator_config_watcher"
+            }
             BlueprintPlannerSkipReason::NoTargetBlueprint => "blueprint_loader",
             BlueprintPlannerSkipReason::NoInventoryCollection => {
                 "inventory_loader"


### PR DESCRIPTION
We now have the handy-dandy `BlueprintPlannerSkipReason` to hang this off of.