### PR TITLE
Allow Nexus to listen on a second address

### DIFF
--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -172,6 +172,15 @@ pub struct DeploymentConfig {
     /// Dropshot configuration for the external API server.
     #[schemars(skip)] // TODO we're protected against dropshot changes
     pub dropshot_external: ConfigDropshotWithTls,
+    /// Optional second address on which to serve the external API.
+    ///
+    /// When set, Nexus launches an additional external API server bound to
+    /// this address, reusing all other settings (TLS, request limits, etc.)
+    /// from `dropshot_external`. This is used to serve the external API on a
+    /// second address version (e.g. IPv6 alongside IPv4).
+    #[schemars(skip)]
+    #[serde(default)]
+    pub dropshot_external_second_address: Option<SocketAddr>,
     /// Dropshot configuration for internal API server.
     #[schemars(skip)] // TODO we're protected against dropshot changes
     pub dropshot_internal: ConfigDropshot,
@@ -1278,6 +1287,7 @@ mod test {
             id = "28b90dc4-c22a-65ba-f49a-f051fe01208f"
             rack_id = "38b90dc4-c22a-65ba-f49a-f051fe01208f"
             external_dns_servers = [ "1.1.1.1", "9.9.9.9" ]
+            dropshot_external_second_address = "[::1]:4567"
             [deployment.external_http_clients]
             interface = "opte0"
             treat_loopback_as_external = "yes_for_test_purposes_only"
@@ -1404,6 +1414,9 @@ mod test {
                             ..Default::default()
                         }
                     },
+                    dropshot_external_second_address: Some(
+                        "[::1]:4567".parse::<SocketAddr>().unwrap(),
+                    ),
                     dropshot_internal: ConfigDropshot {
                         bind_address: "10.1.2.3:4568"
                             .parse::<SocketAddr>()

--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -172,15 +172,15 @@ pub struct DeploymentConfig {
     /// Dropshot configuration for the external API server.
     #[schemars(skip)] // TODO we're protected against dropshot changes
     pub dropshot_external: ConfigDropshotWithTls,
-    /// Optional second address on which to serve the external API.
+    /// Additional addresses to listen on for the external API.
     ///
-    /// When set, Nexus launches an additional external API server bound to
-    /// this address, reusing all other settings (TLS, request limits, etc.)
-    /// from `dropshot_external`. This is used to serve the external API on a
-    /// second address version (e.g. IPv6 alongside IPv4).
+    /// When set, Nexus launches additional external API servers bound to each
+    /// of these addresses, reusing all other settings (TLS, request limits,
+    /// etc.) from `dropshot_external`. This is mainly used to serve the
+    /// external API on both IPv4 and IPv6 addresses.
     #[schemars(skip)]
     #[serde(default)]
-    pub dropshot_external_second_address: Option<SocketAddr>,
+    pub dropshot_external_additional_addresses: Vec<SocketAddr>,
     /// Dropshot configuration for internal API server.
     #[schemars(skip)] // TODO we're protected against dropshot changes
     pub dropshot_internal: ConfigDropshot,
@@ -1287,7 +1287,7 @@ mod test {
             id = "28b90dc4-c22a-65ba-f49a-f051fe01208f"
             rack_id = "38b90dc4-c22a-65ba-f49a-f051fe01208f"
             external_dns_servers = [ "1.1.1.1", "9.9.9.9" ]
-            dropshot_external_second_address = "[::1]:4567"
+            dropshot_external_additional_addresses = [ "[::1]:4567" ]
             [deployment.external_http_clients]
             interface = "opte0"
             treat_loopback_as_external = "yes_for_test_purposes_only"
@@ -1414,9 +1414,9 @@ mod test {
                             ..Default::default()
                         }
                     },
-                    dropshot_external_second_address: Some(
+                    dropshot_external_additional_addresses: vec![
                         "[::1]:4567".parse::<SocketAddr>().unwrap(),
-                    ),
+                    ],
                     dropshot_internal: ConfigDropshot {
                         bind_address: "10.1.2.3:4568"
                             .parse::<SocketAddr>()

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -37,12 +37,12 @@ rack_id = "c19a698f-c6f9-4a17-ae30-20d711b8f7dc"
 # These are the DNS servers it should use.
 external_dns_servers = ["1.1.1.1", "9.9.9.9"]
 
-# Optional second address on which to serve the external API, in addition to
+# Additional addresses on which to serve the external API, in addition to
 # `dropshot_external.bind_address` below. All other settings (TLS, request
 # limits, etc.) are shared with `dropshot_external`. This is used to serve the
 # external API on a second address family (e.g. IPv6 alongside IPv4). If
 # omitted, only `dropshot_external.bind_address` is served.
-# dropshot_external_second_address = "[::1]:12220"
+# dropshot_external_additional_addresses = "[::1]:12220"
 
 # Simulated/development deployments run "external" servers (e.g. webhook
 # receivers) on localhost, so external HTTP clients must be permitted to

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -37,6 +37,13 @@ rack_id = "c19a698f-c6f9-4a17-ae30-20d711b8f7dc"
 # These are the DNS servers it should use.
 external_dns_servers = ["1.1.1.1", "9.9.9.9"]
 
+# Optional second address on which to serve the external API, in addition to
+# `dropshot_external.bind_address` below. All other settings (TLS, request
+# limits, etc.) are shared with `dropshot_external`. This is used to serve the
+# external API on a second address family (e.g. IPv6 alongside IPv4). If
+# omitted, only `dropshot_external.bind_address` is served.
+# dropshot_external_second_address = "[::1]:12220"
+
 # Simulated/development deployments run "external" servers (e.g. webhook
 # receivers) on localhost, so external HTTP clients must be permitted to
 # connect to loopback addresses. This must never be enabled in production

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -42,7 +42,7 @@ external_dns_servers = ["1.1.1.1", "9.9.9.9"]
 # limits, etc.) are shared with `dropshot_external`. This is used to serve the
 # external API on a second address family (e.g. IPv6 alongside IPv4). If
 # omitted, only `dropshot_external.bind_address` is served.
-# dropshot_external_additional_addresses = "[::1]:12220"
+# dropshot_external_additional_addresses = [ "[::1]:12220" ]
 
 # Simulated/development deployments run "external" servers (e.g. webhook
 # receivers) on localhost, so external HTTP clients must be permitted to

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -207,13 +207,14 @@ pub struct Nexus {
     /// saga execution coordinator (SEC)
     sagas: Arc<SagaExecutor>,
 
-    /// External dropshot servers
-    external_server: std::sync::Mutex<Option<DropshotServer>>,
-
-    /// Optional second external dropshot server, serving the external API on a
-    /// second address (e.g. a second address family for dual stack). Present
-    /// only when `dropshot_external_second_address` is configured.
-    second_external_server: std::sync::Mutex<Option<DropshotServer>>,
+    /// External dropshot servers.
+    ///
+    /// The external API is always served on at least one external address, but
+    /// may be served on more to support IPv4 / IPv6 dual-stack deployments.
+    /// Servers are created, stored, and closed in the order they're defined in
+    /// the provided configuration, with the primary server first, then one
+    /// server for zero or more external addresses.
+    external_servers: std::sync::Mutex<Vec<DropshotServer>>,
 
     /// External dropshot server that listens on the internal network to allow
     /// connections from the tech port; see RFD 431.
@@ -565,8 +566,7 @@ impl Nexus {
             db_datastore: Arc::clone(&db_datastore),
             authz: Arc::clone(&authz),
             sagas,
-            external_server: std::sync::Mutex::new(None),
-            second_external_server: std::sync::Mutex::new(None),
+            external_servers: std::sync::Mutex::new(vec![]),
             techport_external_server: std::sync::Mutex::new(None),
             internal_server: std::sync::Mutex::new(None),
             lockstep_server: std::sync::Mutex::new(None),
@@ -819,8 +819,7 @@ impl Nexus {
     // Called to hand off management of external servers to Nexus.
     pub(crate) async fn set_servers(
         &self,
-        external_server: DropshotServer,
-        second_external_server: Option<DropshotServer>,
+        external_servers: Vec<DropshotServer>,
         techport_external_server: DropshotServer,
         internal_server: DropshotServer,
         lockstep_server: DropshotServer,
@@ -830,13 +829,7 @@ impl Nexus {
         let _ = self.close_servers().await;
 
         // Insert the new servers.
-        self.external_server.lock().unwrap().replace(external_server);
-        if let Some(second_external_server) = second_external_server {
-            self.second_external_server
-                .lock()
-                .unwrap()
-                .replace(second_external_server);
-        }
+        *self.external_servers.lock().unwrap() = external_servers;
         self.techport_external_server
             .lock()
             .unwrap()
@@ -863,7 +856,8 @@ impl Nexus {
         // NOTE: All these take the lock and swap out of the option immediately,
         // because they are synchronous mutexes, which cannot be held across the
         // await point these `close()` methods expose.
-        let external_server = self.external_server.lock().unwrap().take();
+        let external_servers =
+            std::mem::take(&mut *self.external_servers.lock().unwrap());
         let mut res = Ok(());
 
         let extend_err =
@@ -877,12 +871,7 @@ impl Nexus {
                 }
             };
 
-        if let Some(server) = external_server {
-            extend_err(&mut res, server.close().await);
-        }
-        let second_external_server =
-            self.second_external_server.lock().unwrap().take();
-        if let Some(server) = second_external_server {
+        for server in external_servers.into_iter() {
             extend_err(&mut res, server.close().await);
         }
         let techport_external_server =
@@ -929,24 +918,37 @@ impl Nexus {
         Ok(())
     }
 
-    pub(crate) fn get_external_server_address(
+    /// Returns the primary server's external address.
+    ///
+    /// There is always at least one address (once the API servers have been
+    /// started), and there may be additional addresses.
+    pub(crate) fn get_external_server_primary_address(
         &self,
     ) -> Option<std::net::SocketAddr> {
-        self.external_server
+        self.external_servers
             .lock()
             .unwrap()
-            .as_ref()
+            .first()
             .map(|server| server.local_addr())
     }
 
-    pub(crate) fn get_second_external_server_address(
+    /// This returns all addresses for the external API servers.
+    ///
+    /// If the servers have not been started yet, then `None` is returned. If
+    /// they have been started, then `Some(_)` is returned, where the contained
+    /// vector has at least one element. `Some(vec![])`, with a contained empty
+    /// vector, is never returned.
+    pub(crate) fn get_all_external_server_addresses(
         &self,
-    ) -> Option<std::net::SocketAddr> {
-        self.second_external_server
+    ) -> Option<Vec<std::net::SocketAddr>> {
+        let addrs: Vec<_> = self
+            .external_servers
             .lock()
             .unwrap()
-            .as_ref()
+            .iter()
             .map(|server| server.local_addr())
+            .collect();
+        if addrs.is_empty() { None } else { Some(addrs) }
     }
 
     pub(crate) fn get_techport_server_address(

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -213,7 +213,7 @@ pub struct Nexus {
     /// may be served on more to support IPv4 / IPv6 dual-stack deployments.
     /// Servers are created, stored, and closed in the order they're defined in
     /// the provided configuration, with the primary server first, then one
-    /// server for zero or more external addresses.
+    /// server for each additional address.
     external_servers: std::sync::Mutex<Vec<DropshotServer>>,
 
     /// External dropshot server that listens on the internal network to allow

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -210,6 +210,11 @@ pub struct Nexus {
     /// External dropshot servers
     external_server: std::sync::Mutex<Option<DropshotServer>>,
 
+    /// Optional second external dropshot server, serving the external API on a
+    /// second address (e.g. a second address family for dual stack). Present
+    /// only when `dropshot_external_second_address` is configured.
+    second_external_server: std::sync::Mutex<Option<DropshotServer>>,
+
     /// External dropshot server that listens on the internal network to allow
     /// connections from the tech port; see RFD 431.
     techport_external_server: std::sync::Mutex<Option<DropshotServer>>,
@@ -561,6 +566,7 @@ impl Nexus {
             authz: Arc::clone(&authz),
             sagas,
             external_server: std::sync::Mutex::new(None),
+            second_external_server: std::sync::Mutex::new(None),
             techport_external_server: std::sync::Mutex::new(None),
             internal_server: std::sync::Mutex::new(None),
             lockstep_server: std::sync::Mutex::new(None),
@@ -814,6 +820,7 @@ impl Nexus {
     pub(crate) async fn set_servers(
         &self,
         external_server: DropshotServer,
+        second_external_server: Option<DropshotServer>,
         techport_external_server: DropshotServer,
         internal_server: DropshotServer,
         lockstep_server: DropshotServer,
@@ -824,6 +831,12 @@ impl Nexus {
 
         // Insert the new servers.
         self.external_server.lock().unwrap().replace(external_server);
+        if let Some(second_external_server) = second_external_server {
+            self.second_external_server
+                .lock()
+                .unwrap()
+                .replace(second_external_server);
+        }
         self.techport_external_server
             .lock()
             .unwrap()
@@ -865,6 +878,11 @@ impl Nexus {
             };
 
         if let Some(server) = external_server {
+            extend_err(&mut res, server.close().await);
+        }
+        let second_external_server =
+            self.second_external_server.lock().unwrap().take();
+        if let Some(server) = second_external_server {
             extend_err(&mut res, server.close().await);
         }
         let techport_external_server =
@@ -915,6 +933,16 @@ impl Nexus {
         &self,
     ) -> Option<std::net::SocketAddr> {
         self.external_server
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|server| server.local_addr())
+    }
+
+    pub(crate) fn get_second_external_server_address(
+        &self,
+    ) -> Option<std::net::SocketAddr> {
+        self.second_external_server
             .lock()
             .unwrap()
             .as_ref()

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -252,11 +252,25 @@ impl Server {
             ))
         };
 
+        // Construct each external API server. There's always at least 1, with
+        // an additional server for each extra address.
+        let mut http_servers_external = Vec::with_capacity(
+            1 + config.deployment.dropshot_external_additional_addresses.len(),
+        );
         let http_server_external = {
             dropshot::ServerBuilder::new(
                 external_api(),
                 apictx.for_external(),
-                log.new(o!("component" => "dropshot_external")),
+                log.new(o!(
+                    "component" => "dropshot_external",
+                    "bind_address" => config
+                        .deployment
+                        .dropshot_external
+                        .dropshot
+                        .bind_address
+                        .ip()
+                        .to_string(),
+                )),
             )
             .config(config.deployment.dropshot_external.dropshot.clone())
             .version_policy(external_version_policy())
@@ -266,32 +280,35 @@ impl Server {
                 format!("initializing external server: {}", error)
             })?
         };
+        http_servers_external.push(http_server_external);
 
-        // Optionally serve the external API on a second address (e.g. a second
+        // Serve the external API on any additional addresses (e.g. a second
         // address family for dual stack), reusing the primary external server's
-        // Dropshot configuration with only the bind address changed.
-        let http_server_second_external = config
-            .deployment
-            .dropshot_external_second_address
-            .map(|bind_address| {
-                let dropshot_config = ConfigDropshot {
-                    bind_address,
-                    ..config.deployment.dropshot_external.dropshot.clone()
-                };
-                dropshot::ServerBuilder::new(
-                    external_api(),
-                    apictx.for_external(),
-                    log.new(o!("component" => "dropshot_external_second")),
-                )
-                .config(dropshot_config)
-                .version_policy(external_version_policy())
-                .tls(tls_config.clone().map(dropshot::ConfigTls::Dynamic))
-                .start()
-                .map_err(|error| {
-                    format!("initializing second external server: {}", error)
-                })
-            })
-            .transpose()?;
+        // Dropshot configuration with only the bind addresses changed.
+        for bind_address in
+            config.deployment.dropshot_external_additional_addresses.into_iter()
+        {
+            let dropshot_config = ConfigDropshot {
+                bind_address,
+                ..config.deployment.dropshot_external.dropshot.clone()
+            };
+            let server = dropshot::ServerBuilder::new(
+                external_api(),
+                apictx.for_external(),
+                log.new(o!(
+                    "component" => "dropshot_external",
+                    "bind_address" => bind_address.ip().to_string(),
+                )),
+            )
+            .config(dropshot_config)
+            .version_policy(external_version_policy())
+            .tls(tls_config.clone().map(dropshot::ConfigTls::Dynamic))
+            .start()
+            .map_err(|error| {
+                format!("initializing additional external server: {}", error)
+            })?;
+            http_servers_external.push(server);
+        }
 
         let http_server_techport_external = {
             dropshot::ServerBuilder::new(
@@ -320,8 +337,7 @@ impl Server {
             .context
             .nexus
             .set_servers(
-                http_server_external,
-                http_server_second_external,
+                http_servers_external,
                 http_server_techport_external,
                 http_server_internal,
                 http_server_lockstep,
@@ -603,11 +619,17 @@ impl nexus_test_interface::NexusServer for Server {
     }
 
     fn get_http_server_external_address(&self) -> SocketAddr {
-        self.apictx.context.nexus.get_external_server_address().unwrap()
+        self.apictx.context.nexus.get_external_server_primary_address().unwrap()
     }
 
     fn get_http_server_second_external_address(&self) -> Option<SocketAddr> {
-        self.apictx.context.nexus.get_second_external_server_address()
+        self.apictx
+            .context
+            .nexus
+            .get_all_external_server_addresses()
+            .unwrap()
+            .get(1)
+            .copied()
     }
 
     fn get_http_server_techport_address(&self) -> SocketAddr {

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -622,14 +622,15 @@ impl nexus_test_interface::NexusServer for Server {
         self.apictx.context.nexus.get_external_server_primary_address().unwrap()
     }
 
-    fn get_http_server_second_external_address(&self) -> Option<SocketAddr> {
+    /// Return all the external server addresses.
+    ///
+    /// This is always non-empty.
+    fn get_all_http_server_external_addresses(&self) -> Vec<SocketAddr> {
         self.apictx
             .context
             .nexus
             .get_all_external_server_addresses()
             .unwrap()
-            .get(1)
-            .copied()
     }
 
     fn get_http_server_techport_address(&self) -> SocketAddr {

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -234,6 +234,24 @@ impl Server {
             ..config.deployment.dropshot_external.dropshot.clone()
         };
 
+        // The external, techport, and (optional) second external servers all
+        // serve the same API with the same version policy; build it here rather
+        // than repeat it for each server.
+        let external_version_policy = || {
+            dropshot::VersionPolicy::Dynamic(Box::new(
+                dropshot::ClientSpecifiesVersionInHeader::new(
+                    omicron_common::api::VERSION_HEADER,
+                    nexus_external_api::latest_version(),
+                )
+                // Since we don't have control over all clients to the external
+                // API, we allow the api-version header to not be specified
+                // (picking the latest version in that case). However, all
+                // clients that *are* under our control should specify the
+                // api-version header.
+                .on_missing(nexus_external_api::latest_version()),
+            ))
+        };
+
         let http_server_external = {
             dropshot::ServerBuilder::new(
                 external_api(),
@@ -241,24 +259,40 @@ impl Server {
                 log.new(o!("component" => "dropshot_external")),
             )
             .config(config.deployment.dropshot_external.dropshot.clone())
-            .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
-                dropshot::ClientSpecifiesVersionInHeader::new(
-                    omicron_common::api::VERSION_HEADER,
-                    nexus_external_api::latest_version(),
-                )
-                // Since we don't have control over all clients to the external
-                // API, we allow the api-version header to not be specified
-                // (picking the latest version in that case). However, all
-                // clients that *are* under our control should specify the
-                // api-version header.
-                .on_missing(nexus_external_api::latest_version()),
-            )))
+            .version_policy(external_version_policy())
             .tls(tls_config.clone().map(dropshot::ConfigTls::Dynamic))
             .start()
             .map_err(|error| {
                 format!("initializing external server: {}", error)
             })?
         };
+
+        // Optionally serve the external API on a second address (e.g. a second
+        // address family for dual stack), reusing the primary external server's
+        // Dropshot configuration with only the bind address changed.
+        let http_server_second_external = config
+            .deployment
+            .dropshot_external_second_address
+            .map(|bind_address| {
+                let dropshot_config = ConfigDropshot {
+                    bind_address,
+                    ..config.deployment.dropshot_external.dropshot.clone()
+                };
+                dropshot::ServerBuilder::new(
+                    external_api(),
+                    apictx.for_external(),
+                    log.new(o!("component" => "dropshot_external_second")),
+                )
+                .config(dropshot_config)
+                .version_policy(external_version_policy())
+                .tls(tls_config.clone().map(dropshot::ConfigTls::Dynamic))
+                .start()
+                .map_err(|error| {
+                    format!("initializing second external server: {}", error)
+                })
+            })
+            .transpose()?;
+
         let http_server_techport_external = {
             dropshot::ServerBuilder::new(
                 external_api(),
@@ -266,18 +300,7 @@ impl Server {
                 log.new(o!("component" => "dropshot_external_techport")),
             )
             .config(techport_server_config)
-            .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
-                dropshot::ClientSpecifiesVersionInHeader::new(
-                    omicron_common::api::VERSION_HEADER,
-                    nexus_external_api::latest_version(),
-                )
-                // Since we don't have control over all clients to the external
-                // API, we allow the api-version header to not be specified
-                // (picking the latest version in that case). However, all
-                // clients that *are* under our control should specify the
-                // api-version header.
-                .on_missing(nexus_external_api::latest_version()),
-            )))
+            .version_policy(external_version_policy())
             .tls(tls_config.map(dropshot::ConfigTls::Dynamic))
             .start()
             .map_err(|error| {
@@ -298,6 +321,7 @@ impl Server {
             .nexus
             .set_servers(
                 http_server_external,
+                http_server_second_external,
                 http_server_techport_external,
                 http_server_internal,
                 http_server_lockstep,
@@ -580,6 +604,10 @@ impl nexus_test_interface::NexusServer for Server {
 
     fn get_http_server_external_address(&self) -> SocketAddr {
         self.apictx.context.nexus.get_external_server_address().unwrap()
+    }
+
+    fn get_http_server_second_external_address(&self) -> Option<SocketAddr> {
+        self.apictx.context.nexus.get_second_external_server_address()
     }
 
     fn get_http_server_techport_address(&self) -> SocketAddr {

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -626,11 +626,7 @@ impl nexus_test_interface::NexusServer for Server {
     ///
     /// This is always non-empty.
     fn get_all_http_server_external_addresses(&self) -> Vec<SocketAddr> {
-        self.apictx
-            .context
-            .nexus
-            .get_all_external_server_addresses()
-            .unwrap()
+        self.apictx.context.nexus.get_all_external_server_addresses().unwrap()
     }
 
     fn get_http_server_techport_address(&self) -> SocketAddr {

--- a/nexus/test-interface/src/lib.rs
+++ b/nexus/test-interface/src/lib.rs
@@ -91,6 +91,7 @@ pub trait NexusServer: Send + Sync + 'static {
     fn inventory_load_rx(&self) -> watch::Receiver<Option<Arc<Collection>>>;
 
     fn get_http_server_external_address(&self) -> SocketAddr;
+    fn get_http_server_second_external_address(&self) -> Option<SocketAddr>;
     fn get_http_server_techport_address(&self) -> SocketAddr;
     fn get_http_server_internal_address(&self) -> SocketAddr;
     fn get_http_server_lockstep_address(&self) -> SocketAddr;

--- a/nexus/test-interface/src/lib.rs
+++ b/nexus/test-interface/src/lib.rs
@@ -91,7 +91,7 @@ pub trait NexusServer: Send + Sync + 'static {
     fn inventory_load_rx(&self) -> watch::Receiver<Option<Arc<Collection>>>;
 
     fn get_http_server_external_address(&self) -> SocketAddr;
-    fn get_http_server_second_external_address(&self) -> Option<SocketAddr>;
+    fn get_all_http_server_external_addresses(&self) -> Vec<SocketAddr>;
     fn get_http_server_techport_address(&self) -> SocketAddr;
     fn get_http_server_internal_address(&self) -> SocketAddr;
     fn get_http_server_lockstep_address(&self) -> SocketAddr;

--- a/nexus/tests/integration_tests/basic.rs
+++ b/nexus/tests/integration_tests/basic.rs
@@ -8,6 +8,7 @@
 //! TODO-coverage add test for racks, sleds
 
 use dropshot::HttpErrorResponseBody;
+use dropshot::test_util::ClientTestContext;
 use http::StatusCode;
 use http::method::Method;
 use nexus_types::external_api::project;
@@ -19,6 +20,8 @@ use omicron_common::api::external::Name;
 use serde::Serialize;
 use uuid::Uuid;
 
+use nexus_test_interface::NexusServer;
+use nexus_test_utils::ControlPlaneBuilder;
 use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
 use nexus_test_utils::http_testing::RequestBuilder;
@@ -556,6 +559,30 @@ async fn test_ping(cptestctx: &ControlPlaneTestContext) {
         .execute_and_parse_unwrap::<system::Ping>()
         .await;
     assert_eq!(health.status, system::PingStatus::Ok);
+}
+
+#[tokio::test]
+async fn test_ping_on_second_external_address() {
+    let cptestctx =
+        ControlPlaneBuilder::new("test_ping_on_second_external_address")
+            .customize_nexus_config(&|config| {
+                config.deployment.dropshot_external_second_address =
+                    Some("[::1]:0".parse().unwrap());
+            })
+            .start::<omicron_nexus::Server>()
+            .await;
+    let second_address = cptestctx
+        .server
+        .get_http_server_second_external_address()
+        .expect("second external server should be running");
+    let second_client =
+        ClientTestContext::new(second_address, cptestctx.logctx.log.clone());
+    let health = NexusRequest::object_get(&second_client, "/v1/ping")
+        .execute_and_parse_unwrap::<system::Ping>()
+        .await;
+    assert_eq!(health.status, system::PingStatus::Ok);
+
+    cptestctx.teardown().await;
 }
 
 /// Test that the external API returns gzip-compressed responses when the

--- a/nexus/tests/integration_tests/basic.rs
+++ b/nexus/tests/integration_tests/basic.rs
@@ -566,8 +566,8 @@ async fn test_ping_on_second_external_address() {
     let cptestctx =
         ControlPlaneBuilder::new("test_ping_on_second_external_address")
             .customize_nexus_config(&|config| {
-                config.deployment.dropshot_external_second_address =
-                    Some("[::1]:0".parse().unwrap());
+                config.deployment.dropshot_external_additional_addresses =
+                    vec!["[::1]:0".parse().unwrap()];
             })
             .start::<omicron_nexus::Server>()
             .await;

--- a/nexus/tests/integration_tests/basic.rs
+++ b/nexus/tests/integration_tests/basic.rs
@@ -571,9 +571,10 @@ async fn test_ping_on_second_external_address() {
             })
             .start::<omicron_nexus::Server>()
             .await;
-    let second_address = cptestctx
+    let second_address = *cptestctx
         .server
-        .get_http_server_second_external_address()
+        .get_all_http_server_external_addresses()
+        .get(1)
         .expect("second external server should be running");
     let second_client =
         ClientTestContext::new(second_address, cptestctx.logctx.log.clone());

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2270,6 +2270,9 @@ impl ServiceManager {
                             compression: dropshot::CompressionConfig::Gzip,
                         },
                     },
+                    // TODO(#9288): populate a second external address here once
+                    // sled-agent assigns dual-stack external IPs to Nexus.
+                    dropshot_external_second_address: None,
                     dropshot_internal: dropshot::ConfigDropshot {
                         bind_address: (*internal_address).into(),
                         default_request_body_max_bytes: 1048576,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2270,9 +2270,9 @@ impl ServiceManager {
                             compression: dropshot::CompressionConfig::Gzip,
                         },
                     },
-                    // TODO(#9288): populate a second external address here once
-                    // sled-agent assigns dual-stack external IPs to Nexus.
-                    dropshot_external_second_address: None,
+                    // TODO(#9288): populate additional external addresses here
+                    // once sled-agent assigns dual-stack external IPs to Nexus.
+                    dropshot_external_additional_addresses: vec![],
                     dropshot_internal: dropshot::ConfigDropshot {
                         bind_address: (*internal_address).into(),
                         default_request_body_max_bytes: 1048576,


### PR DESCRIPTION
- Add a second socket address to Nexus's config format. This is optional, for backwards compatibility. If specified, start a second external API server on the second address, sharing the rest of the Dropshot configuration and API context.
- Fixes #11006