### PR TITLE
data migration tests: run steps twice to check for idempotency

### DIFF
--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -990,7 +990,7 @@ async fn validate_data_migration_from_version_to_target(
             before(&ctx).await;
         }
 
-        apply_update(log, &crdb, version, 1).await;
+        apply_update(log, &crdb, version, 2).await;
         assert_eq!(
             version.semver().to_string(),
             query_crdb_schema_version(&crdb).await

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -990,6 +990,14 @@ async fn validate_data_migration_from_version_to_target(
             before(&ctx).await;
         }
 
+        // Apply each step twice to check for idempotency.
+        //
+        // We already have `update_since_base_has_idempotent_up()` that also
+        // applies each step twice and checks for idempotency, but that runs
+        // against a db with no data in it, so can only check for non-idempotent
+        // schema changes. Running each step twice here lets us catch
+        // non-idempotent steps that only show up with data (e.g., `INSERT ...`
+        // migrations that don't handle conflicts if run twice).
         apply_update(log, &crdb, version, 2).await;
         assert_eq!(
             version.semver().to_string(),


### PR DESCRIPTION
This came up in https://github.com/oxidecomputer/omicron/pull/11114#discussion_r3874575382; if I run this change against that branch in its initial state, we do see a test failure as described in that conversation:

```
    thread 'integration_tests::schema::validate_data_migrations' (1556916) panicked at nexus/tests/integration_tests/schema.rs:71:9:
    Failed to execute update step up02.sql: db error: ERROR: duplicate key value violates unique constraint "inv_omicron_sled_config_zone_external_ip_pkey"
    DETAIL: Key (inv_collection_id,sled_config_id,zone_id,ip)=('d29f7b65-9b2b-4650-9b80-9ba968468083','1fda886f-b3e4-4068-9e20-b29d7d4c9190','ab1d1dc9-2737-4c60-8aeb-f1da4ac92d93','192.0.2.1') already exists.
```

Unfortunately, this also causes some already-shipped migrations to fail. I patched those up by adding `ON CONFLICT DO NOTHING`; retroactively changing migrations seems quite spicy, so I welcome other suggestions. (We could trim our start point up past these two instead?)