### PR TITLE
Update git dependencies and pin revisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,11 +438,11 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?branch=main#ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=4a39ef08d81e5177edee0bddb1146032aa21074d#4a39ef08d81e5177edee0bddb1146032aa21074d"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hex",
  "hubpack",
  "rats-corim 0.1.0 (git+https://github.com/oxidecomputer/rats-corim)",
@@ -457,11 +457,11 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=4a39ef08d81e5177edee0bddb1146032aa21074d#4a39ef08d81e5177edee0bddb1146032aa21074d"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc#ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "hex",
  "hubpack",
  "rats-corim 0.1.0 (git+https://github.com/oxidecomputer/rats-corim)",
@@ -2933,28 +2933,6 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?branch=main#ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc"
-dependencies = [
- "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?branch=main)",
- "const-oid 0.9.6",
- "ed25519-dalek 2.2.0",
- "env_logger",
- "hex",
- "hubpack",
- "libipcc 0.1.0 (git+https://github.com/oxidecomputer/ipcc-rs?rev=7cdf2ab9c8d9e9267a8b366aa780c6c26f9a5ecf)",
- "log",
- "p384 0.13.1",
- "rats-corim 0.1.0 (git+https://github.com/oxidecomputer/rats-corim)",
- "sha3 0.10.8",
- "slog",
- "tempfile",
- "thiserror 2.0.18",
- "x509-cert",
-]
-
-[[package]]
-name = "dice-verifier"
-version = "0.3.0-pre0"
 source = "git+https://github.com/oxidecomputer/dice-util?rev=4a39ef08d81e5177edee0bddb1146032aa21074d#4a39ef08d81e5177edee0bddb1146032aa21074d"
 dependencies = [
  "anyhow",
@@ -2976,6 +2954,28 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "x509-cert",
+]
+
+[[package]]
+name = "dice-verifier"
+version = "0.3.0-pre0"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc#ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc"
+dependencies = [
+ "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc)",
+ "const-oid 0.9.6",
+ "ed25519-dalek 2.2.0",
+ "env_logger",
+ "hex",
+ "hubpack",
+ "libipcc 0.1.0 (git+https://github.com/oxidecomputer/ipcc-rs?rev=7cdf2ab9c8d9e9267a8b366aa780c6c26f9a5ecf)",
+ "log",
+ "p384 0.13.1",
+ "rats-corim 0.1.0 (git+https://github.com/oxidecomputer/rats-corim)",
+ "sha3 0.10.8",
+ "slog",
+ "tempfile",
+ "thiserror 2.0.18",
  "x509-cert",
 ]
 
@@ -4250,7 +4250,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-types",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4277,7 +4277,7 @@ dependencies = [
  "chrono",
  "daft",
  "ereport-types",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-types",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4296,9 +4296,38 @@ dependencies = [
 [[package]]
 name = "gateway-ereport-messages"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57#01f06089a97bd084bec2595d4d62e0f91338cf57"
+dependencies = [
+ "hubpack",
+ "serde",
+ "zerocopy 0.8.55",
+]
+
+[[package]]
+name = "gateway-ereport-messages"
+version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862#6c0aca2545a73fd75536e149d29faa7108be5862"
 dependencies = [
  "serde",
+ "zerocopy 0.8.55",
+]
+
+[[package]]
+name = "gateway-messages"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57#01f06089a97bd084bec2595d4d62e0f91338cf57"
+dependencies = [
+ "bitflags 2.11.0",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "hubpack",
+ "serde",
+ "serde-big-array",
+ "serde_repr",
+ "smoltcp 0.9.1",
+ "static_assertions",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "uuid",
  "zerocopy 0.8.55",
 ]
 
@@ -4323,18 +4352,18 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.2"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862#6c0aca2545a73fd75536e149d29faa7108be5862"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57#01f06089a97bd084bec2595d4d62e0f91338cf57"
 dependencies = [
  "async-trait",
  "backoff",
  "base64 0.22.1",
  "futures",
  "fxhash",
- "gateway-ereport-messages",
- "gateway-messages",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "hex",
  "hubpack",
- "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
+ "hubtools 0.4.9",
  "lru-cache",
  "lzss",
  "nix 0.27.1",
@@ -4356,7 +4385,7 @@ dependencies = [
  "uuid",
  "version_check",
  "zerocopy 0.8.55",
- "zip 0.6.6",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -4366,7 +4395,7 @@ dependencies = [
  "camino",
  "dropshot",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-types",
  "omicron-gateway",
  "omicron-test-utils",
@@ -4393,7 +4422,7 @@ version = "0.1.0"
 dependencies = [
  "daft",
  "dropshot",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "hex",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4759,6 +4788,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -5202,14 +5234,14 @@ source = "git+https://github.com/oxidecomputer/hubtools.git?branch=main#2b1ef9b3
 dependencies = [
  "digest 0.10.7",
  "hex",
- "lpc55_areas",
- "lpc55_sign",
+ "lpc55_areas 0.2.5 (git+https://github.com/oxidecomputer/lpc55_support)",
+ "lpc55_sign 0.3.5 (git+https://github.com/oxidecomputer/lpc55_support)",
  "object 0.30.4",
- "path-slash",
+ "path-slash 0.1.5",
  "rsa 0.9.10",
  "thiserror 1.0.69",
  "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc)",
- "tlvc-text",
+ "tlvc-text 0.3.0",
  "toml 0.7.8",
  "x509-cert",
  "zerocopy 0.6.6",
@@ -5223,18 +5255,39 @@ source = "git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563e
 dependencies = [
  "digest 0.10.7",
  "hex",
- "lpc55_areas",
- "lpc55_sign",
+ "lpc55_areas 0.2.5 (git+https://github.com/oxidecomputer/lpc55_support)",
+ "lpc55_sign 0.3.5 (git+https://github.com/oxidecomputer/lpc55_support)",
  "object 0.30.4",
- "path-slash",
+ "path-slash 0.1.5",
  "rsa 0.9.10",
  "thiserror 1.0.69",
  "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc)",
- "tlvc-text",
+ "tlvc-text 0.3.0",
  "toml 0.7.8",
  "x509-cert",
  "zerocopy 0.6.6",
  "zip 0.6.6",
+]
+
+[[package]]
+name = "hubtools"
+version = "0.4.9"
+source = "git+https://github.com/oxidecomputer/hubtools.git?rev=87881bd389025f7c5692c0be153452c11ae3312e#87881bd389025f7c5692c0be153452c11ae3312e"
+dependencies = [
+ "digest 0.11.3",
+ "hex",
+ "lpc55_areas 0.2.5 (git+https://github.com/oxidecomputer/lpc55_support?rev=fc64732faf5511850b35f1734d572b9953d73374)",
+ "lpc55_sign 0.3.5 (git+https://github.com/oxidecomputer/lpc55_support?rev=fc64732faf5511850b35f1734d572b9953d73374)",
+ "object 0.39.1",
+ "path-slash 0.2.1",
+ "rsa 0.9.10",
+ "thiserror 2.0.18",
+ "tlvc 0.4.1",
+ "tlvc-text 0.4.0",
+ "toml 1.1.2+spec-1.1.0",
+ "x509-cert",
+ "zerocopy 0.8.55",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -6706,12 +6759,48 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 [[package]]
 name = "lpc55_areas"
 version = "0.2.5"
+source = "git+https://github.com/oxidecomputer/lpc55_support?rev=fc64732faf5511850b35f1734d572b9953d73374#fc64732faf5511850b35f1734d572b9953d73374"
+dependencies = [
+ "bitfield",
+ "clap",
+ "packed_struct",
+ "serde",
+]
+
+[[package]]
+name = "lpc55_areas"
+version = "0.2.5"
 source = "git+https://github.com/oxidecomputer/lpc55_support#fc64732faf5511850b35f1734d572b9953d73374"
 dependencies = [
  "bitfield",
  "clap",
  "packed_struct",
  "serde",
+]
+
+[[package]]
+name = "lpc55_sign"
+version = "0.3.5"
+source = "git+https://github.com/oxidecomputer/lpc55_support?rev=fc64732faf5511850b35f1734d572b9953d73374#fc64732faf5511850b35f1734d572b9953d73374"
+dependencies = [
+ "byteorder",
+ "const-oid 0.9.6",
+ "crc-any",
+ "der 0.7.10",
+ "env_logger",
+ "hex",
+ "log",
+ "lpc55_areas 0.2.5 (git+https://github.com/oxidecomputer/lpc55_support?rev=fc64732faf5511850b35f1734d572b9953d73374)",
+ "num-traits",
+ "packed_struct",
+ "pem-rfc7468 0.7.0",
+ "rsa 0.9.10",
+ "serde",
+ "serde-hex",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "x509-cert",
+ "zerocopy 0.8.55",
 ]
 
 [[package]]
@@ -6726,7 +6815,7 @@ dependencies = [
  "env_logger",
  "hex",
  "log",
- "lpc55_areas",
+ "lpc55_areas 0.2.5 (git+https://github.com/oxidecomputer/lpc55_support)",
  "num-traits",
  "packed_struct",
  "pem-rfc7468 0.7.0",
@@ -6908,7 +6997,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-test-utils",
  "libc",
  "omicron-gateway",
@@ -7618,7 +7707,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-test-utils",
  "gateway-types",
  "httpmock",
@@ -7750,11 +7839,11 @@ dependencies = [
  "dropshot",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-test-utils",
  "gateway-types",
  "http",
- "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
+ "hubtools 0.4.9",
  "iddqd",
  "illumos-utils",
  "internal-dns-resolver",
@@ -8167,7 +8256,7 @@ dependencies = [
  "dropshot",
  "fmd-adm-sys",
  "futures",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-test-utils",
  "headers",
  "hickory-resolver 0.25.2",
@@ -8681,6 +8770,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
 name = "olpc-cjson"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9012,7 +9113,7 @@ dependencies = [
  "futures",
  "gateway-api",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-sp-comms",
  "gateway-test-utils",
  "gateway-types",
@@ -9188,7 +9289,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-test-utils",
  "gateway-types",
  "headers",
@@ -9199,7 +9300,7 @@ dependencies = [
  "http-body-util",
  "httpmock",
  "httptest",
- "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
+ "hubtools 0.4.9",
  "hyper",
  "hyper-rustls",
  "hyper-staticfile",
@@ -9411,7 +9512,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -9692,7 +9793,7 @@ dependencies = [
  "crucible-agent-client",
  "crucible-client-types",
  "derive_more 0.99.20",
- "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?branch=main)",
+ "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?rev=ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc)",
  "display-error-chain",
  "dropshot",
  "expectorate",
@@ -9922,8 +10023,8 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
- "gateway-ereport-messages",
- "gateway-messages",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
  "generic-array 0.14.7",
  "getrandom 0.2.17",
  "getrandom 0.4.3",
@@ -11039,6 +11140,12 @@ name = "path-slash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "path-tree"
@@ -14467,7 +14574,7 @@ dependencies = [
  "either",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -14957,11 +15064,11 @@ dependencies = [
  "clap",
  "dropshot",
  "futures",
- "gateway-ereport-messages",
- "gateway-messages",
+ "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-types",
  "hex",
- "hubtools 0.4.7 (git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a)",
+ "hubtools 0.4.9",
  "nexus-types",
  "nix 0.31.2",
  "omicron-common",
@@ -15957,6 +16064,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tlvc"
+version = "0.4.1"
+source = "git+https://github.com/oxidecomputer/tlvc?rev=7a96eab94c8aec9120412d8601ffd68853957da3#7a96eab94c8aec9120412d8601ffd68853957da3"
+dependencies = [
+ "crc",
+ "thiserror 2.0.18",
+ "zerocopy 0.8.55",
+ "zerocopy-derive 0.8.55",
+]
+
+[[package]]
 name = "tlvc-text"
 version = "0.3.0"
 source = "git+https://github.com/oxidecomputer/tlvc#e644a21a7ca973ed31499106ea926bd63ebccc6f"
@@ -15965,6 +16083,17 @@ dependencies = [
  "serde",
  "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc)",
  "zerocopy 0.6.6",
+]
+
+[[package]]
+name = "tlvc-text"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/tlvc?rev=7a96eab94c8aec9120412d8601ffd68853957da3#7a96eab94c8aec9120412d8601ffd68853957da3"
+dependencies = [
+ "ron",
+ "serde",
+ "tlvc 0.4.1",
+ "zerocopy 0.8.55",
 ]
 
 [[package]]
@@ -16285,7 +16414,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "typed-path",
+ "typed-path 0.9.3",
  "untrusted 0.7.1",
  "url",
  "walkdir",
@@ -16318,7 +16447,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "typed-path",
+ "typed-path 0.9.3",
  "untrusted 0.7.1",
  "url",
  "walkdir",
@@ -16907,6 +17036,12 @@ name = "typed-path"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typed-rng"
@@ -17753,7 +17888,7 @@ dependencies = [
  "fs-err 3.3.0",
  "futures",
  "gateway-client",
- "gateway-messages",
+ "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
  "gateway-test-utils",
  "gateway-types",
  "hex",
@@ -17770,7 +17905,7 @@ dependencies = [
  "internal-dns-resolver",
  "internal-dns-types",
  "itertools 0.14.0",
- "lpc55_areas",
+ "lpc55_areas 0.2.5 (git+https://github.com/oxidecomputer/lpc55_support)",
  "maplit",
  "omicron-certificates",
  "omicron-common",
@@ -18766,6 +18901,21 @@ dependencies = [
  "memchr",
  "zopfli",
  "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "bzip2 0.6.1",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path 0.12.3",
+ "zopfli",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,7 +4250,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-types",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4277,7 +4277,7 @@ dependencies = [
  "chrono",
  "daft",
  "ereport-types",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-types",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -4304,39 +4304,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "gateway-ereport-messages"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862#6c0aca2545a73fd75536e149d29faa7108be5862"
-dependencies = [
- "serde",
- "zerocopy 0.8.55",
-]
-
-[[package]]
 name = "gateway-messages"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57#01f06089a97bd084bec2595d4d62e0f91338cf57"
 dependencies = [
  "bitflags 2.11.0",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
- "hubpack",
- "serde",
- "serde-big-array",
- "serde_repr",
- "smoltcp 0.9.1",
- "static_assertions",
- "strum 0.27.2",
- "strum_macros 0.27.2",
- "uuid",
- "zerocopy 0.8.55",
-]
-
-[[package]]
-name = "gateway-messages"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862#6c0aca2545a73fd75536e149d29faa7108be5862"
-dependencies = [
- "bitflags 2.11.0",
+ "gateway-ereport-messages",
  "hubpack",
  "serde",
  "serde-big-array",
@@ -4359,8 +4332,8 @@ dependencies = [
  "base64 0.22.1",
  "futures",
  "fxhash",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-ereport-messages",
+ "gateway-messages",
  "hex",
  "hubpack",
  "hubtools 0.4.9",
@@ -4395,7 +4368,7 @@ dependencies = [
  "camino",
  "dropshot",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-types",
  "omicron-gateway",
  "omicron-test-utils",
@@ -4422,7 +4395,7 @@ version = "0.1.0"
 dependencies = [
  "daft",
  "dropshot",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "hex",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
@@ -6997,7 +6970,7 @@ dependencies = [
  "clap",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-test-utils",
  "libc",
  "omicron-gateway",
@@ -7707,7 +7680,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "httpmock",
@@ -7839,7 +7812,7 @@ dependencies = [
  "dropshot",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -8256,7 +8229,7 @@ dependencies = [
  "dropshot",
  "fmd-adm-sys",
  "futures",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-test-utils",
  "headers",
  "hickory-resolver 0.25.2",
@@ -9113,7 +9086,7 @@ dependencies = [
  "futures",
  "gateway-api",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-sp-comms",
  "gateway-test-utils",
  "gateway-types",
@@ -9289,7 +9262,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "headers",
@@ -9512,7 +9485,7 @@ dependencies = [
  "fmd-adm-sys",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -10023,14 +9996,14 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=6c0aca2545a73fd75536e149d29faa7108be5862)",
+ "gateway-messages",
  "generic-array 0.14.7",
  "getrandom 0.2.17",
  "getrandom 0.4.3",
  "group 0.13.0",
  "hashbrown 0.15.5",
  "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "heck 0.4.1",
  "hex",
  "hickory-proto 0.25.2",
@@ -10141,8 +10114,8 @@ dependencies = [
  "x509-cert",
  "zerocopy 0.8.55",
  "zeroize",
- "zip 0.6.6",
  "zip 4.6.1",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -14574,7 +14547,7 @@ dependencies = [
  "either",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "http",
@@ -15064,8 +15037,8 @@ dependencies = [
  "clap",
  "dropshot",
  "futures",
- "gateway-ereport-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-ereport-messages",
+ "gateway-messages",
  "gateway-types",
  "hex",
  "hubtools 0.4.9",
@@ -17888,7 +17861,7 @@ dependencies = [
  "fs-err 3.3.0",
  "futures",
  "gateway-client",
- "gateway-messages 0.1.0 (git+https://github.com/oxidecomputer/management-gateway-service?rev=01f06089a97bd084bec2595d4d62e0f91338cf57)",
+ "gateway-messages",
  "gateway-test-utils",
  "gateway-types",
  "hex",
@@ -18883,7 +18856,6 @@ dependencies = [
  "bzip2 0.4.4",
  "crc32fast",
  "crossbeam-utils",
- "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -510,7 +510,7 @@ debug-ignore = "1.0.5"
 derive_more = "0.99.20"
 derive-where = "1.5.0"
 dev-tools-common = { path = "dev-tools/common" }
-dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", branch = "main", default-features = false }
+dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc", default-features = false }
 # Having the i-implement-... feature here makes diesel go away from the workspace-hack
 diesel = { version = "2.3.7", features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes", "postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
 diesel-dtrace = "0.5.0"
@@ -547,10 +547,9 @@ gateway-client = { path = "clients/gateway-client" }
 # is "fine", because SP/MGS communication maintains forwards and backwards
 # compatibility, but will mean that faux-mgs might be missing new
 # functionality.)
-#
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", default-features = false, features = ["debug-impls"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862" }
+gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "01f06089a97bd084bec2595d4d62e0f91338cf57", default-features = false, features = ["debug-impls"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "01f06089a97bd084bec2595d4d62e0f91338cf57", default-features = false, features = ["std"] }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "01f06089a97bd084bec2595d4d62e0f91338cf57" }
 gateway-test-utils = { path = "gateway-test-utils" }
 gateway-types = { path = "gateway-types" }
 gateway-types-versions = { path = "gateway-types/versions" }
@@ -581,7 +580,7 @@ http-body-util = "0.1.3"
 http-range = "0.1.5"
 httpmock = "0.8.0-alpha.1"
 httptest = "0.16.3"
-hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", rev = "2b1ef9b38d75563ea800baa3b17327eec17b1b7a" }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", rev = "87881bd389025f7c5692c0be153452c11ae3312e" }
 humantime = "2.2.0"
 hyper = "1.6.0"
 hyper-util = "0.1.16"

--- a/gateway/src/metrics.rs
+++ b/gateway/src/metrics.rs
@@ -636,7 +636,7 @@ impl SpPoller {
                             // These are supposed to always be strings. But, if we
                             // see one that's not a string, fall back to the hex
                             // representation rather than panicking.
-                            let hex = hex::encode(dev.component.id);
+                            let hex = hex::encode(dev.component.id());
                             slog::warn!(
                                 &self.log,
                                 "a SP component ID was not a string! this isn't \
@@ -1277,6 +1277,12 @@ fn comms_error_str(error: CommunicationError) -> &'static str {
         }
         CommunicationError::BadDecompressionSize { .. } => {
             "bad_decompression_size"
+        }
+        CommunicationError::HostPanicDataChanged { .. } => {
+            "host_panic_data_changed"
+        }
+        CommunicationError::HostBootfailDataChanged { .. } => {
+            "host_boot_fail_data_changed"
         }
     }
 }

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -878,7 +878,6 @@ only_for_targets.switch = "stub"
 only_for_targets.image = "standard"
 source.type = "composite"
 source.packages = [
-  "omicron-faux-mgs.tar.gz",
   "omicron-gateway-stub.tar.gz",
   "dendrite-stub.tar.gz",
   "lldp.tar.gz",

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -605,8 +605,8 @@ source.type = "prebuilt"
 source.repo = "management-gateway-service"
 # In general, this commit should match the pinned revision of `gateway-sp-comms`
 # in `Cargo.toml`.
-source.commit = "6c0aca2545a73fd75536e149d29faa7108be5862"
-source.sha256 = "48748a5090ed9c7b4d61cc127d9c6959b228864b75a4ab111468dc22ae20d656"
+source.commit = "01f06089a97bd084bec2595d4d62e0f91338cf57"
+source.sha256 = "22f71d7877e4bcbaa36005a7abe2a2ca2f93f24127a7799161de6ffb071a0ac6"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -878,6 +878,7 @@ only_for_targets.switch = "stub"
 only_for_targets.image = "standard"
 source.type = "composite"
 source.packages = [
+  "omicron-faux-mgs.tar.gz",
   "omicron-gateway-stub.tar.gz",
   "dendrite-stub.tar.gz",
   "lldp.tar.gz",

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -29,9 +29,15 @@ use gateway_messages::DumpError;
 use gateway_messages::DumpSegment;
 use gateway_messages::DumpTask;
 use gateway_messages::Header;
+use gateway_messages::HostBootfailPayloadData;
+use gateway_messages::HostInfoRequest;
+use gateway_messages::HostPanicPayloadData;
 use gateway_messages::MgsRequest;
 use gateway_messages::MgsResponse;
+use gateway_messages::PmbusStatus;
+use gateway_messages::PowerRailName;
 use gateway_messages::PowerStateTransition;
+use gateway_messages::PowerStateWithReason;
 use gateway_messages::RotBootInfo;
 use gateway_messages::RotRequest;
 use gateway_messages::RotResponse;
@@ -40,6 +46,7 @@ use gateway_messages::SpError;
 use gateway_messages::SpPort;
 use gateway_messages::SpRequest;
 use gateway_messages::SpStateV2;
+use gateway_messages::StateChangeReason;
 use gateway_messages::ignition::{self, LinkEvents};
 use gateway_messages::sp_impl::Sender;
 use gateway_messages::sp_impl::SpHandler;
@@ -1287,6 +1294,23 @@ impl SpHandler for Handler {
         Ok(power_state.into())
     }
 
+    fn power_state_with_reason(
+        &mut self,
+    ) -> Result<PowerStateWithReason, SpError> {
+        let power_state = self.power_state()?;
+
+        debug!(
+            &self.log, "received power state with reason";
+            "power_state" => ?power_state,
+        );
+
+        Ok(PowerStateWithReason {
+            state: power_state,
+            reason: StateChangeReason::Other,
+            since: 1,
+        })
+    }
+
     fn set_power_state(
         &mut self,
         sender: Sender<Self::VLanId>,
@@ -1726,6 +1750,31 @@ impl SpHandler for Handler {
 
     fn get_host_flash_hash(&mut self, slot: u16) -> Result<[u8; 32], SpError> {
         self.update_state.get_host_flash_hash(slot)
+    }
+
+    fn get_pmbus_status(
+        &mut self,
+        _rail: &PowerRailName,
+    ) -> Result<PmbusStatus, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn get_host_panic_payload(
+        &mut self,
+        _request: Option<HostInfoRequest>,
+        _len: u32,
+        _trailing_tx_buf: &mut [u8],
+    ) -> Result<HostPanicPayloadData, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn get_host_bootfail_payload(
+        &mut self,
+        _request: Option<HostInfoRequest>,
+        _len: u32,
+        _trailing_tx_buf: &mut [u8],
+    ) -> Result<HostBootfailPayloadData, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
     }
 }
 

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -32,12 +32,18 @@ use gateway_messages::DumpCompression;
 use gateway_messages::DumpError;
 use gateway_messages::DumpSegment;
 use gateway_messages::DumpTask;
+use gateway_messages::HostBootfailPayloadData;
+use gateway_messages::HostInfoRequest;
+use gateway_messages::HostPanicPayloadData;
 use gateway_messages::IgnitionCommand;
 use gateway_messages::IgnitionState;
 use gateway_messages::MgsError;
 use gateway_messages::MgsRequest;
 use gateway_messages::MgsResponse;
+use gateway_messages::PmbusStatus;
+use gateway_messages::PowerRailName;
 use gateway_messages::PowerState;
+use gateway_messages::PowerStateWithReason;
 use gateway_messages::RotBootInfo;
 use gateway_messages::RotRequest;
 use gateway_messages::RotResponse;
@@ -46,6 +52,7 @@ use gateway_messages::SpError;
 use gateway_messages::SpPort;
 use gateway_messages::SpStateV2;
 use gateway_messages::StartupOptions;
+use gateway_messages::StateChangeReason;
 use gateway_messages::ignition;
 use gateway_messages::ignition::IgnitionError;
 use gateway_messages::ignition::LinkEvents;
@@ -885,6 +892,23 @@ impl SpHandler for Handler {
         Ok(self.power_state)
     }
 
+    fn power_state_with_reason(
+        &mut self,
+    ) -> Result<PowerStateWithReason, SpError> {
+        let power_state = self.power_state()?;
+
+        debug!(
+            &self.log, "received power state with reason";
+            "power_state" => ?power_state,
+        );
+
+        Ok(PowerStateWithReason {
+            state: power_state,
+            reason: StateChangeReason::Other,
+            since: 1,
+        })
+    }
+
     fn set_power_state(
         &mut self,
         sender: Sender<Self::VLanId>,
@@ -1323,6 +1347,31 @@ impl SpHandler for Handler {
     }
 
     fn get_host_flash_hash(&mut self, _slot: u16) -> Result<[u8; 32], SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn get_pmbus_status(
+        &mut self,
+        _rail: &PowerRailName,
+    ) -> Result<PmbusStatus, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn get_host_panic_payload(
+        &mut self,
+        _request: Option<HostInfoRequest>,
+        _len: u32,
+        _trailing_tx_buf: &mut [u8],
+    ) -> Result<HostPanicPayloadData, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn get_host_bootfail_payload(
+        &mut self,
+        _request: Option<HostInfoRequest>,
+        _len: u32,
+        _trailing_tx_buf: &mut [u8],
+    ) -> Result<HostBootfailPayloadData, SpError> {
         Err(SpError::RequestUnsupportedForSp)
     }
 }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -64,13 +64,13 @@ futures-core = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
 futures-task = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.32", features = ["channel", "io", "sink"] }
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", default-features = false, features = ["debug-impls", "serde"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", features = ["std"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "01f06089a97bd084bec2595d4d62e0f91338cf57", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["js", "rdrand", "std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.3", default-features = false, features = ["std", "sys_rng", "wasm_js"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }
 hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15.5" }
+hashbrown-9067fe90e8c1f593 = { package = "hashbrown", version = "0.17.0", default-features = false, features = ["default-hasher"] }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16.1" }
 hex = { version = "0.4.3", features = ["serde"] }
 hickory-proto = { version = "0.25.2", features = ["serde", "text-parsing"] }
@@ -167,7 +167,7 @@ x509-cert = { version = "0.2.5" }
 zerocopy = { version = "0.8.55", default-features = false, features = ["derive", "simd"] }
 zeroize = { version = "1.9.0", features = ["aarch64", "serde", "std", "zeroize_derive"] }
 zip-164d15cefe24d7eb = { package = "zip", version = "4.6.1", default-features = false, features = ["bzip2", "deflate", "jiff-02", "zstd"] }
-zip-3b31131e45eafb45 = { package = "zip", version = "0.6.6", default-features = false, features = ["bzip2", "deflate"] }
+zip-181b0d20215bb231 = { package = "zip", version = "8.6.0", default-features = false, features = ["bzip2", "deflate"] }
 
 [build-dependencies]
 ahash = { version = "0.8.12" }
@@ -218,13 +218,13 @@ futures-core = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
 futures-task = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.32", features = ["channel", "io", "sink"] }
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", default-features = false, features = ["debug-impls", "serde"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "6c0aca2545a73fd75536e149d29faa7108be5862", features = ["std"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "01f06089a97bd084bec2595d4d62e0f91338cf57", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.17", default-features = false, features = ["js", "rdrand", "std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4.3", default-features = false, features = ["std", "sys_rng", "wasm_js"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }
 hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15.5" }
+hashbrown-9067fe90e8c1f593 = { package = "hashbrown", version = "0.17.0", default-features = false, features = ["default-hasher"] }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16.1" }
 heck = { version = "0.4.1", features = ["unicode"] }
 hex = { version = "0.4.3", features = ["serde"] }
@@ -327,7 +327,7 @@ x509-cert = { version = "0.2.5" }
 zerocopy = { version = "0.8.55", default-features = false, features = ["derive", "simd"] }
 zeroize = { version = "1.9.0", features = ["aarch64", "serde", "std", "zeroize_derive"] }
 zip-164d15cefe24d7eb = { package = "zip", version = "4.6.1", default-features = false, features = ["bzip2", "deflate", "jiff-02", "zstd"] }
-zip-3b31131e45eafb45 = { package = "zip", version = "0.6.6", default-features = false, features = ["bzip2", "deflate"] }
+zip-181b0d20215bb231 = { package = "zip", version = "8.6.0", default-features = false, features = ["bzip2", "deflate"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }


### PR DESCRIPTION
Change one of the dice-util dependencies so that it refers to a specific pinned revision (copying the one in Cargo.lock) instead of a branch.

before:

```
$ cargo tree -i dice-verifier
error: specification `dice-verifier` is ambiguous
help: re-run this command with one of the following specifications
  git+https://github.com/oxidecomputer/dice-util?branch=main#dice-verifier@0.3.0-pre0
  git+https://github.com/oxidecomputer/dice-util?rev=4a39ef08d81e5177edee0bddb1146032aa21074d#dice-verifier@0.3.0-pre0
```

after:

```
$ cargo tree -i dice-verifier
error: specification `dice-verifier` is ambiguous
help: re-run this command with one of the following specifications
  git+https://github.com/oxidecomputer/dice-util?rev=4a39ef08d81e5177edee0bddb1146032aa21074d#dice-verifier@0.3.0-pre0
  git+https://github.com/oxidecomputer/dice-util?rev=ff9f27aa0d6ef6fb64c349890b6e3c242ea3d8fc#dice-verifier@0.3.0-pre0
```

Update management-gateway-service to the latest rev to pull in the latest hubtools. Also update package-manifest.toml rev and sha256 accordingly. This pulled in some new `SpHandler trait functions that needed implementing, so fill those in.

Also update to the latest hubtools.