### PR TITLE
Skip zones with no in-window logs during support bundle collection

### DIFF
--- a/dev-tools/oxlog/src/lib.rs
+++ b/dev-tools/oxlog/src/lib.rs
@@ -678,6 +678,71 @@ mod tests {
     pub use super::oxide_smf_service_name_from_log_file_name;
 
     #[test]
+    fn test_zones_with_matching_logs() {
+        use super::{DateRange, Filter, Paths, Zones};
+        use jiff::Timestamp;
+        use std::collections::BTreeMap;
+
+        let dir = camino_tempfile::tempdir().unwrap();
+        let mtime = |secs: u64| {
+            std::time::SystemTime::UNIX_EPOCH
+                + std::time::Duration::from_secs(secs)
+        };
+
+        // Three zones: one whose log was last written long ago, one
+        // written recently, and one whose only log is empty.
+        let mut zones = BTreeMap::new();
+        for (zone, mtime_secs, contents) in [
+            ("oxz_old", 1_000, "stale but real data"),
+            ("oxz_recent", 2_000_000, "fresh data"),
+            ("oxz_empty", 2_000_000, ""),
+        ] {
+            let logdir = dir.path().join(zone).join("var/svc/log");
+            std::fs::create_dir_all(&logdir).unwrap();
+            let logfile = logdir.join("oxide-svc:default.log");
+            std::fs::write(&logfile, contents).unwrap();
+            std::fs::File::open(&logfile)
+                .unwrap()
+                .set_modified(mtime(mtime_secs))
+                .unwrap();
+            zones.insert(
+                zone.to_string(),
+                Paths { primary: logdir, debug: vec![], extra: vec![] },
+            );
+        }
+        let zones = Zones { zones };
+
+        let filter = |date_range| Filter {
+            current: true,
+            archived: true,
+            extra: true,
+            show_empty: false,
+            date_range,
+        };
+        let ts = |secs| Timestamp::from_second(secs).unwrap();
+
+        // With no date range, every zone with a non-empty log matches.
+        assert_eq!(
+            zones.zones_with_matching_logs(filter(None)),
+            ["oxz_old", "oxz_recent"]
+        );
+
+        // A range covering only the recent mtime excludes the old zone.
+        let recent_only = DateRange::new(ts(3_000_000), ts(1_000_000));
+        assert_eq!(
+            zones.zones_with_matching_logs(filter(Some(recent_only))),
+            ["oxz_recent"]
+        );
+
+        // A range predating every mtime matches no zone at all.
+        let before_everything = DateRange::new(ts(900), ts(0));
+        assert_eq!(
+            zones.zones_with_matching_logs(filter(Some(before_everything))),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
     fn test_is_oxide_smf_log_file() {
         assert!(is_oxide_smf_log_file("oxide-blah:default.log"));
         assert!(is_oxide_smf_log_file("oxide-blah:default.log.0"));

--- a/dev-tools/oxlog/src/lib.rs
+++ b/dev-tools/oxlog/src/lib.rs
@@ -504,6 +504,21 @@ impl Zones {
             .map(|(zone, _)| self.zone_logs(zone, filter))
             .collect()
     }
+
+    /// Return the names of zones with at least one log file matching
+    /// `filter`, in sorted order.
+    ///
+    /// A zone appears here exactly when [`Self::zone_logs`] with the same
+    /// filter would return at least one file for it, so callers can use
+    /// this to skip zones whose per-zone log retrieval would come back
+    /// empty.
+    pub fn zones_with_matching_logs(&self, filter: Filter) -> Vec<ZoneName> {
+        self.zones
+            .par_iter()
+            .filter(|(zone, _)| !self.zone_logs(zone, filter).is_empty())
+            .map(|(zone, _)| zone.clone())
+            .collect()
+    }
 }
 
 fn sort_logs(output: &mut BTreeMap<String, SvcLogs>) {

--- a/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
+++ b/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
@@ -220,6 +220,7 @@ mod api_impl {
     use sled_agent_types::dataset::LocalStorageDatasetEnsureRequest;
     use sled_agent_types::debug::ChickenSwitchDestroyOrphanedDatasets;
     use sled_agent_types::debug::OperatorSwitchZonePolicy;
+    use sled_agent_types::diagnostics::SledDiagnosticsLogZonesQueryParam;
     use sled_agent_types::diagnostics::SledDiagnosticsLogsDownloadPathParm;
     use sled_agent_types::diagnostics::SledDiagnosticsLogsDownloadQueryParam;
     use sled_agent_types::disk::DiskEnsureBody;
@@ -958,6 +959,7 @@ mod api_impl {
 
         async fn support_logs(
             _request_context: RequestContext<Self::Context>,
+            _query_params: dropshot::Query<SledDiagnosticsLogZonesQueryParam>,
         ) -> Result<HttpResponseOk<Vec<String>>, HttpError> {
             unimplemented!()
         }

--- a/nexus/tests/integration_tests/support_bundles.rs
+++ b/nexus/tests/integration_tests/support_bundles.rs
@@ -639,8 +639,12 @@ async fn test_support_bundle_zone_log_time_range(
         OpContext::for_tests(cptestctx.logctx.log.clone(), datastore.clone());
 
     // Inject synthetic zone logs into the first simulated sled-agent at
-    // three ages: 30 minutes, 6 hours, and 30 days.
+    // three ages: 30 minutes, 6 hours, and 30 days. A second zone holds
+    // only the 30-day log, standing in for the many zones on a real sled
+    // (dead propolis zones especially) whose logs all predate a typical
+    // collection window.
     const ZONE: &str = "oxz_fake_test_zone";
+    const STALE_ZONE: &str = "oxz_fake_stale_zone";
     let now = chrono::Utc::now();
     let sled_agent = cptestctx.sled_agents[0].sled_agent();
     for (filename, age) in [
@@ -657,10 +661,35 @@ async fn test_support_bundle_zone_log_time_range(
             },
         );
     }
+    sled_agent.insert_support_log(
+        STALE_ZONE,
+        SimLogEntry {
+            filename: "fake-svc.log.30-days-old".to_string(),
+            contents: b"totally fake stale log data".to_vec(),
+            mtime: now - chrono::Duration::days(30),
+        },
+    );
+
+    // Names of regular files under logs/<zone>/ within the archive.
+    fn zone_log_files(names: &[String], zone: &str) -> Vec<String> {
+        let prefix = format!("logs/{zone}/");
+        names
+            .iter()
+            .filter(|name| name.contains(&prefix) && !name.ends_with('/'))
+            .cloned()
+            .collect()
+    }
+
+    // True if the archive holds any entry for the zone: a log file, or
+    // even just its (empty) directory.
+    fn has_zone_entry(names: &[String], zone: &str) -> bool {
+        let needle = format!("logs/{zone}");
+        names.iter().any(|name| name.contains(&needle))
+    }
 
     // Creates a bundle with the given window, collects it, and returns the
-    // names of the collected zone-log files.
-    async fn collect_zone_logs_with_range(
+    // names of every entry in the bundle archive.
+    async fn collect_bundle_with_range(
         cptestctx: &ControlPlaneTestContext,
         client: &ClientTestContext,
         opctx: &OpContext,
@@ -692,12 +721,7 @@ async fn test_support_bundle_zone_log_time_range(
 
         let contents = bundle_download(client, bundle.id.into()).await.unwrap();
         let archive = ZipArchive::new(Cursor::new(&contents)).unwrap();
-        let log_prefix = format!("logs/{ZONE}/");
-        let logs = archive
-            .file_names()
-            .filter(|name| name.contains(&log_prefix) && !name.ends_with('/'))
-            .map(String::from)
-            .collect();
+        let names = archive.file_names().map(String::from).collect();
 
         // Delete the bundle (and run the cleanup pass) so the next
         // collection has a free debug dataset to land on.
@@ -706,12 +730,13 @@ async fn test_support_bundle_zone_log_time_range(
             activate_bundle_collection_background_task(&cptestctx).await;
         assert_eq!(output.cleanup_err, None);
 
-        logs
+        names
     }
 
     // A 24-hour window includes the 30-minute and 6-hour logs, but not the
-    // 30-day log.
-    let logs = collect_zone_logs_with_range(
+    // 30-day log. The stale zone has nothing in the window, so it leaves
+    // no trace in the bundle: no log files, and no empty directory either.
+    let names = collect_bundle_with_range(
         &cptestctx,
         client,
         &opctx,
@@ -719,13 +744,19 @@ async fn test_support_bundle_zone_log_time_range(
             .unwrap(),
     )
     .await;
+    let logs = zone_log_files(&names, ZONE);
     assert_eq!(logs.len(), 2, "expected 2 in-window logs, got: {logs:?}");
     assert!(logs.iter().any(|l| l.ends_with("fake-svc.log.30-minutes-old")));
     assert!(logs.iter().any(|l| l.ends_with("fake-svc.log.6-hours-old")));
+    assert!(
+        !has_zone_entry(&names, STALE_ZONE),
+        "out-of-window zone should leave no bundle entry, got: {names:?}"
+    );
 
-    // A window that ends a day ago includes only the 30-day log, exercising
-    // the end bound.
-    let logs = collect_zone_logs_with_range(
+    // A window that ends a day ago includes only the 30-day logs,
+    // exercising the end bound. The stale zone's only log is now in the
+    // window, so the zone is collected.
+    let names = collect_bundle_with_range(
         &cptestctx,
         client,
         &opctx,
@@ -736,22 +767,34 @@ async fn test_support_bundle_zone_log_time_range(
         .unwrap(),
     )
     .await;
+    let logs = zone_log_files(&names, ZONE);
     assert_eq!(logs.len(), 1, "expected 1 in-window log, got: {logs:?}");
     assert!(logs.iter().any(|l| l.ends_with("fake-svc.log.30-days-old")));
+    let stale_logs = zone_log_files(&names, STALE_ZONE);
+    assert_eq!(
+        stale_logs.len(),
+        1,
+        "expected 1 in-window stale-zone log, got: {stale_logs:?}"
+    );
 
     // A window with no bounds does not collect unbounded history: bundle
     // creation fills in the default lookback as the start bound, so the
-    // 30-day log stays excluded.
-    let logs = collect_zone_logs_with_range(
+    // 30-day log stays excluded and the stale zone stays absent.
+    let names = collect_bundle_with_range(
         &cptestctx,
         client,
         &opctx,
         BundleTimeRange::new(None, None).unwrap(),
     )
     .await;
+    let logs = zone_log_files(&names, ZONE);
     assert_eq!(logs.len(), 2, "expected 2 in-lookback logs, got: {logs:?}");
     assert!(logs.iter().any(|l| l.ends_with("fake-svc.log.30-minutes-old")));
     assert!(logs.iter().any(|l| l.ends_with("fake-svc.log.6-hours-old")));
+    assert!(
+        !has_zone_entry(&names, STALE_ZONE),
+        "out-of-lookback zone should leave no bundle entry, got: {names:?}"
+    );
 }
 
 // Test range requests on a bundle

--- a/openapi/sled-agent/sled-agent-52.0.0-6430a4.json
+++ b/openapi/sled-agent/sled-agent-52.0.0-6430a4.json
@@ -1,0 +1,11037 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Oxide Sled Agent API",
+    "description": "API for interacting with individual sleds",
+    "contact": {
+      "url": "https://oxide.computer",
+      "email": "api@oxide.computer"
+    },
+    "version": "52.0.0"
+  },
+  "paths": {
+    "/artifacts": {
+      "get": {
+        "operationId": "artifact_list",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactListResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/artifacts/{sha256}": {
+      "put": {
+        "operationId": "artifact_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sha256",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "hex string (32 bytes)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "generation",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Generation"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactPutResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/artifacts/{sha256}/copy-from-depot": {
+      "post": {
+        "operationId": "artifact_copy_from_depot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sha256",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "hex string (32 bytes)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "generation",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Generation"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtifactCopyFromDepotBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactCopyFromDepotResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/artifacts-config": {
+      "get": {
+        "operationId": "artifact_config_get",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactConfig"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "operationId": "artifact_config_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtifactConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/bootstore/status": {
+      "get": {
+        "summary": "Get the internal state of the local bootstore node",
+        "operationId": "bootstore_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BootstoreStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/debug/switch-zone-policy": {
+      "get": {
+        "summary": "A debugging endpoint only used by `omdb` that allows us to test",
+        "description": "restarting the switch zone without restarting sled-agent. See <https://github.com/oxidecomputer/omicron/issues/8480> for context.",
+        "operationId": "debug_operator_switch_zone_policy_get",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorSwitchZonePolicy"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "A debugging endpoint only used by `omdb` that allows us to test",
+        "description": "restarting the switch zone without restarting sled-agent. See <https://github.com/oxidecomputer/omicron/issues/8480> for context.\n\nSetting the switch zone policy is asynchronous and inherently racy with the standard process of starting the switch zone. If the switch zone is in the process of being started or stopped when this policy is changed, the new policy may not take effect until that transition completes.",
+        "operationId": "debug_operator_switch_zone_policy_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OperatorSwitchZonePolicy"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/eip-gateways": {
+      "put": {
+        "summary": "Update per-NIC IP address <-> internet gateway mappings.",
+        "operationId": "set_eip_gateways",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExternalIpGatewayMap"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/inventory": {
+      "get": {
+        "summary": "Fetch basic information about this sled",
+        "operationId": "inventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Inventory"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/local-storage": {
+      "post": {
+        "summary": "Create a local storage dataset",
+        "operationId": "local_storage_dataset_ensure",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LocalStorageDatasetEnsureRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a local storage dataset",
+        "operationId": "local_storage_dataset_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LocalStorageDatasetDeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/network-bootstore-config": {
+      "put": {
+        "operationId": "write_network_bootstore_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WriteNetworkConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/omicron-config": {
+      "put": {
+        "operationId": "omicron_config_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OmicronSledConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/probes": {
+      "put": {
+        "summary": "Update the entire set of probe zones on this sled.",
+        "description": "Probe zones are used to debug networking configuration. They look similar to instances, in that they have an OPTE port on a VPC subnet and external addresses, but no actual VM.",
+        "operationId": "probes_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProbeSet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/rot/{rot}/attest": {
+      "post": {
+        "summary": "Return attestation over recorded measurments and nonce from the RoT.",
+        "operationId": "rot_attest",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rot",
+            "description": "Which RoT to use",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Rot"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Nonce"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Attestation"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/rot/{rot}/certificate-chain": {
+      "get": {
+        "summary": "Return the certificate chain for the attestation signer from the RoT.",
+        "operationId": "rot_certificate_chain",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rot",
+            "description": "Which RoT to use",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Rot"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateChain"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/rot/{rot}/measurement-log": {
+      "get": {
+        "summary": "Return the set of measurments recorded by the RoT.",
+        "operationId": "rot_measurement_log",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rot",
+            "description": "Which RoT to use",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Rot"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeasurementLog"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/sled-identifiers": {
+      "get": {
+        "summary": "Fetch sled identifiers",
+        "operationId": "sled_identifiers",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledIdentifiers"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/sleds": {
+      "put": {
+        "summary": "Add a sled to a rack that was already initialized via RSS",
+        "operationId": "sled_add",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddSledRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/dladm-info": {
+      "get": {
+        "operationId": "support_dladm_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/health-check": {
+      "get": {
+        "operationId": "support_health_check",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/ipadm-info": {
+      "get": {
+        "operationId": "support_ipadm_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/logs/download/{zone}": {
+      "get": {
+        "summary": "This endpoint returns a zip file of a zone's logs organized by service.",
+        "operationId": "support_logs_download",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "zone",
+            "description": "The zone for which one would like to collect logs for",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_time",
+            "description": "Upper bound (inclusive) on collected log content. Files whose content begins after this are excluded. Filtering is per-file: a file created before this bound but still modified after it is included in full, so the archive may contain data newer than this bound. If absent, no upper bound is applied.",
+            "schema": {
+              "nullable": true,
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "max_rotated",
+            "description": "The max number of rotated logs to include in the final support bundle. If absent, no count cap is applied.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_time",
+            "description": "Lower bound (inclusive) on collected log content. Files whose last modification (`mtime`) predates this are excluded; a file's `mtime` is the timestamp of its newest content, so excluded files contain no data from the window. If absent, no lower bound is applied.",
+            "schema": {
+              "nullable": true,
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support/logs/zones": {
+      "get": {
+        "summary": "This endpoint returns a list of known zones on a sled that have service",
+        "description": "logs that can be collected into a support bundle.",
+        "operationId": "support_logs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "end_time",
+            "description": "Upper bound (inclusive) on log content. A zone is omitted when every one of its log files has content beginning after this. If absent, no upper bound is applied.",
+            "schema": {
+              "nullable": true,
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_time",
+            "description": "Lower bound (inclusive) on log content. A zone is omitted when the last modification (`mtime`) of every one of its log files predates this; a file's `mtime` is the timestamp of its newest content, so an omitted zone has no log data from the window. If absent, no lower bound is applied.",
+            "schema": {
+              "nullable": true,
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_String",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/nvmeadm-info": {
+      "get": {
+        "operationId": "support_nvmeadm_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/pargs-info": {
+      "get": {
+        "operationId": "support_pargs_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/pfiles-info": {
+      "get": {
+        "operationId": "support_pfiles_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/pstack-info": {
+      "get": {
+        "operationId": "support_pstack_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/zfs-info": {
+      "get": {
+        "operationId": "support_zfs_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/zoneadm-info": {
+      "get": {
+        "operationId": "support_zoneadm_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/zpool-info": {
+      "get": {
+        "operationId": "support_zpool_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}": {
+      "get": {
+        "summary": "List all support bundles within a particular dataset",
+        "operationId": "support_bundle_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SupportBundleMetadata",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SupportBundleMetadata"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}": {
+      "post": {
+        "summary": "Starts creation of a support bundle within a particular dataset",
+        "description": "Callers should transfer chunks of the bundle with \"support_bundle_transfer\", and then call \"support_bundle_finalize\" once the bundle has finished transferring.\n\nIf a support bundle was previously created without being finalized successfully, this endpoint will reset the state.\n\nIf a support bundle was previously created and finalized successfully, this endpoint will return metadata indicating that it already exists.",
+        "operationId": "support_bundle_start_creation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportBundleMetadata"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a support bundle from a particular dataset",
+        "operationId": "support_bundle_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/download": {
+      "get": {
+        "summary": "Fetch a support bundle from a particular dataset",
+        "operationId": "support_bundle_download",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "summary": "Fetch metadata about a support bundle from a particular dataset",
+        "operationId": "support_bundle_head",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/download/{file}": {
+      "get": {
+        "summary": "Fetch a file within a support bundle from a particular dataset",
+        "operationId": "support_bundle_download_file",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "file",
+            "description": "The path of the file within the support bundle to query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "summary": "Fetch metadata about a file within a support bundle from a particular dataset",
+        "operationId": "support_bundle_head_file",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "file",
+            "description": "The path of the file within the support bundle to query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/finalize": {
+      "post": {
+        "summary": "Finalizes the creation of a support bundle",
+        "description": "If the requested hash matched the bundle, the bundle is created. Otherwise, an error is returned.",
+        "operationId": "support_bundle_finalize",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "hash",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "hex string (32 bytes)"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportBundleMetadata"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/index": {
+      "get": {
+        "summary": "Fetch the index (list of files within a support bundle)",
+        "operationId": "support_bundle_index",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "summary": "Fetch metadata about the list of files within a support bundle",
+        "operationId": "support_bundle_head_index",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/transfer": {
+      "put": {
+        "summary": "Transfers a chunk of a support bundle within a particular dataset",
+        "operationId": "support_bundle_transfer",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportBundleMetadata"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/commit": {
+      "put": {
+        "summary": "Commit a trust quorum configuration",
+        "operationId": "trust_quorum_commit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/configuration": {
+      "post": {
+        "summary": "Initiate a trust quorum reconfiguration",
+        "operationId": "trust_quorum_reconfigure",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReconfigureMsg"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/coordinator-status": {
+      "get": {
+        "summary": "Get the coordinator status if this node is coordinating a reconfiguration",
+        "operationId": "trust_quorum_coordinator_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoordinatorStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/network-config": {
+      "get": {
+        "summary": "Get the current network config from trust quorum",
+        "operationId": "trust_quorum_network_config_get",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrustQuorumNetworkConfig"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update the network config in trust quorum",
+        "operationId": "trust_quorum_network_config_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrustQuorumNetworkConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/prepare-and-commit": {
+      "put": {
+        "summary": "Attempt to prepare and commit a trust quorum configuration",
+        "operationId": "trust_quorum_prepare_and_commit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrepareAndCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/proxy/commit": {
+      "put": {
+        "summary": "Proxy a commit operation to another trust quorum node",
+        "operationId": "trust_quorum_proxy_commit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProxyCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/proxy/prepare-and-commit": {
+      "put": {
+        "summary": "Proxy a prepare-and-commit operation to another trust quorum node",
+        "operationId": "trust_quorum_proxy_prepare_and_commit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProxyPrepareAndCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/proxy/status": {
+      "get": {
+        "summary": "Proxy a status request to another trust quorum node",
+        "operationId": "trust_quorum_proxy_status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "part_number",
+            "description": "Oxide Part Number",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "serial_number",
+            "description": "Serial number (unique for a given part number)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodeStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/status": {
+      "get": {
+        "summary": "Get the status of this trust quorum node",
+        "operationId": "trust_quorum_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodeStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/upgrade": {
+      "post": {
+        "summary": "Initiate an upgrade from LRTQ",
+        "operationId": "trust_quorum_upgrade_from_lrtq",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LrtqUpgradeMsg"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v2p": {
+      "get": {
+        "summary": "List v2p mappings present on sled",
+        "operationId": "list_v2p",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_VirtualNetworkInterfaceHost",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VirtualNetworkInterfaceHost"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Create a mapping from a virtual NIC to a physical host",
+        "operationId": "set_v2p",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VirtualNetworkInterfaceHost"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a mapping from a virtual NIC to a physical host",
+        "operationId": "del_v2p",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VirtualNetworkInterfaceHost"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}": {
+      "put": {
+        "operationId": "vmm_register",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceEnsureBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledVmmState"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "vmm_unregister",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VmmUnregisterResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/attached-subnets": {
+      "put": {
+        "summary": "Update the subnets attached to an instance.",
+        "operationId": "vmm_put_attached_subnets",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttachedSubnets"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "post": {
+        "summary": "Attach a subnet to an instance.",
+        "operationId": "vmm_post_attached_subnet",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttachedSubnet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete all subnets attached to an instance.",
+        "operationId": "vmm_delete_attached_subnets",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/attached-subnets/{subnet}": {
+      "delete": {
+        "summary": "Detach a subnet from an instance.",
+        "operationId": "vmm_delete_attached_subnet",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "subnet",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IpNet"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/disks/{disk_id}/snapshot": {
+      "post": {
+        "summary": "Take a snapshot of a disk that is attached to an instance",
+        "operationId": "vmm_issue_disk_snapshot_request",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VmmIssueDiskSnapshotRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VmmIssueDiskSnapshotRequestResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/external-ip": {
+      "put": {
+        "operationId": "vmm_put_external_ip",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceExternalIpBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "vmm_delete_external_ip",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceExternalIpBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/multicast-group": {
+      "put": {
+        "operationId": "vmm_join_multicast_group",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceMulticastBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "vmm_leave_multicast_group",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceMulticastBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/state": {
+      "get": {
+        "operationId": "vmm_get_state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledVmmState"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "operationId": "vmm_put_state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VmmPutStateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VmmPutStateResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vpc/{vpc_id}/firewall/rules": {
+      "put": {
+        "operationId": "vpc_firewall_rules_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vpc_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpcFirewallRulesEnsureBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vpc-routes": {
+      "get": {
+        "summary": "Get the current versions of VPC routing rules.",
+        "operationId": "list_vpc_routes",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_ResolvedVpcRouteState",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResolvedVpcRouteState"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update VPC routing rules.",
+        "operationId": "set_vpc_routes",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "title": "Array_of_ResolvedVpcRouteSet",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ResolvedVpcRouteSet"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones": {
+      "get": {
+        "summary": "List the zones that are currently managed by the sled agent.",
+        "operationId": "zones_list",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_String",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundle-cleanup": {
+      "post": {
+        "summary": "Trigger a zone bundle cleanup.",
+        "operationId": "zone_bundle_cleanup",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Map_of_CleanupCount",
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/CleanupCount"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundle-cleanup/context": {
+      "get": {
+        "summary": "Return context used by the zone-bundle cleanup task.",
+        "operationId": "zone_bundle_cleanup_context",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CleanupContext"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update context used by the zone-bundle cleanup task.",
+        "operationId": "zone_bundle_cleanup_context_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CleanupContextUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundle-cleanup/utilization": {
+      "get": {
+        "summary": "Return utilization information about all zone bundles.",
+        "operationId": "zone_bundle_utilization",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Map_of_BundleUtilization",
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/BundleUtilization"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundles": {
+      "get": {
+        "summary": "List all zone bundles that exist, even for now-deleted zones.",
+        "operationId": "zone_bundle_list_all",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "An optional substring used to filter zone bundles.",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_ZoneBundleMetadata",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ZoneBundleMetadata"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundles/{zone_name}": {
+      "get": {
+        "summary": "List the zone bundles that are available for a running zone.",
+        "operationId": "zone_bundle_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "zone_name",
+            "description": "The name of the zone.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_ZoneBundleMetadata",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ZoneBundleMetadata"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundles/{zone_name}/{bundle_id}": {
+      "get": {
+        "summary": "Fetch the binary content of a single zone bundle.",
+        "operationId": "zone_bundle_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "bundle_id",
+            "description": "The ID for this bundle itself.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zone_name",
+            "description": "The name of the zone this bundle is derived from.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a zone bundle.",
+        "operationId": "zone_bundle_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "bundle_id",
+            "description": "The ID for this bundle itself.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zone_name",
+            "description": "The name of the zone this bundle is derived from.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AddSledRequest": {
+        "description": "A request to Add a given sled after rack initialization has occurred",
+        "type": "object",
+        "properties": {
+          "sled_id": {
+            "$ref": "#/components/schemas/BaseboardId"
+          },
+          "start_request": {
+            "$ref": "#/components/schemas/StartSledAgentRequest"
+          }
+        },
+        "required": [
+          "sled_id",
+          "start_request"
+        ]
+      },
+      "Alarm": {
+        "description": "An alarm indicating a protocol invariant violation.",
+        "oneOf": [
+          {
+            "description": "Different configurations found for the same epoch.\n\nReason: Nexus creates configurations and stores them in CRDB before sending them to a coordinator of its choosing. Nexus will not send the same reconfiguration request to different coordinators. If it does those coordinators will generate different key shares. However, since Nexus will not tell different nodes to coordinate the same configuration, this state should be impossible to reach.",
+            "type": "object",
+            "properties": {
+              "mismatched_configurations": {
+                "type": "object",
+                "properties": {
+                  "config1": {
+                    "$ref": "#/components/schemas/Configuration"
+                  },
+                  "config2": {
+                    "$ref": "#/components/schemas/Configuration"
+                  },
+                  "from": {
+                    "description": "Either a stringified `BaseboardId` or \"Nexus\".",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "config1",
+                  "config2",
+                  "from"
+                ]
+              }
+            },
+            "required": [
+              "mismatched_configurations"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "The `keyShareComputer` could not compute this node's share.\n\nReason: A threshold of valid key shares were received based on the the share digests in the Configuration. However, computation of the share still failed. This should be impossible.",
+            "type": "object",
+            "properties": {
+              "share_computation_failed": {
+                "type": "object",
+                "properties": {
+                  "epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "err": {
+                    "$ref": "#/components/schemas/CombineError"
+                  }
+                },
+                "required": [
+                  "epoch",
+                  "err"
+                ]
+              }
+            },
+            "required": [
+              "share_computation_failed"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "We started collecting shares for a committed configuration, but we no longer have that configuration in our persistent state.",
+            "type": "object",
+            "properties": {
+              "committed_configuration_lost": {
+                "type": "object",
+                "properties": {
+                  "collecting_epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "latest_committed_epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "collecting_epoch",
+                  "latest_committed_epoch"
+                ]
+              }
+            },
+            "required": [
+              "committed_configuration_lost"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "Decrypting the encrypted rack secrets failed when presented with a `valid` RackSecret.\n\n`Configuration` membership contains the hashes of each valid share. All shares utilized to reconstruct the rack secret were validated against these hashes, and the rack secret was reconstructed. However, using the rack secret to derive encryption keys and decrypt the secrets from old configurations still failed. This should never be possible, and therefore we raise an alarm.",
+            "type": "object",
+            "properties": {
+              "rack_secret_decryption_failed": {
+                "type": "object",
+                "properties": {
+                  "epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "err": {
+                    "$ref": "#/components/schemas/DecryptionError"
+                  }
+                },
+                "required": [
+                  "epoch",
+                  "err"
+                ]
+              }
+            },
+            "required": [
+              "rack_secret_decryption_failed"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "Reconstructing the rack secret failed when presented with `valid` shares.\n\n`Configuration` membership contains the hashes of each valid share. All shares utilized to reconstruct the rack secret were validated against these hashes, and yet, the reconstruction still failed. This indicates either a bit flip in a share after validation, or, more likely, an invalid hash.",
+            "type": "object",
+            "properties": {
+              "rack_secret_reconstruction_failed": {
+                "type": "object",
+                "properties": {
+                  "epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "err": {
+                    "$ref": "#/components/schemas/RackSecretReconstructError"
+                  }
+                },
+                "required": [
+                  "epoch",
+                  "err"
+                ]
+              }
+            },
+            "required": [
+              "rack_secret_reconstruction_failed"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ArtifactConfig": {
+        "description": "Artifact configuration.\n\nThis type is used in both GET (response) and PUT (request) operations.",
+        "type": "object",
+        "properties": {
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "hex string (32 bytes)"
+            },
+            "uniqueItems": true
+          },
+          "generation": {
+            "$ref": "#/components/schemas/Generation"
+          }
+        },
+        "required": [
+          "artifacts",
+          "generation"
+        ]
+      },
+      "ArtifactCopyFromDepotBody": {
+        "description": "Request body for copying artifacts from a depot.",
+        "type": "object",
+        "properties": {
+          "depot_base_url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "depot_base_url"
+        ]
+      },
+      "ArtifactCopyFromDepotResponse": {
+        "description": "Response for copying artifacts from a depot.",
+        "type": "object"
+      },
+      "ArtifactListResponse": {
+        "description": "Response for listing artifacts.",
+        "type": "object",
+        "properties": {
+          "generation": {
+            "$ref": "#/components/schemas/Generation"
+          },
+          "list": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          }
+        },
+        "required": [
+          "generation",
+          "list"
+        ]
+      },
+      "ArtifactPutResponse": {
+        "description": "Response for putting an artifact.",
+        "type": "object",
+        "properties": {
+          "datasets": {
+            "description": "The number of valid M.2 artifact datasets we found on the sled. There is typically one of these datasets for each functional M.2.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "successful_writes": {
+            "description": "The number of valid writes to the M.2 artifact datasets. This should be less than or equal to the number of artifact datasets.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "datasets",
+          "successful_writes"
+        ]
+      },
+      "AttachedSubnet": {
+        "description": "A subnet attached to a single instance.",
+        "type": "object",
+        "properties": {
+          "kind": {
+            "description": "The kind of subnet that is attached.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AttachedSubnetKind"
+              }
+            ]
+          },
+          "subnet": {
+            "description": "The IP subnet.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IpNet"
+              }
+            ]
+          }
+        },
+        "required": [
+          "kind",
+          "subnet"
+        ]
+      },
+      "AttachedSubnetKind": {
+        "description": "The kind of attached subnet.",
+        "oneOf": [
+          {
+            "description": "This is a VPC subnet.",
+            "type": "string",
+            "enum": [
+              "vpc"
+            ]
+          },
+          {
+            "description": "This is an external subnet.",
+            "type": "string",
+            "enum": [
+              "external"
+            ]
+          }
+        ]
+      },
+      "AttachedSubnets": {
+        "description": "Subnets attached to a single instance.",
+        "type": "object",
+        "properties": {
+          "subnets": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/AttachedSubnet"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AttachedSubnet"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "subnets"
+        ]
+      },
+      "Attestation": {
+        "description": "An RoT produced attestation that represents a signature over the provided [`Nonce`] combined with the [`MeasurementLog`] and signed by a key certified by the [`CertificateChain`].",
+        "oneOf": [
+          {
+            "description": "An Ed25519 signature.",
+            "type": "object",
+            "properties": {
+              "ed25519": {
+                "type": "string",
+                "format": "hex string (64 bytes)"
+              }
+            },
+            "required": [
+              "ed25519"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Baseboard": {
+        "description": "Describes properties that should uniquely identify a Gimlet.\n\nThis is the frozen, original form of the baseboard as published by Sled Agent API versions 1 through 39. Newer versions report a [`BaseboardId`] instead. The `Unknown` variant is retained here solely to preserve the blessed schema of these older versions; it is no longer produced.\n\n[`BaseboardId`]: sled_hardware_types::BaseboardId",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "gimlet"
+                ]
+              }
+            },
+            "required": [
+              "identifier",
+              "model",
+              "revision",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "unknown"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "pc"
+                ]
+              }
+            },
+            "required": [
+              "identifier",
+              "model",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BaseboardId": {
+        "description": "A representation of a Baseboard ID as used in the inventory subsystem.\n\nThis type is essentially the same as a `Baseboard` except it doesn't have a revision or HW type (Gimlet, PC, Unknown).",
+        "type": "object",
+        "properties": {
+          "part_number": {
+            "description": "Oxide Part Number",
+            "type": "string"
+          },
+          "serial_number": {
+            "description": "Serial number (unique for a given part number)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "part_number",
+          "serial_number"
+        ]
+      },
+      "BfdMode": {
+        "description": "BFD connection mode.",
+        "type": "string",
+        "enum": [
+          "single_hop",
+          "multi_hop"
+        ]
+      },
+      "BfdPeerConfig": {
+        "type": "object",
+        "properties": {
+          "detection_threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "local": {
+            "nullable": true,
+            "type": "string",
+            "format": "ip"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/BfdMode"
+          },
+          "remote": {
+            "type": "string",
+            "format": "ip"
+          },
+          "required_rx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "switch": {
+            "$ref": "#/components/schemas/SwitchSlot"
+          }
+        },
+        "required": [
+          "detection_threshold",
+          "mode",
+          "remote",
+          "required_rx",
+          "switch"
+        ]
+      },
+      "BgpConfig": {
+        "type": "object",
+        "properties": {
+          "asn": {
+            "description": "The autonomous system number for the BGP configuration.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "checker": {
+            "nullable": true,
+            "description": "Checker to apply to incoming messages.",
+            "default": null,
+            "type": "string"
+          },
+          "max_paths": {
+            "description": "Maximum number of paths to use when multiple \"best paths\" exist",
+            "default": 1,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaxPathConfig"
+              }
+            ]
+          },
+          "originate": {
+            "description": "The set of prefixes for the BGP router to originate.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IpNet"
+            }
+          },
+          "shaper": {
+            "nullable": true,
+            "description": "Shaper to apply to outgoing messages.",
+            "default": null,
+            "type": "string"
+          }
+        },
+        "required": [
+          "asn",
+          "originate"
+        ]
+      },
+      "BgpPeerConfig": {
+        "description": "A BGP peer configuration for a port.",
+        "type": "object",
+        "properties": {
+          "addr": {
+            "description": "Address of the peer (numbered or unnumbered).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RouterPeerType"
+              }
+            ]
+          },
+          "allowed_export": {
+            "description": "Define export policy for a peer.",
+            "default": {
+              "type": "no_filtering"
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImportExportPolicy"
+              }
+            ]
+          },
+          "allowed_import": {
+            "description": "Define import policy for a peer.",
+            "default": {
+              "type": "no_filtering"
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImportExportPolicy"
+              }
+            ]
+          },
+          "asn": {
+            "description": "The autonomous system number of the router the peer belongs to.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "communities": {
+            "description": "Include the provided communities in updates sent to the peer.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          "connect_retry": {
+            "nullable": true,
+            "description": "The interval in seconds between peer connection retry attempts.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "delay_open": {
+            "nullable": true,
+            "description": "How long to delay sending open messages to a peer. In seconds.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "enforce_first_as": {
+            "description": "Enforce that the first AS in paths received from this peer is the peer's AS.",
+            "default": false,
+            "type": "boolean"
+          },
+          "hold_time": {
+            "nullable": true,
+            "description": "How long to keep a session alive without a keepalive in seconds. Defaults to 6.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "idle_hold_time": {
+            "nullable": true,
+            "description": "How long to keep a peer in idle after a state machine reset in seconds.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "keepalive": {
+            "nullable": true,
+            "description": "The interval to send keepalive messages at.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "local_pref": {
+            "nullable": true,
+            "description": "Apply a local preference to routes received from this peer.",
+            "default": null,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "md5_auth_key": {
+            "nullable": true,
+            "description": "Use the given key for TCP-MD5 authentication with the peer.",
+            "default": null,
+            "type": "string"
+          },
+          "min_ttl": {
+            "nullable": true,
+            "description": "Require messages from a peer have a minimum IP time to live field.",
+            "default": null,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "multi_exit_discriminator": {
+            "nullable": true,
+            "description": "Apply the provided multi-exit discriminator (MED) updates sent to the peer.",
+            "default": null,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "port": {
+            "description": "Switch port the peer is reachable on.",
+            "type": "string"
+          },
+          "remote_asn": {
+            "nullable": true,
+            "description": "Require that a peer has a specified ASN.",
+            "default": null,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "vlan_id": {
+            "nullable": true,
+            "description": "Associate a VLAN ID with a BGP peer session.",
+            "default": null,
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "addr",
+          "asn",
+          "port"
+        ]
+      },
+      "BlobStorageBackend": {
+        "description": "A storage backend for a disk whose initial contents are given explicitly by the specification.",
+        "type": "object",
+        "properties": {
+          "base64": {
+            "description": "The disk's initial contents, encoded as a base64 string.",
+            "type": "string"
+          },
+          "readonly": {
+            "description": "Indicates whether the storage is read-only.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "base64",
+          "readonly"
+        ],
+        "additionalProperties": false
+      },
+      "BlueprintExternalNetworkingConfig": {
+        "description": "External networking configuration controlled by Reconfigurator via blueprints.",
+        "type": "object",
+        "properties": {
+          "blueprint_external_networking_generation": {
+            "description": "The current generation number of the blueprint's external networking config.\n\nThis generation number is only bumped when a new blueprint is produced that changes the external networking configuration in some way.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Generation"
+              }
+            ]
+          },
+          "service_zone_nat_entries": {
+            "description": "Set of all Omicron service zone NAT entries.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ServiceZoneNatEntries"
+              }
+            ]
+          }
+        },
+        "required": [
+          "blueprint_external_networking_generation",
+          "service_zone_nat_entries"
+        ]
+      },
+      "Board": {
+        "description": "A VM's mainboard.",
+        "type": "object",
+        "properties": {
+          "chipset": {
+            "description": "The chipset to expose to guest software.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Chipset"
+              }
+            ]
+          },
+          "cpuid": {
+            "nullable": true,
+            "description": "The CPUID values to expose to the guest. If `None`, bhyve will derive default values from the host's CPUID values.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Cpuid"
+              }
+            ]
+          },
+          "cpus": {
+            "description": "The number of virtual logical processors attached to this VM.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "guest_hv_interface": {
+            "description": "The hypervisor platform to expose to the guest. The default is a bhyve-compatible interface with no additional features.\n\nFor compatibility with older versions of Propolis, this field is only serialized if it specifies a non-default interface.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GuestHypervisorInterface"
+              }
+            ]
+          },
+          "memory_mb": {
+            "description": "The amount of guest RAM attached to this VM.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "chipset",
+          "cpus",
+          "memory_mb"
+        ],
+        "additionalProperties": false
+      },
+      "BootImageHeader": {
+        "type": "object",
+        "properties": {
+          "data_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "flags": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "image_name": {
+            "type": "string"
+          },
+          "image_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "sha256": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            },
+            "minItems": 32,
+            "maxItems": 32
+          },
+          "target_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "data_size",
+          "flags",
+          "image_name",
+          "image_size",
+          "sha256",
+          "target_size"
+        ]
+      },
+      "BootOrderEntry": {
+        "description": "An entry in the boot order stored in a [`BootSettings`] component.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of another component in the spec that Propolis should try to boot from.\n\nCurrently, only disk device components are supported.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "BootPartitionContents": {
+        "type": "object",
+        "properties": {
+          "boot_disk": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/M2Slot"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/M2Slot"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "slot_a": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/BootPartitionDetails"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/BootPartitionDetails"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "slot_b": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/BootPartitionDetails"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/BootPartitionDetails"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "boot_disk",
+          "slot_a",
+          "slot_b"
+        ]
+      },
+      "BootPartitionDetails": {
+        "type": "object",
+        "properties": {
+          "artifact_hash": {
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          },
+          "artifact_size": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "header": {
+            "$ref": "#/components/schemas/BootImageHeader"
+          }
+        },
+        "required": [
+          "artifact_hash",
+          "artifact_size",
+          "header"
+        ]
+      },
+      "BootSettings": {
+        "description": "Settings supplied to the guest's firmware image that specify the order in which it should consider its options when selecting a device to try to boot from.",
+        "type": "object",
+        "properties": {
+          "order": {
+            "description": "An ordered list of components to attempt to boot from.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BootOrderEntry"
+            }
+          }
+        },
+        "required": [
+          "order"
+        ],
+        "additionalProperties": false
+      },
+      "BootstoreStatus": {
+        "description": "Status of the local bootstore node.",
+        "type": "object",
+        "properties": {
+          "accepted_connections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "established_connections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EstablishedConnection"
+            }
+          },
+          "fsm_ledger_generation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "fsm_state": {
+            "type": "string"
+          },
+          "negotiating_connections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "network_config_ledger_generation": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "peers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "accepted_connections",
+          "established_connections",
+          "fsm_ledger_generation",
+          "fsm_state",
+          "negotiating_connections",
+          "peers"
+        ]
+      },
+      "BundleUtilization": {
+        "description": "The portion of a debug dataset used for zone bundles.",
+        "type": "object",
+        "properties": {
+          "bytes_available": {
+            "description": "The total number of bytes available for zone bundles.\n\nThis is `dataset_quota` multiplied by the context's storage limit.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "bytes_used": {
+            "description": "Total bundle usage, in bytes.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "dataset_quota": {
+            "description": "The total dataset quota, in bytes.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "bytes_available",
+          "bytes_used",
+          "dataset_quota"
+        ]
+      },
+      "ByteCount": {
+        "description": "Byte count to express memory or storage capacity.",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0
+      },
+      "CertificateChain": {
+        "description": "A chain of PEM-encoded X.509 certificates (RFC5280) that link an attestation signing key to a trusted PKI root.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "Chipset": {
+        "description": "A kind of virtual chipset.",
+        "oneOf": [
+          {
+            "description": "An Intel 440FX-compatible chipset.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i440_fx"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/I440Fx"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "CleanupContext": {
+        "description": "Context provided for the zone bundle cleanup task.",
+        "type": "object",
+        "properties": {
+          "period": {
+            "description": "The period on which automatic checks and cleanup is performed.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CleanupPeriod"
+              }
+            ]
+          },
+          "priority": {
+            "description": "The priority ordering for keeping old bundles.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PriorityOrder"
+              }
+            ]
+          },
+          "storage_limit": {
+            "description": "The limit on the dataset quota available for zone bundles.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StorageLimit"
+              }
+            ]
+          }
+        },
+        "required": [
+          "period",
+          "priority",
+          "storage_limit"
+        ]
+      },
+      "CleanupContextUpdate": {
+        "description": "Parameters used to update the zone bundle cleanup context.",
+        "type": "object",
+        "properties": {
+          "period": {
+            "nullable": true,
+            "description": "The new period on which automatic cleanups are run.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          },
+          "priority": {
+            "nullable": true,
+            "description": "The priority ordering for preserving old zone bundles.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PriorityOrder"
+              }
+            ]
+          },
+          "storage_limit": {
+            "nullable": true,
+            "description": "The new limit on the underlying dataset quota allowed for bundles.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        }
+      },
+      "CleanupCount": {
+        "description": "The count of bundles / bytes removed during a cleanup operation.",
+        "type": "object",
+        "properties": {
+          "bundles": {
+            "description": "The number of bundles removed.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "bytes": {
+            "description": "The number of bytes removed.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "bundles",
+          "bytes"
+        ]
+      },
+      "CleanupPeriod": {
+        "description": "A period on which bundles are automatically cleaned up.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Duration"
+          }
+        ]
+      },
+      "CombineError": {
+        "type": "string",
+        "enum": [
+          "too_few_shares",
+          "duplicate_x_coordinates",
+          "invalid_share_lengths",
+          "invalid_share_id"
+        ]
+      },
+      "CommitRequest": {
+        "description": "Request to commit a trust quorum configuration at a given epoch.",
+        "type": "object",
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "rack_id": {
+            "$ref": "#/components/schemas/RackUuid"
+          }
+        },
+        "required": [
+          "epoch",
+          "rack_id"
+        ]
+      },
+      "CommitStatus": {
+        "description": "Whether or not a configuration has been committed or is still underway.",
+        "type": "string",
+        "enum": [
+          "committed",
+          "pending"
+        ]
+      },
+      "Component": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/VirtioDisk"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "virtio_disk"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/NvmeDisk"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "nvme_disk"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/VirtioNic"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "virtio_nic"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/SerialPort"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "serial_port"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/PciPciBridge"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "pci_pci_bridge"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/QemuPvpanic"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "qemu_pvpanic"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/BootSettings"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "boot_settings"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/VirtioSocket"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "virtio_socket"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/SoftNpuPciPort"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "soft_npu_pci_port"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/SoftNpuPort"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "soft_npu_port"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/SoftNpuP9"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "soft_npu_p9"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/P9fs"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "p9fs"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/MigrationFailureInjector"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "migration_failure_injector"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/CrucibleStorageBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "crucible_storage_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/FileStorageBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "file_storage_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/BlobStorageBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "blob_storage_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/VirtioNetworkBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "virtio_network_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/DlpiNetworkBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dlpi_network_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "CompressionAlgorithm": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "on"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "off"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "gzip"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "level": {
+                "$ref": "#/components/schemas/GzipLevel"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "gzip_n"
+                ]
+              }
+            },
+            "required": [
+              "level",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "lz4"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "lzjb"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "zle"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "ConfigReconcilerInventory": {
+        "description": "Describes the last attempt made by the sled-agent-config-reconciler to reconcile the current sled config against the actual state of the sled.",
+        "type": "object",
+        "properties": {
+          "boot_partitions": {
+            "$ref": "#/components/schemas/BootPartitionContents"
+          },
+          "datasets": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigReconcilerInventoryResult"
+            }
+          },
+          "external_disks": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigReconcilerInventoryResult"
+            }
+          },
+          "last_reconciled_config": {
+            "$ref": "#/components/schemas/OmicronSledConfig"
+          },
+          "orphaned_datasets": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/OrphanedDataset"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrphanedDataset"
+            },
+            "uniqueItems": true
+          },
+          "remove_mupdate_override": {
+            "nullable": true,
+            "description": "The result of removing the mupdate override file on disk.\n\n`None` if `remove_mupdate_override` was not provided in the sled config.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RemoveMupdateOverrideInventory"
+              }
+            ]
+          },
+          "zones": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigReconcilerInventoryResult"
+            }
+          }
+        },
+        "required": [
+          "boot_partitions",
+          "datasets",
+          "external_disks",
+          "last_reconciled_config",
+          "orphaned_datasets",
+          "zones"
+        ]
+      },
+      "ConfigReconcilerInventoryResult": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "result": {
+                "type": "string",
+                "enum": [
+                  "ok"
+                ]
+              }
+            },
+            "required": [
+              "result"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "result": {
+                "type": "string",
+                "enum": [
+                  "err"
+                ]
+              }
+            },
+            "required": [
+              "message",
+              "result"
+            ]
+          }
+        ]
+      },
+      "ConfigReconcilerInventoryStatus": {
+        "description": "Status of the sled-agent-config-reconciler task.",
+        "oneOf": [
+          {
+            "description": "The reconciler task has not yet run for the first time since sled-agent started.",
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "not_yet_run"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "description": "The reconciler task is actively running.",
+            "type": "object",
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/OmicronSledConfig"
+              },
+              "running_for": {
+                "$ref": "#/components/schemas/Duration"
+              },
+              "started_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "running"
+                ]
+              }
+            },
+            "required": [
+              "config",
+              "running_for",
+              "started_at",
+              "status"
+            ]
+          },
+          {
+            "description": "The reconciler task is currently idle, but previously did complete a reconciliation attempt.\n\nThis variant does not include the `OmicronSledConfig` used in the last attempt, because that's always available via [`ConfigReconcilerInventory::last_reconciled_config`].",
+            "type": "object",
+            "properties": {
+              "completed_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "ran_for": {
+                "$ref": "#/components/schemas/Duration"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "idle"
+                ]
+              }
+            },
+            "required": [
+              "completed_at",
+              "ran_for",
+              "status"
+            ]
+          }
+        ]
+      },
+      "Configuration": {
+        "description": "The configuration for a given epoch.\n\nOnly valid for non-lrtq configurations.",
+        "type": "object",
+        "properties": {
+          "coordinator": {
+            "description": "Who was the coordinator of this reconfiguration?",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          },
+          "encrypted_rack_secrets": {
+            "nullable": true,
+            "description": "There are no encrypted rack secrets for the initial configuration.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EncryptedRackSecrets"
+              }
+            ]
+          },
+          "epoch": {
+            "description": "Unique, monotonically increasing identifier for a configuration.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "members": {
+            "description": "All members of the current configuration and the hash of their key shares.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfigurationMember"
+            }
+          },
+          "rack_id": {
+            "description": "Unique Id of the rack.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RackUuid"
+              }
+            ]
+          },
+          "threshold": {
+            "description": "The number of sleds required to reconstruct the rack secret.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "coordinator",
+          "epoch",
+          "members",
+          "rack_id",
+          "threshold"
+        ]
+      },
+      "ConfigurationMember": {
+        "description": "A member entry in a trust quorum configuration.\n\nThis type is used for OpenAPI schema generation since OpenAPI v3.0.x doesn't support tuple arrays.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The baseboard ID of the member.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          },
+          "share_digest": {
+            "description": "The SHA3-256 hash of the member's key share.",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          }
+        },
+        "required": [
+          "id",
+          "share_digest"
+        ]
+      },
+      "CoordinatorStatus": {
+        "description": "Status of the node coordinating the reconfiguration or LRTQ upgrade.",
+        "type": "object",
+        "properties": {
+          "acked_prepares": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseboardId"
+            },
+            "uniqueItems": true
+          },
+          "config": {
+            "$ref": "#/components/schemas/Configuration"
+          }
+        },
+        "required": [
+          "acked_prepares",
+          "config"
+        ]
+      },
+      "Cpuid": {
+        "description": "A set of CPUID values to expose to a guest.",
+        "type": "object",
+        "properties": {
+          "entries": {
+            "description": "A list of CPUID leaves/subleaves and their associated values.\n\nPropolis servers require that each entry's `leaf` be unique and that it falls in either the \"standard\" (0 to 0xFFFF) or \"extended\" (0x8000_0000 to 0x8000_FFFF) function ranges, since these are the only valid input ranges currently defined by Intel and AMD. See the Intel 64 and IA-32 Architectures Software Developer's Manual (June 2024) Table 3-17 and the AMD64 Architecture Programmer's Manual (March 2024) Volume 3's documentation of the CPUID instruction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CpuidEntry"
+            }
+          },
+          "vendor": {
+            "description": "The CPU vendor to emulate.\n\nCPUID leaves in the extended range (0x8000_0000 to 0x8000_FFFF) have vendor-defined semantics. Propolis uses this value to determine these semantics when deciding whether it needs to specialize the supplied template values for these leaves.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CpuidVendor"
+              }
+            ]
+          }
+        },
+        "required": [
+          "entries",
+          "vendor"
+        ],
+        "additionalProperties": false
+      },
+      "CpuidEntry": {
+        "description": "A full description of a CPUID leaf/subleaf and the values it produces.",
+        "type": "object",
+        "properties": {
+          "eax": {
+            "description": "The value to return in eax.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "ebx": {
+            "description": "The value to return in ebx.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "ecx": {
+            "description": "The value to return in ecx.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "edx": {
+            "description": "The value to return in edx.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "leaf": {
+            "description": "The leaf (function) number for this entry.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "subleaf": {
+            "nullable": true,
+            "description": "The subleaf (index) number for this entry, if it uses subleaves.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "eax",
+          "ebx",
+          "ecx",
+          "edx",
+          "leaf"
+        ],
+        "additionalProperties": false
+      },
+      "CpuidVendor": {
+        "description": "A CPU vendor to use when interpreting the meanings of CPUID leaves in the extended ID range (0x80000000 to 0x8000FFFF).",
+        "type": "string",
+        "enum": [
+          "amd",
+          "intel"
+        ]
+      },
+      "CrucibleStorageBackend": {
+        "description": "A Crucible storage backend.",
+        "type": "object",
+        "properties": {
+          "readonly": {
+            "description": "Indicates whether the storage is read-only.",
+            "type": "boolean"
+          },
+          "request_json": {
+            "description": "A serialized `[crucible_client_types::VolumeConstructionRequest]`. This is stored in serialized form so that breaking changes to the definition of a `VolumeConstructionRequest` do not inadvertently break instance spec deserialization.\n\nWhen using a spec to initialize a new instance, the spec author must ensure this request is well-formed and can be deserialized by the version of `crucible_client_types` used by the target Propolis.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "readonly",
+          "request_json"
+        ],
+        "additionalProperties": false
+      },
+      "DatasetConfig": {
+        "description": "Configuration information necessary to request a single dataset.\n\nThese datasets are tracked directly by Nexus.",
+        "type": "object",
+        "properties": {
+          "compression": {
+            "description": "The compression mode to be used by the dataset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CompressionAlgorithm"
+              }
+            ]
+          },
+          "id": {
+            "description": "The UUID of the dataset being requested",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetUuid"
+              }
+            ]
+          },
+          "name": {
+            "description": "The dataset's name",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetName"
+              }
+            ]
+          },
+          "quota": {
+            "nullable": true,
+            "description": "The upper bound on the amount of storage used by this dataset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "reservation": {
+            "nullable": true,
+            "description": "The lower bound on the amount of storage usable by this dataset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          }
+        },
+        "required": [
+          "compression",
+          "id",
+          "name"
+        ]
+      },
+      "DatasetKind": {
+        "description": "The kind of dataset. See the `DatasetKind` enum in omicron-common for possible values.",
+        "type": "string"
+      },
+      "DatasetName": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/DatasetKind"
+          },
+          "pool_name": {
+            "$ref": "#/components/schemas/ZpoolName"
+          }
+        },
+        "required": [
+          "kind",
+          "pool_name"
+        ]
+      },
+      "DatasetUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::DatasetUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "DecryptionError": {
+        "description": "Error decrypting rack secrets.",
+        "oneOf": [
+          {
+            "description": "An opaque error indicating decryption failed.",
+            "type": "string",
+            "enum": [
+              "aead"
+            ]
+          },
+          {
+            "description": "The length of the plaintext is not the correct size and cannot be decoded.",
+            "type": "string",
+            "enum": [
+              "invalid_length"
+            ]
+          }
+        ]
+      },
+      "DelegatedZvol": {
+        "description": "Delegate a ZFS volume to a zone",
+        "oneOf": [
+          {
+            "description": "Delegate a slice of the _unencrypted_ local storage dataset present on this pool into the zone.",
+            "type": "object",
+            "properties": {
+              "dataset_id": {
+                "$ref": "#/components/schemas/DatasetUuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "local_storage_unencrypted"
+                ]
+              },
+              "zpool_id": {
+                "$ref": "#/components/schemas/ExternalZpoolUuid"
+              }
+            },
+            "required": [
+              "dataset_id",
+              "type",
+              "zpool_id"
+            ]
+          },
+          {
+            "description": "Delegate a slice of the _encrypted_ local storage dataset present on this pool into the zone.",
+            "type": "object",
+            "properties": {
+              "dataset_id": {
+                "$ref": "#/components/schemas/DatasetUuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "local_storage_encrypted"
+                ]
+              },
+              "zpool_id": {
+                "$ref": "#/components/schemas/ExternalZpoolUuid"
+              }
+            },
+            "required": [
+              "dataset_id",
+              "type",
+              "zpool_id"
+            ]
+          }
+        ]
+      },
+      "DhcpConfig": {
+        "description": "DHCP configuration for a port\n\nNot present here: Hostname (DHCPv4 option 12; used in DHCPv6 option 39); we use `InstanceRuntimeState::hostname` for this value.",
+        "type": "object",
+        "properties": {
+          "dns_servers": {
+            "description": "DNS servers to send to the instance\n\n(DHCPv4 option 6; DHCPv6 option 23)",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
+          "host_domain": {
+            "nullable": true,
+            "description": "DNS zone this instance's hostname belongs to (e.g. the `project.example` part of `instance1.project.example`)\n\n(DHCPv4 option 15; used in DHCPv6 option 39)",
+            "type": "string"
+          },
+          "search_domains": {
+            "description": "DNS search domains\n\n(DHCPv4 option 119; DHCPv6 option 24)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "dns_servers",
+          "search_domains"
+        ]
+      },
+      "DiskIdentity": {
+        "description": "Uniquely identifies a disk.",
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "serial": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "model",
+          "serial",
+          "vendor"
+        ]
+      },
+      "DiskVariant": {
+        "type": "string",
+        "enum": [
+          "U2",
+          "M2"
+        ]
+      },
+      "DlpiNetworkBackend": {
+        "description": "A network backend associated with a DLPI VNIC on the host.",
+        "type": "object",
+        "properties": {
+          "vnic_name": {
+            "description": "The name of the VNIC to use as a backend.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vnic_name"
+        ],
+        "additionalProperties": false
+      },
+      "Duration": {
+        "type": "object",
+        "properties": {
+          "nanos": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "secs": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "nanos",
+          "secs"
+        ]
+      },
+      "EncryptedRackSecrets": {
+        "description": "All possibly relevant __encrypted__ rack secrets for _prior_ committed configurations.",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "Encrypted data.",
+            "type": "string",
+            "format": "hex string"
+          },
+          "salt": {
+            "description": "A random value used to derive the key to encrypt the rack secrets for prior committed epochs.",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          }
+        },
+        "required": [
+          "data",
+          "salt"
+        ]
+      },
+      "Error": {
+        "description": "Error information from a response.",
+        "type": "object",
+        "properties": {
+          "error_code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "request_id"
+        ]
+      },
+      "EstablishedConnection": {
+        "description": "An established connection to a bootstore peer.",
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "baseboard": {
+            "$ref": "#/components/schemas/Baseboard"
+          }
+        },
+        "required": [
+          "addr",
+          "baseboard"
+        ]
+      },
+      "ExpungedMetadata": {
+        "description": "Metadata about a node being expunged from the trust quorum.",
+        "type": "object",
+        "properties": {
+          "epoch": {
+            "description": "The committed epoch, later than its current configuration at which the node learned that it had been expunged.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "from": {
+            "description": "Which node this commit information was learned from.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          }
+        },
+        "required": [
+          "epoch",
+          "from"
+        ]
+      },
+      "ExternalIp": {
+        "description": "An external IP address used by a probe.",
+        "type": "object",
+        "properties": {
+          "first_port": {
+            "description": "The first port used by the address.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "ip": {
+            "description": "The external IP address.",
+            "type": "string",
+            "format": "ip"
+          },
+          "kind": {
+            "description": "The kind of address this is.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IpKind"
+              }
+            ]
+          },
+          "last_port": {
+            "description": "The last port used by the address.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_port",
+          "ip",
+          "kind",
+          "last_port"
+        ]
+      },
+      "ExternalIpConfig": {
+        "description": "External IP address configuration.\n\nThis encapsulates all external addresses for an instance, with separate optional configurations for IPv4 and IPv6.",
+        "type": "object",
+        "properties": {
+          "v4": {
+            "nullable": true,
+            "description": "IPv4 external IP configuration.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalIpv4Config"
+              }
+            ]
+          },
+          "v6": {
+            "nullable": true,
+            "description": "IPv6 external IP configuration.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalIpv6Config"
+              }
+            ]
+          }
+        }
+      },
+      "ExternalIpGatewayMap": {
+        "description": "Per-NIC mappings from external IP addresses to the Internet Gateways which can choose them as a source.",
+        "type": "object",
+        "properties": {
+          "mappings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "uniqueItems": true
+              }
+            }
+          }
+        },
+        "required": [
+          "mappings"
+        ]
+      },
+      "ExternalIpv4Config": {
+        "type": "object",
+        "properties": {
+          "ephemeral_ip": {
+            "nullable": true,
+            "description": "An Ephemeral address for in- and outbound connectivity.",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "floating_ips": {
+            "description": "Additional Floating IPs for in- and outbound connectivity.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ipv4"
+            },
+            "uniqueItems": true
+          },
+          "source_nat": {
+            "nullable": true,
+            "description": "Source NAT configuration, for outbound-only connectivity.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SourceNatConfigV4"
+              }
+            ]
+          }
+        },
+        "required": [
+          "floating_ips"
+        ]
+      },
+      "ExternalIpv6Config": {
+        "type": "object",
+        "properties": {
+          "ephemeral_ip": {
+            "nullable": true,
+            "description": "An Ephemeral address for in- and outbound connectivity.",
+            "type": "string",
+            "format": "ipv6"
+          },
+          "floating_ips": {
+            "description": "Additional Floating IPs for in- and outbound connectivity.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ipv6"
+            },
+            "uniqueItems": true
+          },
+          "source_nat": {
+            "nullable": true,
+            "description": "Source NAT configuration, for outbound-only connectivity.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SourceNatConfigV6"
+              }
+            ]
+          }
+        },
+        "required": [
+          "floating_ips"
+        ]
+      },
+      "ExternalZpoolUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::ExternalZpoolUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "FileStorageBackend": {
+        "description": "A storage backend backed by a file in the host system's file system.",
+        "type": "object",
+        "properties": {
+          "block_size": {
+            "description": "Block size of the backend",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "path": {
+            "description": "A path to a file that backs a disk.",
+            "type": "string"
+          },
+          "readonly": {
+            "description": "Indicates whether the storage is read-only.",
+            "type": "boolean"
+          },
+          "workers": {
+            "nullable": true,
+            "description": "Optional worker threads for the file backend, exposed for testing only.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "block_size",
+          "path",
+          "readonly"
+        ],
+        "additionalProperties": false
+      },
+      "FmdHostCase": {
+        "description": "A diagnosed fault case from the illumos Fault Management Daemon on a sled.",
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "Diagnostic code (e.g. \"PCIEX-8000-DJ\").",
+            "type": "string"
+          },
+          "event": {
+            "nullable": true,
+            "description": "Full fault event payload as JSON, if present. Contains the fault-list with classes, certainties, affected FMRIs, and other diagnostic detail."
+          },
+          "url": {
+            "description": "URL for human-readable information about this fault (e.g. `http://illumos.org/msg/PCIEX-8000-DJ`).",
+            "type": "string"
+          },
+          "uuid": {
+            "description": "Unique identifier for this case.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FmdHostCaseUuid"
+              }
+            ]
+          }
+        },
+        "required": [
+          "code",
+          "url",
+          "uuid"
+        ]
+      },
+      "FmdHostCaseUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::FmdHostCaseUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "FmdInventory": {
+        "description": "Successfully collected FMD fault data.",
+        "type": "object",
+        "properties": {
+          "cases": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/FmdHostCase"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FmdHostCase"
+            },
+            "uniqueItems": true
+          },
+          "resources": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/FmdResource"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FmdResource"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "cases",
+          "resources"
+        ]
+      },
+      "FmdInventoryError": {
+        "description": "An error reported by sled-agent in place of an [`FmdInventory`].\n\n`kind` is a typed discriminator suitable for filtering / monitoring. `message` is a human-readable description (built via `Display`); it is informational only and should not be parsed.",
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/FmdInventoryErrorKind"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "message"
+        ]
+      },
+      "FmdInventoryErrorKind": {
+        "description": "Classification of an [`FmdInventoryError`].\n\n`FmdError` is a catch-all for any FMD-side failure: the daemon was unreachable, a case/resource listing failed, or the platform doesn't have FMD at all. The accompanying message disambiguates these cases. `TooManyCases` and `TooManyResources` are first-class because exceeding those bounds is operationally distinct from a transient FMD failure.",
+        "oneOf": [
+          {
+            "description": "Catch-all for FMD-side failures.",
+            "type": "string",
+            "enum": [
+              "fmd_error"
+            ]
+          },
+          {
+            "description": "Number of FMD cases exceeded [`FMD_MAX_CASES`].",
+            "type": "string",
+            "enum": [
+              "too_many_cases"
+            ]
+          },
+          {
+            "description": "Number of FMD resources exceeded [`FMD_MAX_RESOURCES`].",
+            "type": "string",
+            "enum": [
+              "too_many_resources"
+            ]
+          }
+        ]
+      },
+      "FmdResource": {
+        "description": "A resource affected by a diagnosed fault.",
+        "type": "object",
+        "properties": {
+          "case_id": {
+            "description": "UUID of the case that diagnosed this fault.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FmdHostCaseUuid"
+              }
+            ]
+          },
+          "faulty": {
+            "description": "Whether the resource is marked faulty.",
+            "type": "boolean"
+          },
+          "fmri": {
+            "description": "Fault Management Resource Identifier (e.g. \"dev:////pci@af,0/pci1022,1483@3,5\").",
+            "type": "string"
+          },
+          "invisible": {
+            "description": "Whether the resource is marked invisible.",
+            "type": "boolean"
+          },
+          "unusable": {
+            "description": "Whether the resource is marked unusable.",
+            "type": "boolean"
+          },
+          "uuid": {
+            "description": "Unique identifier for this resource entry.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FmdResourceUuid"
+              }
+            ]
+          }
+        },
+        "required": [
+          "case_id",
+          "faulty",
+          "fmri",
+          "invisible",
+          "unusable",
+          "uuid"
+        ]
+      },
+      "FmdResourceUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::FmdResourceUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "Generation": {
+        "description": "Generation numbers stored in the database, used for optimistic concurrency control",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0
+      },
+      "GuestHypervisorInterface": {
+        "description": "A hypervisor interface to expose to the guest.",
+        "oneOf": [
+          {
+            "description": "Expose a bhyve-like interface (\"bhyve bhyve \" as the hypervisor ID in leaf 0x4000_0000 and no additional leaves or features).",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "bhyve"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "Expose a Hyper-V-compatible hypervisor interface with the supplied features enabled.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "hyper_v"
+                ]
+              },
+              "value": {
+                "type": "object",
+                "properties": {
+                  "features": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/HyperVFeatureFlag"
+                    },
+                    "uniqueItems": true
+                  }
+                },
+                "required": [
+                  "features"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "GzipLevel": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0
+      },
+      "HostIdentifier": {
+        "description": "A `HostIdentifier` represents either an IP host or network (v4 or v6), or an entire VPC (identified by its VNI). It is used in firewall rule host filters.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/IpNet"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vpc"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Vni"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "HostPhase2DesiredContents": {
+        "description": "Describes the desired contents of a host phase 2 slot (i.e., the boot partition on one of the internal M.2 drives).",
+        "oneOf": [
+          {
+            "description": "Do not change the current contents.\n\nWe use this value when we've detected a sled has been mupdated (and we don't want to overwrite phase 2 images until we understand how to recover from that mupdate) and as the default value when reading an [`OmicronSledConfig`] that was ledgered before this concept existed.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "current_contents"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Set the phase 2 slot to the given artifact.\n\nThe artifact will come from an unpacked and distributed TUF repo.",
+            "type": "object",
+            "properties": {
+              "hash": {
+                "type": "string",
+                "format": "hex string (32 bytes)"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "artifact"
+                ]
+              }
+            },
+            "required": [
+              "hash",
+              "type"
+            ]
+          }
+        ]
+      },
+      "HostPhase2DesiredSlots": {
+        "description": "Describes the desired contents for both host phase 2 slots.",
+        "type": "object",
+        "properties": {
+          "slot_a": {
+            "$ref": "#/components/schemas/HostPhase2DesiredContents"
+          },
+          "slot_b": {
+            "$ref": "#/components/schemas/HostPhase2DesiredContents"
+          }
+        },
+        "required": [
+          "slot_a",
+          "slot_b"
+        ]
+      },
+      "Hostname": {
+        "title": "An RFC-1035-compliant hostname",
+        "description": "A hostname identifies a host on a network, and is usually a dot-delimited sequence of labels, where each label contains only letters, digits, or the hyphen. See RFCs 1035 and 952 for more details.",
+        "type": "string",
+        "pattern": "^([a-zA-Z0-9]+[a-zA-Z0-9\\-]*(?<!-))(\\.[a-zA-Z0-9]+[a-zA-Z0-9\\-]*(?<!-))*$",
+        "minLength": 1,
+        "maxLength": 253
+      },
+      "HyperVFeatureFlag": {
+        "description": "Flags that enable \"simple\" Hyper-V enlightenments that require no feature-specific configuration.",
+        "type": "string",
+        "enum": [
+          "reference_tsc"
+        ]
+      },
+      "I440Fx": {
+        "description": "An Intel 440FX-compatible chipset.",
+        "type": "object",
+        "properties": {
+          "enable_pcie": {
+            "description": "Specifies whether the chipset should allow PCI configuration space to be accessed through the PCIe extended configuration mechanism.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enable_pcie"
+        ],
+        "additionalProperties": false
+      },
+      "IcmpParamRange": {
+        "example": "3",
+        "title": "A range of ICMP(v6) types or codes",
+        "description": "An inclusive-inclusive range of ICMP(v6) types or codes. The second value may be omitted to represent a single parameter.",
+        "type": "string",
+        "pattern": "^[0-9]{1,3}(-[0-9]{1,3})?$",
+        "minLength": 1,
+        "maxLength": 7
+      },
+      "ImportExportPolicy": {
+        "description": "Define policy relating to the import and export of prefixes from a BGP peer.",
+        "oneOf": [
+          {
+            "description": "Do not perform any filtering.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "no_filtering"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "allow"
+                ]
+              },
+              "value": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/IpNet"
+                }
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "InstanceEnsureBody": {
+        "description": "The body of a request to ensure that a instance and VMM are known to a sled agent.",
+        "type": "object",
+        "properties": {
+          "instance_id": {
+            "description": "The ID of the instance for which this VMM is being created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceUuid"
+              }
+            ]
+          },
+          "local_config": {
+            "description": "Information about the sled-local configuration that needs to be established to make the VM's virtual hardware fully functional.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceSledLocalConfig"
+              }
+            ]
+          },
+          "metadata": {
+            "description": "Metadata used to track instance statistics.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceMetadata"
+              }
+            ]
+          },
+          "migration_id": {
+            "nullable": true,
+            "description": "The ID of the migration in to this VMM, if this VMM is being ensured is part of a migration in. If this is `None`, the VMM is not being created due to a migration.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "propolis_addr": {
+            "description": "The address at which this VMM should serve a Propolis server API.",
+            "type": "string"
+          },
+          "vmm_runtime": {
+            "description": "The initial VMM runtime state for the VMM being registered.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmRuntimeState"
+              }
+            ]
+          },
+          "vmm_spec": {
+            "description": "The virtual hardware configuration this virtual machine should have when it is started.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmSpec"
+              }
+            ]
+          }
+        },
+        "required": [
+          "instance_id",
+          "local_config",
+          "metadata",
+          "propolis_addr",
+          "vmm_runtime",
+          "vmm_spec"
+        ]
+      },
+      "InstanceExternalIpBody": {
+        "description": "Used to dynamically update external IPs attached to an instance.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ephemeral"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "floating"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "InstanceMetadata": {
+        "description": "Metadata used to track statistics about an instance.",
+        "type": "object",
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "silo_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "project_id",
+          "silo_id"
+        ]
+      },
+      "InstanceMigrationTargetParams": {
+        "description": "Parameters used when directing Propolis to initialize itself via live migration.",
+        "type": "object",
+        "properties": {
+          "src_propolis_addr": {
+            "description": "The address of the Propolis server that will serve as the migration source.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "src_propolis_addr"
+        ]
+      },
+      "InstanceMulticastBody": {
+        "description": "Request body for multicast group operations.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "join": {
+                "$ref": "#/components/schemas/InstanceMulticastMembership"
+              }
+            },
+            "required": [
+              "join"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "leave": {
+                "$ref": "#/components/schemas/InstanceMulticastMembership"
+              }
+            },
+            "required": [
+              "leave"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "InstanceMulticastMembership": {
+        "description": "Represents a multicast group membership for an instance.\n\nIntroduced in v7.",
+        "type": "object",
+        "properties": {
+          "group_ip": {
+            "type": "string",
+            "format": "ip"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          }
+        },
+        "required": [
+          "group_ip",
+          "sources"
+        ]
+      },
+      "InstanceSledLocalConfig": {
+        "description": "Describes sled-local configuration that a sled-agent must establish to make the instance's virtual hardware fully functional.",
+        "type": "object",
+        "properties": {
+          "attached_subnets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AttachedSubnet"
+            }
+          },
+          "delegated_zvols": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DelegatedZvol"
+            }
+          },
+          "dhcp_config": {
+            "$ref": "#/components/schemas/DhcpConfig"
+          },
+          "external_ips": {
+            "$ref": "#/components/schemas/ExternalIpConfig"
+          },
+          "firewall_rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedVpcFirewallRule"
+            }
+          },
+          "hostname": {
+            "$ref": "#/components/schemas/Hostname"
+          },
+          "multicast_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstanceMulticastMembership"
+            }
+          },
+          "nics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkInterface"
+            }
+          },
+          "primary_nic_mtu": {
+            "nullable": true,
+            "description": "The MTU to apply to the instance's primary OPTE port, in bytes. If `None`, the OPTE default is used (1500). Set when the fleet has enabled external jumbo frames and the instance has opted in.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "attached_subnets",
+          "delegated_zvols",
+          "dhcp_config",
+          "external_ips",
+          "firewall_rules",
+          "hostname",
+          "multicast_groups",
+          "nics"
+        ]
+      },
+      "InstanceSpec": {
+        "type": "object",
+        "properties": {
+          "board": {
+            "$ref": "#/components/schemas/Board"
+          },
+          "components": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Component"
+            }
+          },
+          "smbios": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SmbiosType1Input"
+              }
+            ]
+          }
+        },
+        "required": [
+          "board",
+          "components"
+        ]
+      },
+      "InstanceUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::InstanceUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "InternalZpoolUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::InternalZpoolUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "InternetGatewayRouterTarget": {
+        "description": "An Internet Gateway router target.",
+        "oneOf": [
+          {
+            "description": "Targets the gateway for the system-internal services VPC.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "system"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Targets a gateway for an instance's VPC.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "instance"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "InvalidRackSecretSizeError": {
+        "description": "Error indicating the rack secret has an invalid size.",
+        "type": "string",
+        "enum": [
+          null
+        ]
+      },
+      "Inventory": {
+        "description": "Identity and basic status information about this sled agent",
+        "type": "object",
+        "properties": {
+          "baseboard_id": {
+            "$ref": "#/components/schemas/BaseboardId"
+          },
+          "cpu_family": {
+            "$ref": "#/components/schemas/SledCpuFamily"
+          },
+          "datasets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InventoryDataset"
+            }
+          },
+          "disks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InventoryDisk"
+            }
+          },
+          "file_source_resolver": {
+            "$ref": "#/components/schemas/OmicronFileSourceResolverInventory"
+          },
+          "fmd": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/FmdInventory"
+                },
+                {
+                  "$ref": "#/components/schemas/FmdInventoryError"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/FmdInventory"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "$ref": "#/components/schemas/FmdInventoryError"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "last_reconciliation": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConfigReconcilerInventory"
+              }
+            ]
+          },
+          "ledgered_sled_config": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OmicronSledConfig"
+              }
+            ]
+          },
+          "reconciler_status": {
+            "$ref": "#/components/schemas/ConfigReconcilerInventoryStatus"
+          },
+          "reference_measurements": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/SingleMeasurementInventory"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SingleMeasurementInventory"
+            },
+            "uniqueItems": true
+          },
+          "reservoir_size": {
+            "$ref": "#/components/schemas/ByteCount"
+          },
+          "sled_agent_address": {
+            "type": "string"
+          },
+          "sled_id": {
+            "$ref": "#/components/schemas/SledUuid"
+          },
+          "sled_role": {
+            "$ref": "#/components/schemas/SledRole"
+          },
+          "smf_services_enabled_not_online": {
+            "$ref": "#/components/schemas/SvcsEnabledNotOnlineResult"
+          },
+          "usable_hardware_threads": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "usable_physical_ram": {
+            "$ref": "#/components/schemas/ByteCount"
+          },
+          "zpools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InventoryZpool"
+            }
+          }
+        },
+        "required": [
+          "baseboard_id",
+          "cpu_family",
+          "datasets",
+          "disks",
+          "file_source_resolver",
+          "fmd",
+          "reconciler_status",
+          "reference_measurements",
+          "reservoir_size",
+          "sled_agent_address",
+          "sled_id",
+          "sled_role",
+          "smf_services_enabled_not_online",
+          "usable_hardware_threads",
+          "usable_physical_ram",
+          "zpools"
+        ]
+      },
+      "InventoryDataset": {
+        "description": "Identifies information about datasets within Oxide-managed zpools",
+        "type": "object",
+        "properties": {
+          "available": {
+            "description": "The amount of remaining space usable by the dataset (and children) assuming there is no other activity within the pool.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "compression": {
+            "description": "The compression algorithm used for this dataset, if any.",
+            "type": "string"
+          },
+          "id": {
+            "nullable": true,
+            "description": "Although datasets mandated by the control plane will have UUIDs, datasets can be created (and have been created) without UUIDs.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetUuid"
+              }
+            ]
+          },
+          "name": {
+            "description": "This name is the full path of the dataset.",
+            "type": "string"
+          },
+          "quota": {
+            "nullable": true,
+            "description": "The maximum amount of space usable by a dataset and all descendents.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "reservation": {
+            "nullable": true,
+            "description": "The minimum amount of space guaranteed to a dataset and descendents.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "used": {
+            "description": "The amount of space consumed by this dataset and descendents.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          }
+        },
+        "required": [
+          "available",
+          "compression",
+          "name",
+          "used"
+        ]
+      },
+      "InventoryDisk": {
+        "description": "Identifies information about disks which may be attached to Sleds.",
+        "type": "object",
+        "properties": {
+          "active_firmware_slot": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "identity": {
+            "$ref": "#/components/schemas/DiskIdentity"
+          },
+          "next_active_firmware_slot": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "number_of_firmware_slots": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "slot": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "slot1_is_read_only": {
+            "type": "boolean"
+          },
+          "slot_firmware_versions": {
+            "type": "array",
+            "items": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          "variant": {
+            "$ref": "#/components/schemas/DiskVariant"
+          }
+        },
+        "required": [
+          "active_firmware_slot",
+          "identity",
+          "number_of_firmware_slots",
+          "slot",
+          "slot1_is_read_only",
+          "slot_firmware_versions",
+          "variant"
+        ]
+      },
+      "InventoryZpool": {
+        "description": "Identifies information about zpools managed by the control plane",
+        "type": "object",
+        "properties": {
+          "health": {
+            "$ref": "#/components/schemas/ZpoolHealth"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ZpoolUuid"
+          },
+          "total_size": {
+            "$ref": "#/components/schemas/ByteCount"
+          }
+        },
+        "required": [
+          "health",
+          "id",
+          "total_size"
+        ]
+      },
+      "IpKind": {
+        "description": "The kind of external IP address of a probe.",
+        "type": "string",
+        "enum": [
+          "snat",
+          "ephemeral",
+          "floating"
+        ]
+      },
+      "IpNet": {
+        "x-rust-type": {
+          "crate": "oxnet",
+          "path": "oxnet::IpNet",
+          "version": "0.1.0"
+        },
+        "oneOf": [
+          {
+            "title": "v4",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv4Net"
+              }
+            ]
+          },
+          {
+            "title": "v6",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            ]
+          }
+        ]
+      },
+      "Ipv4Net": {
+        "example": "192.168.1.0/24",
+        "title": "An IPv4 subnet",
+        "description": "An IPv4 subnet, including prefix and prefix length",
+        "x-rust-type": {
+          "crate": "oxnet",
+          "path": "oxnet::Ipv4Net",
+          "version": "0.1.0"
+        },
+        "type": "string",
+        "pattern": "^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|1[0-9]|2[0-9]|3[0-2])$"
+      },
+      "Ipv6Net": {
+        "example": "fd12:3456::/64",
+        "title": "An IPv6 subnet",
+        "description": "An IPv6 subnet, including prefix and subnet mask",
+        "x-rust-type": {
+          "crate": "oxnet",
+          "path": "oxnet::Ipv6Net",
+          "version": "0.1.0"
+        },
+        "type": "string",
+        "pattern": "^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$"
+      },
+      "Ipv6Subnet": {
+        "description": "Wraps an [`Ipv6Net`] with a compile-time prefix length.",
+        "type": "object",
+        "properties": {
+          "net": {
+            "$ref": "#/components/schemas/Ipv6Net"
+          }
+        },
+        "required": [
+          "net"
+        ]
+      },
+      "L4PortRange": {
+        "example": "22",
+        "title": "A range of IP ports",
+        "description": "An inclusive-inclusive range of IP ports. The second port may be omitted to represent a single port.",
+        "type": "string",
+        "pattern": "^[0-9]{1,5}(-[0-9]{1,5})?$",
+        "minLength": 1,
+        "maxLength": 11
+      },
+      "LinkFec": {
+        "description": "The forward error correction mode of a link.",
+        "oneOf": [
+          {
+            "description": "Firecode forward error correction.",
+            "type": "string",
+            "enum": [
+              "firecode"
+            ]
+          },
+          {
+            "description": "No forward error correction.",
+            "type": "string",
+            "enum": [
+              "none"
+            ]
+          },
+          {
+            "description": "Reed-Solomon forward error correction.",
+            "type": "string",
+            "enum": [
+              "rs"
+            ]
+          }
+        ]
+      },
+      "LinkSpeed": {
+        "description": "The speed of a link.",
+        "oneOf": [
+          {
+            "description": "Zero gigabits per second.",
+            "type": "string",
+            "enum": [
+              "speed0_g"
+            ]
+          },
+          {
+            "description": "1 gigabit per second.",
+            "type": "string",
+            "enum": [
+              "speed1_g"
+            ]
+          },
+          {
+            "description": "10 gigabits per second.",
+            "type": "string",
+            "enum": [
+              "speed10_g"
+            ]
+          },
+          {
+            "description": "25 gigabits per second.",
+            "type": "string",
+            "enum": [
+              "speed25_g"
+            ]
+          },
+          {
+            "description": "40 gigabits per second.",
+            "type": "string",
+            "enum": [
+              "speed40_g"
+            ]
+          },
+          {
+            "description": "50 gigabits per second.",
+            "type": "string",
+            "enum": [
+              "speed50_g"
+            ]
+          },
+          {
+            "description": "100 gigabits per second.",
+            "type": "string",
+            "enum": [
+              "speed100_g"
+            ]
+          },
+          {
+            "description": "200 gigabits per second.",
+            "type": "string",
+            "enum": [
+              "speed200_g"
+            ]
+          },
+          {
+            "description": "400 gigabits per second.",
+            "type": "string",
+            "enum": [
+              "speed400_g"
+            ]
+          }
+        ]
+      },
+      "LldpAdminStatus": {
+        "description": "To what extent should this port participate in LLDP",
+        "type": "string",
+        "enum": [
+          "enabled",
+          "disabled",
+          "rx_only",
+          "tx_only"
+        ]
+      },
+      "LldpPortConfig": {
+        "description": "Per-port LLDP configuration settings.  Only the \"status\" setting is mandatory.  All other fields have natural defaults or may be inherited from the switch.",
+        "type": "object",
+        "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "Chassis ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "management_addrs": {
+            "nullable": true,
+            "description": "Management IP addresses to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
+          "port_description": {
+            "nullable": true,
+            "description": "Port description to advertise.  If this is not set, no description will be advertised.",
+            "type": "string"
+          },
+          "port_id": {
+            "nullable": true,
+            "description": "Port ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be set to the port name. e.g., qsfp0/0.",
+            "type": "string"
+          },
+          "status": {
+            "description": "To what extent should this port participate in LLDP",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpAdminStatus"
+              }
+            ]
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "System description to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "System name to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "LocalStorageDatasetDeleteRequest": {
+        "description": "Dataset details for a Local Storage dataset delete request.",
+        "type": "object",
+        "properties": {
+          "dataset_id": {
+            "description": "ID of the local storage dataset allocation, not the local storage dataset!",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetUuid"
+              }
+            ]
+          },
+          "encrypted_at_rest": {
+            "description": "Whether or not to use the encrypted dataset",
+            "type": "boolean"
+          },
+          "zpool_id": {
+            "$ref": "#/components/schemas/ExternalZpoolUuid"
+          }
+        },
+        "required": [
+          "dataset_id",
+          "encrypted_at_rest",
+          "zpool_id"
+        ]
+      },
+      "LocalStorageDatasetEnsureRequest": {
+        "description": "Dataset and Volume details for a Local Storage dataset ensure request.",
+        "type": "object",
+        "properties": {
+          "dataset_id": {
+            "description": "ID of the local storage dataset allocation, not the local storage dataset!",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetUuid"
+              }
+            ]
+          },
+          "dataset_size": {
+            "description": "Size of the parent dataset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "encrypted_at_rest": {
+            "description": "Whether or not to use the encrypted dataset",
+            "type": "boolean"
+          },
+          "volume_size": {
+            "description": "Size of the zvol",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "zpool_id": {
+            "$ref": "#/components/schemas/ExternalZpoolUuid"
+          }
+        },
+        "required": [
+          "dataset_id",
+          "dataset_size",
+          "encrypted_at_rest",
+          "volume_size",
+          "zpool_id"
+        ]
+      },
+      "LrtqUpgradeMsg": {
+        "description": "A request from Nexus informing a node to start coordinating an upgrade from LRTQ.",
+        "type": "object",
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseboardId"
+            },
+            "uniqueItems": true
+          },
+          "rack_id": {
+            "$ref": "#/components/schemas/RackUuid"
+          },
+          "threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "epoch",
+          "members",
+          "rack_id",
+          "threshold"
+        ]
+      },
+      "M2Slot": {
+        "description": "Describes an M.2 slot, often in the context of writing a system image to it.",
+        "type": "string",
+        "enum": [
+          "A",
+          "B"
+        ]
+      },
+      "MacAddr": {
+        "example": "ff:ff:ff:ff:ff:ff",
+        "title": "A MAC address",
+        "description": "A Media Access Control address, in EUI-48 format",
+        "type": "string",
+        "pattern": "^([0-9a-fA-F]{0,2}:){5}[0-9a-fA-F]{0,2}$",
+        "minLength": 5,
+        "maxLength": 17
+      },
+      "ManifestBootInventory": {
+        "description": "Inventory representation of zone artifacts on the boot disk.\n\nPart of [`ManifestInventory`].",
+        "type": "object",
+        "properties": {
+          "artifacts": {
+            "title": "IdOrdMap",
+            "description": "The artifacts on disk.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ZoneArtifactInventory"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ZoneArtifactInventory"
+            },
+            "uniqueItems": true
+          },
+          "source": {
+            "description": "The manifest source.\n\nIn production this is [`OmicronInstallManifestSource::Installinator`], but in some development and testing flows Sled Agent synthesizes zone manifests. In those cases, the source is [`OmicronInstallManifestSource::SledAgent`].",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OmicronInstallManifestSource"
+              }
+            ]
+          }
+        },
+        "required": [
+          "artifacts",
+          "source"
+        ]
+      },
+      "ManifestInventory": {
+        "description": "Inventory representation of a manifest.\n\nPart of [`ZoneImageResolverInventory`].\n\nA manifest is used for both zones and reference measurements. A zone manifest is a listing of all the zones present in a system's install dataset. A measurement manifset is a listing of all the reference measurements present in a system's install dataset. This struct contains information about the install dataset gathered from a system.",
+        "type": "object",
+        "properties": {
+          "boot_disk_path": {
+            "description": "The full path to the zone manifest file on the boot disk.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "boot_inventory": {
+            "description": "The manifest read from the boot disk, and whether the manifest is valid.",
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ManifestBootInventory"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/ManifestBootInventory"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "non_boot_status": {
+            "title": "IdOrdMap",
+            "description": "Information about the install dataset on non-boot disks.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ManifestNonBootInventory"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ManifestNonBootInventory"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "boot_disk_path",
+          "boot_inventory",
+          "non_boot_status"
+        ]
+      },
+      "ManifestNonBootInventory": {
+        "description": "Inventory representation of a zone manifest on a non-boot disk.\n\nUnlike [`ManifestBootInventory`] which is structured since Reconfigurator makes decisions based on it, information about non-boot disks is purely advisory. For simplicity, we store information in an unstructured format.",
+        "type": "object",
+        "properties": {
+          "is_valid": {
+            "description": "Whether the status is valid.",
+            "type": "boolean"
+          },
+          "message": {
+            "description": "A message describing the status.\n\nIf `is_valid` is true, then the message describes the list of artifacts found and their hashes.\n\nIf `is_valid` is false, then this message describes the reason for the invalid status. This could include errors reading the zone manifest, or zone file mismatches.",
+            "type": "string"
+          },
+          "path": {
+            "description": "The full path to the zone manifest JSON on the non-boot disk.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "zpool_id": {
+            "description": "The ID of the non-boot zpool.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InternalZpoolUuid"
+              }
+            ]
+          }
+        },
+        "required": [
+          "is_valid",
+          "message",
+          "path",
+          "zpool_id"
+        ]
+      },
+      "MaxPathConfig": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 1,
+        "maximum": 32
+      },
+      "Measurement": {
+        "description": "An RoT provided measurement which represents a digest of some component in the trusted computing base (TCB) for the attestor.",
+        "oneOf": [
+          {
+            "description": "A SHA3-256 digest.",
+            "type": "object",
+            "properties": {
+              "sha3_256": {
+                "type": "string",
+                "format": "hex string (32 bytes)"
+              }
+            },
+            "required": [
+              "sha3_256"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "MeasurementLog": {
+        "description": "The set of measurments provided by the RoT.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Measurement"
+        }
+      },
+      "MigrationFailureInjector": {
+        "description": "Describes a synthetic device that registers for VM lifecycle notifications and returns errors during attempts to migrate.\n\nThis is only supported by Propolis servers compiled with the `failure-injection` feature.",
+        "type": "object",
+        "properties": {
+          "fail_exports": {
+            "description": "The number of times this device should fail requests to export state.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "fail_imports": {
+            "description": "The number of times this device should fail requests to import state.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "fail_exports",
+          "fail_imports"
+        ],
+        "additionalProperties": false
+      },
+      "MigrationRuntimeState": {
+        "description": "An update from a sled regarding the state of a migration, indicating the role of the VMM whose migration state was updated.",
+        "type": "object",
+        "properties": {
+          "gen": {
+            "$ref": "#/components/schemas/Generation"
+          },
+          "migration_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "state": {
+            "$ref": "#/components/schemas/MigrationState"
+          },
+          "time_updated": {
+            "description": "Timestamp for the migration state update.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "gen",
+          "migration_id",
+          "state",
+          "time_updated"
+        ]
+      },
+      "MigrationState": {
+        "description": "The state of an instance's live migration.",
+        "oneOf": [
+          {
+            "description": "The migration has not started for this VMM.",
+            "type": "string",
+            "enum": [
+              "pending"
+            ]
+          },
+          {
+            "description": "The migration is in progress.",
+            "type": "string",
+            "enum": [
+              "in_progress"
+            ]
+          },
+          {
+            "description": "The migration has failed.",
+            "type": "string",
+            "enum": [
+              "failed"
+            ]
+          },
+          {
+            "description": "The migration has completed.",
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          }
+        ]
+      },
+      "MupdateOverrideBootInventory": {
+        "description": "Inventory representation of the MUPdate override on the boot disk.",
+        "type": "object",
+        "properties": {
+          "mupdate_override_id": {
+            "description": "The ID of the MUPdate override.\n\nThis is unique and generated by Installinator each time it is run. During a MUPdate, each sled gets a MUPdate override ID. (The ID is shared across boot disks and non-boot disks, though.)",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MupdateOverrideUuid"
+              }
+            ]
+          }
+        },
+        "required": [
+          "mupdate_override_id"
+        ]
+      },
+      "MupdateOverrideInventory": {
+        "description": "Inventory representation of MUPdate override status.\n\nPart of [`ZoneImageResolverInventory`].\n\nThis is used by Reconfigurator to determine if a MUPdate override has occurred. For more about mixing MUPdate and updates, see RFD 556.",
+        "type": "object",
+        "properties": {
+          "boot_disk_path": {
+            "description": "The full path to the mupdate override JSON on the boot disk.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "boot_override": {
+            "description": "The boot disk override, or an error if it could not be parsed.\n\nThis is `None` if the override is not present.",
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/MupdateOverrideBootInventory",
+                  "nullable": true
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "nullable": true,
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/MupdateOverrideBootInventory"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "non_boot_status": {
+            "title": "IdOrdMap",
+            "description": "Information about the MUPdate override on non-boot disks.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/MupdateOverrideNonBootInventory"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MupdateOverrideNonBootInventory"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "boot_disk_path",
+          "boot_override",
+          "non_boot_status"
+        ]
+      },
+      "MupdateOverrideNonBootInventory": {
+        "description": "Inventory representation of the MUPdate override on a non-boot disk.\n\nUnlike [`MupdateOverrideBootInventory`] which is structured since Reconfigurator makes decisions based on it, information about non-boot disks is purely advisory. For simplicity, we store information in an unstructured format.",
+        "type": "object",
+        "properties": {
+          "is_valid": {
+            "description": "Whether the status is valid.",
+            "type": "boolean"
+          },
+          "message": {
+            "description": "A message describing the status.\n\nIf `is_valid` is true, then the message is a short description saying that it matches the boot disk, and whether the MUPdate override is present.\n\nIf `is_valid` is false, then this message describes the reason for the invalid status. This could include errors reading the MUPdate override JSON, or a mismatch between the boot and non-boot disks.",
+            "type": "string"
+          },
+          "path": {
+            "description": "The path to the mupdate override JSON on the non-boot disk.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "zpool_id": {
+            "description": "The non-boot zpool ID.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InternalZpoolUuid"
+              }
+            ]
+          }
+        },
+        "required": [
+          "is_valid",
+          "message",
+          "path",
+          "zpool_id"
+        ]
+      },
+      "MupdateOverrideUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::MupdateOverrideUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "MupdateUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::MupdateUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "Name": {
+        "title": "A name unique within the parent collection",
+        "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They can be at most 63 characters long.",
+        "type": "string",
+        "pattern": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z]([a-zA-Z0-9-]*[a-zA-Z0-9]+)?$",
+        "minLength": 1,
+        "maxLength": 63
+      },
+      "NetworkInterface": {
+        "description": "Information required to construct a virtual network interface",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ip_config": {
+            "$ref": "#/components/schemas/PrivateIpConfig"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/NetworkInterfaceKind"
+          },
+          "mac": {
+            "$ref": "#/components/schemas/MacAddr"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "primary": {
+            "type": "boolean"
+          },
+          "slot": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
+          }
+        },
+        "required": [
+          "id",
+          "ip_config",
+          "kind",
+          "mac",
+          "name",
+          "primary",
+          "slot",
+          "vni"
+        ]
+      },
+      "NetworkInterfaceKind": {
+        "description": "The type of network interface",
+        "oneOf": [
+          {
+            "description": "A vNIC attached to a guest instance",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "instance"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type"
+            ]
+          },
+          {
+            "description": "A vNIC associated with an internal service",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "service"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type"
+            ]
+          },
+          {
+            "description": "A vNIC associated with a probe",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "probe"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type"
+            ]
+          }
+        ]
+      },
+      "NodePersistentStateSummary": {
+        "description": "A summary of a node's persistent state.",
+        "type": "object",
+        "properties": {
+          "commits": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            "uniqueItems": true
+          },
+          "configs": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            "uniqueItems": true
+          },
+          "expunged": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExpungedMetadata"
+              }
+            ]
+          },
+          "has_lrtq_share": {
+            "type": "boolean"
+          },
+          "shares": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "commits",
+          "configs",
+          "has_lrtq_share",
+          "shares"
+        ]
+      },
+      "NodeStatus": {
+        "description": "Details about a given node's status.",
+        "type": "object",
+        "properties": {
+          "alarms": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Alarm"
+            },
+            "uniqueItems": true
+          },
+          "connected_peers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseboardId"
+            },
+            "uniqueItems": true
+          },
+          "persistent_state": {
+            "$ref": "#/components/schemas/NodePersistentStateSummary"
+          },
+          "proxied_requests": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "alarms",
+          "connected_peers",
+          "persistent_state",
+          "proxied_requests"
+        ]
+      },
+      "Nonce": {
+        "description": "A random nonce provided as part of an attestation challenge to guarantee freshness thereby preventing replay attacks.",
+        "anyOf": [
+          {
+            "description": "A 32-byte nonce.",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          }
+        ]
+      },
+      "NvmeDisk": {
+        "description": "A disk that presents an NVMe interface to the guest.",
+        "type": "object",
+        "properties": {
+          "backend_id": {
+            "description": "The name of the disk's backend component.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          },
+          "has_write_cache": {
+            "description": "Control if the NVMe disk reports the presence of a volatile write cache.\n\nThis generally should be configured in consideration of the storage backend for the NVMe device. \"true\" is a safe default, and was historically the only configurable value. If the storage backend will not lose data once writes are accepted, even in the face of unplanned crashes or power loss (or, if you really want to lie to guests), setting this to \"false\" can advise guests they may skip issuing flushes to the device.",
+            "type": "boolean"
+          },
+          "pci_path": {
+            "description": "The PCI bus/device/function at which this disk should be attached.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          },
+          "serial_number": {
+            "description": "The serial number to return in response to an NVMe Identify Controller command.",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            },
+            "minItems": 20,
+            "maxItems": 20
+          }
+        },
+        "required": [
+          "backend_id",
+          "has_write_cache",
+          "pci_path",
+          "serial_number"
+        ],
+        "additionalProperties": false
+      },
+      "OmicronFileSourceResolverInventory": {
+        "description": "Inventory representation of zone image resolver and measurement resolver status and health. Previously known as `ZoneImageResolverInventory`",
+        "type": "object",
+        "properties": {
+          "measurement_manifest": {
+            "description": "The measurement manifest status.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ManifestInventory"
+              }
+            ]
+          },
+          "mupdate_override": {
+            "$ref": "#/components/schemas/MupdateOverrideInventory"
+          },
+          "zone_manifest": {
+            "description": "The zone manifest status.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ManifestInventory"
+              }
+            ]
+          }
+        },
+        "required": [
+          "measurement_manifest",
+          "mupdate_override",
+          "zone_manifest"
+        ]
+      },
+      "OmicronInstallManifestSource": {
+        "description": "The source of truth for an Omicron zone manifest.",
+        "oneOf": [
+          {
+            "description": "The manifest was written out by installinator and the mupdate process.",
+            "type": "object",
+            "properties": {
+              "mupdate_id": {
+                "description": "The UUID of the mupdate.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/MupdateUuid"
+                  }
+                ]
+              },
+              "source": {
+                "type": "string",
+                "enum": [
+                  "installinator"
+                ]
+              }
+            },
+            "required": [
+              "mupdate_id",
+              "source"
+            ]
+          },
+          {
+            "description": "The zone manifest was not found during the install process. A synthetic zone manifest was generated by Sled Agent by looking at all the `.tar.gz` files in the install dataset.",
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "enum": [
+                  "sled_agent"
+                ]
+              }
+            },
+            "required": [
+              "source"
+            ]
+          }
+        ]
+      },
+      "OmicronPhysicalDiskConfig": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/PhysicalDiskUuid"
+          },
+          "identity": {
+            "$ref": "#/components/schemas/DiskIdentity"
+          },
+          "pool_id": {
+            "$ref": "#/components/schemas/ZpoolUuid"
+          }
+        },
+        "required": [
+          "id",
+          "identity",
+          "pool_id"
+        ]
+      },
+      "OmicronSingleMeasurement": {
+        "description": "Represents a single measurement artfact from the TUF artifact store (aka \"TUF repo depot\"). The fully resolved measurement set is used with trust quorum.\n\nMeasurements may also come from outside the TUF repo depot via the install dataset from MUPdate but are not represented here",
+        "type": "object",
+        "properties": {
+          "hash": {
+            "description": "Measurements are the artifacts matching the hashes from the TUF artifact store (aka \"TUF repo depot\")\n\nMeasurements may also come from outside the TUF repo depot via the install dataset from MUPdate but are not explicitly tracked here",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          }
+        },
+        "required": [
+          "hash"
+        ]
+      },
+      "OmicronSledConfig": {
+        "description": "Describes the set of Reconfigurator-managed configuration elements of a sled",
+        "type": "object",
+        "properties": {
+          "datasets": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/DatasetConfig"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatasetConfig"
+            },
+            "uniqueItems": true
+          },
+          "disks": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/OmicronPhysicalDiskConfig"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OmicronPhysicalDiskConfig"
+            },
+            "uniqueItems": true
+          },
+          "generation": {
+            "$ref": "#/components/schemas/SledConfigGeneration"
+          },
+          "host_phase_2": {
+            "$ref": "#/components/schemas/HostPhase2DesiredSlots"
+          },
+          "measurements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OmicronSingleMeasurement"
+            },
+            "uniqueItems": true
+          },
+          "remove_mupdate_override": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MupdateOverrideUuid"
+              }
+            ]
+          },
+          "update_disposition": {
+            "$ref": "#/components/schemas/OmicronSledUpdateDisposition"
+          },
+          "zones": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/OmicronZoneConfig"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OmicronZoneConfig"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "datasets",
+          "disks",
+          "generation",
+          "host_phase_2",
+          "measurements",
+          "update_disposition",
+          "zones"
+        ]
+      },
+      "OmicronSledUpdateDisposition": {
+        "description": "Controls a sled's availability for VMM provisioning.\n\nThis is a simplified version of `BlueprintSledUpdateDisposition`. The blueprint version of this type includes information describing _how_ the sled should be evacuated as well as blueprint-specific metadata. From sled-agent itself, we only need to know the high-level state; we use this to determine whether or not to accept new VMM registration requests.",
+        "type": "string",
+        "enum": [
+          "available",
+          "evacuating"
+        ]
+      },
+      "OmicronZoneConfig": {
+        "description": "Describes one Omicron-managed zone running on a sled",
+        "type": "object",
+        "properties": {
+          "filesystem_pool": {
+            "nullable": true,
+            "description": "The pool on which we'll place this zone's root filesystem.\n\nNote that the root filesystem is transient -- the sled agent is permitted to destroy this dataset each time the zone is initialized.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ZpoolName"
+              }
+            ]
+          },
+          "id": {
+            "$ref": "#/components/schemas/OmicronZoneUuid"
+          },
+          "image_source": {
+            "default": {
+              "type": "install_dataset"
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OmicronZoneImageSource"
+              }
+            ]
+          },
+          "zone_type": {
+            "$ref": "#/components/schemas/OmicronZoneType"
+          }
+        },
+        "required": [
+          "id",
+          "zone_type"
+        ]
+      },
+      "OmicronZoneDataset": {
+        "description": "Describes a persistent ZFS dataset associated with an Omicron zone",
+        "type": "object",
+        "properties": {
+          "pool_name": {
+            "$ref": "#/components/schemas/ZpoolName"
+          }
+        },
+        "required": [
+          "pool_name"
+        ]
+      },
+      "OmicronZoneImageSource": {
+        "description": "Where Sled Agent should get the image for a zone.",
+        "oneOf": [
+          {
+            "description": "This zone's image source is whatever happens to be on the sled's \"install\" dataset.\n\nThis is whatever was put in place at the factory or by the latest MUPdate. The image used here can vary by sled and even over time (if the sled gets MUPdated again).\n\nHistorically, this was the only source for zone images. In an system with automated control-plane-driven update we expect to only use this variant in emergencies where the system had to be recovered via MUPdate.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "install_dataset"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "This zone's image source is the artifact matching this hash from the TUF artifact store (aka \"TUF repo depot\").\n\nThis originates from TUF repos uploaded to Nexus which are then replicated out to all sleds.",
+            "type": "object",
+            "properties": {
+              "hash": {
+                "type": "string",
+                "format": "hex string (32 bytes)"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "artifact"
+                ]
+              }
+            },
+            "required": [
+              "hash",
+              "type"
+            ]
+          }
+        ]
+      },
+      "OmicronZoneType": {
+        "description": "Describes what kind of zone this is (i.e., what component is running in it) as well as any type-specific configuration",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dns_servers": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "ip"
+                }
+              },
+              "domain": {
+                "nullable": true,
+                "type": "string"
+              },
+              "nic": {
+                "description": "The service vNIC providing outbound connectivity using OPTE.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NetworkInterface"
+                  }
+                ]
+              },
+              "ntp_servers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "snat_cfg": {
+                "description": "The SNAT configuration for outbound connections.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SourceNatConfigGeneric"
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "boundary_ntp"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dns_servers",
+              "nic",
+              "ntp_servers",
+              "snat_cfg",
+              "type"
+            ]
+          },
+          {
+            "description": "Type of clickhouse zone used for a single node clickhouse deployment",
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "clickhouse"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "description": "A zone used to run a Clickhouse Keeper node\n\nKeepers are only used in replicated clickhouse setups",
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "clickhouse_keeper"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "description": "A zone used to run a Clickhouse Server in a replicated deployment",
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "clickhouse_server"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "cockroach_db"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "crucible"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "crucible_pantry"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "dns_address": {
+                "description": "The address at which the external DNS server is reachable.",
+                "type": "string"
+              },
+              "http_address": {
+                "description": "The address at which the external DNS server API is reachable.",
+                "type": "string"
+              },
+              "nic": {
+                "description": "The service vNIC providing external connectivity using OPTE.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NetworkInterface"
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "external_dns"
+                ]
+              }
+            },
+            "required": [
+              "dataset",
+              "dns_address",
+              "http_address",
+              "nic",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "dns_address": {
+                "type": "string"
+              },
+              "gz_address": {
+                "description": "The addresses in the global zone which should be created\n\nFor the DNS service, which exists outside the sleds's typical subnet - adding an address in the GZ is necessary to allow inter-zone traffic routing.",
+                "type": "string",
+                "format": "ipv6"
+              },
+              "gz_address_index": {
+                "description": "The address is also identified with an auxiliary bit of information to ensure that the created global zone address can have a unique name.",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "http_address": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internal_dns"
+                ]
+              }
+            },
+            "required": [
+              "dataset",
+              "dns_address",
+              "gz_address",
+              "gz_address_index",
+              "http_address",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internal_ntp"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "external_dns_servers": {
+                "description": "External DNS servers Nexus can use to resolve external hosts.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "ip"
+                }
+              },
+              "external_ip": {
+                "description": "The address at which the external nexus server is reachable.",
+                "type": "string",
+                "format": "ip"
+              },
+              "external_tls": {
+                "description": "Whether Nexus's external endpoint should use TLS",
+                "type": "boolean"
+              },
+              "internal_address": {
+                "description": "The address at which the internal nexus server is reachable.",
+                "type": "string"
+              },
+              "lockstep_port": {
+                "description": "The port at which the internal lockstep server is reachable. This shares the same IP address with `internal_address`.",
+                "default": 12232,
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "nic": {
+                "description": "The service vNIC providing external connectivity using OPTE.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NetworkInterface"
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "nexus"
+                ]
+              }
+            },
+            "required": [
+              "external_dns_servers",
+              "external_ip",
+              "external_tls",
+              "internal_address",
+              "nic",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "oximeter"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ]
+          }
+        ]
+      },
+      "OmicronZoneUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::OmicronZoneUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "OperatorSwitchZonePolicy": {
+        "description": "Policy allowing an operator (via `omdb`) to control whether the switch zone is started or stopped.\n\nThis is an _extremely_ dicey operation in general; a stopped switch zone leaves the rack inoperable! We are only adding this as a workaround and test tool for handling sidecar resets; see <https://github.com/oxidecomputer/omicron/issues/8480> for background.",
+        "oneOf": [
+          {
+            "description": "Start the switch zone if a switch is present.\n\nThis is the default policy.",
+            "type": "object",
+            "properties": {
+              "policy": {
+                "type": "string",
+                "enum": [
+                  "start_if_switch_present"
+                ]
+              }
+            },
+            "required": [
+              "policy"
+            ]
+          },
+          {
+            "description": "Even if a switch zone is present, stop the switch zone.",
+            "type": "object",
+            "properties": {
+              "policy": {
+                "type": "string",
+                "enum": [
+                  "stop_despite_switch_presence"
+                ]
+              }
+            },
+            "required": [
+              "policy"
+            ]
+          }
+        ]
+      },
+      "OrphanedDataset": {
+        "type": "object",
+        "properties": {
+          "available": {
+            "$ref": "#/components/schemas/ByteCount"
+          },
+          "id": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetUuid"
+              }
+            ]
+          },
+          "mounted": {
+            "type": "boolean"
+          },
+          "name": {
+            "$ref": "#/components/schemas/DatasetName"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "used": {
+            "$ref": "#/components/schemas/ByteCount"
+          }
+        },
+        "required": [
+          "available",
+          "mounted",
+          "name",
+          "reason",
+          "used"
+        ]
+      },
+      "P9fs": {
+        "description": "Describes a filesystem to expose through a P9 device.\n\nThis is only supported by Propolis servers compiled with the `falcon` feature.",
+        "type": "object",
+        "properties": {
+          "chunk_size": {
+            "description": "The chunk size to use in the 9P protocol. Vanilla Helios images should use 8192. Falcon Helios base images and Linux can use up to 65536.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "pci_path": {
+            "description": "The PCI path at which to attach the guest to this P9 filesystem.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          },
+          "source": {
+            "description": "The host source path to mount into the guest.",
+            "type": "string"
+          },
+          "target": {
+            "description": "The 9P target filesystem tag.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "chunk_size",
+          "pci_path",
+          "source",
+          "target"
+        ],
+        "additionalProperties": false
+      },
+      "PciPath": {
+        "description": "A PCI bus/device/function tuple.",
+        "type": "object",
+        "properties": {
+          "bus": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "device": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "function": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "bus",
+          "device",
+          "function"
+        ]
+      },
+      "PciPciBridge": {
+        "description": "A PCI-PCI bridge.",
+        "type": "object",
+        "properties": {
+          "downstream_bus": {
+            "description": "The logical bus number of this bridge's downstream bus. Other devices may use this bus number in their PCI paths to indicate they should be attached to this bridge's bus.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "pci_path": {
+            "description": "The PCI path at which to attach this bridge.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "downstream_bus",
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "PhysicalDiskUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::PhysicalDiskUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "PortConfig": {
+        "type": "object",
+        "properties": {
+          "addresses": {
+            "description": "This port's addresses and optional vlan IDs",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UplinkAddressConfig"
+            }
+          },
+          "allow_ddm_traffic": {
+            "description": "Whether or not to allow DDM traffic on this port",
+            "default": false,
+            "type": "boolean"
+          },
+          "autoneg": {
+            "description": "Whether or not to set autonegotiation",
+            "default": false,
+            "type": "boolean"
+          },
+          "bgp_peers": {
+            "description": "BGP peers on this port",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BgpPeerConfig"
+            }
+          },
+          "lldp": {
+            "nullable": true,
+            "description": "LLDP configuration for this port",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpPortConfig"
+              }
+            ]
+          },
+          "port": {
+            "description": "Name of the port this config applies to.",
+            "type": "string"
+          },
+          "routes": {
+            "description": "The set of routes associated with this port.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RouteConfig"
+            }
+          },
+          "switch": {
+            "description": "Switch the port belongs to.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SwitchSlot"
+              }
+            ]
+          },
+          "tx_eq": {
+            "nullable": true,
+            "description": "TX-EQ configuration for this port",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TxEqConfig"
+              }
+            ]
+          },
+          "uplink_port_fec": {
+            "nullable": true,
+            "description": "Port forward error correction type.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkFec"
+              }
+            ]
+          },
+          "uplink_port_speed": {
+            "description": "Port speed.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkSpeed"
+              }
+            ]
+          }
+        },
+        "required": [
+          "addresses",
+          "bgp_peers",
+          "port",
+          "routes",
+          "switch",
+          "uplink_port_speed"
+        ]
+      },
+      "PrepareAndCommitRequest": {
+        "description": "Request to prepare and commit a trust quorum configuration.\n\nThis is the `Configuration` sent to a node that missed the `Prepare` phase.",
+        "type": "object",
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/Configuration"
+          }
+        },
+        "required": [
+          "config"
+        ]
+      },
+      "PriorityDimension": {
+        "description": "A dimension along with bundles can be sorted, to determine priority.",
+        "oneOf": [
+          {
+            "description": "Sorting by time, with older bundles with lower priority.",
+            "type": "string",
+            "enum": [
+              "time"
+            ]
+          },
+          {
+            "description": "Sorting by the cause for creating the bundle.",
+            "type": "string",
+            "enum": [
+              "cause"
+            ]
+          }
+        ]
+      },
+      "PriorityOrder": {
+        "description": "The priority order for bundles during cleanup.\n\nBundles are sorted along the dimensions in [`PriorityDimension`], with each dimension appearing exactly once. During cleanup, lesser-priority bundles are pruned first, to maintain the dataset quota. Note that bundles are sorted by each dimension in the order in which they appear, with each dimension having higher priority than the next.\n\nTODO: The serde deserializer does not currently verify uniqueness of dimensions.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PriorityDimension"
+        },
+        "minItems": 2,
+        "maxItems": 2
+      },
+      "PrivateIpConfig": {
+        "description": "VPC-private IP address configuration for a network interface.",
+        "oneOf": [
+          {
+            "description": "The interface has only an IPv4 configuration.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "v4"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/PrivateIpv4Config"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "The interface has only an IPv6 configuration.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "v6"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/PrivateIpv6Config"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "The interface is dual-stack.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dual_stack"
+                ]
+              },
+              "value": {
+                "type": "object",
+                "properties": {
+                  "v4": {
+                    "description": "The interface's IPv4 configuration.",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/PrivateIpv4Config"
+                      }
+                    ]
+                  },
+                  "v6": {
+                    "description": "The interface's IPv6 configuration.",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/PrivateIpv6Config"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "v4",
+                  "v6"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "PrivateIpv4Config": {
+        "description": "VPC-private IPv4 configuration for a network interface.",
+        "type": "object",
+        "properties": {
+          "ip": {
+            "description": "VPC-private IP address.",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "subnet": {
+            "description": "The IP subnet.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv4Net"
+              }
+            ]
+          },
+          "transit_ips": {
+            "description": "Additional networks on which the interface can send / receive traffic.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ipv4Net"
+            }
+          }
+        },
+        "required": [
+          "ip",
+          "subnet"
+        ]
+      },
+      "PrivateIpv6Config": {
+        "description": "VPC-private IPv6 configuration for a network interface.",
+        "type": "object",
+        "properties": {
+          "ip": {
+            "description": "VPC-private IP address.",
+            "type": "string",
+            "format": "ipv6"
+          },
+          "subnet": {
+            "description": "The IP subnet.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            ]
+          },
+          "transit_ips": {
+            "description": "Additional networks on which the interface can send / receive traffic.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ipv6Net"
+            }
+          }
+        },
+        "required": [
+          "ip",
+          "subnet",
+          "transit_ips"
+        ]
+      },
+      "ProbeCreate": {
+        "description": "Parameters used to create a probe.",
+        "type": "object",
+        "properties": {
+          "external_ips": {
+            "description": "The external IP addresses assigned to the probe.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExternalIp"
+            }
+          },
+          "id": {
+            "description": "The ID for the probe.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProbeUuid"
+              }
+            ]
+          },
+          "interface": {
+            "description": "The probe's networking interface.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NetworkInterface"
+              }
+            ]
+          }
+        },
+        "required": [
+          "external_ips",
+          "id",
+          "interface"
+        ]
+      },
+      "ProbeSet": {
+        "description": "A set of probes that the target sled should run.",
+        "type": "object",
+        "properties": {
+          "probes": {
+            "title": "IdHashMap",
+            "description": "The exact set of probes to run.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ProbeCreate"
+                }
+              ],
+              "path": "iddqd::IdHashMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProbeCreate"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "probes"
+        ]
+      },
+      "ProbeUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::ProbeUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "ProxyCommitRequest": {
+        "description": "Request to proxy a commit operation to another trust quorum node.",
+        "type": "object",
+        "properties": {
+          "destination": {
+            "description": "The target node to proxy the request to.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          },
+          "request": {
+            "description": "The commit request to proxy.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommitRequest"
+              }
+            ]
+          }
+        },
+        "required": [
+          "destination",
+          "request"
+        ]
+      },
+      "ProxyPrepareAndCommitRequest": {
+        "description": "Request to proxy a prepare-and-commit operation to another trust quorum node.",
+        "type": "object",
+        "properties": {
+          "destination": {
+            "description": "The target node to proxy the request to.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          },
+          "request": {
+            "description": "The prepare-and-commit request to proxy.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PrepareAndCommitRequest"
+              }
+            ]
+          }
+        },
+        "required": [
+          "destination",
+          "request"
+        ]
+      },
+      "QemuPvpanic": {
+        "type": "object",
+        "properties": {
+          "enable_isa": {
+            "description": "Enable the QEMU PVPANIC ISA bus device (I/O port 0x505).",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enable_isa"
+        ],
+        "additionalProperties": false
+      },
+      "RackNetworkConfig": {
+        "description": "Initial network configuration",
+        "type": "object",
+        "properties": {
+          "bfd": {
+            "description": "BFD configuration for connecting the rack to external networks",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BfdPeerConfig"
+            }
+          },
+          "bgp": {
+            "description": "BGP configurations for connecting the rack to external networks",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BgpConfig"
+            }
+          },
+          "infra_ip_first": {
+            "description": "First ip address to be used for configuring network infrastructure",
+            "type": "string",
+            "format": "ip"
+          },
+          "infra_ip_last": {
+            "description": "Last ip address to be used for configuring network infrastructure",
+            "type": "string",
+            "format": "ip"
+          },
+          "ports": {
+            "description": "Uplinks for connecting the rack to external networks",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UplinkPorts"
+              }
+            ]
+          },
+          "rack_subnet": {
+            "$ref": "#/components/schemas/Ipv6Net"
+          }
+        },
+        "required": [
+          "bgp",
+          "infra_ip_first",
+          "infra_ip_last",
+          "ports",
+          "rack_subnet"
+        ]
+      },
+      "RackSecretReconstructError": {
+        "description": "Error reconstructing a rack secret from shares.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "combine": {
+                "$ref": "#/components/schemas/CombineError"
+              }
+            },
+            "required": [
+              "combine"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "size": {
+                "$ref": "#/components/schemas/InvalidRackSecretSizeError"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "RackUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::RackUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "ReconfigureMsg": {
+        "description": "A request from Nexus informing a node to start coordinating a reconfiguration.",
+        "type": "object",
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "last_committed_epoch": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseboardId"
+            },
+            "uniqueItems": true
+          },
+          "rack_id": {
+            "$ref": "#/components/schemas/RackUuid"
+          },
+          "threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "epoch",
+          "members",
+          "rack_id",
+          "threshold"
+        ]
+      },
+      "RemoveMupdateOverrideBootSuccessInventory": {
+        "description": "Status of removing the mupdate override on the boot disk.",
+        "oneOf": [
+          {
+            "description": "The mupdate override was successfully removed.",
+            "type": "string",
+            "enum": [
+              "removed"
+            ]
+          },
+          {
+            "description": "No mupdate override was found.\n\nThis is considered a success for idempotency reasons.",
+            "type": "string",
+            "enum": [
+              "no_override"
+            ]
+          }
+        ]
+      },
+      "RemoveMupdateOverrideInventory": {
+        "description": "Status of removing the mupdate override in the inventory.",
+        "type": "object",
+        "properties": {
+          "boot_disk_result": {
+            "description": "The result of removing the mupdate override on the boot disk.",
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/RemoveMupdateOverrideBootSuccessInventory"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/RemoveMupdateOverrideBootSuccessInventory"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "non_boot_message": {
+            "description": "What happened on non-boot disks.\n\nWe aren't modeling this out in more detail, because we plan to not try and keep ledgered data in sync across both disks in the future.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "boot_disk_result",
+          "non_boot_message"
+        ]
+      },
+      "ResolvedVpcFirewallRule": {
+        "description": "VPC firewall rule after object name resolution has been performed by Nexus.",
+        "type": "object",
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/VpcFirewallRuleAction"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/VpcFirewallRuleDirection"
+          },
+          "filter_hosts": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HostIdentifier"
+            },
+            "uniqueItems": true
+          },
+          "filter_ports": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/L4PortRange"
+            }
+          },
+          "filter_protocols": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcFirewallRuleProtocol"
+            }
+          },
+          "priority": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "status": {
+            "$ref": "#/components/schemas/VpcFirewallRuleStatus"
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkInterface"
+            }
+          }
+        },
+        "required": [
+          "action",
+          "direction",
+          "priority",
+          "status",
+          "targets"
+        ]
+      },
+      "ResolvedVpcRoute": {
+        "description": "A VPC route resolved into a concrete target.",
+        "type": "object",
+        "properties": {
+          "dest": {
+            "$ref": "#/components/schemas/IpNet"
+          },
+          "target": {
+            "$ref": "#/components/schemas/RouterTarget"
+          }
+        },
+        "required": [
+          "dest",
+          "target"
+        ]
+      },
+      "ResolvedVpcRouteSet": {
+        "description": "An updated set of routes for a given VPC and/or subnet.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RouterId"
+          },
+          "routes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedVpcRoute"
+            },
+            "uniqueItems": true
+          },
+          "version": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RouterVersion"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "routes"
+        ]
+      },
+      "ResolvedVpcRouteState": {
+        "description": "Version information for routes on a given VPC subnet.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RouterId"
+          },
+          "version": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RouterVersion"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "RouteConfig": {
+        "type": "object",
+        "properties": {
+          "destination": {
+            "description": "The destination of the route.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IpNet"
+              }
+            ]
+          },
+          "nexthop": {
+            "description": "The nexthop/gateway address.",
+            "type": "string",
+            "format": "ip"
+          },
+          "rib_priority": {
+            "nullable": true,
+            "description": "The RIB priority (i.e. Admin Distance) associated with this route.",
+            "default": null,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "vlan_id": {
+            "nullable": true,
+            "description": "The VLAN id associated with this route.",
+            "default": null,
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "destination",
+          "nexthop"
+        ]
+      },
+      "RouterId": {
+        "description": "Identifier for a VPC and/or subnet.",
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/RouterKind"
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
+          }
+        },
+        "required": [
+          "kind",
+          "vni"
+        ]
+      },
+      "RouterKind": {
+        "description": "The scope of a set of VPC router rules.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "system"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "subnet": {
+                "$ref": "#/components/schemas/IpNet"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "custom"
+                ]
+              }
+            },
+            "required": [
+              "subnet",
+              "type"
+            ]
+          }
+        ]
+      },
+      "RouterLifetimeConfig": {
+        "description": "Router lifetime in seconds for unnumbered BGP peers",
+        "type": "integer",
+        "format": "uint16",
+        "minimum": 0,
+        "maximum": 9000
+      },
+      "RouterPeerType": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "router_lifetime": {
+                "description": "Router lifetime in seconds for unnumbered BGP peers.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RouterLifetimeConfig"
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "unnumbered"
+                ]
+              }
+            },
+            "required": [
+              "router_lifetime",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "src_addr": {
+                "nullable": true,
+                "description": "Optional local IP address to bind when establishing outbound TCP connections to this peer. If `None`, the OS selects the source address.",
+                "default": null,
+                "type": "string",
+                "format": "ip"
+              },
+              "target_addr": {
+                "description": "Target IP address for numbered BGP peers.",
+                "type": "string",
+                "format": "ip"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "numbered"
+                ]
+              }
+            },
+            "required": [
+              "target_addr",
+              "type"
+            ]
+          }
+        ]
+      },
+      "RouterTarget": {
+        "description": "The target for a given router entry.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "drop"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internet_gateway"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/InternetGatewayRouterTarget"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vpc_subnet"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/IpNet"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "RouterVersion": {
+        "description": "Information on the current parent router (and version) of a route set according to the control plane.",
+        "type": "object",
+        "properties": {
+          "router_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "version": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "router_id",
+          "version"
+        ]
+      },
+      "SerialPort": {
+        "description": "A serial port device.",
+        "type": "object",
+        "properties": {
+          "num": {
+            "description": "The serial port number for this port.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SerialPortNumber"
+              }
+            ]
+          }
+        },
+        "required": [
+          "num"
+        ],
+        "additionalProperties": false
+      },
+      "SerialPortNumber": {
+        "description": "A serial port identifier, which determines what I/O ports a guest can use to access a port.",
+        "type": "string",
+        "enum": [
+          "com1",
+          "com2",
+          "com3",
+          "com4"
+        ]
+      },
+      "ServiceZoneNatEntries": {
+        "title": "IdOrdMap",
+        "description": "Description of all NAT entries for control plane services.",
+        "x-rust-type": {
+          "crate": "iddqd",
+          "parameters": [
+            {
+              "$ref": "#/components/schemas/ServiceZoneNatEntry"
+            }
+          ],
+          "path": "iddqd::IdOrdMap",
+          "version": "*"
+        },
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ServiceZoneNatEntry"
+        },
+        "uniqueItems": true
+      },
+      "ServiceZoneNatEntry": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/ServiceZoneNatKind"
+          },
+          "nic_mac": {
+            "$ref": "#/components/schemas/MacAddr"
+          },
+          "sled_underlay_ip": {
+            "type": "string",
+            "format": "ipv6"
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
+          },
+          "zone_id": {
+            "$ref": "#/components/schemas/OmicronZoneUuid"
+          }
+        },
+        "required": [
+          "kind",
+          "nic_mac",
+          "sled_underlay_ip",
+          "vni",
+          "zone_id"
+        ]
+      },
+      "ServiceZoneNatKind": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "boundary_ntp"
+                ]
+              },
+              "snat_cfg": {
+                "$ref": "#/components/schemas/SourceNatConfigGeneric"
+              }
+            },
+            "required": [
+              "kind",
+              "snat_cfg"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "external_ip": {
+                "type": "string",
+                "format": "ip"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "external_dns"
+                ]
+              }
+            },
+            "required": [
+              "external_ip",
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "external_ip": {
+                "type": "string",
+                "format": "ip"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "nexus"
+                ]
+              }
+            },
+            "required": [
+              "external_ip",
+              "kind"
+            ]
+          }
+        ]
+      },
+      "SingleMeasurementInventory": {
+        "description": "An attempt at resolving a single measurement file to a valid path",
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "result": {
+            "$ref": "#/components/schemas/ConfigReconcilerInventoryResult"
+          }
+        },
+        "required": [
+          "path",
+          "result"
+        ]
+      },
+      "SledConfigGeneration": {
+        "description": "Generation numbers stored in the database, used for optimistic concurrency control",
+        "x-rust-type": {
+          "crate": "omicron-generation-kinds",
+          "path": "omicron_generation_kinds::SledConfigGeneration",
+          "version": "*"
+        },
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0
+      },
+      "SledCpuFamily": {
+        "description": "Identifies the kind of CPU present on a sled, determined by reading CPUID.\n\nThis is intended to broadly support the control plane answering the question \"can I run this instance on that sled?\" given an instance with either no or some CPU platform requirement. It is not enough information for more precise placement questions - for example, is a CPU a high-frequency part or many-core part? We don't include Genoa here, but in that CPU family there are high frequency parts, many-core parts, and large-cache parts. To support those questions (or satisfactorily answer #8730) we would need to collect additional information and send it along.",
+        "oneOf": [
+          {
+            "description": "The CPU vendor or its family number don't correspond to any of the known family variants.",
+            "type": "string",
+            "enum": [
+              "unknown"
+            ]
+          },
+          {
+            "description": "AMD Milan processors (or very close). Could be an actual Milan in a Gimlet, a close-to-Milan client Zen 3 part, or Zen 4 (for which Milan is the greatest common denominator).",
+            "type": "string",
+            "enum": [
+              "amd_milan"
+            ]
+          },
+          {
+            "description": "AMD Turin processors (or very close). Could be an actual Turin in a Cosmo, or a close-to-Turin client Zen 5 part.",
+            "type": "string",
+            "enum": [
+              "amd_turin"
+            ]
+          },
+          {
+            "description": "AMD Turin Dense processors. There are no \"Turin Dense-like\" CPUs unlike other cases, so this means a bona fide Zen 5c Turin Dense part.",
+            "type": "string",
+            "enum": [
+              "amd_turin_dense"
+            ]
+          }
+        ]
+      },
+      "SledDiagnosticsQueryOutput": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "object",
+                "properties": {
+                  "command": {
+                    "description": "The command and its arguments.",
+                    "type": "string"
+                  },
+                  "exit_code": {
+                    "nullable": true,
+                    "description": "The exit code if one was present when the command exited.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "exit_status": {
+                    "description": "The exit status of the command. This will be the exit code (if any) and exit reason such as from a signal.",
+                    "type": "string"
+                  },
+                  "stdio": {
+                    "description": "Any stdout/stderr produced by the command.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "command",
+                  "exit_status",
+                  "stdio"
+                ]
+              }
+            },
+            "required": [
+              "success"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "failure": {
+                "type": "object",
+                "properties": {
+                  "error": {
+                    "description": "The reason the command failed to execute.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "error"
+                ]
+              }
+            },
+            "required": [
+              "failure"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "SledIdentifiers": {
+        "description": "Identifiers for a single sled.\n\nThis is intended primarily to be used in timeseries, to identify sled from which metric data originates.",
+        "type": "object",
+        "properties": {
+          "model": {
+            "description": "Model name of the sled",
+            "type": "string"
+          },
+          "rack_id": {
+            "description": "Control plane ID of the rack this sled is a member of",
+            "type": "string",
+            "format": "uuid"
+          },
+          "revision": {
+            "description": "Revision number of the sled",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "serial": {
+            "description": "Serial number of the sled",
+            "type": "string"
+          },
+          "sled_id": {
+            "description": "Control plane ID for the sled itself",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "model",
+          "rack_id",
+          "revision",
+          "serial",
+          "sled_id"
+        ]
+      },
+      "SledRole": {
+        "description": "Describes the role of the sled within the rack.\n\nNote that this may change if the sled is physically moved within the rack.",
+        "oneOf": [
+          {
+            "description": "The sled is a general compute sled.",
+            "type": "string",
+            "enum": [
+              "gimlet"
+            ]
+          },
+          {
+            "description": "The sled is attached to the network switch, and has additional responsibilities.",
+            "type": "string",
+            "enum": [
+              "scrimlet"
+            ]
+          }
+        ]
+      },
+      "SledUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::SledUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "SledVmmState": {
+        "description": "A wrapper type containing a sled's total knowledge of the state of a VMM.",
+        "type": "object",
+        "properties": {
+          "migration_in": {
+            "nullable": true,
+            "description": "The current state of any inbound migration to this VMM.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MigrationRuntimeState"
+              }
+            ]
+          },
+          "migration_out": {
+            "nullable": true,
+            "description": "The state of any outbound migration from this VMM.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MigrationRuntimeState"
+              }
+            ]
+          },
+          "vmm_state": {
+            "description": "The most recent state of the sled's VMM process.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmRuntimeState"
+              }
+            ]
+          }
+        },
+        "required": [
+          "vmm_state"
+        ]
+      },
+      "SmbiosType1Input": {
+        "type": "object",
+        "properties": {
+          "manufacturer": {
+            "type": "string"
+          },
+          "product_name": {
+            "type": "string"
+          },
+          "serial_number": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "manufacturer",
+          "product_name",
+          "serial_number",
+          "version"
+        ],
+        "additionalProperties": false
+      },
+      "SoftNpuP9": {
+        "description": "Describes a PCI device that shares host files with the guest using the P9 protocol.\n\nThis is only supported by Propolis servers compiled with the `falcon` feature.",
+        "type": "object",
+        "properties": {
+          "pci_path": {
+            "description": "The PCI path at which to attach the guest to this port.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "SoftNpuPciPort": {
+        "description": "Describes a SoftNPU PCI device.\n\nThis is only supported by Propolis servers compiled with the `falcon` feature.",
+        "type": "object",
+        "properties": {
+          "pci_path": {
+            "description": "The PCI path at which to attach the guest to this port.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "SoftNpuPort": {
+        "description": "Describes a port in a SoftNPU emulated ASIC.\n\nThis is only supported by Propolis servers compiled with the `falcon` feature.",
+        "type": "object",
+        "properties": {
+          "backend_id": {
+            "description": "The name of the port's associated DLPI backend.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          },
+          "link_name": {
+            "description": "The data link name for this port.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "backend_id",
+          "link_name"
+        ],
+        "additionalProperties": false
+      },
+      "SourceNatConfigGeneric": {
+        "description": "An IP address and port range used for source NAT, i.e., making outbound network connections from guests or services.",
+        "type": "object",
+        "properties": {
+          "first_port": {
+            "description": "The first port used for source NAT, inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "ip": {
+            "description": "The external address provided to the instance or service.",
+            "type": "string",
+            "format": "ip"
+          },
+          "last_port": {
+            "description": "The last port used for source NAT, also inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_port",
+          "ip",
+          "last_port"
+        ]
+      },
+      "SourceNatConfigV4": {
+        "description": "An IP address and port range used for source NAT, i.e., making outbound network connections from guests or services.",
+        "type": "object",
+        "properties": {
+          "first_port": {
+            "description": "The first port used for source NAT, inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "ip": {
+            "description": "The external address provided to the instance or service.",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "last_port": {
+            "description": "The last port used for source NAT, also inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_port",
+          "ip",
+          "last_port"
+        ]
+      },
+      "SourceNatConfigV6": {
+        "description": "An IP address and port range used for source NAT, i.e., making outbound network connections from guests or services.",
+        "type": "object",
+        "properties": {
+          "first_port": {
+            "description": "The first port used for source NAT, inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "ip": {
+            "description": "The external address provided to the instance or service.",
+            "type": "string",
+            "format": "ipv6"
+          },
+          "last_port": {
+            "description": "The last port used for source NAT, also inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_port",
+          "ip",
+          "last_port"
+        ]
+      },
+      "SpecKey": {
+        "description": "A key identifying a component in an instance spec.",
+        "oneOf": [
+          {
+            "title": "uuid",
+            "allOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              }
+            ]
+          },
+          {
+            "title": "name",
+            "allOf": [
+              {
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "StartSledAgentRequest": {
+        "description": "Configuration information for launching a Sled Agent.",
+        "type": "object",
+        "properties": {
+          "body": {
+            "$ref": "#/components/schemas/StartSledAgentRequestBody"
+          },
+          "generation": {
+            "description": "The current generation number of data as stored in CRDB.\n\nThe initial generation is set during RSS time and then only mutated by Nexus. For now, we don't actually anticipate mutating this data, but we leave open the possiblity.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "schema_version": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "body",
+          "generation",
+          "schema_version"
+        ]
+      },
+      "StartSledAgentRequestBody": {
+        "description": "This is the actual app level data of `StartSledAgentRequest`\n\nWe nest it below the \"header\" of `generation` and `schema_version` so that we can perform partial deserialization of `EarlyNetworkConfig` to only read the header and defer deserialization of the body once we know the schema version. This is possible via the use of [`serde_json::value::RawValue`] in future (post-v1) deserialization paths.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Uuid of the Sled Agent to be created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledUuid"
+              }
+            ]
+          },
+          "is_lrtq_learner": {
+            "description": "Is this node an LRTQ learner node?\n\nWe only put the node into learner mode if `use_trust_quorum` is also true.",
+            "type": "boolean"
+          },
+          "rack_id": {
+            "description": "Uuid of the rack to which this sled agent belongs.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RackUuid"
+              }
+            ]
+          },
+          "subnet": {
+            "description": "Portion of the IP space to be managed by the Sled Agent.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Subnet"
+              }
+            ]
+          },
+          "use_trust_quorum": {
+            "description": "Use trust quorum for key generation",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "is_lrtq_learner",
+          "rack_id",
+          "subnet",
+          "use_trust_quorum"
+        ]
+      },
+      "StorageLimit": {
+        "description": "The limit on space allowed for zone bundles, as a percentage of the overall dataset's quota.",
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0
+      },
+      "SupportBundleMetadata": {
+        "description": "Metadata about a support bundle.",
+        "type": "object",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/SupportBundleState"
+          },
+          "support_bundle_id": {
+            "$ref": "#/components/schemas/SupportBundleUuid"
+          }
+        },
+        "required": [
+          "state",
+          "support_bundle_id"
+        ]
+      },
+      "SupportBundleState": {
+        "description": "State of a support bundle.",
+        "type": "string",
+        "enum": [
+          "complete",
+          "incomplete"
+        ]
+      },
+      "SupportBundleUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::SupportBundleUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "SvcEnabledNotOnline": {
+        "description": "Information about an SMF service that is enabled but not running",
+        "type": "object",
+        "properties": {
+          "fmri": {
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/SvcEnabledNotOnlineState"
+          },
+          "zone": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "fmri",
+          "state",
+          "zone"
+        ]
+      },
+      "SvcEnabledNotOnlineState": {
+        "description": "Each service instance is always in a well-defined state based on its dependencies, the results of the execution of its methods, and its potential contracts events.\n\nThis enum contains all possible states except `online`, `disabled`, `uninitialized` and `legacy_run`. We only want to represent states that represent some sort of \"unhealthy\" or \"unexpected\" state. See <https://illumos.org/man/7/smf> for more information.",
+        "oneOf": [
+          {
+            "description": "The instance is enabled, but not yet running or available to run.",
+            "type": "string",
+            "enum": [
+              "offline"
+            ]
+          },
+          {
+            "description": "The instance is enabled and running or available to run. It is, however, functioning at a limited capacity in comparison to normal operation.",
+            "type": "string",
+            "enum": [
+              "degraded"
+            ]
+          },
+          {
+            "description": "The instance is enabled, but not able to run.",
+            "type": "string",
+            "enum": [
+              "maintenance"
+            ]
+          },
+          {
+            "description": "An instance whose state is absent or unrecognized. Note: as per `man svcs`, \"Absent or unrecognized states are denoted by a question mark (?) character\". So there is not an \"unrecognized\" state per se in svcs.",
+            "type": "string",
+            "enum": [
+              "unrecognized"
+            ]
+          }
+        ]
+      },
+      "SvcsEnabledNotOnline": {
+        "description": "Lists services that are enabled but not in an online state if any, the time the sample was collected, and any errors that may have ocurred during the collection",
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SvcEnabledNotOnline"
+            }
+          },
+          "time_of_status": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "errors",
+          "services",
+          "time_of_status"
+        ]
+      },
+      "SvcsEnabledNotOnlineResult": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "svcs_enabled_not_online"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/SvcsEnabledNotOnline"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "svcs_cmd_error"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/SvcsError"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "data_unavailable"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "SvcsError": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "time_of_status": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "error",
+          "time_of_status"
+        ]
+      },
+      "SwitchSlot": {
+        "description": "Identifies switch physical location",
+        "oneOf": [
+          {
+            "description": "Switch in upper slot",
+            "type": "string",
+            "enum": [
+              "switch0"
+            ]
+          },
+          {
+            "description": "Switch in lower slot",
+            "type": "string",
+            "enum": [
+              "switch1"
+            ]
+          }
+        ]
+      },
+      "SystemNetworkingConfig": {
+        "description": "All configuration needed to set up system-level networking.",
+        "type": "object",
+        "properties": {
+          "blueprint_external_networking_config": {
+            "nullable": true,
+            "description": "External networking configuration specified by blueprints.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BlueprintExternalNetworkingConfig"
+              }
+            ]
+          },
+          "rack_network_config": {
+            "$ref": "#/components/schemas/RackNetworkConfig"
+          }
+        },
+        "required": [
+          "rack_network_config"
+        ]
+      },
+      "TrustQuorumNetworkConfig": {
+        "description": "Network configuration used to bring up the control plane.\n\nThis type mirrors `bootstore::schemes::v0::NetworkConfig` but adds `JsonSchema` for API compatibility.",
+        "type": "object",
+        "properties": {
+          "blob": {
+            "description": "A serialized blob of configuration data (base64 encoded).",
+            "type": "string"
+          },
+          "generation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "blob",
+          "generation"
+        ]
+      },
+      "TxEqConfig": {
+        "description": "Per-port tx-eq overrides.  This can be used to fine-tune the transceiver equalization settings to improve signal integrity.",
+        "type": "object",
+        "properties": {
+          "main": {
+            "nullable": true,
+            "description": "Main tap",
+            "type": "integer",
+            "format": "int32"
+          },
+          "post1": {
+            "nullable": true,
+            "description": "Post-cursor tap1",
+            "type": "integer",
+            "format": "int32"
+          },
+          "post2": {
+            "nullable": true,
+            "description": "Post-cursor tap2",
+            "type": "integer",
+            "format": "int32"
+          },
+          "pre1": {
+            "nullable": true,
+            "description": "Pre-cursor tap1",
+            "type": "integer",
+            "format": "int32"
+          },
+          "pre2": {
+            "nullable": true,
+            "description": "Pre-cursor tap2",
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "UplinkAddress": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "addrconf"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "ip_net": {
+                "$ref": "#/components/schemas/IpNet"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "static"
+                ]
+              }
+            },
+            "required": [
+              "ip_net",
+              "type"
+            ]
+          }
+        ]
+      },
+      "UplinkAddressConfig": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "description": "The address to be used on the uplink.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UplinkAddress"
+              }
+            ]
+          },
+          "vlan_id": {
+            "nullable": true,
+            "description": "The VLAN id (if any) associated with this address.",
+            "default": null,
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "address"
+        ]
+      },
+      "UplinkPorts": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PortConfig"
+        },
+        "minItems": 1
+      },
+      "VirtioDisk": {
+        "description": "A disk that presents a virtio-block interface to the guest.",
+        "type": "object",
+        "properties": {
+          "backend_id": {
+            "description": "The name of the disk's backend component.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          },
+          "pci_path": {
+            "description": "The PCI bus/device/function at which this disk should be attached.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "backend_id",
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "VirtioNetworkBackend": {
+        "description": "A network backend associated with a virtio-net (viona) VNIC on the host.",
+        "type": "object",
+        "properties": {
+          "vnic_name": {
+            "description": "The name of the viona VNIC to use as a backend.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vnic_name"
+        ],
+        "additionalProperties": false
+      },
+      "VirtioNic": {
+        "description": "A network card that presents a virtio-net interface to the guest.",
+        "type": "object",
+        "properties": {
+          "backend_id": {
+            "description": "The name of the device's backend.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          },
+          "interface_id": {
+            "description": "A caller-defined correlation identifier for this interface. If Propolis is configured to collect network interface kstats in its Oximeter metrics, the metric series for this interface will be associated with this identifier.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "pci_path": {
+            "description": "The PCI path at which to attach this device.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "backend_id",
+          "interface_id",
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "VirtioSocket": {
+        "description": "A socket device that presents a virtio-socket interface to the guest.",
+        "type": "object",
+        "properties": {
+          "guest_cid": {
+            "description": "The guest's Context ID.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "pci_path": {
+            "description": "The PCI path at which to attach this device.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "guest_cid",
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "VirtualNetworkInterfaceHost": {
+        "description": "A mapping from a virtual NIC to a physical host",
+        "type": "object",
+        "properties": {
+          "physical_host_ip": {
+            "type": "string",
+            "format": "ipv6"
+          },
+          "virtual_ip": {
+            "type": "string",
+            "format": "ip"
+          },
+          "virtual_mac": {
+            "$ref": "#/components/schemas/MacAddr"
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
+          }
+        },
+        "required": [
+          "physical_host_ip",
+          "virtual_ip",
+          "virtual_mac",
+          "vni"
+        ]
+      },
+      "VmmIssueDiskSnapshotRequestBody": {
+        "description": "Request body for VMM disk snapshot requests.",
+        "type": "object",
+        "properties": {
+          "snapshot_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "snapshot_id"
+        ]
+      },
+      "VmmIssueDiskSnapshotRequestResponse": {
+        "description": "Response for VMM disk snapshot requests.",
+        "type": "object",
+        "properties": {
+          "snapshot_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "snapshot_id"
+        ]
+      },
+      "VmmPutStateBody": {
+        "description": "The body of a request to move a previously-ensured instance into a specific runtime state.",
+        "type": "object",
+        "properties": {
+          "state": {
+            "description": "The state into which the instance should be driven.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmStateRequested"
+              }
+            ]
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "VmmPutStateResponse": {
+        "description": "The response sent from a request to move an instance into a specific runtime state.",
+        "type": "object",
+        "properties": {
+          "updated_runtime": {
+            "nullable": true,
+            "description": "The current runtime state of the instance after handling the request to change its state. If the instance's state did not change, this field is `None`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledVmmState"
+              }
+            ]
+          }
+        }
+      },
+      "VmmRuntimeState": {
+        "description": "The dynamic runtime properties of an individual VMM process.",
+        "type": "object",
+        "properties": {
+          "gen": {
+            "description": "The generation number for this VMM's state.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Generation"
+              }
+            ]
+          },
+          "state": {
+            "description": "The last state reported by this VMM.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmState"
+              }
+            ]
+          },
+          "time_updated": {
+            "description": "Timestamp for the VMM's state.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "gen",
+          "state",
+          "time_updated"
+        ]
+      },
+      "VmmSpec": {
+        "description": "Specifies the virtual hardware configuration of a new Propolis VMM in the form of a Propolis instance specification.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InstanceSpec"
+          }
+        ]
+      },
+      "VmmState": {
+        "description": "One of the states that a VMM can be in.",
+        "oneOf": [
+          {
+            "description": "The VMM is initializing and has not started running guest CPUs yet.",
+            "type": "string",
+            "enum": [
+              "starting"
+            ]
+          },
+          {
+            "description": "The VMM has finished initializing and may be running guest CPUs.",
+            "type": "string",
+            "enum": [
+              "running"
+            ]
+          },
+          {
+            "description": "The VMM is shutting down.",
+            "type": "string",
+            "enum": [
+              "stopping"
+            ]
+          },
+          {
+            "description": "The VMM's guest has stopped, and the guest will not run again, but the VMM process may not have released all of its resources yet.",
+            "type": "string",
+            "enum": [
+              "stopped"
+            ]
+          },
+          {
+            "description": "The VMM is being restarted or its guest OS is rebooting.",
+            "type": "string",
+            "enum": [
+              "rebooting"
+            ]
+          },
+          {
+            "description": "The VMM is part of a live migration.",
+            "type": "string",
+            "enum": [
+              "migrating"
+            ]
+          },
+          {
+            "description": "The VMM process reported an internal failure.",
+            "type": "string",
+            "enum": [
+              "failed"
+            ]
+          },
+          {
+            "description": "The VMM process has been destroyed and its resources have been released.",
+            "type": "string",
+            "enum": [
+              "destroyed"
+            ]
+          }
+        ]
+      },
+      "VmmStateRequested": {
+        "description": "Requestable running state of an Instance.\n\nA subset of [`omicron_common::api::external::InstanceState`].",
+        "oneOf": [
+          {
+            "description": "Run this instance by migrating in from a previous running incarnation of the instance.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "migration_target"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/InstanceMigrationTargetParams"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "Start the instance if it is not already running.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "running"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Stop the instance.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "stopped"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Immediately reset the instance, as though it had stopped and immediately began to run again.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "reboot"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "VmmUnregisterResponse": {
+        "description": "The response sent from a request to unregister an instance.",
+        "type": "object",
+        "properties": {
+          "updated_runtime": {
+            "nullable": true,
+            "description": "The current state of the instance after handling the request to unregister it. If the instance's state did not change, this field is `None`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledVmmState"
+              }
+            ]
+          }
+        }
+      },
+      "Vni": {
+        "description": "A Geneve Virtual Network Identifier",
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      },
+      "VpcFirewallIcmpFilter": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IcmpParamRange"
+              }
+            ]
+          },
+          "icmp_type": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "icmp_type"
+        ]
+      },
+      "VpcFirewallRuleAction": {
+        "type": "string",
+        "enum": [
+          "allow",
+          "deny"
+        ]
+      },
+      "VpcFirewallRuleDirection": {
+        "type": "string",
+        "enum": [
+          "inbound",
+          "outbound"
+        ]
+      },
+      "VpcFirewallRuleProtocol": {
+        "description": "The protocols that may be specified in a firewall rule's filter",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "tcp"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "udp"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "icmp"
+                ]
+              },
+              "value": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/VpcFirewallIcmpFilter"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "icmp6"
+                ]
+              },
+              "value": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/VpcFirewallIcmpFilter"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "VpcFirewallRuleStatus": {
+        "type": "string",
+        "enum": [
+          "disabled",
+          "enabled"
+        ]
+      },
+      "VpcFirewallRulesEnsureBody": {
+        "description": "Update firewall rules for a VPC",
+        "type": "object",
+        "properties": {
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedVpcFirewallRule"
+            }
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
+          }
+        },
+        "required": [
+          "rules",
+          "vni"
+        ]
+      },
+      "WriteNetworkConfigRequest": {
+        "description": "Structure for requests from Nexus to sled-agent to write a new [`SystemNetworkingConfig`] into the replicated bootstore.\n\n[`WriteNetworkConfigRequest`] INTENTIONALLY does not have a `From` implementation from prior API versions. It is critically important that sled-agent not attempt to rewrite old [`SystemNetworkingConfig`] types to the latest version. For more about this, see the comments on the relevant endpoint in `sled-agent-api`.",
+        "type": "object",
+        "properties": {
+          "body": {
+            "$ref": "#/components/schemas/SystemNetworkingConfig"
+          },
+          "generation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "body",
+          "generation"
+        ]
+      },
+      "ZoneArtifactInventory": {
+        "description": "Inventory representation of a single zone artifact on a boot disk.\n\nPart of [`ManifestBootInventory`].",
+        "type": "object",
+        "properties": {
+          "expected_hash": {
+            "description": "The expected digest of the file's contents.",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          },
+          "expected_size": {
+            "description": "The expected size of the file, in bytes.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "file_name": {
+            "description": "The name of the zone file on disk, for example `nexus.tar.gz`. Zone files are always \".tar.gz\".",
+            "type": "string"
+          },
+          "path": {
+            "description": "The full path to the zone file.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "status": {
+            "description": "The status of the artifact.\n\nThis is `Ok(())` if the artifact is present and matches the expected size and digest, or an error message if it is missing or does not match.",
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "type": "string",
+                    "enum": [
+                      null
+                    ]
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "expected_hash",
+          "expected_size",
+          "file_name",
+          "path",
+          "status"
+        ]
+      },
+      "ZoneBundleCause": {
+        "description": "The reason or cause for a zone bundle, i.e., why it was created.",
+        "oneOf": [
+          {
+            "description": "Some other, unspecified reason.",
+            "type": "string",
+            "enum": [
+              "other"
+            ]
+          },
+          {
+            "description": "A zone bundle taken when a sled agent finds a zone that it does not expect to be running.",
+            "type": "string",
+            "enum": [
+              "unexpected_zone"
+            ]
+          },
+          {
+            "description": "An instance zone was terminated.",
+            "type": "string",
+            "enum": [
+              "terminated_instance"
+            ]
+          }
+        ]
+      },
+      "ZoneBundleId": {
+        "description": "An identifier for a zone bundle.",
+        "type": "object",
+        "properties": {
+          "bundle_id": {
+            "description": "The ID for this bundle itself.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "zone_name": {
+            "description": "The name of the zone this bundle is derived from.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bundle_id",
+          "zone_name"
+        ]
+      },
+      "ZoneBundleMetadata": {
+        "description": "Metadata about a zone bundle.",
+        "type": "object",
+        "properties": {
+          "cause": {
+            "description": "The reason or cause a bundle was created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ZoneBundleCause"
+              }
+            ]
+          },
+          "id": {
+            "description": "Identifier for this zone bundle",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ZoneBundleId"
+              }
+            ]
+          },
+          "time_created": {
+            "description": "The time at which this zone bundle was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "version": {
+            "description": "A version number for this zone bundle.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "cause",
+          "id",
+          "time_created",
+          "version"
+        ]
+      },
+      "ZpoolHealth": {
+        "oneOf": [
+          {
+            "description": "The device is online and functioning.",
+            "type": "string",
+            "enum": [
+              "online"
+            ]
+          },
+          {
+            "description": "One or more components are degraded or faulted, but sufficient replicas exist to continue functioning.",
+            "type": "string",
+            "enum": [
+              "degraded"
+            ]
+          },
+          {
+            "description": "One or more components are degraded or faulted, and insufficient replicas exist to continue functioning.",
+            "type": "string",
+            "enum": [
+              "faulted"
+            ]
+          },
+          {
+            "description": "The device was explicitly taken offline by \"zpool offline\".",
+            "type": "string",
+            "enum": [
+              "offline"
+            ]
+          },
+          {
+            "description": "The device was physically removed.",
+            "type": "string",
+            "enum": [
+              "removed"
+            ]
+          },
+          {
+            "description": "The device could not be opened.",
+            "type": "string",
+            "enum": [
+              "unavailable"
+            ]
+          }
+        ]
+      },
+      "ZpoolName": {
+        "title": "The name of a Zpool",
+        "description": "Zpool names are of the format ox{i,p}_<UUID>. They are either Internal or External, and should be unique",
+        "type": "string",
+        "pattern": "^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      },
+      "ZpoolUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::ZpoolUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "Rot": {
+        "description": "A Root of Trust (RoT) which provides measurments and signed attestations.",
+        "oneOf": [
+          {
+            "description": "The per-sled RoT in an Oxide rack.",
+            "type": "string",
+            "enum": [
+              "oxide"
+            ]
+          }
+        ]
+      },
+      "PropolisUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::PropolisUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/sled-agent/sled-agent-latest.json
+++ b/openapi/sled-agent/sled-agent-latest.json
@@ -1,1 +1,1 @@
-sled-agent-51.0.0-553561.json
+sled-agent-52.0.0-6430a4.json

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -39,6 +39,7 @@ api_versions!([
     // |  example for the next person.
     // v
     // (next_int, IDENT),
+    (52, FILTER_LOG_ZONE_LIST),
     (51, ADD_LOG_TIME_RANGE),
     (50, TYPED_SLED_CONFIG_GENERATION),
     (49, ADD_UPDATE_DISPOSITION),
@@ -1563,10 +1564,37 @@ pub trait SledAgentApi {
     #[endpoint {
         method = GET,
         path = "/support/logs/zones",
+        versions = VERSION_FILTER_LOG_ZONE_LIST..,
     }]
     async fn support_logs(
         request_context: RequestContext<Self::Context>,
+        query_params: Query<
+            latest::diagnostics::SledDiagnosticsLogZonesQueryParam,
+        >,
     ) -> Result<HttpResponseOk<Vec<String>>, HttpError>;
+
+    /// This endpoint returns a list of known zones on a sled that have service
+    /// logs that can be collected into a support bundle.
+    #[endpoint {
+        operation_id = "support_logs",
+        method = GET,
+        path = "/support/logs/zones",
+        versions = ..VERSION_FILTER_LOG_ZONE_LIST,
+    }]
+    async fn support_logs_v1(
+        request_context: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<Vec<String>>, HttpError> {
+        Self::support_logs(
+            request_context,
+            Query::from(
+                latest::diagnostics::SledDiagnosticsLogZonesQueryParam {
+                    start_time: None,
+                    end_time: None,
+                },
+            ),
+        )
+        .await
+    }
 
     /// This endpoint returns a zip file of a zone's logs organized by service.
     #[endpoint {

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -38,7 +38,8 @@ use sled_agent_types::dataset::{
 };
 use sled_agent_types::debug::OperatorSwitchZonePolicy;
 use sled_agent_types::diagnostics::{
-    SledDiagnosticsLogsDownloadPathParam, SledDiagnosticsLogsDownloadQueryParam,
+    SledDiagnosticsLogZonesQueryParam, SledDiagnosticsLogsDownloadPathParam,
+    SledDiagnosticsLogsDownloadQueryParam,
 };
 use sled_agent_types::disk::{DiskEnsureBody, DiskPathParam};
 use sled_agent_types::early_networking::EarlyNetworkConfigEnvelope;
@@ -1489,12 +1490,18 @@ impl SledAgentApi for SledAgentImpl {
 
     async fn support_logs(
         request_context: RequestContext<Self::Context>,
+        query_params: Query<SledDiagnosticsLogZonesQueryParam>,
     ) -> Result<HttpResponseOk<Vec<String>>, HttpError> {
         let sa = request_context.context();
+        let SledDiagnosticsLogZonesQueryParam { start_time, end_time } =
+            query_params.into_inner();
         sa.latencies()
             .instrument_dropshot_handler(&request_context, async {
                 sa.as_support_bundle_logs()
-                    .zones_list(sled_diagnostics::LogTimeWindow::default())
+                    .zones_list(sled_diagnostics::LogTimeWindow {
+                        start: start_time,
+                        end: end_time,
+                    })
                     .await
                     .map(HttpResponseOk)
                     .map_err(HttpError::from)

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -1494,7 +1494,7 @@ impl SledAgentApi for SledAgentImpl {
         sa.latencies()
             .instrument_dropshot_handler(&request_context, async {
                 sa.as_support_bundle_logs()
-                    .zones_list()
+                    .zones_list(sled_diagnostics::LogTimeWindow::default())
                     .await
                     .map(HttpResponseOk)
                     .map_err(HttpError::from)

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -49,7 +49,8 @@ use sled_agent_types::dataset::{
 };
 use sled_agent_types::debug::OperatorSwitchZonePolicy;
 use sled_agent_types::diagnostics::{
-    SledDiagnosticsLogsDownloadPathParam, SledDiagnosticsLogsDownloadQueryParam,
+    SledDiagnosticsLogZonesQueryParam, SledDiagnosticsLogsDownloadPathParam,
+    SledDiagnosticsLogsDownloadQueryParam,
 };
 use sled_agent_types::disk::{DiskEnsureBody, DiskPathParam};
 use sled_agent_types::early_networking::EarlyNetworkConfigEnvelope;
@@ -1057,10 +1058,19 @@ impl SledAgentApi for SledAgentSimImpl {
 
     async fn support_logs(
         request_context: RequestContext<Self::Context>,
+        query_params: Query<SledDiagnosticsLogZonesQueryParam>,
     ) -> Result<HttpResponseOk<Vec<String>>, HttpError> {
-        // Return the zones tests have injected logs for (empty by default).
+        // Return the zones tests have injected logs for (empty by default),
+        // limited to zones with an entry inside the requested window.
         let sa = request_context.context();
-        Ok(HttpResponseOk(sa.support_log_zones()))
+        let SledDiagnosticsLogZonesQueryParam { start_time, end_time } =
+            query_params.into_inner();
+        Ok(HttpResponseOk(sa.support_log_zones(
+            &sled_diagnostics::LogTimeWindow {
+                start: start_time,
+                end: end_time,
+            },
+        )))
     }
 
     async fn support_logs_download(

--- a/sled-agent/src/sim/sim_support_logs.rs
+++ b/sled-agent/src/sim/sim_support_logs.rs
@@ -13,10 +13,32 @@
 //! of capping rotated logs per service, and zip paths are flat rather
 //! than nested by service and log type.
 
+use super::sled_agent::SimLogEntry;
 use super::sled_agent::SledAgent;
 use dropshot::HttpError;
 use sled_diagnostics::LogTimeWindow;
 use std::io::Write;
+
+/// Returns true if `entry`'s mtime falls inside `window` (inclusive on
+/// both ends). Shared by the zone-listing and download endpoints so the
+/// two can't drift: a zone is listed exactly when at least one of its
+/// entries would be served.
+pub(super) fn entry_in_window(
+    entry: &SimLogEntry,
+    window: &LogTimeWindow,
+) -> bool {
+    if let Some(start) = window.start {
+        if entry.mtime < start {
+            return false;
+        }
+    }
+    if let Some(end) = window.end {
+        if entry.mtime > end {
+            return false;
+        }
+    }
+    true
+}
 
 /// Build a zip of synthetic log entries for `zone` and return it as an
 /// `application/zip` HTTP response. See the module docs for how the
@@ -32,19 +54,7 @@ pub(super) fn serve_zip(
         logs.get(zone).cloned().unwrap_or_default()
     };
 
-    entries.retain(|e| {
-        if let Some(start) = window.start {
-            if e.mtime < start {
-                return false;
-            }
-        }
-        if let Some(end) = window.end {
-            if e.mtime > end {
-                return false;
-            }
-        }
-        true
-    });
+    entries.retain(|e| entry_in_window(e, &window));
 
     // Sort newest-first so the count cap takes the most recent.
     entries.sort_by_key(|e| std::cmp::Reverse(e.mtime));

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -228,9 +228,23 @@ impl SledAgent {
             .push(entry);
     }
 
-    /// Returns the names of zones with injected support logs.
-    pub(super) fn support_log_zones(&self) -> Vec<String> {
-        self.support_logs.lock().unwrap().keys().cloned().collect()
+    /// Returns the names of zones with at least one injected support log
+    /// inside `window`, mirroring the real endpoint's time filtering.
+    pub(super) fn support_log_zones(
+        &self,
+        window: &sled_diagnostics::LogTimeWindow,
+    ) -> Vec<String> {
+        self.support_logs
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(_, entries)| {
+                entries.iter().any(|e| {
+                    super::sim_support_logs::entry_in_window(e, window)
+                })
+            })
+            .map(|(zone, _)| zone.clone())
+            .collect()
     }
 
     pub async fn instance_register(

--- a/sled-agent/src/support_bundle/logs.rs
+++ b/sled-agent/src/support_bundle/logs.rs
@@ -57,13 +57,16 @@ impl<'a> SupportBundleLogs<'a> {
     }
 
     /// Get a list of zones on a sled containing logs that we want to include in
-    /// a support bundle.
-    pub async fn zones_list(&self) -> Result<Vec<String>, Error> {
+    /// a support bundle, limited to zones with log content in `window`.
+    pub async fn zones_list(
+        &self,
+        window: sled_diagnostics::LogTimeWindow,
+    ) -> Result<Vec<String>, Error> {
         tokio::task::spawn_blocking(move || {
             // We rely on sled-diagnostics to tell us about zones because other
             // methods within sled-agent usually do some sort of filtering and
             // we want all logs, even those in the global zone.
-            sled_diagnostics::LogsHandle::get_zones()
+            sled_diagnostics::LogsHandle::get_zones(window)
         })
         .await
         .map_err(Error::Join)?

--- a/sled-agent/types/versions/src/filter_log_zone_list/diagnostics.rs
+++ b/sled-agent/types/versions/src/filter_log_zone_list/diagnostics.rs
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Diagnostics types for Sled Agent API `FILTER_LOG_ZONE_LIST`.
+
+use chrono::DateTime;
+use chrono::Utc;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+/// Query parameters for sled-diagnostics zone-listing requests.
+#[derive(Deserialize, JsonSchema)]
+pub struct SledDiagnosticsLogZonesQueryParam {
+    /// Lower bound (inclusive) on log content. A zone is omitted when the
+    /// last modification (`mtime`) of every one of its log files predates
+    /// this; a file's `mtime` is the timestamp of its newest content, so an
+    /// omitted zone has no log data from the window. If absent, no lower
+    /// bound is applied.
+    #[serde(default)]
+    pub start_time: Option<DateTime<Utc>>,
+
+    /// Upper bound (inclusive) on log content. A zone is omitted when every
+    /// one of its log files has content beginning after this. If absent, no
+    /// upper bound is applied.
+    #[serde(default)]
+    pub end_time: Option<DateTime<Utc>>,
+}

--- a/sled-agent/types/versions/src/filter_log_zone_list/mod.rs
+++ b/sled-agent/types/versions/src/filter_log_zone_list/mod.rs
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Version `FILTER_LOG_ZONE_LIST` of the Sled Agent API.
+//!
+//! Adds optional inclusive `start_time`/`end_time` bounds to the
+//! sled-diagnostics zone-listing request, so callers can skip zones
+//! with no log content in a time window.
+
+pub mod diagnostics;

--- a/sled-agent/types/versions/src/latest.rs
+++ b/sled-agent/types/versions/src/latest.rs
@@ -43,6 +43,8 @@ pub mod diagnostics {
     pub use crate::v1::diagnostics::SledDiagnosticsLogsDownloadPathParm;
 
     pub use crate::v51::diagnostics::SledDiagnosticsLogsDownloadQueryParam;
+
+    pub use crate::v52::diagnostics::SledDiagnosticsLogZonesQueryParam;
 }
 
 pub mod disk {

--- a/sled-agent/types/versions/src/lib.rs
+++ b/sled-agent/types/versions/src/lib.rs
@@ -107,6 +107,8 @@ pub mod v49;
 pub mod v50;
 #[path = "add_log_time_range/mod.rs"]
 pub mod v51;
+#[path = "filter_log_zone_list/mod.rs"]
+pub mod v52;
 #[path = "add_probe_put_endpoint/mod.rs"]
 pub mod v6;
 #[path = "multicast_support/mod.rs"]

--- a/sled-diagnostics/src/logs.rs
+++ b/sled-diagnostics/src/logs.rs
@@ -399,11 +399,26 @@ impl LogsHandle {
         }
     }
 
-    /// Get all of the zones on a sled containing logs.
-    pub fn get_zones() -> Result<Vec<String>, LogError> {
-        oxlog::Zones::load()
-            .map(|z| z.zones.into_keys().collect())
-            .map_err(|e| LogError::OxLog(e))
+    /// Get all of the zones on a sled containing logs with content in
+    /// `window`.
+    ///
+    /// This applies the same per-file predicate as
+    /// [`LogsHandle::get_zone_logs`] (oxlog's date-range filter, skipping
+    /// empty files), so a zone omitted here would only ever produce an
+    /// empty archive. The converse is not guaranteed: a listed zone can
+    /// still yield an empty archive in corner cases (such as a zone whose
+    /// only in-window file is a rotated log that was never archived), so
+    /// callers collecting from listed zones should still tolerate empty
+    /// results. This is a metadata-only scan; no ZFS snapshots are taken.
+    pub fn get_zones(window: LogTimeWindow) -> Result<Vec<String>, LogError> {
+        let zones = oxlog::Zones::load().map_err(LogError::OxLog)?;
+        Ok(zones.zones_with_matching_logs(oxlog::Filter {
+            current: true,
+            archived: true,
+            extra: true,
+            show_empty: false,
+            date_range: window.to_date_range(),
+        }))
     }
 
     async fn find_log_in_snapshot(

--- a/support-bundle-collection/src/steps/host_info.rs
+++ b/support-bundle-collection/src/steps/host_info.rs
@@ -237,9 +237,22 @@ async fn collect_data_from_sled(
         }
     }
 
+    // Ask the sled-agent only for zones with log content in the bundle's
+    // time window: a sled accumulates log directories for every zone that
+    // has ever run on it, and there is no point requesting logs from zones
+    // whose files all fall outside the window.
+    //
+    // Bind with names so the positional Progenitor call below can't
+    // accidentally swap start and end: query parameters are supplied in
+    // alphabetical order, which is why "end time" comes before
+    // "start time".
+    let (start, end) = (time_range.start(), time_range.end());
     let zones = tokio::select! {
         _ = collection.cancelled() => return Ok(CollectionStepOutput::None),
-        result = sled_client.support_logs() => result?.into_inner(),
+        result = sled_client.support_logs(
+            end.as_ref(),
+            start.as_ref(),
+        ) => result?.into_inner(),
     };
 
     // For each zone we fire off a request to its sled-agent to collect

--- a/support-bundle-collection/src/steps/host_info.rs
+++ b/support-bundle-collection/src/steps/host_info.rs
@@ -376,12 +376,13 @@ async fn save_zone_log_zip_or_error(
         Ok(res) => {
             let bytestream = res.into_inner();
             let output_dir = path.join(format!("logs/{zone}"));
-            let zipfile_path = output_dir.join("logs.zip");
 
-            // Ensure the logs output directory exists.
-            tokio::fs::create_dir_all(&output_dir).await.with_context(
-                || format!("failed to create output directory: {output_dir}"),
-            )?;
+            // Stream the zip somewhere outside the zone's output directory:
+            // a zone can legitimately produce an empty archive (its listing
+            // and its download race against log rotation and archival), and
+            // an empty archive must leave no trace in the bundle, not even
+            // an empty directory.
+            let zipfile_path = path.join(format!("{zone}.logs.zip.partial"));
 
             // Stream the log zip file to disk.
             let mut file =
@@ -396,7 +397,8 @@ async fn save_zone_log_zip_or_error(
             let _nbytes = tokio::io::copy(&mut reader, &mut file).await?;
             file.flush().await?;
 
-            // Unzip the log file into the same directory.
+            // Unzip the log file into the zone's output directory, unless
+            // the archive turns out to be empty.
             let zip_path = zipfile_path.clone();
             tokio::task::spawn_blocking(move || {
                 extract_zip_file(&output_dir, &zip_path)
@@ -435,6 +437,11 @@ fn extract_zip_file(
     let mut zip = std::fs::File::open(&zip_file)
         .with_context(|| format!("failed to open zip file: {zip_file}"))?;
     let mut archive = zip::ZipArchive::new(&mut zip)?;
+    // An empty archive contributes nothing to the bundle; extraction would
+    // only leave an empty directory behind.
+    if archive.is_empty() {
+        return Ok(());
+    }
     archive.extract(&output_dir).with_context(|| {
         format!("failed to extract log zip file to: {output_dir}")
     })?;

--- a/support-bundle-collection/src/steps/host_info.rs
+++ b/support-bundle-collection/src/steps/host_info.rs
@@ -447,3 +447,47 @@ fn extract_zip_file(
     })?;
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::io::Write;
+
+    fn write_zip(path: &Utf8Path, entries: &[(&str, &str)]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        for (name, contents) in entries {
+            let opts: zip::write::FileOptions<'_, ()> =
+                zip::write::FileOptions::default();
+            zip.start_file(*name, opts).unwrap();
+            zip.write_all(contents.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    #[test]
+    fn extract_zip_file_skips_empty_archives() {
+        let dir = camino_tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("logs.zip");
+        let output_dir = dir.path().join("logs/oxz_test");
+
+        // An empty archive leaves nothing behind, not even the output
+        // directory: an empty logs/<zone>/ entry would otherwise survive
+        // into the final bundle.
+        write_zip(&zip_path, &[]);
+        extract_zip_file(&output_dir, &zip_path).unwrap();
+        assert!(
+            !output_dir.exists(),
+            "empty archive must not create {output_dir}"
+        );
+
+        // A non-empty archive extracts under the output directory as usual.
+        write_zip(&zip_path, &[("svc/current/svc.log", "hello")]);
+        extract_zip_file(&output_dir, &zip_path).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(output_dir.join("svc/current/svc.log"))
+                .unwrap(),
+            "hello"
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #11113, which bounds zone-log collection with a bundle-wide time range.

On dogfood, `oxlog zones | wc -l` reports over 7000 zones, mostly propolis zones for VMMs that stopped running long ago. #11113 already keeps their out-of-window log files (and any ZFS snapshots for them) out of the bundle, but the collection workflow still paid a per-zone cost for every one of them: the collector fetched the full zone list and issued one `support_logs_download` request per zone, and each such request made the sled-agent re-run oxlog's filesystem scan, probe every debug dataset with `zfs get available` to pick temporary storage, and assemble an empty zip, before the collector wrote an empty `logs/<zone>/` directory into the bundle.

This PR filters the zone list at the source and keeps empty results out of the bundle entirely:

- **Filter the sled-diagnostics zone listing by a log time window.** oxlog gains `Zones::zones_with_matching_logs`, and `LogsHandle::get_zones` takes a `LogTimeWindow`, applying the same per-file date predicate as `get_zone_logs`. A zone omitted from the listing would only ever have produced an empty archive; the scan is metadata-only and takes no ZFS snapshots.

- **Add sled-agent API v52: time-window params on the zone-log listing.** `support_logs` gains optional inclusive `start_time`/`end_time` query parameters; the v1 shim keeps serving older callers with an unbounded window. The simulated sled-agent filters its zone list through the same predicate as its download endpoint, and the collector passes the bundle's time range, so sleds skip zones with no in-window log content. Since omdb shares the collection crate, `omdb support-bundle collect --since/--until` benefits automatically.

- **Leave no bundle entry for a zone whose log archive is empty.** The collector streams each zone's zip to a scratch path and skips extraction when the archive has no entries, so `logs/<zone>/` exists only when it holds logs. This also covers sled-agents that predate the filtered listing (they still return the full zone list), and listing/download races.