### PR TITLE
Listen on multiple addresses in the DNS server(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,6 +3140,7 @@ dependencies = [
  "dns-server-api",
  "dns-service-client",
  "dropshot",
+ "flume",
  "git-stub-vcs",
  "hickory-client",
  "hickory-proto 0.25.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,7 +3140,6 @@ dependencies = [
  "dns-server-api",
  "dns-service-client",
  "dropshot",
- "flume",
  "git-stub-vcs",
  "hickory-client",
  "hickory-proto 0.25.2",

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -585,7 +585,7 @@ async fn test_omdb_success_cases() {
     let mut bundle_output = String::new();
     let p = postgres_url.clone();
     let dns =
-        cptestctx.internal_dns.dns_server.first_local_address().to_string();
+        cptestctx.internal_dns.dns_server.sole_local_address().to_string();
     do_run_no_redactions(
         &mut bundle_output,
         move |exec| exec.env("OMDB_DB_URL", &p).env("OMDB_DNS_SERVER", &dns),
@@ -627,7 +627,7 @@ async fn test_omdb_success_cases() {
     let cmd_path_owned = cmd_path.to_path_buf();
     let p = postgres_url.clone();
     let dns =
-        cptestctx.internal_dns.dns_server.first_local_address().to_string();
+        cptestctx.internal_dns.dns_server.sole_local_address().to_string();
     let stream_tempdir = tmpdir.path().to_owned();
     let exit_status = tokio::task::spawn_blocking(move || {
         Exec::cmd(&cmd_path_owned)
@@ -715,7 +715,7 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
     let ox_url = format!("http://{}/", cptestctx.oximeter.server_address());
     let ox_test_producer = cptestctx.producer.address().ip();
     let ch_url = format!("http://{}/", cptestctx.clickhouse.http_address());
-    let dns_sockaddr = cptestctx.internal_dns.dns_server.first_local_address();
+    let dns_sockaddr = cptestctx.internal_dns.dns_server.sole_local_address();
     let mut output = String::new();
 
     // The blueprint_rendezvous task needs an inventory collection to run.

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -584,7 +584,8 @@ async fn test_omdb_success_cases() {
     ];
     let mut bundle_output = String::new();
     let p = postgres_url.clone();
-    let dns = cptestctx.internal_dns.dns_server.local_address().to_string();
+    let dns =
+        cptestctx.internal_dns.dns_server.first_local_address().to_string();
     do_run_no_redactions(
         &mut bundle_output,
         move |exec| exec.env("OMDB_DB_URL", &p).env("OMDB_DNS_SERVER", &dns),
@@ -625,7 +626,8 @@ async fn test_omdb_success_cases() {
         std::fs::File::create(&stdout_path).expect("create stdout capture");
     let cmd_path_owned = cmd_path.to_path_buf();
     let p = postgres_url.clone();
-    let dns = cptestctx.internal_dns.dns_server.local_address().to_string();
+    let dns =
+        cptestctx.internal_dns.dns_server.first_local_address().to_string();
     let stream_tempdir = tmpdir.path().to_owned();
     let exit_status = tokio::task::spawn_blocking(move || {
         Exec::cmd(&cmd_path_owned)
@@ -713,7 +715,7 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
     let ox_url = format!("http://{}/", cptestctx.oximeter.server_address());
     let ox_test_producer = cptestctx.producer.address().ip();
     let ch_url = format!("http://{}/", cptestctx.clickhouse.http_address());
-    let dns_sockaddr = cptestctx.internal_dns.dns_server.local_address();
+    let dns_sockaddr = cptestctx.internal_dns.dns_server.first_local_address();
     let mut output = String::new();
 
     // The blueprint_rendezvous task needs an inventory collection to run.

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -584,8 +584,12 @@ async fn test_omdb_success_cases() {
     ];
     let mut bundle_output = String::new();
     let p = postgres_url.clone();
-    let dns =
-        cptestctx.internal_dns.dns_server.sole_local_address().to_string();
+    let dns = cptestctx
+        .internal_dns
+        .dns_server
+        .sole_local_address()
+        .expect("exactly one internal DNS address")
+        .to_string();
     do_run_no_redactions(
         &mut bundle_output,
         move |exec| exec.env("OMDB_DB_URL", &p).env("OMDB_DNS_SERVER", &dns),
@@ -626,8 +630,12 @@ async fn test_omdb_success_cases() {
         std::fs::File::create(&stdout_path).expect("create stdout capture");
     let cmd_path_owned = cmd_path.to_path_buf();
     let p = postgres_url.clone();
-    let dns =
-        cptestctx.internal_dns.dns_server.sole_local_address().to_string();
+    let dns = cptestctx
+        .internal_dns
+        .dns_server
+        .sole_local_address()
+        .expect("exactly one internal DNS address")
+        .to_string();
     let stream_tempdir = tmpdir.path().to_owned();
     let exit_status = tokio::task::spawn_blocking(move || {
         Exec::cmd(&cmd_path_owned)
@@ -715,7 +723,11 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
     let ox_url = format!("http://{}/", cptestctx.oximeter.server_address());
     let ox_test_producer = cptestctx.producer.address().ip();
     let ch_url = format!("http://{}/", cptestctx.clickhouse.http_address());
-    let dns_sockaddr = cptestctx.internal_dns.dns_server.sole_local_address();
+    let dns_sockaddr = cptestctx
+        .internal_dns
+        .dns_server
+        .sole_local_address()
+        .expect("exactly one internal DNS address");
     let mut output = String::new();
 
     // The blueprint_rendezvous task needs an inventory collection to run.

--- a/dev-tools/omicron-dev/src/main.rs
+++ b/dev-tools/omicron-dev/src/main.rs
@@ -156,7 +156,11 @@ impl RunAllArgs {
         );
         println!(
             "omicron-dev: internal DNS:           {}",
-            cptestctx.internal_dns.dns_server.sole_local_address()
+            cptestctx
+                .internal_dns
+                .dns_server
+                .sole_local_address()
+                .context("Expected exactly 1 internal DNS address")?,
         );
         println!(
             "omicron-dev: external DNS name:      {}",

--- a/dev-tools/omicron-dev/src/main.rs
+++ b/dev-tools/omicron-dev/src/main.rs
@@ -156,7 +156,7 @@ impl RunAllArgs {
         );
         println!(
             "omicron-dev: internal DNS:           {}",
-            cptestctx.internal_dns.dns_server.local_address()
+            cptestctx.internal_dns.dns_server.first_local_address()
         );
         println!(
             "omicron-dev: external DNS name:      {}",
@@ -168,12 +168,12 @@ impl RunAllArgs {
         );
         println!(
             "omicron-dev: external DNS:           {}",
-            cptestctx.external_dns.dns_server.local_address()
+            cptestctx.external_dns.dns_server.first_local_address()
         );
         println!(
             "omicron-dev:   e.g. `dig @{} -p {} {}.sys.{}`",
-            cptestctx.external_dns.dns_server.local_address().ip(),
-            cptestctx.external_dns.dns_server.local_address().port(),
+            cptestctx.external_dns.dns_server.first_local_address().ip(),
+            cptestctx.external_dns.dns_server.first_local_address().port(),
             cptestctx.silo_name,
             cptestctx.external_dns_zone_name,
         );

--- a/dev-tools/omicron-dev/src/main.rs
+++ b/dev-tools/omicron-dev/src/main.rs
@@ -156,7 +156,7 @@ impl RunAllArgs {
         );
         println!(
             "omicron-dev: internal DNS:           {}",
-            cptestctx.internal_dns.dns_server.first_local_address()
+            cptestctx.internal_dns.dns_server.sole_local_address()
         );
         println!(
             "omicron-dev: external DNS name:      {}",
@@ -166,17 +166,16 @@ impl RunAllArgs {
             "omicron-dev: external DNS HTTP:      http://{}",
             cptestctx.external_dns.dropshot_server.local_addr()
         );
-        println!(
-            "omicron-dev: external DNS:           {}",
-            cptestctx.external_dns.dns_server.first_local_address()
-        );
-        println!(
-            "omicron-dev:   e.g. `dig @{} -p {} {}.sys.{}`",
-            cptestctx.external_dns.dns_server.first_local_address().ip(),
-            cptestctx.external_dns.dns_server.first_local_address().port(),
-            cptestctx.silo_name,
-            cptestctx.external_dns_zone_name,
-        );
+        for addr in cptestctx.external_dns.dns_server.local_addresses() {
+            println!("omicron-dev: external DNS:           {}", addr,);
+            println!(
+                "omicron-dev:   e.g. `dig @{} -p {} {}.sys.{}`",
+                addr.ip(),
+                addr.port(),
+                cptestctx.silo_name,
+                cptestctx.external_dns_zone_name,
+            );
+        }
         for (switch_slot, gateway) in &cptestctx.gateway {
             println!(
                 "omicron-dev: management gateway:     {} ({:?})",

--- a/dns-server/Cargo.toml
+++ b/dns-server/Cargo.toml
@@ -14,6 +14,7 @@ chrono.workspace = true
 clap.workspace = true
 dns-server-api.workspace = true
 dropshot.workspace = true
+flume.workspace = true
 hickory-proto.workspace = true
 hickory-resolver.workspace = true
 hickory-server.workspace = true

--- a/dns-server/Cargo.toml
+++ b/dns-server/Cargo.toml
@@ -14,7 +14,6 @@ chrono.workspace = true
 clap.workspace = true
 dns-server-api.workspace = true
 dropshot.workspace = true
-flume.workspace = true
 hickory-proto.workspace = true
 hickory-resolver.workspace = true
 hickory-server.workspace = true

--- a/dns-server/dnsadm/tests/commands_test.rs
+++ b/dns-server/dnsadm/tests/commands_test.rs
@@ -31,10 +31,11 @@ async fn test_dnsadm() {
     let (_dns_server, dropshot_server) = dns_server::start_servers(
         logctx.log.clone(),
         store,
-        &dns_server::dns_server::Config {
-            bind_addresses: vec!["[::1]:0".parse().unwrap()],
-            ..Default::default()
-        },
+        &dns_server::dns_server::ConfigBuilder::new(vec![
+            "[::1]:0".parse().unwrap(),
+        ])
+        .build()
+        .expect("valid DNS configuration"),
         &dropshot::ConfigDropshot {
             bind_address: "[::1]:0".parse().unwrap(),
             ..Default::default()

--- a/dns-server/dnsadm/tests/commands_test.rs
+++ b/dns-server/dnsadm/tests/commands_test.rs
@@ -32,7 +32,8 @@ async fn test_dnsadm() {
         logctx.log.clone(),
         store,
         &dns_server::dns_server::Config {
-            bind_address: "[::1]:0".parse().unwrap(),
+            bind_addresses: vec!["[::1]:0".parse().unwrap()],
+            ..Default::default()
         },
         &dropshot::ConfigDropshot {
             bind_address: "[::1]:0".parse().unwrap(),

--- a/dns-server/dnsadm/tests/commands_test.rs
+++ b/dns-server/dnsadm/tests/commands_test.rs
@@ -31,11 +31,8 @@ async fn test_dnsadm() {
     let (_dns_server, dropshot_server) = dns_server::start_servers(
         logctx.log.clone(),
         store,
-        &dns_server::dns_server::ConfigBuilder::new(vec![
-            "[::1]:0".parse().unwrap(),
-        ])
-        .build()
-        .expect("valid DNS configuration"),
+        &dns_server::dns_server::Config::new(vec!["[::1]:0".parse().unwrap()])
+            .expect("valid DNS configuration"),
         &dropshot::ConfigDropshot {
             bind_address: "[::1]:0".parse().unwrap(),
             ..Default::default()

--- a/dns-server/src/bin/dns-server.rs
+++ b/dns-server/src/bin/dns-server.rs
@@ -17,19 +17,11 @@ use std::path::PathBuf;
 #[derive(Clone, Debug)]
 struct SocketAddrs(Vec<SocketAddr>);
 
-impl IntoIterator for SocketAddrs {
-    type Item = SocketAddr;
-
-    type IntoIter = <Vec<SocketAddr> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
 impl SocketAddrs {
     /// Construct self from a comma-delimited list.
     fn from_delimited_list(input: &str) -> anyhow::Result<Self> {
+        // NOTE: This is either non-empty or we fail, because split() always
+        // returns _something_ and so we always have something to parse.
         let addrs = input
             .split(',')
             .map(|each| {
@@ -38,10 +30,6 @@ impl SocketAddrs {
                 })
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
-        anyhow::ensure!(
-            !addrs.is_empty(),
-            "Must provide at least one socket address"
-        );
         Ok(Self(addrs))
     }
 }
@@ -97,10 +85,10 @@ async fn main_impl() -> Result<(), anyhow::Error> {
         .to_logger("dns-server")
         .context("failed to create logger")?;
 
-    let dns_server_config = dns_server::dns_server::Config {
-        bind_addresses: args.dns_addresses.0,
-        ..Default::default()
-    };
+    let dns_server_config =
+        dns_server::dns_server::ConfigBuilder::new(args.dns_addresses.0)
+            .build()
+            .context("building DNS configuration")?;
 
     info!(&log, "config";
         "config" => ?config,

--- a/dns-server/src/bin/dns-server.rs
+++ b/dns-server/src/bin/dns-server.rs
@@ -14,16 +14,60 @@ use slog::o;
 use std::net::{SocketAddr, SocketAddrV6};
 use std::path::PathBuf;
 
+#[derive(Clone, Debug)]
+struct SocketAddrs(Vec<SocketAddr>);
+
+impl IntoIterator for SocketAddrs {
+    type Item = SocketAddr;
+
+    type IntoIter = <Vec<SocketAddr> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl SocketAddrs {
+    /// Construct self from a comma-delimited list.
+    fn from_delimited_list(input: &str) -> anyhow::Result<Self> {
+        let addrs = input
+            .split(',')
+            .map(|each| {
+                each.parse::<SocketAddr>().with_context(|| {
+                    format!("Parsing '{}' as socket addr", each)
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        anyhow::ensure!(
+            !addrs.is_empty(),
+            "Must provide at least one socket address"
+        );
+        Ok(Self(addrs))
+    }
+}
+
 #[derive(Parser, Debug)]
 struct Args {
     #[clap(long, action)]
     config_file: PathBuf,
 
+    /// Socket address for the Dropshot server used to program DNS records.
     #[clap(long, action)]
     http_address: SocketAddrV6,
 
-    #[clap(long, action)]
-    dns_address: SocketAddr,
+    /// One or more socket address on which to serve DNS records.
+    ///
+    /// Multiple addresses may be separated by a comma (,). The DNS server will
+    /// listen for requests on each address, using the same underlying storage.
+    #[clap(
+        long,
+        action,
+        value_parser = SocketAddrs::from_delimited_list,
+        // Preserve the pre-existing `--dns-address` flag, which is how SMF
+        // populates it.
+        visible_alias = "dns-address",
+    )]
+    dns_addresses: SocketAddrs,
 }
 
 #[derive(Deserialize, Debug)]
@@ -53,8 +97,10 @@ async fn main_impl() -> Result<(), anyhow::Error> {
         .to_logger("dns-server")
         .context("failed to create logger")?;
 
-    let dns_server_config =
-        dns_server::dns_server::Config { bind_address: args.dns_address };
+    let dns_server_config = dns_server::dns_server::Config {
+        bind_addresses: args.dns_addresses.0,
+        ..Default::default()
+    };
 
     info!(&log, "config";
         "config" => ?config,
@@ -78,4 +124,48 @@ async fn main_impl() -> Result<(), anyhow::Error> {
     dropshot_server
         .await
         .map_err(|error_message| anyhow!("server exiting: {}", error_message))
+}
+
+#[cfg(test)]
+mod test {
+    use super::SocketAddrs;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn can_parse_single_socket_addr() {
+        let addr = "[fd00::1]:53".parse::<SocketAddr>().unwrap();
+        assert_eq!(
+            SocketAddrs::from_delimited_list(addr.to_string().as_str())
+                .unwrap()
+                .0,
+            vec![addr],
+        );
+    }
+
+    #[test]
+    fn can_parse_multiple_valid_socket_addrs() {
+        let addr1 = "[fd00::1]:53".parse::<SocketAddr>().unwrap();
+        let addr2 = "1.2.3.4:53".parse::<SocketAddr>().unwrap();
+        assert_eq!(
+            SocketAddrs::from_delimited_list(
+                format!("{},{}", addr1, addr2).as_str(),
+            )
+            .unwrap()
+            .0,
+            vec![addr1, addr2],
+        );
+    }
+
+    #[test]
+    fn fail_on_one_invalid_socket_addr() {
+        let addr1 = "[fd00::1]:53".parse::<SocketAddr>().unwrap();
+        let res =
+            SocketAddrs::from_delimited_list(format!("{},foo", addr1).as_str());
+        assert!(res.unwrap_err().to_string().contains("as socket addr"));
+    }
+
+    #[test]
+    fn fail_on_empty_input() {
+        assert!(SocketAddrs::from_delimited_list("").is_err());
+    }
 }

--- a/dns-server/src/bin/dns-server.rs
+++ b/dns-server/src/bin/dns-server.rs
@@ -43,7 +43,7 @@ struct Args {
     #[clap(long, action)]
     http_address: SocketAddrV6,
 
-    /// One or more socket address on which to serve DNS records.
+    /// One or more socket addresses on which to serve DNS records.
     ///
     /// Multiple addresses may be separated by a comma (,). The DNS server will
     /// listen for requests on each address, using the same underlying storage.

--- a/dns-server/src/bin/dns-server.rs
+++ b/dns-server/src/bin/dns-server.rs
@@ -15,6 +15,7 @@ use slog::o;
 use std::net::{SocketAddr, SocketAddrV6};
 use std::path::PathBuf;
 
+/// Helper type to parse one or more socket address from CLI arguments.
 #[derive(Clone, Debug)]
 struct SocketAddrs(Vec<SocketAddr>);
 
@@ -102,7 +103,7 @@ async fn main_impl() -> Result<(), anyhow::Error> {
     )
     .context("initializing persistent storage")?;
 
-    let (mut dns_server, dropshot_server) = dns_server::start_servers(
+    let (dns_server, dropshot_server) = dns_server::start_servers(
         log,
         store,
         &dns_server_config,

--- a/dns-server/src/bin/dns-server.rs
+++ b/dns-server/src/bin/dns-server.rs
@@ -8,7 +8,6 @@
 use anyhow::Context;
 use anyhow::anyhow;
 use clap::Parser;
-use dns_server::dns_server::ExitDetails;
 use serde::Deserialize;
 use slog::info;
 use slog::o;
@@ -88,8 +87,7 @@ async fn main_impl() -> Result<(), anyhow::Error> {
         .context("failed to create logger")?;
 
     let dns_server_config =
-        dns_server::dns_server::ConfigBuilder::new(args.dns_addresses.0)
-            .build()
+        dns_server::dns_server::Config::new(args.dns_addresses.0)
             .context("building DNS configuration")?;
 
     info!(&log, "config";
@@ -120,18 +118,10 @@ async fn main_impl() -> Result<(), anyhow::Error> {
         }
         dns_result = dns_server.wait_for_exit() => {
             match dns_result {
-                Some(Ok(ExitDetails::DnsWorker { index } )) => {
-                    anyhow::bail!("DNS worker task {index} exited unexpectedly");
-                }
-                Some(Ok(ExitDetails::UdpReader { index, result } )) => {
-                    result.with_context(|| {
-                        format!("UDP reader task {index} exited")
-                    })
-                }
-                Some(Err(je)) => anyhow::bail!(
+                Ok(res) => anyhow::bail!("DNS server task exited unexpectedly: {res:?}"),
+                Err(je) => anyhow::bail!(
                     "Error joining DNS server task: '{je}'"
                 ),
-                None => unreachable!("Should always spawn >= 1 task"),
             }
         }
     }

--- a/dns-server/src/bin/dns-server.rs
+++ b/dns-server/src/bin/dns-server.rs
@@ -8,6 +8,7 @@
 use anyhow::Context;
 use anyhow::anyhow;
 use clap::Parser;
+use dns_server::dns_server::ExitDetails;
 use serde::Deserialize;
 use slog::info;
 use slog::o;
@@ -101,7 +102,7 @@ async fn main_impl() -> Result<(), anyhow::Error> {
     )
     .context("initializing persistent storage")?;
 
-    let (_dns_server, dropshot_server) = dns_server::start_servers(
+    let (mut dns_server, dropshot_server) = dns_server::start_servers(
         log,
         store,
         &dns_server_config,
@@ -109,9 +110,30 @@ async fn main_impl() -> Result<(), anyhow::Error> {
     )
     .await?;
 
-    dropshot_server
-        .await
-        .map_err(|error_message| anyhow!("server exiting: {}", error_message))
+    // Wait for either the Dropshot server or any of the tasks in the DNS
+    // server to exit.
+    tokio::select! {
+        dropshot_result = dropshot_server => {
+            dropshot_result
+                .map_err(|e| anyhow!("server exiting: {}", e))
+        }
+        dns_result = dns_server.wait_for_exit() => {
+            match dns_result {
+                Some(Ok(ExitDetails::DnsWorker { index } )) => {
+                    anyhow::bail!("DNS worker task {index} exited unexpectedly");
+                }
+                Some(Ok(ExitDetails::UdpReader { index, result } )) => {
+                    result.with_context(|| {
+                        format!("UDP reader task {index} exited")
+                    })
+                }
+                Some(Err(je)) => anyhow::bail!(
+                    "Error joining DNS server task: '{je}'"
+                ),
+                None => unreachable!("Should always spawn >= 1 task"),
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -118,7 +118,7 @@ impl ServerHandle {
     /// # Panics
     ///
     /// This panics if there is not exactly one address. If you want to handle
-    /// any number of addresses, call [`local_addresses`] instead.
+    /// any number of addresses, call [`ServerHandle::local_addresses`] instead.
     pub fn sole_local_address(&self) -> SocketAddr {
         assert_eq!(
             self.local_addresses.len(),

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -112,20 +112,16 @@ pub struct ServerHandle {
 }
 
 impl ServerHandle {
-    /// Return the address the server is bound it, if there is exactly one. This
-    /// is intended for test contexts.
-    ///
-    /// # Panics
-    ///
-    /// This panics if there is not exactly one address. If you want to handle
-    /// any number of addresses, call [`ServerHandle::local_addresses`] instead.
-    pub fn sole_local_address(&self) -> SocketAddr {
-        assert_eq!(
+    /// Return the address the server is bound it, if there is exactly one, or
+    /// an error otherwise. This is mostly intended for test contexts.
+    pub fn sole_local_address(&self) -> anyhow::Result<SocketAddr> {
+        anyhow::ensure!(
+            self.local_addresses.len() == 1,
+            "Expected the DNS server to have exactly 1 address, but \
+            it actually has {}",
             self.local_addresses.len(),
-            1,
-            "DNS server does not have exactly one bound address"
         );
-        self.local_addresses[0]
+        Ok(self.local_addresses[0])
     }
 
     /// The addresses the server is bound to.
@@ -135,7 +131,7 @@ impl ServerHandle {
 
     /// Wait for any of the internal tasks to exit.
     pub async fn wait_for_exit(
-        &mut self,
+        mut self,
     ) -> Option<Result<ExitDetails, JoinError>> {
         self.tasks.join_next().await
     }

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -29,11 +29,9 @@ use hickory_server::authority::MessageResponseBuilder;
 use internal_dns_types::config::DnsRecord;
 use internal_dns_types::config::Srv;
 use pretty_hex::*;
-use slog::warn;
 use slog::{Logger, debug, error, info, o, trace};
 use slog_error_chain::InlineErrorChain;
 use std::net::SocketAddr;
-use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
 use thiserror::Error;
@@ -47,68 +45,31 @@ use uuid::Uuid;
 pub struct Config {
     /// The addresses to listen for DNS requests on.
     bind_addresses: Vec<SocketAddr>,
-
-    /// The number of received requests to buffer before dropping them.
-    request_queue_size: NonZeroUsize,
-
-    /// The number of worker tasks that generate DNS answers.
-    n_workers: NonZeroUsize,
 }
 
-pub struct ConfigBuilder {
-    bind_addresses: Vec<SocketAddr>,
-    request_queue_size: Option<NonZeroUsize>,
-    n_workers: Option<NonZeroUsize>,
-}
-
-impl ConfigBuilder {
-    pub fn new(bind_addresses: Vec<SocketAddr>) -> Self {
-        Self { bind_addresses, request_queue_size: None, n_workers: None }
-    }
-
-    pub fn request_queue_size(
-        &mut self,
-        request_queue_size: NonZeroUsize,
-    ) -> &mut Self {
-        self.request_queue_size = Some(request_queue_size);
-        self
-    }
-
-    pub fn n_workers(&mut self, n_workers: NonZeroUsize) -> &mut Self {
-        self.n_workers = Some(n_workers);
-        self
-    }
-
-    pub fn build(self) -> anyhow::Result<Config> {
+impl Config {
+    /// Construct from a list of addresses. This fails if the list is empty.
+    pub fn new(bind_addresses: Vec<SocketAddr>) -> anyhow::Result<Self> {
         anyhow::ensure!(
-            !self.bind_addresses.is_empty(),
-            "Must provide at least one bind address",
+            !bind_addresses.is_empty(),
+            "Must provide at least one bind address"
         );
-        Ok(Config {
-            bind_addresses: self.bind_addresses,
-            request_queue_size: self
-                .request_queue_size
-                .unwrap_or(NonZeroUsize::new(128).unwrap()),
-            n_workers: self.n_workers.unwrap_or(NonZeroUsize::new(16).unwrap()),
-        })
+        Ok(Self { bind_addresses })
     }
 }
 
-/// The exit details of one of the DNS server's internal tasks.
-pub enum ExitDetails {
-    /// One of the DNS worker tasks exited.
-    DnsWorker { index: usize },
-    /// One of the UDP packet reader tasks exited.
-    UdpReader { index: usize, result: anyhow::Result<()> },
-}
-
-/// Handle to the DNS server
+/// Handle to the DNS servers.
 ///
-/// Dropping this handle shuts down the DNS server. All of its receiver and
-/// worker tasks are aborted.
+/// Dropping this handle shuts down the DNS servers.
 pub struct ServerHandle {
+    /// Local address each single server is bound to.
     local_addresses: Vec<SocketAddr>,
-    tasks: JoinSet<ExitDetails>,
+    /// Join set in which all spawned server tasks run.
+    ///
+    /// NOTE: This does _not_ include the tasks handling an individual DNS
+    /// request, i.e., `handle_dns_packet()`. Those are spawned outside the set
+    /// and continue to run even if this is dropped.
+    server_tasks: JoinSet<anyhow::Result<()>>,
 }
 
 impl ServerHandle {
@@ -129,11 +90,11 @@ impl ServerHandle {
         self.local_addresses.iter().copied()
     }
 
-    /// Wait for any of the internal tasks to exit.
+    /// Wait for any of the individual servers to exit.
     pub async fn wait_for_exit(
         mut self,
-    ) -> Option<Result<ExitDetails, JoinError>> {
-        self.tasks.join_next().await
+    ) -> Result<anyhow::Result<()>, JoinError> {
+        self.server_tasks.join_next().await.expect("Always at least one server")
     }
 }
 
@@ -144,152 +105,73 @@ impl ServerHandle {
 pub struct Server;
 
 impl Server {
-    /// Starts a DNS server whose DNS data comes from the given `store`.
-    ///
-    /// The server binds each address in `config.bind_addresses` and serves DNS
-    /// on all of them from the same `store`.
+    /// Starts a DNS server whose DNS data comes from the given `store`
     pub async fn start(
         log: Logger,
         store: storage::Store,
         config: &Config,
     ) -> anyhow::Result<ServerHandle> {
-        anyhow::ensure!(
-            !config.bind_addresses.is_empty(),
-            "DNS server requires at least one bind address"
-        );
-
-        // Queue from tasks receiving UDP packets to the workers servicing them.
-        let (tx, rx) =
-            flume::bounded::<Incoming>(config.request_queue_size.get());
-
-        // Worker pool, which handle UDP packets from the store and serve
-        // answers.
-        let mut tasks = JoinSet::new();
-        for index in 0..config.n_workers.get() {
-            let log = log.new(o!("dns_worker" => index));
-            let store = store.clone();
-            let rx = rx.clone();
-            tasks.spawn(async move {
-                respond_to_dns_packets(log, store, rx).await;
-                ExitDetails::DnsWorker { index }
-            });
-        }
-
-        // Bind each address and spawn a receiver task for it.
+        let mut server_tasks = JoinSet::new();
         let mut local_addresses =
             Vec::with_capacity(config.bind_addresses.len());
-        for (index, bind_address) in config.bind_addresses.iter().enumerate() {
-            let socket = Arc::new(
-                UdpSocket::bind(bind_address).await.with_context(|| {
-                    format!("DNS server start: UDP bind to {:?}", bind_address)
+        for bind_address in config.bind_addresses.iter() {
+            let server_socket = Arc::new(
+                UdpSocket::bind(*bind_address).await.with_context(|| {
+                    format!("DNS server start: UDP bind to {:?}", bind_address,)
                 })?,
             );
-            let local_address = socket.local_addr().context(
+            let local_address = server_socket.local_addr().context(
                 "DNS server start: failed to get local address of bound socket",
             )?;
-            info!(&log, "DNS server bound to address";
-                "local_address" => ?local_address
-            );
+            let log = log.new(o!("bind_address" => local_address.to_string()));
+            info!(&log, "DNS server bound to address");
             local_addresses.push(local_address);
-
-            let log = log.new(o!(
-                "udp_reader" => index,
-                "bind_address" => local_address.to_string()
-            ));
-            let tx_ = tx.clone();
-            tasks.spawn(async move {
-                let result = read_udp_packets(log, socket, tx_).await;
-                ExitDetails::UdpReader { index, result }
-            });
+            let single_server =
+                SingleServer { log, store: store.clone(), server_socket };
+            server_tasks.spawn(single_server.run());
         }
-
-        Ok(ServerHandle { local_addresses, tasks })
+        Ok(ServerHandle { local_addresses, server_tasks })
     }
 }
 
-/// A received DNS packet, waiting to be answered by a worker.
-struct Incoming {
-    /// The socket the packet arrived on, used to send the reply.
-    socket: Arc<UdpSocket>,
-    /// Address we received the packet from.
-    client_addr: SocketAddr,
-    /// Raw packet data.
-    packet: Vec<u8>,
-}
-
-/// Receive packets on a single bound socket and forward them to the worker
-/// pool.
-//
-// NOTE: In practice this never returns Ok(_), only an error.
-async fn read_udp_packets(
-    log: Logger,
-    socket: Arc<UdpSocket>,
-    tx: flume::Sender<Incoming>,
-) -> anyhow::Result<()> {
-    loop {
-        let mut buf = vec![0u8; 16384];
-        let (n, client_addr) = socket
-            .recv_from(&mut buf)
-            .await
-            .context("receiving packet from UDP listen socket")?;
-        buf.resize(n, 0);
-        let incoming =
-            Incoming { socket: socket.clone(), client_addr, packet: buf };
-        match tx.try_send(incoming) {
-            Ok(()) => {
-                trace!(
-                    &log,
-                    "sent UDP packet to worker queue";
-                    "client_addr" => %client_addr,
-                    "packet_size" => n,
-                );
-            }
-            Err(flume::TrySendError::Full(_)) => {
-                debug!(
-                    &log,
-                    "dropping DNS request: worker queue full";
-                    "client_addr" => %client_addr,
-                );
-            }
-            Err(flume::TrySendError::Disconnected(_)) => {
-                warn!(&log, "All DNS worker tasks disconnected, exiting");
-                anyhow::bail!("All DNS worker tasks disconnected");
-            }
-        }
-    }
-}
-
-/// Pull received UDP packets off the queue and answer them.
-async fn respond_to_dns_packets(
+/// A DNS server bound to a single UDP socket.
+struct SingleServer {
     log: Logger,
     store: storage::Store,
-    rx: flume::Receiver<Incoming>,
-) {
-    while let Ok(Incoming { socket, client_addr, packet }) =
-        rx.recv_async().await
-    {
-        trace!(
-            &log,
-            "DNS worker tasks received incoming UDP packet";
-            "client_addr" => %client_addr,
-            "packet_size" => &packet.len(),
-        );
-        let req_id = Uuid::new_v4();
-        let log = log.new(o!(
-            "req_id" => req_id.to_string(),
-            "peer_addr" => client_addr.to_string(),
-        ));
+    server_socket: Arc<UdpSocket>,
+}
 
-        let request = Request {
-            log,
-            store: store.clone(),
-            socket,
-            client_addr,
-            packet,
-            req_id,
-        };
+impl SingleServer {
+    async fn run(self) -> anyhow::Result<()> {
+        // The guts of the DNS server: read packets from the bound socket and
+        // handle them.
+        loop {
+            let mut buf = vec![0u8; 16384];
+            let (n, client_addr) = self
+                .server_socket
+                .recv_from(&mut buf)
+                .await
+                .context("receiving packet from UDP listen socket")?;
+            buf.resize(n, 0);
 
-        handle_dns_packet(request).await;
+            let req_id = Uuid::new_v4();
+            let log = self.log.new(o!(
+                "req_id" => req_id.to_string(),
+                "peer_addr" => client_addr.to_string(),
+            ));
+            let request = Request {
+                log,
+                store: self.store.clone(),
+                socket: self.server_socket.clone(),
+                client_addr,
+                packet: buf,
+                req_id,
+            };
+
+            // TODO-robustness We should cap the number of tokio tasks that
+            // we're willing to spawn if we receive a flood of requests.
+            tokio::spawn(handle_dns_packet(request));
+        }
     }
 }
 

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -38,6 +38,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::net::UdpSocket;
+use tokio::task::JoinError;
+use tokio::task::JoinSet;
 use uuid::Uuid;
 
 /// Configuration related to the DNS server
@@ -92,25 +94,21 @@ impl ConfigBuilder {
     }
 }
 
+/// The exit details of one of the DNS server's internal tasks.
+pub enum ExitDetails {
+    /// One of the DNS worker tasks exited.
+    DnsWorker { index: usize },
+    /// One of the UDP packet reader tasks exited.
+    UdpReader { index: usize, result: anyhow::Result<()> },
+}
+
 /// Handle to the DNS server
 ///
 /// Dropping this handle shuts down the DNS server. All of its receiver and
 /// worker tasks are aborted.
 pub struct ServerHandle {
     local_addresses: Vec<SocketAddr>,
-    receiver_tasks: Vec<tokio::task::JoinHandle<anyhow::Result<()>>>,
-    worker_tasks: Vec<tokio::task::JoinHandle<()>>,
-}
-
-impl Drop for ServerHandle {
-    fn drop(&mut self) {
-        for task in &self.receiver_tasks {
-            task.abort();
-        }
-        for task in &self.worker_tasks {
-            task.abort();
-        }
-    }
+    tasks: JoinSet<ExitDetails>,
 }
 
 impl ServerHandle {
@@ -125,6 +123,13 @@ impl ServerHandle {
     /// The addresses the server is bound to.
     pub fn local_addresses(&self) -> impl Iterator<Item = SocketAddr> + '_ {
         self.local_addresses.iter().copied()
+    }
+
+    /// Wait for any of the internal tasks to exit.
+    pub async fn wait_for_exit(
+        &mut self,
+    ) -> Option<Result<ExitDetails, JoinError>> {
+        self.tasks.join_next().await
     }
 }
 
@@ -155,27 +160,21 @@ impl Server {
 
         // Worker pool, which handle UDP packets from the store and serve
         // answers.
-        let worker_tasks = (0..config.n_workers.get())
-            .map(|i| {
-                let log = log.new(o!("worker" => i));
-                let store = store.clone();
-                let rx = rx.clone();
-                tokio::task::spawn(respond_to_dns_packets(log, store, rx))
-            })
-            .collect();
-
-        // Build the server handle now, so that failures to bind to any of the
-        // UDP sockets ensures we run our drop impl and reap any tasks we've
-        // spawned.
-        let n_addresses = config.bind_addresses.len();
-        let mut handle = ServerHandle {
-            local_addresses: Vec::with_capacity(n_addresses),
-            receiver_tasks: Vec::with_capacity(n_addresses),
-            worker_tasks,
-        };
+        let mut tasks = JoinSet::new();
+        for index in 0..config.n_workers.get() {
+            let log = log.new(o!("dns_worker" => index));
+            let store = store.clone();
+            let rx = rx.clone();
+            tasks.spawn(async move {
+                respond_to_dns_packets(log, store, rx).await;
+                ExitDetails::DnsWorker { index }
+            });
+        }
 
         // Bind each address and spawn a receiver task for it.
-        for bind_address in &config.bind_addresses {
+        let mut local_addresses =
+            Vec::with_capacity(config.bind_addresses.len());
+        for (index, bind_address) in config.bind_addresses.iter().enumerate() {
             let socket = Arc::new(
                 UdpSocket::bind(bind_address).await.with_context(|| {
                     format!("DNS server start: UDP bind to {:?}", bind_address)
@@ -187,17 +186,20 @@ impl Server {
             info!(&log, "DNS server bound to address";
                 "local_address" => ?local_address
             );
-            handle.local_addresses.push(local_address);
+            local_addresses.push(local_address);
 
-            let log = log.new(o!("bind_address" => local_address.to_string()));
-            handle.receiver_tasks.push(tokio::task::spawn(read_udp_packets(
-                log,
-                socket,
-                tx.clone(),
-            )));
+            let log = log.new(o!(
+                "udp_reader" => index,
+                "bind_address" => local_address.to_string()
+            ));
+            let tx_ = tx.clone();
+            tasks.spawn(async move {
+                let result = read_udp_packets(log, socket, tx_).await;
+                ExitDetails::UdpReader { index, result }
+            });
         }
 
-        Ok(handle)
+        Ok(ServerHandle { local_addresses, tasks })
     }
 }
 
@@ -213,6 +215,8 @@ struct Incoming {
 
 /// Receive packets on a single bound socket and forward them to the worker
 /// pool.
+//
+// NOTE: In practice this never returns Ok(_), only an error.
 async fn read_udp_packets(
     log: Logger,
     socket: Arc<UdpSocket>,
@@ -245,7 +249,7 @@ async fn read_udp_packets(
             }
             Err(flume::TrySendError::Disconnected(_)) => {
                 warn!(&log, "All DNS worker tasks disconnected, exiting");
-                return Ok(());
+                anyhow::bail!("All DNS worker tasks disconnected");
             }
         }
     }

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -112,11 +112,19 @@ pub struct ServerHandle {
 }
 
 impl ServerHandle {
-    /// The first address the server is bound to.
+    /// Return the address the server is bound it, if there is exactly one. This
+    /// is intended for test contexts.
     ///
-    /// The server always binds at least one address, so this is always
-    /// available.
-    pub fn first_local_address(&self) -> SocketAddr {
+    /// # Panics
+    ///
+    /// This panics if there is not exactly one address. If you want to handle
+    /// any number of addresses, call [`local_addresses`] instead.
+    pub fn sole_local_address(&self) -> SocketAddr {
+        assert_eq!(
+            self.local_addresses.len(),
+            1,
+            "DNS server does not have exactly one bound address"
+        );
         self.local_addresses[0]
     }
 

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -44,22 +44,51 @@ use uuid::Uuid;
 #[derive(Debug, Clone)]
 pub struct Config {
     /// The addresses to listen for DNS requests on.
-    pub bind_addresses: Vec<SocketAddr>,
+    bind_addresses: Vec<SocketAddr>,
 
     /// The number of received requests to buffer before dropping them.
-    pub request_queue_size: NonZeroUsize,
+    request_queue_size: NonZeroUsize,
 
     /// The number of worker tasks that generate DNS answers.
-    pub n_workers: NonZeroUsize,
+    n_workers: NonZeroUsize,
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            bind_addresses: Vec::new(),
-            request_queue_size: NonZeroUsize::new(128).unwrap(),
-            n_workers: NonZeroUsize::new(16).unwrap(),
-        }
+pub struct ConfigBuilder {
+    bind_addresses: Vec<SocketAddr>,
+    request_queue_size: Option<NonZeroUsize>,
+    n_workers: Option<NonZeroUsize>,
+}
+
+impl ConfigBuilder {
+    pub fn new(bind_addresses: Vec<SocketAddr>) -> Self {
+        Self { bind_addresses, request_queue_size: None, n_workers: None }
+    }
+
+    pub fn request_queue_size(
+        &mut self,
+        request_queue_size: NonZeroUsize,
+    ) -> &mut Self {
+        self.request_queue_size = Some(request_queue_size);
+        self
+    }
+
+    pub fn n_workers(&mut self, n_workers: NonZeroUsize) -> &mut Self {
+        self.n_workers = Some(n_workers);
+        self
+    }
+
+    pub fn build(self) -> anyhow::Result<Config> {
+        anyhow::ensure!(
+            !self.bind_addresses.is_empty(),
+            "Must provide at least one bind address",
+        );
+        Ok(Config {
+            bind_addresses: self.bind_addresses,
+            request_queue_size: self
+                .request_queue_size
+                .unwrap_or(NonZeroUsize::new(128).unwrap()),
+            n_workers: self.n_workers.unwrap_or(NonZeroUsize::new(16).unwrap()),
+        })
     }
 }
 
@@ -135,11 +164,17 @@ impl Server {
             })
             .collect();
 
+        // Build the server handle now, so that failures to bind to any of the
+        // UDP sockets ensures we run our drop impl and reap any tasks we've
+        // spawned.
+        let n_addresses = config.bind_addresses.len();
+        let mut handle = ServerHandle {
+            local_addresses: Vec::with_capacity(n_addresses),
+            receiver_tasks: Vec::with_capacity(n_addresses),
+            worker_tasks,
+        };
+
         // Bind each address and spawn a receiver task for it.
-        let mut local_addresses =
-            Vec::with_capacity(config.bind_addresses.len());
-        let mut receiver_tasks =
-            Vec::with_capacity(config.bind_addresses.len());
         for bind_address in &config.bind_addresses {
             let socket = Arc::new(
                 UdpSocket::bind(bind_address).await.with_context(|| {
@@ -152,17 +187,17 @@ impl Server {
             info!(&log, "DNS server bound to address";
                 "local_address" => ?local_address
             );
-            local_addresses.push(local_address);
+            handle.local_addresses.push(local_address);
 
             let log = log.new(o!("bind_address" => local_address.to_string()));
-            receiver_tasks.push(tokio::task::spawn(read_udp_packets(
+            handle.receiver_tasks.push(tokio::task::spawn(read_udp_packets(
                 log,
                 socket,
                 tx.clone(),
             )));
         }
 
-        Ok(ServerHandle { local_addresses, receiver_tasks, worker_tasks })
+        Ok(handle)
     }
 }
 
@@ -205,7 +240,7 @@ async fn read_udp_packets(
                 debug!(
                     &log,
                     "dropping DNS request: worker queue full";
-                    "peer_addr" => client_addr.to_string(),
+                    "client_addr" => %client_addr,
                 );
             }
             Err(flume::TrySendError::Disconnected(_)) => {

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -29,10 +29,11 @@ use hickory_server::authority::MessageResponseBuilder;
 use internal_dns_types::config::DnsRecord;
 use internal_dns_types::config::Srv;
 use pretty_hex::*;
-use serde::Deserialize;
+use slog::warn;
 use slog::{Logger, debug, error, info, o, trace};
 use slog_error_chain::InlineErrorChain;
 use std::net::SocketAddr;
+use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
 use thiserror::Error;
@@ -40,29 +41,61 @@ use tokio::net::UdpSocket;
 use uuid::Uuid;
 
 /// Configuration related to the DNS server
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct Config {
-    /// The address to listen for DNS requests on
-    pub bind_address: SocketAddr,
+    /// The addresses to listen for DNS requests on.
+    pub bind_addresses: Vec<SocketAddr>,
+
+    /// The number of received requests to buffer before dropping them.
+    pub request_queue_size: NonZeroUsize,
+
+    /// The number of worker tasks that generate DNS answers.
+    pub n_workers: NonZeroUsize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            bind_addresses: Vec::new(),
+            request_queue_size: NonZeroUsize::new(128).unwrap(),
+            n_workers: NonZeroUsize::new(16).unwrap(),
+        }
+    }
 }
 
 /// Handle to the DNS server
 ///
-/// Dropping this handle shuts down the DNS server.
+/// Dropping this handle shuts down the DNS server. All of its receiver and
+/// worker tasks are aborted.
 pub struct ServerHandle {
-    local_address: SocketAddr,
-    handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+    local_addresses: Vec<SocketAddr>,
+    receiver_tasks: Vec<tokio::task::JoinHandle<anyhow::Result<()>>>,
+    worker_tasks: Vec<tokio::task::JoinHandle<()>>,
 }
 
 impl Drop for ServerHandle {
     fn drop(&mut self) {
-        self.handle.abort()
+        for task in &self.receiver_tasks {
+            task.abort();
+        }
+        for task in &self.worker_tasks {
+            task.abort();
+        }
     }
 }
 
 impl ServerHandle {
-    pub fn local_address(&self) -> SocketAddr {
-        self.local_address
+    /// The first address the server is bound to.
+    ///
+    /// The server always binds at least one address, so this is always
+    /// available.
+    pub fn first_local_address(&self) -> SocketAddr {
+        self.local_addresses[0]
+    }
+
+    /// The addresses the server is bound to.
+    pub fn local_addresses(&self) -> impl Iterator<Item = SocketAddr> + '_ {
+        self.local_addresses.iter().copied()
     }
 }
 
@@ -70,72 +103,150 @@ impl ServerHandle {
 ///
 /// You construct one of these with [`Server::start()`].  But what you get back
 /// is a [`ServerHandle`].  You don't deal with the Server directly.
-pub struct Server {
-    log: Logger,
-    store: storage::Store,
-    server_socket: Arc<UdpSocket>,
-}
+pub struct Server;
 
 impl Server {
-    /// Starts a DNS server whose DNS data comes from the given `store`
+    /// Starts a DNS server whose DNS data comes from the given `store`.
+    ///
+    /// The server binds each address in `config.bind_addresses` and serves DNS
+    /// on all of them from the same `store`.
     pub async fn start(
         log: Logger,
         store: storage::Store,
         config: &Config,
     ) -> anyhow::Result<ServerHandle> {
-        let server_socket = Arc::new(
-            UdpSocket::bind(config.bind_address).await.with_context(|| {
-                format!(
-                    "DNS server start: UDP bind to {:?}",
-                    config.bind_address
-                )
-            })?,
+        anyhow::ensure!(
+            !config.bind_addresses.is_empty(),
+            "DNS server requires at least one bind address"
         );
 
-        let local_address = server_socket.local_addr().context(
-            "DNS server start: failed to get local address of bound socket",
-        )?;
+        // Queue from tasks receiving UDP packets to the workers servicing them.
+        let (tx, rx) =
+            flume::bounded::<Incoming>(config.request_queue_size.get());
 
-        info!(&log, "DNS server bound to address";
-            "local_address" => ?local_address
-        );
+        // Worker pool, which handle UDP packets from the store and serve
+        // answers.
+        let worker_tasks = (0..config.n_workers.get())
+            .map(|i| {
+                let log = log.new(o!("worker" => i));
+                let store = store.clone();
+                let rx = rx.clone();
+                tokio::task::spawn(respond_to_dns_packets(log, store, rx))
+            })
+            .collect();
 
-        let server = Server { log, store, server_socket };
-        let handle = tokio::task::spawn(server.run());
-        Ok(ServerHandle { local_address, handle })
-    }
+        // Bind each address and spawn a receiver task for it.
+        let mut local_addresses =
+            Vec::with_capacity(config.bind_addresses.len());
+        let mut receiver_tasks =
+            Vec::with_capacity(config.bind_addresses.len());
+        for bind_address in &config.bind_addresses {
+            let socket = Arc::new(
+                UdpSocket::bind(bind_address).await.with_context(|| {
+                    format!("DNS server start: UDP bind to {:?}", bind_address)
+                })?,
+            );
+            let local_address = socket.local_addr().context(
+                "DNS server start: failed to get local address of bound socket",
+            )?;
+            info!(&log, "DNS server bound to address";
+                "local_address" => ?local_address
+            );
+            local_addresses.push(local_address);
 
-    async fn run(self) -> anyhow::Result<()> {
-        // The guts of the DNS server: read packets from the bound socket and
-        // handle them.
-        loop {
-            let mut buf = vec![0u8; 16384];
-            let (n, client_addr) = self
-                .server_socket
-                .recv_from(&mut buf)
-                .await
-                .context("receiving packet from UDP listen socket")?;
-            buf.resize(n, 0);
-
-            let req_id = Uuid::new_v4();
-            let log = self.log.new(o!(
-                "req_id" => req_id.to_string(),
-                "peer_addr" => client_addr.to_string(),
-            ));
-
-            let request = Request {
+            let log = log.new(o!("bind_address" => local_address.to_string()));
+            receiver_tasks.push(tokio::task::spawn(read_udp_packets(
                 log,
-                store: self.store.clone(),
-                socket: self.server_socket.clone(),
-                client_addr,
-                packet: buf,
-                req_id,
-            };
-
-            // TODO-robustness We should cap the number of tokio tasks that
-            // we're willing to spawn if we receive a flood of requests.
-            tokio::spawn(handle_dns_packet(request));
+                socket,
+                tx.clone(),
+            )));
         }
+
+        Ok(ServerHandle { local_addresses, receiver_tasks, worker_tasks })
+    }
+}
+
+/// A received DNS packet, waiting to be answered by a worker.
+struct Incoming {
+    /// The socket the packet arrived on, used to send the reply.
+    socket: Arc<UdpSocket>,
+    /// Address we received the packet from.
+    client_addr: SocketAddr,
+    /// Raw packet data.
+    packet: Vec<u8>,
+}
+
+/// Receive packets on a single bound socket and forward them to the worker
+/// pool.
+async fn read_udp_packets(
+    log: Logger,
+    socket: Arc<UdpSocket>,
+    tx: flume::Sender<Incoming>,
+) -> anyhow::Result<()> {
+    loop {
+        let mut buf = vec![0u8; 16384];
+        let (n, client_addr) = socket
+            .recv_from(&mut buf)
+            .await
+            .context("receiving packet from UDP listen socket")?;
+        buf.resize(n, 0);
+        let incoming =
+            Incoming { socket: socket.clone(), client_addr, packet: buf };
+        match tx.try_send(incoming) {
+            Ok(()) => {
+                trace!(
+                    &log,
+                    "sent UDP packet to worker queue";
+                    "client_addr" => %client_addr,
+                    "packet_size" => n,
+                );
+            }
+            Err(flume::TrySendError::Full(_)) => {
+                debug!(
+                    &log,
+                    "dropping DNS request: worker queue full";
+                    "peer_addr" => client_addr.to_string(),
+                );
+            }
+            Err(flume::TrySendError::Disconnected(_)) => {
+                warn!(&log, "All DNS worker tasks disconnected, exiting");
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Pull received UDP packets off the queue and answer them.
+async fn respond_to_dns_packets(
+    log: Logger,
+    store: storage::Store,
+    rx: flume::Receiver<Incoming>,
+) {
+    while let Ok(Incoming { socket, client_addr, packet }) =
+        rx.recv_async().await
+    {
+        trace!(
+            &log,
+            "DNS worker tasks received incoming UDP packet";
+            "client_addr" => %client_addr,
+            "packet_size" => &packet.len(),
+        );
+        let req_id = Uuid::new_v4();
+        let log = log.new(o!(
+            "req_id" => req_id.to_string(),
+            "peer_addr" => client_addr.to_string(),
+        ));
+
+        let request = Request {
+            log,
+            store: store.clone(),
+            socket,
+            client_addr,
+            packet,
+            req_id,
+        };
+
+        handle_dns_packet(request).await;
     }
 }
 

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -73,7 +73,7 @@ pub struct ServerHandle {
 }
 
 impl ServerHandle {
-    /// Return the address the server is bound it, if there is exactly one, or
+    /// Return the address the server is bound to, if there is exactly one, or
     /// an error otherwise. This is mostly intended for test contexts.
     pub fn sole_local_address(&self) -> anyhow::Result<SocketAddr> {
         anyhow::ensure!(

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -69,7 +69,7 @@ pub async fn a_crud() -> Result<(), anyhow::Error> {
     // is authoritative, so we'll have to query again with a lower level
     // interface to validate that.
     let raw_response = raw_dns_client_query(
-        test_ctx.dns_server.local_address(),
+        test_ctx.dns_server.first_local_address(),
         Name::from_ascii(&fqdn).expect("name is valid"),
         RecordType::A,
     )
@@ -114,7 +114,7 @@ pub async fn aaaa_crud() -> Result<(), anyhow::Error> {
     // is authoritative, so we'll have to query again with a lower level
     // interface to validate that.
     let raw_response = raw_dns_client_query(
-        test_ctx.dns_server.local_address(),
+        test_ctx.dns_server.first_local_address(),
         Name::from_ascii(&fqdn).expect("name is valid"),
         RecordType::AAAA,
     )
@@ -160,7 +160,7 @@ pub async fn answers_match_question() -> Result<(), anyhow::Error> {
     // `raw_dns_client_query` avoids using a hickory Resolver, so we can assert
     // on the exact answer from our server.
     let raw_response = raw_dns_client_query(
-        test_ctx.dns_server.local_address(),
+        test_ctx.dns_server.first_local_address(),
         name,
         RecordType::A,
     )
@@ -245,7 +245,7 @@ pub async fn srv_crud() -> Result<(), anyhow::Error> {
         .expect("can construct name for query");
 
     let response = raw_dns_client_query(
-        test_ctx.dns_server.local_address(),
+        test_ctx.dns_server.first_local_address(),
         name,
         RecordType::SRV,
     )
@@ -422,7 +422,7 @@ pub async fn name_contains_zone() -> Result<(), anyhow::Error> {
 
     // A lookup shouldn't work without the zone's name appended twice.
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.local_address(),
+        test_ctx.dns_server.first_local_address(),
         resolver,
         "epsilon3.oxide.test",
         ResponseCode::NXDomain,
@@ -452,7 +452,7 @@ pub async fn empty_record() -> Result<(), anyhow::Error> {
 
     // resolve the name
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.local_address(),
+        test_ctx.dns_server.first_local_address(),
         &resolver,
         &(name + "." + TEST_ZONE + "."),
         ResponseCode::NXDomain,
@@ -554,7 +554,7 @@ pub async fn soa() -> Result<(), anyhow::Error> {
 
     // As with other NXDomain answers, we should see the authoritative bit.
     let raw_response = raw_query_expect_err(
-        test_ctx.dns_server.local_address(),
+        test_ctx.dns_server.first_local_address(),
         &no_soa_name,
         RecordType::A,
     )
@@ -605,7 +605,7 @@ pub async fn nxdomain() -> Result<(), anyhow::Error> {
     // asking for a nonexistent record within the domain of the internal DNS
     // server should result in an NXDOMAIN
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.local_address(),
+        test_ctx.dns_server.first_local_address(),
         &resolver,
         &format!("unicorn.{}.", TEST_ZONE),
         ResponseCode::NXDomain,
@@ -626,12 +626,83 @@ pub async fn servfail() -> Result<(), anyhow::Error> {
     // SERVFAIL.  Further, `lookup_ip_expect_error_code` will check that the
     // error is not authoritative.
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.local_address(),
+        test_ctx.dns_server.first_local_address(),
         &resolver,
         "unicorn.oxide.internal",
         ResponseCode::ServFail,
     )
     .await;
+
+    test_ctx.cleanup().await;
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn receives_on_multiple_sockets() -> Result<(), anyhow::Error> {
+    // Bind mix of IPv4 / IPv6 sockets.
+    let requested: Vec<std::net::SocketAddr> = vec![
+        "[::1]:0".parse().unwrap(),
+        "[::1]:0".parse().unwrap(),
+        "127.0.0.1:0".parse().unwrap(),
+    ];
+    let test_ctx = init_client_server_with_bind_addresses(
+        "receives_on_multiple_sockets",
+        requested.clone(),
+    )
+    .await?;
+    let client = &test_ctx.client;
+
+    // The server should have bound one socket per requested address.
+    let bound: Vec<std::net::SocketAddr> =
+        test_ctx.dns_server.local_addresses().collect();
+    assert_eq!(
+        bound.len(),
+        requested.len(),
+        "expected one bound socket per requested address"
+    );
+
+    // Add a single record, served from the store shared by all sockets.
+    let name = "devron".to_string();
+    let fqdn = name.clone() + "." + TEST_ZONE + ".";
+    let addr = Ipv4Addr::new(10, 1, 2, 3);
+    dns_records_create(
+        client,
+        TEST_ZONE,
+        HashMap::from([(name.clone(), vec![DnsRecord::A(addr)])]),
+    )
+    .await?;
+
+    // A query sent to each bound socket must be answered the same way.
+    let mut first_answers: Option<Vec<_>> = None;
+    for bind_addr in bound {
+        let response = raw_dns_client_query(
+            bind_addr,
+            Name::from_ascii(&fqdn).expect("name is valid"),
+            RecordType::A,
+        )
+        .await
+        .with_context(|| format!("querying bound socket {bind_addr}"))?;
+        assert!(
+            response.authoritative(),
+            "response from {bind_addr} was not authoritative"
+        );
+        assert_eq!(
+            response.answers().len(),
+            1,
+            "expected exactly one answer from {bind_addr}"
+        );
+        // Every socket is backed by the same store, so they must all return
+        // the same answer records. Records each have a unique ID, so only look
+        // at the answer section.
+        let answers = response.answers().to_vec();
+        match &first_answers {
+            None => first_answers = Some(answers),
+            Some(first) => assert_eq!(
+                &answers, first,
+                "socket {bind_addr} returned different answers"
+            ),
+        }
+    }
 
     test_ctx.cleanup().await;
     Ok(())
@@ -658,6 +729,17 @@ impl TestContext {
 async fn init_client_server(
     test_name: &str,
 ) -> Result<TestContext, anyhow::Error> {
+    init_client_server_with_bind_addresses(
+        test_name,
+        vec!["[::1]:0".parse().unwrap()],
+    )
+    .await
+}
+
+async fn init_client_server_with_bind_addresses(
+    test_name: &str,
+    bind_addresses: Vec<std::net::SocketAddr>,
+) -> Result<TestContext, anyhow::Error> {
     // initialize dns server config
     let (tmp, config_storage, config_dropshot, logctx) =
         test_config(test_name)?;
@@ -672,9 +754,8 @@ async fn init_client_server(
     assert!(store.is_new());
 
     // launch a dns server
-    let dns_server_config = dns_server::dns_server::Config {
-        bind_address: "[::1]:0".parse().unwrap(),
-    };
+    let dns_server_config =
+        dns_server::dns_server::Config { bind_addresses, ..Default::default() };
     let (dns_server, dropshot_server) = dns_server::start_servers(
         log.clone(),
         store,
@@ -685,7 +766,7 @@ async fn init_client_server(
 
     let mut resolver_config = ResolverConfig::new();
     resolver_config.add_name_server(NameServerConfig::new(
-        dns_server.local_address(),
+        dns_server.first_local_address(),
         Protocol::Udp,
     ));
     let mut resolver_opts = ResolverOpts::default();

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -768,7 +768,11 @@ async fn init_client_server_with_bind_addresses(
 
     let mut resolver_config = ResolverConfig::new();
     resolver_config.add_name_server(NameServerConfig::new(
-        dns_server.sole_local_address(),
+        dns_server
+            .local_addresses()
+            .into_iter()
+            .next()
+            .context("fetching local DNS addresses")?,
         Protocol::Udp,
     ));
     let mut resolver_opts = ResolverOpts::default();

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -754,10 +754,8 @@ async fn init_client_server_with_bind_addresses(
     assert!(store.is_new());
 
     // launch a dns server
-    let dns_server_config =
-        dns_server::dns_server::ConfigBuilder::new(bind_addresses)
-            .build()
-            .context("building DNS configuration")?;
+    let dns_server_config = dns_server::dns_server::Config::new(bind_addresses)
+        .context("building DNS configuration")?;
     let (dns_server, dropshot_server) = dns_server::start_servers(
         log.clone(),
         store,
@@ -768,7 +766,7 @@ async fn init_client_server_with_bind_addresses(
 
     let mut resolver_config = ResolverConfig::new();
     resolver_config.add_name_server(NameServerConfig::new(
-        dns_server.sole_local_address().expect("exactly one address"),
+        dns_server.local_addresses().next().expect("at least one address"),
         Protocol::Udp,
     ));
     let mut resolver_opts = ResolverOpts::default();

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -770,7 +770,6 @@ async fn init_client_server_with_bind_addresses(
     resolver_config.add_name_server(NameServerConfig::new(
         dns_server
             .local_addresses()
-            .into_iter()
             .next()
             .context("fetching local DNS addresses")?,
         Protocol::Udp,

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -755,7 +755,9 @@ async fn init_client_server_with_bind_addresses(
 
     // launch a dns server
     let dns_server_config =
-        dns_server::dns_server::Config { bind_addresses, ..Default::default() };
+        dns_server::dns_server::ConfigBuilder::new(bind_addresses)
+            .build()
+            .context("building DNS configuration")?;
     let (dns_server, dropshot_server) = dns_server::start_servers(
         log.clone(),
         store,

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -69,7 +69,7 @@ pub async fn a_crud() -> Result<(), anyhow::Error> {
     // is authoritative, so we'll have to query again with a lower level
     // interface to validate that.
     let raw_response = raw_dns_client_query(
-        test_ctx.dns_server.first_local_address(),
+        test_ctx.dns_server.sole_local_address(),
         Name::from_ascii(&fqdn).expect("name is valid"),
         RecordType::A,
     )
@@ -114,7 +114,7 @@ pub async fn aaaa_crud() -> Result<(), anyhow::Error> {
     // is authoritative, so we'll have to query again with a lower level
     // interface to validate that.
     let raw_response = raw_dns_client_query(
-        test_ctx.dns_server.first_local_address(),
+        test_ctx.dns_server.sole_local_address(),
         Name::from_ascii(&fqdn).expect("name is valid"),
         RecordType::AAAA,
     )
@@ -160,7 +160,7 @@ pub async fn answers_match_question() -> Result<(), anyhow::Error> {
     // `raw_dns_client_query` avoids using a hickory Resolver, so we can assert
     // on the exact answer from our server.
     let raw_response = raw_dns_client_query(
-        test_ctx.dns_server.first_local_address(),
+        test_ctx.dns_server.sole_local_address(),
         name,
         RecordType::A,
     )
@@ -245,7 +245,7 @@ pub async fn srv_crud() -> Result<(), anyhow::Error> {
         .expect("can construct name for query");
 
     let response = raw_dns_client_query(
-        test_ctx.dns_server.first_local_address(),
+        test_ctx.dns_server.sole_local_address(),
         name,
         RecordType::SRV,
     )
@@ -422,7 +422,7 @@ pub async fn name_contains_zone() -> Result<(), anyhow::Error> {
 
     // A lookup shouldn't work without the zone's name appended twice.
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.first_local_address(),
+        test_ctx.dns_server.sole_local_address(),
         resolver,
         "epsilon3.oxide.test",
         ResponseCode::NXDomain,
@@ -452,7 +452,7 @@ pub async fn empty_record() -> Result<(), anyhow::Error> {
 
     // resolve the name
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.first_local_address(),
+        test_ctx.dns_server.sole_local_address(),
         &resolver,
         &(name + "." + TEST_ZONE + "."),
         ResponseCode::NXDomain,
@@ -554,7 +554,7 @@ pub async fn soa() -> Result<(), anyhow::Error> {
 
     // As with other NXDomain answers, we should see the authoritative bit.
     let raw_response = raw_query_expect_err(
-        test_ctx.dns_server.first_local_address(),
+        test_ctx.dns_server.sole_local_address(),
         &no_soa_name,
         RecordType::A,
     )
@@ -605,7 +605,7 @@ pub async fn nxdomain() -> Result<(), anyhow::Error> {
     // asking for a nonexistent record within the domain of the internal DNS
     // server should result in an NXDOMAIN
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.first_local_address(),
+        test_ctx.dns_server.sole_local_address(),
         &resolver,
         &format!("unicorn.{}.", TEST_ZONE),
         ResponseCode::NXDomain,
@@ -626,7 +626,7 @@ pub async fn servfail() -> Result<(), anyhow::Error> {
     // SERVFAIL.  Further, `lookup_ip_expect_error_code` will check that the
     // error is not authoritative.
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.first_local_address(),
+        test_ctx.dns_server.sole_local_address(),
         &resolver,
         "unicorn.oxide.internal",
         ResponseCode::ServFail,
@@ -768,7 +768,7 @@ async fn init_client_server_with_bind_addresses(
 
     let mut resolver_config = ResolverConfig::new();
     resolver_config.add_name_server(NameServerConfig::new(
-        dns_server.first_local_address(),
+        dns_server.sole_local_address(),
         Protocol::Udp,
     ));
     let mut resolver_opts = ResolverOpts::default();

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -69,7 +69,7 @@ pub async fn a_crud() -> Result<(), anyhow::Error> {
     // is authoritative, so we'll have to query again with a lower level
     // interface to validate that.
     let raw_response = raw_dns_client_query(
-        test_ctx.dns_server.sole_local_address(),
+        test_ctx.dns_server.sole_local_address().expect("exactly one address"),
         Name::from_ascii(&fqdn).expect("name is valid"),
         RecordType::A,
     )
@@ -114,7 +114,7 @@ pub async fn aaaa_crud() -> Result<(), anyhow::Error> {
     // is authoritative, so we'll have to query again with a lower level
     // interface to validate that.
     let raw_response = raw_dns_client_query(
-        test_ctx.dns_server.sole_local_address(),
+        test_ctx.dns_server.sole_local_address().expect("exactly one address"),
         Name::from_ascii(&fqdn).expect("name is valid"),
         RecordType::AAAA,
     )
@@ -160,7 +160,7 @@ pub async fn answers_match_question() -> Result<(), anyhow::Error> {
     // `raw_dns_client_query` avoids using a hickory Resolver, so we can assert
     // on the exact answer from our server.
     let raw_response = raw_dns_client_query(
-        test_ctx.dns_server.sole_local_address(),
+        test_ctx.dns_server.sole_local_address().expect("exactly one address"),
         name,
         RecordType::A,
     )
@@ -245,7 +245,7 @@ pub async fn srv_crud() -> Result<(), anyhow::Error> {
         .expect("can construct name for query");
 
     let response = raw_dns_client_query(
-        test_ctx.dns_server.sole_local_address(),
+        test_ctx.dns_server.sole_local_address().expect("exactly one address"),
         name,
         RecordType::SRV,
     )
@@ -422,7 +422,7 @@ pub async fn name_contains_zone() -> Result<(), anyhow::Error> {
 
     // A lookup shouldn't work without the zone's name appended twice.
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.sole_local_address(),
+        test_ctx.dns_server.sole_local_address().expect("exactly one address"),
         resolver,
         "epsilon3.oxide.test",
         ResponseCode::NXDomain,
@@ -452,7 +452,7 @@ pub async fn empty_record() -> Result<(), anyhow::Error> {
 
     // resolve the name
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.sole_local_address(),
+        test_ctx.dns_server.sole_local_address().expect("exactly one address"),
         &resolver,
         &(name + "." + TEST_ZONE + "."),
         ResponseCode::NXDomain,
@@ -554,7 +554,7 @@ pub async fn soa() -> Result<(), anyhow::Error> {
 
     // As with other NXDomain answers, we should see the authoritative bit.
     let raw_response = raw_query_expect_err(
-        test_ctx.dns_server.sole_local_address(),
+        test_ctx.dns_server.sole_local_address().expect("exactly one address"),
         &no_soa_name,
         RecordType::A,
     )
@@ -605,7 +605,7 @@ pub async fn nxdomain() -> Result<(), anyhow::Error> {
     // asking for a nonexistent record within the domain of the internal DNS
     // server should result in an NXDOMAIN
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.sole_local_address(),
+        test_ctx.dns_server.sole_local_address().expect("exactly one address"),
         &resolver,
         &format!("unicorn.{}.", TEST_ZONE),
         ResponseCode::NXDomain,
@@ -626,7 +626,7 @@ pub async fn servfail() -> Result<(), anyhow::Error> {
     // SERVFAIL.  Further, `lookup_ip_expect_error_code` will check that the
     // error is not authoritative.
     lookup_ip_expect_error_code(
-        test_ctx.dns_server.sole_local_address(),
+        test_ctx.dns_server.sole_local_address().expect("exactly one address"),
         &resolver,
         "unicorn.oxide.internal",
         ResponseCode::ServFail,
@@ -768,10 +768,7 @@ async fn init_client_server_with_bind_addresses(
 
     let mut resolver_config = ResolverConfig::new();
     resolver_config.add_name_server(NameServerConfig::new(
-        dns_server
-            .local_addresses()
-            .next()
-            .context("fetching local DNS addresses")?,
+        dns_server.sole_local_address().expect("exactly one address"),
         Protocol::Udp,
     ));
     let mut resolver_opts = ResolverOpts::default();

--- a/dns-server/tests/cross_version_test.rs
+++ b/dns-server/tests/cross_version_test.rs
@@ -226,11 +226,9 @@ async fn init_client_server(
     assert!(store.is_new());
 
     // launch a dns server
-    let dns_server_config = dns_server::dns_server::ConfigBuilder::new(vec![
-        "[::1]:0".parse().unwrap(),
-    ])
-    .build()
-    .context("building DNS configuration")?;
+    let dns_server_config =
+        dns_server::dns_server::Config::new(vec!["[::1]:0".parse().unwrap()])
+            .context("building DNS configuration")?;
     let (dns_server, dropshot_server) = dns_server::start_servers(
         log.clone(),
         store,

--- a/dns-server/tests/cross_version_test.rs
+++ b/dns-server/tests/cross_version_test.rs
@@ -227,7 +227,8 @@ async fn init_client_server(
 
     // launch a dns server
     let dns_server_config = dns_server::dns_server::Config {
-        bind_address: "[::1]:0".parse().unwrap(),
+        bind_addresses: vec!["[::1]:0".parse().unwrap()],
+        ..Default::default()
     };
     let (dns_server, dropshot_server) = dns_server::start_servers(
         log.clone(),

--- a/dns-server/tests/cross_version_test.rs
+++ b/dns-server/tests/cross_version_test.rs
@@ -226,10 +226,11 @@ async fn init_client_server(
     assert!(store.is_new());
 
     // launch a dns server
-    let dns_server_config = dns_server::dns_server::Config {
-        bind_addresses: vec!["[::1]:0".parse().unwrap()],
-        ..Default::default()
-    };
+    let dns_server_config = dns_server::dns_server::ConfigBuilder::new(vec![
+        "[::1]:0".parse().unwrap(),
+    ])
+    .build()
+    .context("building DNS configuration")?;
     let (dns_server, dropshot_server) = dns_server::start_servers(
         log.clone(),
         store,

--- a/dns-server/transient/src/lib.rs
+++ b/dns-server/transient/src/lib.rs
@@ -88,7 +88,7 @@ impl TransientDnsServer {
     pub async fn resolver(&self) -> Result<TokioResolver, anyhow::Error> {
         let mut resolver_config = ResolverConfig::new();
         resolver_config.add_name_server(NameServerConfig::new(
-            self.dns_server.sole_local_address(),
+            self.dns_server.sole_local_address()?,
             hickory_proto::xfer::Protocol::Udp,
         ));
         let mut resolver_opts = ResolverOpts::default();

--- a/dns-server/transient/src/lib.rs
+++ b/dns-server/transient/src/lib.rs
@@ -54,7 +54,10 @@ impl TransientDnsServer {
         let (dns_server, dropshot_server) = dns_server::start_servers(
             dns_log,
             store,
-            &dns_server::dns_server::Config { bind_address: dns_bind_address },
+            &dns_server::dns_server::Config {
+                bind_addresses: vec![dns_bind_address],
+                ..Default::default()
+            },
             &dropshot::ConfigDropshot {
                 bind_address: "[::1]:0".parse().unwrap(),
                 default_request_body_max_bytes: 4 * 1024 * 1024,
@@ -86,7 +89,7 @@ impl TransientDnsServer {
     pub async fn resolver(&self) -> Result<TokioResolver, anyhow::Error> {
         let mut resolver_config = ResolverConfig::new();
         resolver_config.add_name_server(NameServerConfig::new(
-            self.dns_server.local_address(),
+            self.dns_server.first_local_address(),
             hickory_proto::xfer::Protocol::Udp,
         ));
         let mut resolver_opts = ResolverOpts::default();

--- a/dns-server/transient/src/lib.rs
+++ b/dns-server/transient/src/lib.rs
@@ -88,7 +88,7 @@ impl TransientDnsServer {
     pub async fn resolver(&self) -> Result<TokioResolver, anyhow::Error> {
         let mut resolver_config = ResolverConfig::new();
         resolver_config.add_name_server(NameServerConfig::new(
-            self.dns_server.first_local_address(),
+            self.dns_server.sole_local_address(),
             hickory_proto::xfer::Protocol::Udp,
         ));
         let mut resolver_opts = ResolverOpts::default();

--- a/dns-server/transient/src/lib.rs
+++ b/dns-server/transient/src/lib.rs
@@ -54,8 +54,7 @@ impl TransientDnsServer {
         let (dns_server, dropshot_server) = dns_server::start_servers(
             dns_log,
             store,
-            &dns_server::dns_server::ConfigBuilder::new(vec![dns_bind_address])
-                .build()
+            &dns_server::dns_server::Config::new(vec![dns_bind_address])
                 .context("building DNS configuration")?,
             &dropshot::ConfigDropshot {
                 bind_address: "[::1]:0".parse().unwrap(),

--- a/dns-server/transient/src/lib.rs
+++ b/dns-server/transient/src/lib.rs
@@ -54,10 +54,9 @@ impl TransientDnsServer {
         let (dns_server, dropshot_server) = dns_server::start_servers(
             dns_log,
             store,
-            &dns_server::dns_server::Config {
-                bind_addresses: vec![dns_bind_address],
-                ..Default::default()
-            },
+            &dns_server::dns_server::ConfigBuilder::new(vec![dns_bind_address])
+                .build()
+                .context("building DNS configuration")?,
             &dropshot::ConfigDropshot {
                 bind_address: "[::1]:0".parse().unwrap(),
                 default_request_body_max_bytes: 4 * 1024 * 1024,

--- a/docs/how-to-run-simulated.adoc
+++ b/docs/how-to-run-simulated.adoc
@@ -192,7 +192,7 @@ CAUTION: This step does not currently work.  See https://github.com/oxidecompute
 +
 [source,text]
 ----
-$ cargo run --bin=dns-server -- --config-file dns-server/examples/config.toml --http-address [::1]:5353 --dns-address [::1]:5354
+$ cargo run --bin=dns-server -- --config-file dns-server/examples/config.toml --http-address [::1]:5353 --dns-addresses [::1]:5354
 ----
 . `sled-agent-sim` only accepts configuration on the command line.  Run it with a uuid identifying itself (this would be a uuid for the sled it's managing), an IP:port for itself, and the IP:port of `nexus`'s _internal_ interface.  It's recommended that you also provide some arguments specific to RSS (the rack setup service): Nexus's _external_ address and the external DNS server's _internal_ address.  Using default config, this might look like this:
 +

--- a/internal-dns/resolver/src/resolver.rs
+++ b/internal-dns/resolver/src/resolver.rs
@@ -509,10 +509,9 @@ mod test {
             let (dns_server, dropshot_server) = dns_server::start_servers(
                 log.clone(),
                 store,
-                &dns_server::dns_server::ConfigBuilder::new(vec![
+                &dns_server::dns_server::Config::new(vec![
                     "[::1]:0".parse().unwrap(),
                 ])
-                .build()
                 .expect("valid DNS configuration"),
                 &dropshot::ConfigDropshot {
                     bind_address: "[::1]:0".parse().unwrap(),

--- a/internal-dns/resolver/src/resolver.rs
+++ b/internal-dns/resolver/src/resolver.rs
@@ -510,7 +510,8 @@ mod test {
                 log.clone(),
                 store,
                 &dns_server::dns_server::Config {
-                    bind_address: "[::1]:0".parse().unwrap(),
+                    bind_addresses: vec!["[::1]:0".parse().unwrap()],
+                    ..Default::default()
                 },
                 &dropshot::ConfigDropshot {
                     bind_address: "[::1]:0".parse().unwrap(),
@@ -539,7 +540,7 @@ mod test {
         }
 
         fn dns_server_address(&self) -> SocketAddr {
-            self.dns_server.local_address()
+            self.dns_server.first_local_address()
         }
 
         fn cleanup_successful(mut self) {
@@ -893,7 +894,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            &[dns_server.dns_server.local_address()],
+            &[dns_server.dns_server.first_local_address()],
         )
         .unwrap();
 
@@ -973,8 +974,8 @@ mod test {
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
             &[
-                dns_server1.dns_server.local_address(),
-                dns_server2.dns_server.local_address(),
+                dns_server1.dns_server.first_local_address(),
+                dns_server2.dns_server.first_local_address(),
             ],
         )
         .unwrap();
@@ -1050,7 +1051,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            &[dns_server.dns_server.local_address()],
+            &[dns_server.dns_server.first_local_address()],
         )
         .unwrap();
 

--- a/internal-dns/resolver/src/resolver.rs
+++ b/internal-dns/resolver/src/resolver.rs
@@ -541,7 +541,7 @@ mod test {
         }
 
         fn dns_server_address(&self) -> SocketAddr {
-            self.dns_server.first_local_address()
+            self.dns_server.sole_local_address()
         }
 
         fn cleanup_successful(mut self) {
@@ -895,7 +895,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            &[dns_server.dns_server.first_local_address()],
+            &[dns_server.dns_server.sole_local_address()],
         )
         .unwrap();
 
@@ -975,8 +975,8 @@ mod test {
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
             &[
-                dns_server1.dns_server.first_local_address(),
-                dns_server2.dns_server.first_local_address(),
+                dns_server1.dns_server.sole_local_address(),
+                dns_server2.dns_server.sole_local_address(),
             ],
         )
         .unwrap();
@@ -1052,7 +1052,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            &[dns_server.dns_server.first_local_address()],
+            &[dns_server.dns_server.sole_local_address()],
         )
         .unwrap();
 

--- a/internal-dns/resolver/src/resolver.rs
+++ b/internal-dns/resolver/src/resolver.rs
@@ -541,7 +541,7 @@ mod test {
         }
 
         fn dns_server_address(&self) -> SocketAddr {
-            self.dns_server.sole_local_address()
+            self.dns_server.sole_local_address().expect("exactly one address")
         }
 
         fn cleanup_successful(mut self) {
@@ -895,7 +895,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            &[dns_server.dns_server.sole_local_address()],
+            &dns_server.dns_server.local_addresses().collect::<Vec<_>>(),
         )
         .unwrap();
 
@@ -975,8 +975,14 @@ mod test {
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
             &[
-                dns_server1.dns_server.sole_local_address(),
-                dns_server2.dns_server.sole_local_address(),
+                dns_server1
+                    .dns_server
+                    .sole_local_address()
+                    .expect("exactly one address"),
+                dns_server2
+                    .dns_server
+                    .sole_local_address()
+                    .expect("exactly one address"),
             ],
         )
         .unwrap();
@@ -1052,7 +1058,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            &[dns_server.dns_server.sole_local_address()],
+            &dns_server.dns_server.local_addresses().collect::<Vec<_>>(),
         )
         .unwrap();
 

--- a/internal-dns/resolver/src/resolver.rs
+++ b/internal-dns/resolver/src/resolver.rs
@@ -509,10 +509,11 @@ mod test {
             let (dns_server, dropshot_server) = dns_server::start_servers(
                 log.clone(),
                 store,
-                &dns_server::dns_server::Config {
-                    bind_addresses: vec!["[::1]:0".parse().unwrap()],
-                    ..Default::default()
-                },
+                &dns_server::dns_server::ConfigBuilder::new(vec![
+                    "[::1]:0".parse().unwrap(),
+                ])
+                .build()
+                .expect("valid DNS configuration"),
                 &dropshot::ConfigDropshot {
                     bind_address: "[::1]:0".parse().unwrap(),
                     default_request_body_max_bytes: 8 * 1024,

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -1587,7 +1587,7 @@ mod tests {
         {
             let resolver = Resolver::new_from_addrs(
                 logctx.log.clone(),
-                &[dns.dns_server.sole_local_address()],
+                &dns.dns_server.local_addresses().collect::<Vec<_>>(),
             )
             .expect("created DNS resolver");
 
@@ -1693,7 +1693,7 @@ mod tests {
         // Query with the qorb DNS resolver.
         {
             let resolver =
-                QorbResolver::new(vec![dns.dns_server.sole_local_address()]);
+                QorbResolver::new(dns.dns_server.local_addresses().collect());
 
             // Ensure that service names can be looked up via the qorb resolver.
             let mut services_with_errors = BTreeMap::new();

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -1587,7 +1587,7 @@ mod tests {
         {
             let resolver = Resolver::new_from_addrs(
                 logctx.log.clone(),
-                &[dns.dns_server.local_address()],
+                &[dns.dns_server.first_local_address()],
             )
             .expect("created DNS resolver");
 
@@ -1693,7 +1693,7 @@ mod tests {
         // Query with the qorb DNS resolver.
         {
             let resolver =
-                QorbResolver::new(vec![dns.dns_server.local_address()]);
+                QorbResolver::new(vec![dns.dns_server.first_local_address()]);
 
             // Ensure that service names can be looked up via the qorb resolver.
             let mut services_with_errors = BTreeMap::new();

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -1587,7 +1587,7 @@ mod tests {
         {
             let resolver = Resolver::new_from_addrs(
                 logctx.log.clone(),
-                &[dns.dns_server.first_local_address()],
+                &[dns.dns_server.sole_local_address()],
             )
             .expect("created DNS resolver");
 
@@ -1693,7 +1693,7 @@ mod tests {
         // Query with the qorb DNS resolver.
         {
             let resolver =
-                QorbResolver::new(vec![dns.dns_server.first_local_address()]);
+                QorbResolver::new(vec![dns.dns_server.sole_local_address()]);
 
             // Ensure that service names can be looked up via the qorb resolver.
             let mut services_with_errors = BTreeMap::new();

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -1594,10 +1594,9 @@ pub mod test {
         let (_, new_dns_dropshot_server) = dns_server::start_servers(
             log.clone(),
             store,
-            &dns_server::dns_server::ConfigBuilder::new(vec![
+            &dns_server::dns_server::Config::new(vec![
                 "[::1]:0".parse().unwrap(),
             ])
-            .build()
             .expect("valid DNS configuration"),
             &dropshot::ConfigDropshot {
                 bind_address: "[::1]:0".parse().unwrap(),

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -1595,7 +1595,8 @@ pub mod test {
             log.clone(),
             store,
             &dns_server::dns_server::Config {
-                bind_address: "[::1]:0".parse().unwrap(),
+                bind_addresses: vec!["[::1]:0".parse().unwrap()],
+                ..Default::default()
             },
             &dropshot::ConfigDropshot {
                 bind_address: "[::1]:0".parse().unwrap(),

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -1594,10 +1594,11 @@ pub mod test {
         let (_, new_dns_dropshot_server) = dns_server::start_servers(
             log.clone(),
             store,
-            &dns_server::dns_server::Config {
-                bind_addresses: vec!["[::1]:0".parse().unwrap()],
-                ..Default::default()
-            },
+            &dns_server::dns_server::ConfigBuilder::new(vec![
+                "[::1]:0".parse().unwrap(),
+            ])
+            .build()
+            .expect("valid DNS configuration"),
             &dropshot::ConfigDropshot {
                 bind_address: "[::1]:0".parse().unwrap(),
                 default_request_body_max_bytes: 8 * 1024,

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -528,7 +528,7 @@ mod test {
         // Spin up the inventory collector background task.
         let resolver = internal_dns_resolver::Resolver::new_from_addrs(
             log.clone(),
-            &[cptestctx.internal_dns.dns_server.local_address()],
+            &[cptestctx.internal_dns.dns_server.first_local_address()],
         )
         .expect("can't start resolver");
         let mut collector = InventoryCollector::new(

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -528,7 +528,11 @@ mod test {
         // Spin up the inventory collector background task.
         let resolver = internal_dns_resolver::Resolver::new_from_addrs(
             log.clone(),
-            &[cptestctx.internal_dns.dns_server.sole_local_address()],
+            &cptestctx
+                .internal_dns
+                .dns_server
+                .local_addresses()
+                .collect::<Vec<_>>(),
         )
         .expect("can't start resolver");
         let mut collector = InventoryCollector::new(

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -528,7 +528,7 @@ mod test {
         // Spin up the inventory collector background task.
         let resolver = internal_dns_resolver::Resolver::new_from_addrs(
             log.clone(),
-            &[cptestctx.internal_dns.dns_server.first_local_address()],
+            &[cptestctx.internal_dns.dns_server.sole_local_address()],
         )
         .expect("can't start resolver");
         let mut collector = InventoryCollector::new(

--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -294,7 +294,7 @@ mod test {
 
         let resolver = internal_dns_resolver::Resolver::new_from_addrs(
             cptestctx.logctx.log.clone(),
-            &[cptestctx.internal_dns.dns_server.local_address()],
+            &[cptestctx.internal_dns.dns_server.first_local_address()],
         )
         .unwrap();
 

--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -294,7 +294,7 @@ mod test {
 
         let resolver = internal_dns_resolver::Resolver::new_from_addrs(
             cptestctx.logctx.log.clone(),
-            &[cptestctx.internal_dns.dns_server.first_local_address()],
+            &[cptestctx.internal_dns.dns_server.sole_local_address()],
         )
         .unwrap();
 

--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -294,7 +294,11 @@ mod test {
 
         let resolver = internal_dns_resolver::Resolver::new_from_addrs(
             cptestctx.logctx.log.clone(),
-            &[cptestctx.internal_dns.dns_server.sole_local_address()],
+            &cptestctx
+                .internal_dns
+                .dns_server
+                .local_addresses()
+                .collect::<Vec<_>>(),
         )
         .unwrap();
 

--- a/nexus/src/app/external_client.rs
+++ b/nexus/src/app/external_client.rs
@@ -1417,7 +1417,7 @@ mod test {
         .expect("DNS server must accept its config");
 
         let resolver = Arc::new(external_dns::Resolver::new_from_addr(
-            dns.dns_server.first_local_address(),
+            dns.dns_server.sole_local_address(),
             test_policy(TreatLoopbackAsExternal::YesForTestPurposesOnly),
         ));
         let client = client_with_resolver(builder, resolver);

--- a/nexus/src/app/external_client.rs
+++ b/nexus/src/app/external_client.rs
@@ -1417,7 +1417,7 @@ mod test {
         .expect("DNS server must accept its config");
 
         let resolver = Arc::new(external_dns::Resolver::new_from_addr(
-            dns.dns_server.sole_local_address(),
+            dns.dns_server.sole_local_address().expect("exactly one address"),
             test_policy(TreatLoopbackAsExternal::YesForTestPurposesOnly),
         ));
         let client = client_with_resolver(builder, resolver);

--- a/nexus/src/app/external_client.rs
+++ b/nexus/src/app/external_client.rs
@@ -1417,7 +1417,7 @@ mod test {
         .expect("DNS server must accept its config");
 
         let resolver = Arc::new(external_dns::Resolver::new_from_addr(
-            dns.dns_server.local_address(),
+            dns.dns_server.first_local_address(),
             test_policy(TreatLoopbackAsExternal::YesForTestPurposesOnly),
         ));
         let client = client_with_resolver(builder, resolver);

--- a/nexus/test-utils/src/starter.rs
+++ b/nexus/test-utils/src/starter.rs
@@ -598,7 +598,7 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
                 .as_ref()
                 .expect("Must initialize internal DNS server first")
                 .dns_server
-                .first_local_address(),
+                .sole_local_address(),
         };
         self.config.deployment.database = Database::FromUrl {
             url: self
@@ -1179,7 +1179,7 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
 
         let dns = TransientDnsServer::new(&log).await.unwrap();
 
-        let SocketAddr::V6(dns_address) = dns.dns_server.first_local_address()
+        let SocketAddr::V6(dns_address) = dns.dns_server.sole_local_address()
         else {
             panic!("Unsupported IPv4 DNS address");
         };
@@ -1206,7 +1206,7 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
             .parse()
             .unwrap();
 
-        let ip_config = if dns.dns_server.first_local_address().is_ipv4() {
+        let ip_config = if dns.dns_server.sole_local_address().is_ipv4() {
             PrivateIpConfig::new_ipv4(
                 DNS_OPTE_IPV4_SUBNET
                     .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES + 1)
@@ -1262,7 +1262,7 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
         let log = self.logctx.log.new(o!("component" => "internal_dns_server"));
         let dns = TransientDnsServer::new(&log).await.unwrap();
 
-        let SocketAddr::V6(dns_address) = dns.dns_server.first_local_address()
+        let SocketAddr::V6(dns_address) = dns.dns_server.sole_local_address()
         else {
             panic!("Unsupported IPv4 DNS address");
         };

--- a/nexus/test-utils/src/starter.rs
+++ b/nexus/test-utils/src/starter.rs
@@ -598,7 +598,7 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
                 .as_ref()
                 .expect("Must initialize internal DNS server first")
                 .dns_server
-                .local_address(),
+                .first_local_address(),
         };
         self.config.deployment.database = Database::FromUrl {
             url: self
@@ -1179,7 +1179,8 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
 
         let dns = TransientDnsServer::new(&log).await.unwrap();
 
-        let SocketAddr::V6(dns_address) = dns.dns_server.local_address() else {
+        let SocketAddr::V6(dns_address) = dns.dns_server.first_local_address()
+        else {
             panic!("Unsupported IPv4 DNS address");
         };
         let SocketAddr::V6(dropshot_address) = dns.dropshot_server.local_addr()
@@ -1205,7 +1206,7 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
             .parse()
             .unwrap();
 
-        let ip_config = if dns.dns_server.local_address().is_ipv4() {
+        let ip_config = if dns.dns_server.first_local_address().is_ipv4() {
             PrivateIpConfig::new_ipv4(
                 DNS_OPTE_IPV4_SUBNET
                     .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES + 1)
@@ -1261,7 +1262,8 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
         let log = self.logctx.log.new(o!("component" => "internal_dns_server"));
         let dns = TransientDnsServer::new(&log).await.unwrap();
 
-        let SocketAddr::V6(dns_address) = dns.dns_server.local_address() else {
+        let SocketAddr::V6(dns_address) = dns.dns_server.first_local_address()
+        else {
             panic!("Unsupported IPv4 DNS address");
         };
         let SocketAddr::V6(http_address) = dns.dropshot_server.local_addr()

--- a/nexus/test-utils/src/starter.rs
+++ b/nexus/test-utils/src/starter.rs
@@ -598,7 +598,8 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
                 .as_ref()
                 .expect("Must initialize internal DNS server first")
                 .dns_server
-                .sole_local_address(),
+                .sole_local_address()
+                .map_err(|e| e.to_string())?,
         };
         self.config.deployment.database = Database::FromUrl {
             url: self
@@ -1179,7 +1180,10 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
 
         let dns = TransientDnsServer::new(&log).await.unwrap();
 
-        let SocketAddr::V6(dns_address) = dns.dns_server.sole_local_address()
+        let SocketAddr::V6(dns_address) = dns
+            .dns_server
+            .sole_local_address()
+            .expect("exactly one external DNS address")
         else {
             panic!("Unsupported IPv4 DNS address");
         };
@@ -1206,7 +1210,12 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
             .parse()
             .unwrap();
 
-        let ip_config = if dns.dns_server.sole_local_address().is_ipv4() {
+        let ip_config = if dns
+            .dns_server
+            .sole_local_address()
+            .expect("exactly one external DNS address")
+            .is_ipv4()
+        {
             PrivateIpConfig::new_ipv4(
                 DNS_OPTE_IPV4_SUBNET
                     .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES + 1)
@@ -1262,7 +1271,10 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
         let log = self.logctx.log.new(o!("component" => "internal_dns_server"));
         let dns = TransientDnsServer::new(&log).await.unwrap();
 
-        let SocketAddr::V6(dns_address) = dns.dns_server.sole_local_address()
+        let SocketAddr::V6(dns_address) = dns
+            .dns_server
+            .sole_local_address()
+            .expect("exactly one internal DNS address")
         else {
             panic!("Unsupported IPv4 DNS address");
         };

--- a/nexus/tests/integration_tests/certificates.rs
+++ b/nexus/tests/integration_tests/certificates.rs
@@ -359,7 +359,7 @@ async fn test_silo_certificates() {
     // create the other Silos and their users.
     let resolver = Arc::new(
         CustomDnsResolver::new(
-            cptestctx.external_dns.dns_server.first_local_address(),
+            cptestctx.external_dns.dns_server.sole_local_address(),
         )
         .unwrap(),
     );

--- a/nexus/tests/integration_tests/certificates.rs
+++ b/nexus/tests/integration_tests/certificates.rs
@@ -359,7 +359,7 @@ async fn test_silo_certificates() {
     // create the other Silos and their users.
     let resolver = Arc::new(
         CustomDnsResolver::new(
-            cptestctx.external_dns.dns_server.local_address(),
+            cptestctx.external_dns.dns_server.first_local_address(),
         )
         .unwrap(),
     );

--- a/nexus/tests/integration_tests/certificates.rs
+++ b/nexus/tests/integration_tests/certificates.rs
@@ -359,7 +359,11 @@ async fn test_silo_certificates() {
     // create the other Silos and their users.
     let resolver = Arc::new(
         CustomDnsResolver::new(
-            cptestctx.external_dns.dns_server.sole_local_address(),
+            cptestctx
+                .external_dns
+                .dns_server
+                .sole_local_address()
+                .expect("exactly one DNS address"),
         )
         .unwrap(),
     );

--- a/nexus/tests/integration_tests/initialization.rs
+++ b/nexus/tests/integration_tests/initialization.rs
@@ -56,7 +56,7 @@ async fn test_nexus_boots_before_cockroach() {
             .as_ref()
             .expect("Must start Internal DNS before acquiring an address")
             .dns_server
-            .local_address(),
+            .first_local_address(),
     };
     let nexus_config = starter.config.clone();
     let nexus_log = log.clone();
@@ -139,7 +139,7 @@ async fn test_nexus_boots_before_dendrite() {
             .as_ref()
             .expect("Must start Internal DNS before acquiring an address")
             .dns_server
-            .local_address(),
+            .first_local_address(),
     };
     let nexus_config = starter.config.clone();
     let nexus_log = log.clone();

--- a/nexus/tests/integration_tests/initialization.rs
+++ b/nexus/tests/integration_tests/initialization.rs
@@ -56,7 +56,7 @@ async fn test_nexus_boots_before_cockroach() {
             .as_ref()
             .expect("Must start Internal DNS before acquiring an address")
             .dns_server
-            .first_local_address(),
+            .sole_local_address(),
     };
     let nexus_config = starter.config.clone();
     let nexus_log = log.clone();
@@ -139,7 +139,7 @@ async fn test_nexus_boots_before_dendrite() {
             .as_ref()
             .expect("Must start Internal DNS before acquiring an address")
             .dns_server
-            .first_local_address(),
+            .sole_local_address(),
     };
     let nexus_config = starter.config.clone();
     let nexus_log = log.clone();

--- a/nexus/tests/integration_tests/initialization.rs
+++ b/nexus/tests/integration_tests/initialization.rs
@@ -56,7 +56,8 @@ async fn test_nexus_boots_before_cockroach() {
             .as_ref()
             .expect("Must start Internal DNS before acquiring an address")
             .dns_server
-            .sole_local_address(),
+            .sole_local_address()
+            .expect("exactly one internal DNS address"),
     };
     let nexus_config = starter.config.clone();
     let nexus_log = log.clone();
@@ -139,7 +140,8 @@ async fn test_nexus_boots_before_dendrite() {
             .as_ref()
             .expect("Must start Internal DNS before acquiring an address")
             .dns_server
-            .sole_local_address(),
+            .sole_local_address()
+            .expect("exactly one internal DNS address"),
     };
     let nexus_config = starter.config.clone();
     let nexus_log = log.clone();

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -2869,7 +2869,7 @@ mod tests {
             let resolver = Arc::new(
                 Resolver::new_from_addrs(
                     log.clone(),
-                    &[_dns_server.dns_server.local_address()],
+                    &[_dns_server.dns_server.first_local_address()],
                 )
                 .unwrap(),
             );

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -2862,14 +2862,14 @@ mod tests {
                 Box::new(NexusServer { observed_runtime_state: state_tx }),
             );
 
-            let dns_server =
+            let _dns_server =
                 crate::fakes::nexus::start_dns_server(&log, &_nexus_server)
                     .await;
 
             let resolver = Arc::new(
                 Resolver::new_from_addrs(
                     log.clone(),
-                    &[dns_server.dns_server.sole_local_address()],
+                    &[_dns_server.dns_server.sole_local_address()],
                 )
                 .unwrap(),
             );
@@ -2880,7 +2880,7 @@ mod tests {
                 _nexus_server.local_addr().port(),
             );
 
-            Self { nexus_client, _nexus_server, state_rx, dns_server }
+            Self { nexus_client, _nexus_server, state_rx, _dns_server }
         }
     }
 

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -2869,7 +2869,7 @@ mod tests {
             let resolver = Arc::new(
                 Resolver::new_from_addrs(
                     log.clone(),
-                    &[_dns_server.dns_server.sole_local_address()],
+                    &_dns_server.dns_server.local_addresses(),
                 )
                 .unwrap(),
             );

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -2869,7 +2869,10 @@ mod tests {
             let resolver = Arc::new(
                 Resolver::new_from_addrs(
                     log.clone(),
-                    &_dns_server.dns_server.local_addresses(),
+                    &_dns_server
+                        .dns_server
+                        .local_addresses()
+                        .collect::<Vec<_>>(),
                 )
                 .unwrap(),
             );

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -2862,14 +2862,14 @@ mod tests {
                 Box::new(NexusServer { observed_runtime_state: state_tx }),
             );
 
-            let _dns_server =
+            let dns_server =
                 crate::fakes::nexus::start_dns_server(&log, &_nexus_server)
                     .await;
 
             let resolver = Arc::new(
                 Resolver::new_from_addrs(
                     log.clone(),
-                    &[_dns_server.dns_server.first_local_address()],
+                    &[dns_server.dns_server.sole_local_address()],
                 )
                 .unwrap(),
             );
@@ -2880,7 +2880,7 @@ mod tests {
                 _nexus_server.local_addr().port(),
             );
 
-            Self { nexus_client, _nexus_server, state_rx, _dns_server }
+            Self { nexus_client, _nexus_server, state_rx, dns_server }
         }
     }
 

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -458,7 +458,7 @@ pub async fn run_standalone_server(
                 blueprint_zone_type::InternalDns {
                     dataset: OmicronZoneDataset { pool_name },
                     http_address: http_bound,
-                    dns_address: match dns.dns_server.sole_local_address() {
+                    dns_address: match dns.dns_server.sole_local_address()? {
                         SocketAddr::V4(_) => {
                             panic!("did not expect v4 address")
                         }

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -458,7 +458,7 @@ pub async fn run_standalone_server(
                 blueprint_zone_type::InternalDns {
                     dataset: OmicronZoneDataset { pool_name },
                     http_address: http_bound,
-                    dns_address: match dns.dns_server.first_local_address() {
+                    dns_address: match dns.dns_server.sole_local_address() {
                         SocketAddr::V4(_) => {
                             panic!("did not expect v4 address")
                         }

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -458,7 +458,7 @@ pub async fn run_standalone_server(
                 blueprint_zone_type::InternalDns {
                     dataset: OmicronZoneDataset { pool_name },
                     http_address: http_bound,
-                    dns_address: match dns.dns_server.local_address() {
+                    dns_address: match dns.dns_server.first_local_address() {
                         SocketAddr::V4(_) => {
                             panic!("did not expect v4 address")
                         }

--- a/smf/external-dns/manifest.xml
+++ b/smf/external-dns/manifest.xml
@@ -22,7 +22,7 @@
   </dependency>
 
   <exec_method type='method' name='start'
-      exec='ctrun -l child -o noorphan,regent /opt/oxide/dns-server/bin/dns-server --config-file /var/svc/manifest/site/external_dns/config.toml --http-address %{config/http_address} --dns-address %{config/dns_address} &amp;'
+      exec='ctrun -l child -o noorphan,regent /opt/oxide/dns-server/bin/dns-server --config-file /var/svc/manifest/site/external_dns/config.toml --http-address %{config/http_address} --dns-addresses %{config/dns_address} &amp;'
     timeout_seconds='0' />
   <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
 

--- a/smf/internal-dns/manifest.xml
+++ b/smf/internal-dns/manifest.xml
@@ -17,7 +17,7 @@
   </dependency>
 
   <exec_method type='method' name='start'
-      exec='ctrun -l child -o noorphan,regent /opt/oxide/dns-server/bin/dns-server --config-file /var/svc/manifest/site/internal_dns/config.toml --http-address %{config/http_address} --dns-address %{config/dns_address} &amp;'
+      exec='ctrun -l child -o noorphan,regent /opt/oxide/dns-server/bin/dns-server --config-file /var/svc/manifest/site/internal_dns/config.toml --http-address %{config/http_address} --dns-addresses %{config/dns_address} &amp;'
     timeout_seconds='0' />
   <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
 


### PR DESCRIPTION
- Expand the DNS configuration with a list of socket addresses instead of a single one, to support binding multiple UDP sockets in the same server.
- Also add some limits on the concurrency of the DNS server, by spawning a set of tasks to handling UDP packets and processs DNS queries separately, with a limited queue between them. Overload on the queue is shed and relies on DNS clients retrying.
- Fixes #11008