### PR TITLE
[nexus] activate the blueprint planner when a sled is expunged

### DIFF
--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -164,6 +164,10 @@ impl super::Nexus {
         // for the next periodic activation before they can be cleaned up.
         self.background_tasks.task_instance_watcher.activate();
 
+        // The blueprint planner is going to perform actions based on the
+        // expungement, so kick it off now.
+        self.background_tasks.task_blueprint_planner.activate();
+
         Ok(prev_policy)
     }
 

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -1209,9 +1209,9 @@ async fn test_debug_files(cptestctx: &ControlPlaneTestContext) {
 
     // We need to wait until there's a new target blueprint.  As usual, we wait
     // for the thing we care about rather than waiting precisely for one more
-    // activation of the background task.  That's because there's other
-    // asynchrony involved here (e.g., the updated reconfigurator config needs
-    // to be loaded, too).
+    // activation of the background task.  Expunging the sled activates the
+    // planner, but there's also other asynchrony involved here (e.g., the
+    // updated reconfigurator config needs to be loaded, too).
     let bp4_id = wait_for_condition(
         || async {
             let target = datastore


### PR DESCRIPTION
Fix [this flake](https://buildomat.eng.oxide.computer/wg/0/details/01M0ZQCHKJ72E82ZRK40JNGE4R/aXKT3HVzRjvEdHqZzqmQ3ZENCtCJmCx950FpOWxtSNf9ELLO/01M0ZQD0BFM18YXJH9MNDE8YGS) which had a missed activation.