### PR TITLE
[nexus] use DB-precision timestamps for time_made_target

### DIFF
--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -9,13 +9,13 @@ use crate::app::BlueprintDebugAction;
 use crate::app::background::BackgroundTask;
 use crate::app::background::tasks::blueprint_load::LoadedTargetBlueprint;
 use crate::app::deployment::SetTargetDebugWriter;
-use chrono::Utc;
 use futures::future::BoxFuture;
 use iddqd::IdOrdMap;
 use nexus_auth::authz;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
 use nexus_db_queries::db::DataStore;
+use nexus_inventory::now_db_precision;
 use nexus_reconfigurator_planning::planner::Planner;
 use nexus_reconfigurator_planning::planner::PlannerRng;
 use nexus_reconfigurator_preparation::PlanningInputFromDb;
@@ -321,7 +321,7 @@ impl BlueprintPlanner {
         let target = BlueprintTarget {
             target_id: blueprint_id,
             enabled: target.enabled, // copy previous `enabled` flag
-            time_made_target: Utc::now(),
+            time_made_target: now_db_precision(),
         };
         match self.datastore.blueprint_target_set_current(opctx, target).await {
             Ok(()) => (),

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -11,6 +11,7 @@ use iddqd::IdOrdMap;
 use nexus_db_model::TargetReleaseSource;
 use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;
+use nexus_inventory::now_db_precision;
 use nexus_reconfigurator_planning::planner::Planner;
 use nexus_reconfigurator_planning::planner::PlannerRng;
 use nexus_reconfigurator_preparation::PlanningInputFromDb;
@@ -153,7 +154,7 @@ impl super::Nexus {
         let new_target = BlueprintTarget {
             target_id: params.target_id,
             enabled: params.enabled,
-            time_made_target: chrono::Utc::now(),
+            time_made_target: now_db_precision(),
         };
 
         // Use `SetTargetDebugWriter` to write out debugging files related to
@@ -201,7 +202,7 @@ impl super::Nexus {
         let new_target = BlueprintTarget {
             target_id: params.target_id,
             enabled: params.enabled,
-            time_made_target: chrono::Utc::now(),
+            time_made_target: now_db_precision(),
         };
 
         // We don't need to create or archive a Reconfigurator state file here


### PR DESCRIPTION
These timestamps get stored as DB precision, and there's a bit of a footgun here if we don't do that here and later check for equality after roundtripping through the db.

(Maybe we should have a newtype for timestamps with DB precision...)

Extracted out of #11178.