### PR TITLE
[nexus] fix tautological assertion in test_blueprint_planner

### DIFF
--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -627,7 +627,7 @@ mod test {
                 report: _,
                 blueprint_count: _,
                 limit: _,
-            } if parent_blueprint_id == parent_blueprint_id
+            } if parent_blueprint_id == blueprint_id
         );
 
         // Enable execution.


### PR DESCRIPTION
`parent_blueprint_id == parent_blueprint_id` is always true, so the assertion did not check what it was supposed to: that the unchanged plan was based on the target that had just been set. Instead, compare against `blueprint_id`, as the check later in the test already does.