### PR TITLE
[antithesis] first cut of the Antithesis harness for Nexus and CockroachDB

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -55,4 +55,8 @@ third-party = [
     # a feature only we can use that; until then, it's fine to just exclude
     # this crate entirely: it's not very big and isn't used by many things.
     { name = "scuffle" },
+
+    # TODO-RAINCLAUDE: the Antithesis SDK must stay a no-op except under the `antithesis` features of omicron-nexus and omicron-antithesis-workload; unifying it through the workspace-hack would turn on `full` for every build.
+    { name = "antithesis_sdk" },
+    { name = "antithesis-instrumentation" },
 ]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# TODO-RAINCLAUDE: keeps build outputs and VCS state out of the Antithesis image build context (antithesis/Dockerfile).
+target/
+out/
+.jj/
+.git/

--- a/.snouty.toml
+++ b/.snouty.toml
@@ -1,0 +1,5 @@
+# TODO-RAINCLAUDE: project-level snouty settings (see antithesis/README.adoc). Credentials never go here: snouty reads the API key from ANTITHESIS_API_KEY or its credential store. `container_engine` is set because this repo's developers use rootless podman with Compose v2.
+tenant = "oxide"
+# TODO-RAINCLAUDE: the full registry path, not the bare repository name: snouty pushes to `{repository}/{image}:{tag}`, and a bare name sends podman to docker.io.
+repository = "us-central1-docker.pkg.dev/molten-verve-216720/oxide-repository"
+container_engine = "podman"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "antithesis-instrumentation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6b548668212c6d3a942a4ac7be13bc4fc25715bf661328438f30e3fd342cf0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "antithesis_sdk"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08410fcac93669a476c006cd6c4512ac1e2b30fd117231a5d55d8a2c76599b82"
+dependencies = [
+ "libc",
+ "libloading",
+ "linkme",
+ "once_cell",
+ "rand 0.8.6",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +3178,7 @@ dependencies = [
 name = "dns-server"
 version = "0.1.0"
 dependencies = [
+ "antithesis-instrumentation",
  "anyhow",
  "camino",
  "camino-tempfile",
@@ -7438,6 +7464,7 @@ dependencies = [
 name = "nexus-db-queries"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "anyhow",
  "assert_matches",
  "async-bb8-diesel",
@@ -8746,6 +8773,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "omicron-antithesis-workload"
+version = "0.1.0"
+dependencies = [
+ "antithesis-instrumentation",
+ "antithesis_sdk",
+ "anyhow",
+ "clap",
+ "dropshot",
+ "futures",
+ "http",
+ "nexus-config",
+ "nexus-lockstep-client",
+ "omicron-workspace-hack",
+ "oxide-client",
+ "oxide-tokio-rt",
+ "reqwest 0.13.2",
+ "serde_json",
+ "slog",
+ "tokio",
+]
+
+[[package]]
 name = "omicron-certificates"
 version = "0.1.0"
 dependencies = [
@@ -9198,6 +9247,8 @@ dependencies = [
 name = "omicron-nexus"
 version = "0.1.0"
 dependencies = [
+ "antithesis-instrumentation",
+ "antithesis_sdk",
  "anyhow",
  "assert_matches",
  "async-bb8-diesel",
@@ -9427,6 +9478,7 @@ dependencies = [
 name = "omicron-omdb"
 version = "0.1.0"
 dependencies = [
+ "antithesis-instrumentation",
  "anyhow",
  "async-bb8-diesel",
  "async-trait",
@@ -9716,6 +9768,7 @@ dependencies = [
 name = "omicron-sled-agent"
 version = "0.1.0"
 dependencies = [
+ "antithesis-instrumentation",
  "anyhow",
  "assert_matches",
  "async-trait",
@@ -9737,6 +9790,7 @@ dependencies = [
  "derive_more 0.99.20",
  "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?branch=main)",
  "display-error-chain",
+ "dns-service-client",
  "dpd-client 0.1.0 (git+https://github.com/oxidecomputer/dendrite?rev=cc0c307c617f2988aafdca4e3bd35ea178b64801)",
  "dropshot",
  "expectorate",
@@ -10020,9 +10074,7 @@ dependencies = [
  "predicates",
  "proc-macro2",
  "quote",
- "rand 0.8.6",
  "rand 0.9.2",
- "rand_chacha 0.3.1",
  "rand_chacha 0.9.0",
  "regex",
  "regex-automata",
@@ -13155,6 +13207,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
+ "semver 1.0.28",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version 0.4.1",
  "semver 1.0.28",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "antithesis/workload",
     "api_identity",
     "bootstore",
     "certificates",
@@ -195,6 +196,7 @@ members = [
 ]
 
 default-members = [
+    "antithesis/workload",
     "api_identity",
     "bootstore",
     "certificates",
@@ -439,6 +441,8 @@ cast_lossless = "warn"
 [workspace.dependencies]
 anyhow = "1.0"
 anstyle = "1.0.11"
+antithesis-instrumentation = "0.1.0"
+antithesis_sdk = { version = "0.2.9", default-features = false }
 api_identity = { path = "api_identity" }
 approx = "0.5.1"
 assert_matches = "1.5.0"
@@ -987,6 +991,12 @@ opt-level = 3
 
 [profile.release]
 panic = "abort"
+
+# TODO-RAINCLAUDE: profile for Antithesis binaries (antithesis/README.adoc); keeps DWARF line tables unstripped for symbolization, while sancov instrumentation comes from antithesis/cargo-config.toml.
+[profile.antithesis]
+inherits = "release"
+debug = "line-tables-only"
+strip = "none"
 
 # proptest based test generation and shrinking is expensive. Let's optimize it.
 [profile.dev.package.proptest]

--- a/antithesis/Dockerfile
+++ b/antithesis/Dockerfile
@@ -1,0 +1,120 @@
+# syntax=docker/dockerfile:1
+# TODO-RAINCLAUDE: images for running the simulated control plane under Antithesis; build via antithesis/config/docker-compose.yaml (context is the repo root).
+
+# TODO-RAINCLAUDE: the toolchain here must match rust-toolchain.toml (rustup would otherwise download a second one), and the Debian release must match the runtime images below so the binaries link against the same libc and xmlsec generation they run on. Debian releases are pinned rather than `stable` because package names change across releases (trixie renamed libxmlsec1 to libxmlsec1t64).
+FROM rust:1.97.1-trixie AS builder-base
+
+# TODO-RAINCLAUDE: package list mirrors the Linux branch of tools/install_builder_prerequisites.sh.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libclang-dev \
+        libpq-dev \
+        libxmlsec1-dev \
+        libxmlsec1-openssl \
+        pkg-config \
+        xmlsec1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# TODO-RAINCLAUDE: build scripts materialize `.gitstub` files through git-stub-vcs, which needs real history at the repo root and rejects shallow clones. The build context carries no VCS (see .dockerignore), so the builder gets a treeless partial clone: commits only, with trees and blobs fetched on demand, which git-stub-vcs does not classify as shallow. It must not be bare because cargo walks the package's git repo to fingerprint build scripts and rejects bare repos; --no-checkout leaves the index empty so cargo sees every source file as untracked and lists it. Cloned before COPY so the layer survives source edits; the fetch after COPY picks up commits newer than the cached clone.
+ARG OMICRON_GIT_URL=https://github.com/oxidecomputer/omicron
+RUN git clone --no-checkout --filter=tree:0 "$OMICRON_GIT_URL" /omicron-history
+
+WORKDIR /omicron
+COPY . .
+RUN git -C /omicron-history fetch --filter=tree:0 origin \
+    && printf 'gitdir: /omicron-history/.git\n' > /omicron/.git
+
+
+# TODO-RAINCLAUDE: no cargo here on purpose; compose builds images in parallel and two cargo processes racing on the shared registry cache mount corrupt it. The pin and checksum are the same ones cargo xtask download uses (tools/cockroachdb_checksums), and the URL mirrors dev-tools/downloader/src/lib.rs.
+FROM debian:trixie-slim AS cockroach-download
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY tools/cockroachdb_checksums /cockroachdb_checksums
+
+RUN set -eu \
+    && . /cockroachdb_checksums \
+    && curl --fail --silent --show-error --location \
+        --output /cockroach.tgz \
+        "https://buildomat.eng.oxide.computer/public/file/oxidecomputer/cockroach/linux-amd64/${COCKROACH_COMMIT}/cockroach.tgz" \
+    && echo "${CIDL_SHA256_LINUX}  /cockroach.tgz" | sha256sum --check --strict \
+    && mkdir -p /out /unpack \
+    && tar -xzf /cockroach.tgz -C /unpack \
+    && cp /unpack/cockroach/cockroach /out/cockroach \
+    && /out/cockroach version
+
+
+FROM builder-base AS builder
+
+# TODO-RAINCLAUDE: the sancov rustflags in antithesis/cargo-config.toml plus the `antithesis` features are what make these binaries Antithesis-instrumented; sharing=locked keeps any future concurrent cargo stage from racing on these caches.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/omicron/target,sharing=locked \
+    mkdir -p /out \
+    && cargo build \
+        --profile antithesis \
+        --config antithesis/cargo-config.toml \
+        --features omicron-nexus/antithesis,omicron-antithesis-workload/antithesis,dns-server/antithesis,omicron-sled-agent/antithesis,omicron-omdb/antithesis \
+        --bin nexus \
+        --bin sled-agent-sim \
+        --bin dns-server \
+        --bin schema-updater \
+        --bin omdb \
+        --bin omicron-antithesis-workload \
+    && for bin in nexus sled-agent-sim dns-server schema-updater omdb omicron-antithesis-workload; do \
+        cp "target/x86_64-unknown-linux-gnu/antithesis/$bin" "/out/$bin"; \
+    done
+
+
+FROM debian:trixie-slim AS omicron-antithesis
+
+# TODO-RAINCLAUDE: libpq5 is the runtime half of the pq-sys dependency and libxmlsec1t64-openssl (with the libxmlsec1t64 and libxml2 it pulls in) is the runtime half of samael's SAML support; curl is for compose healthchecks. Verify with `ldd /opt/oxide/bin/* | grep "not found"` after changing the builder image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libpq5 \
+        libxmlsec1t64-openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV NO_COLOR=1
+ENV PATH=/opt/oxide/bin:$PATH
+
+COPY --from=builder /out/nexus /out/sled-agent-sim /out/dns-server /out/schema-updater /out/omdb /out/omicron-antithesis-workload /opt/oxide/bin/
+COPY schema/crdb /opt/oxide/sc  hema/crdb
+# TODO-RAINCLAUDE: service configs are baked in rather than bind-mounted from antithesis/config so the image runs identically under Antithesis and under rootless podman on SELinux hosts, where host file mounts are unreadable without relabeling.
+COPY antithesis/config/nexus.toml antithesis/config/dns-server.toml /opt/oxide/config/
+
+# TODO-RAINCLAUDE: Antithesis reads DWARF from /symbols; the binaries are unstripped so symlinks are enough.
+RUN mkdir -p /symbols /var/oxide/dns-storage /var/tmp/omicron_tmp \
+    && for bin in nexus sled-agent-sim dns-server schema-updater omdb omicron-antithesis-workload; do \
+        ln -s "/opt/oxide/bin/$bin" "/symbols/$bin"; \
+    done
+
+
+# TODO-RAINCLAUDE: the test commands live only in the workload image; Antithesis discovers /opt/antithesis/test/v1 in every container and would otherwise run each command once per service built from the shared image.
+FROM omicron-antithesis AS omicron-antithesis-workload
+
+COPY antithesis/test/v1 /opt/antithesis/test/v1
+
+
+FROM debian:trixie-slim AS omicron-antithesis-cockroach
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV NO_COLOR=1
+ENV PATH=/opt/oxide/bin:$PATH
+
+COPY --from=cockroach-download /out/cockroach /opt/oxide/bin/cockroach
+COPY schema/crdb/dbinit.sql /opt/oxide/schema/crdb/dbinit.sql
+COPY antithesis/cockroach-seed-antithesis.sql /opt/oxide/schema/cockroach-seed-antithesis.sql
+COPY antithesis/cockroach-healthcheck.sh antithesis/cockroach-seed.sh /opt/oxide/bin/
+
+# TODO-RAINCLAUDE: seeding at build time keeps the runtime hermetic and fast; the store already holds the omicron schema at the version Nexus expects.
+RUN /opt/oxide/bin/cockroach-seed.sh /data
+
+VOLUME /data

--- a/antithesis/README.adoc
+++ b/antithesis/README.adoc
@@ -1,0 +1,230 @@
+:showtitle:
+:toc: left
+:icons: font
+
+= Running Omicron under Antithesis
+
+This directory holds everything needed to run the simulated control plane
+(Nexus, CockroachDB, internal DNS, and a simulated sled agent) inside
+https://antithesis.com[Antithesis], whose fault injector partitions, throttles,
+pauses, and (when enabled) kills containers while properties asserted through
+the Antithesis SDK are checked.
+
+The plan behind this layout, including the phased roadmap and the seed property
+catalog, is in `scratchbook/plan.md`. The layout follows what the
+https://github.com/antithesishq/antithesis-skills[antithesis-skills] expect, so
+those skills and the `snouty` CLI work here unmodified.
+
+== Layout
+
+[cols="1,3"]
+|===
+| Path | Purpose
+
+| `Dockerfile`
+| Multi-stage build. `omicron-antithesis` holds the instrumented Rust binaries
+  (`nexus`, `sled-agent-sim`, `dns-server`, `schema-updater`, `omdb`,
+  `omicron-antithesis-workload`), the CockroachDB schema, and the test commands.
+  `omicron-antithesis-cockroach` holds the pinned Oxide CockroachDB fork with a
+  store pre-seeded from `schema/crdb/dbinit.sql`.
+
+| `cargo-config.toml`
+| The rustflags that add Antithesis coverage instrumentation. Passed
+  explicitly with `cargo build --config`; never part of `.cargo/config.toml`.
+
+| `config/docker-compose.yaml`
+| The five-container topology on an IPv6 network. The addresses in it, in
+  `config/nexus.toml`, and in the `sled-agent-sim` arguments must agree.
+
+| `config/nexus.toml`, `config/dns-server.toml`
+| Service configuration mounted into the containers.
+
+| `test/v1/nexus/`
+| Antithesis test commands. The filename prefix (`first_`, `parallel_driver_`,
+  `eventually_`, and so on) tells Antithesis when to run each one. They are
+  baked into the `omicron-antithesis` image at `/opt/antithesis/test/v1`.
+
+| `workload/`
+| The `omicron-antithesis-workload` crate that the test commands call. It
+  emits the `setup_complete` signal, seeds a project and IP pool, and checks
+  properties.
+
+| `scratchbook/`
+| Analysis artifacts consumed by the `antithesis-research`, `antithesis-setup`,
+  and `antithesis-workload` skills.
+|===
+
+== How the pieces fit together
+
+. `cockroach` starts on a pre-seeded store, so no migration runs at boot.
+. `internal-dns` starts empty.
+. `nexus` starts its internal and lockstep APIs and waits for rack
+  initialization. Its healthcheck only checks the internal API; the external
+  API does not exist until the handoff below.
+. `sled-agent-sim` registers a simulated Gimlet with Nexus, populates
+  `internal-dns` (including the CockroachDB record), and performs the rack
+  setup handoff. This is the same path `omicron-dev run-all` exercises, but
+  across container boundaries.
+. `workload` runs `omicron-antithesis-workload wait-ready`, which waits for
+  the external API, a successful login as the recovery user, and a registered
+  sled, then writes the Antithesis `setup_complete` signal. Testing starts
+  from that moment.
+
+The recovery silo is `demo-silo` and the user is `demo-privileged` with
+password `oxide`; both names are `sled-agent-sim` options.
+
+== Building the images
+
+The build runs on x86-64 Linux only (Antithesis runs x86-64 containers, and the
+instrumentation flags target `x86_64-unknown-linux-gnu`). From the repository
+root:
+
+[source,text]
+----
+$ docker compose -f antithesis/config/docker-compose.yaml build
+----
+
+Docker is not required. Rootless podman works as long as `podman compose`
+resolves to Compose v2 rather than podman-compose (install the
+`docker-compose` binary from https://github.com/docker/compose/releases into
+`~/.docker/cli-plugins/`); then substitute `podman` for `docker` in every
+command in this document. Paths handed to podman must be visible to the host
+that runs it.
+
+The build context deliberately excludes `.git` and `.jj` (see the repository's
+`.dockerignore`). Build scripts that materialize `.gitstub` files still need
+git history, so the builder stage makes a treeless, checkout-less partial clone of
+`https://github.com/oxidecomputer/omicron` (override with
+`--build-arg OMICRON_GIT_URL=...`) and points `/omicron/.git` at it. A stub
+that references a commit not yet pushed to that remote will fail to
+materialize inside the image build.
+
+The builder stage compiles the workspace once with `--profile antithesis` and
+the flags from `cargo-config.toml`. Expect this to take well over an hour on a
+laptop the first time; the `target` and registry directories are BuildKit
+cache mounts, so rebuilds are incremental.
+
+To check that a binary is instrumented:
+
+[source,text]
+----
+$ docker run --rm omicron-antithesis:latest sh -c 'nm /opt/oxide/bin/nexus | grep antithesis_load_libvoidstar'
+$ docker run --rm omicron-antithesis:latest sh -c 'readelf -S /opt/oxide/bin/nexus | grep sancov'
+----
+
+== Running locally
+
+[source,text]
+----
+$ docker compose -f antithesis/config/docker-compose.yaml up
+----
+
+Wait for the `workload` container to log `sent setup_complete`. Then the test
+commands can be exercised by hand:
+
+[source,text]
+----
+$ docker compose -f antithesis/config/docker-compose.yaml exec workload /opt/antithesis/test/v1/nexus/first_seed.sh
+$ docker compose -f antithesis/config/docker-compose.yaml exec workload /opt/antithesis/test/v1/nexus/eventually_sagas_settle.sh
+----
+
+The external API is reachable from the host only if Docker publishes it;
+inside the network it is `http://[fd00:1122:3344:101::5]:12220`.
+
+=== Proving the deployment is hermetic
+
+Antithesis runs without internet access. To confirm nothing at runtime depends
+on it, bring the stack up inside a network namespace with no external
+connectivity:
+
+[source,text]
+----
+$ sudo unshare -n docker compose -f antithesis/config/docker-compose.yaml up
+----
+
+=== Validating with snouty
+
+With https://github.com/antithesishq/snouty[snouty] installed:
+
+[source,text]
+----
+$ snouty doctor
+$ SNOUTY_TEMP_DIR=$HOME/.cache/snouty-validate-$(date +%s) snouty validate antithesis/config --timeout 480
+----
+
+`validate` needs no credentials at all; `doctor` needs them only for its API
+connectivity check (see <<Authenticating>>). `--timeout` is in seconds
+(the default of 120 is enough here; the stack reaches `setup_complete`
+within about a minute). `SNOUTY_TEMP_DIR` must be a fresh directory that the
+host's container engine can bind-mount: snouty relabels it for SELinux and
+watches it for the `setup_complete` event, and the repository's
+`.snouty.toml` selects podman. A successful run ends with
+`Setup validation successful.` and a count of discovered test commands; the
+count should match the files in `test/v1/nexus/` exactly once, because only
+the workload image carries them.
+
+`snouty validate` builds the images, brings the stack up, and waits for the
+`setup_complete` signal.
+
+[#Authenticating]
+=== Authenticating
+
+The tenant (`oxide`) and repository
+(`us-central1-docker.pkg.dev/molten-verve-216720/oxide-repository`) are in
+`.snouty.toml` at the repository root. The repository has to be that whole
+path: `snouty` pushes to `{repository}/{image}:{tag}`, so a bare
+`oxide-repository` sends the push to Docker Hub, which fails late with a
+confusing `requested access to the resource is denied` after uploading
+several gigabytes of blobs. Two secrets are not in the file: an API key, which
+`snouty` uses to talk to the API, and a Google service-account key, which the
+container engine uses to push images to Antithesis's registry. Oxide keeps
+both in 1Password.
+
+`snouty` reads the API key from the environment, so it never has to be stored
+on disk:
+
+[source,text]
+----
+$ export ANTITHESIS_API_KEY="$(op read 'op://Private/antithesis api key/notesPlain' | tail -1)"
+$ snouty doctor
+----
+
+`snouty login` is the alternative; it persists the key under `$HOME` instead.
+
+Pushing images needs a separate `docker login` against Google Artifact
+Registry, which `snouty launch` then reuses:
+
+[source,text]
+----
+$ op read 'op://Private/antithesis gar key/notesPlain' \
+    | docker login -u _json_key --password-stdin us-central1-docker.pkg.dev
+----
+
+Two notes for podman users. Drop the `https://` scheme Antithesis's own
+instructions carry: podman rejects it. And the credential lands in
+`$XDG_RUNTIME_DIR/containers/auth.json`, which is a tmpfs, so the login has to
+be repeated after a reboot. If podman runs on the host through a distrobox
+shim, run this so that it reaches the same host engine that builds and pushes.
+
+== Adding a property
+
+Assertions inside Nexus use `antithesis_sdk` directly (see
+`nexus/src/app/saga.rs` and `nexus/db-queries/src/transaction_retry.rs`). The
+crate is a no-op unless the `antithesis` feature of `omicron-nexus` is enabled,
+which only the Dockerfile does, so nothing changes for production builds or
+the test suite. Assertion names must be string literals: Antithesis catalogs
+them statically.
+
+Properties checked from outside Nexus go in the workload crate, with a
+wrapper script in `test/v1/nexus/`. Scripts whose names start with `helper_`
+are ignored by Antithesis.
+
+== Still blocked on Antithesis
+
+* Confirmation that Antithesis's compose environment supports IPv6 networks
+  with static `ipv6_address` assignments. Omicron's internal DNS records are
+  IPv6-only, so this topology depends on it. The fallback in
+  `scratchbook/plan.md` keeps `cockroach` and `workload` as separate
+  containers over IPv4 and co-locates the rest on `::1`.
+* Enabling node termination faults for the `nexus` container once saga
+  recovery properties exist.

--- a/antithesis/cargo-config.toml
+++ b/antithesis/cargo-config.toml
@@ -1,0 +1,15 @@
+# TODO-RAINCLAUDE: pass with `cargo build --config antithesis/cargo-config.toml`; kept out of .cargo/config.toml because sancov slows every crate's build.
+# TODO-RAINCLAUDE: an explicit build.target keeps the rustflags off host artifacts (build scripts, proc macros), which cannot link without the instrumentation crate's sancov hooks.
+[build]
+target = "x86_64-unknown-linux-gnu"
+
+# TODO-RAINCLAUDE: target rustflags replace build.rustflags, so --cfg tokio_unstable is repeated here; --build-id is required by Antithesis for symbolization.
+[target.x86_64-unknown-linux-gnu]
+rustflags = [
+    "--cfg", "tokio_unstable",
+    "-Ccodegen-units=1",
+    "-Cpasses=sancov-module",
+    "-Cllvm-args=-sanitizer-coverage-level=3",
+    "-Cllvm-args=-sanitizer-coverage-trace-pc-guard",
+    "-Clink-args=-Wl,--build-id",
+]

--- a/antithesis/cockroach-healthcheck.sh
+++ b/antithesis/cockroach-healthcheck.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# TODO-RAINCLAUDE: compose healthcheck; ready=1 makes CockroachDB report unhealthy while draining or before it accepts SQL.
+
+set -euo pipefail
+
+exec curl --silent --fail --output /dev/null "http://127.0.0.1:8080/health?ready=1"

--- a/antithesis/cockroach-seed-antithesis.sql
+++ b/antithesis/cockroach-seed-antithesis.sql
@@ -1,0 +1,5 @@
+-- TODO-RAINCLAUDE: applied by cockroach-seed.sh after dbinit.sql. Rows here stand in for state that real deployments get from services the phase 1 Antithesis topology does not run.
+
+-- TODO-RAINCLAUDE: the RSS handoff sets a port-settings id on the uplink port named in the rack network config (nexus/src/app/rack.rs, `switch_port_get_id`), and that row is normally created by Nexus's populate_switch_ports task from dendrite's port list. There is no dendrite here, so the placeholder uplink port that sled-agent-sim reports is created up front. The rack id is the one hard-coded in sled-agent/src/sim/server.rs `handoff_to_nexus` and in antithesis/config/nexus.toml.
+INSERT INTO omicron.public.switch_port (id, rack_id, port_name, port_settings_id, switch_slot)
+VALUES (gen_random_uuid(), 'c19a698f-c6f9-4a17-ae30-20d711b8f7dc', 'qsfp0', NULL, 'switch0');

--- a/antithesis/cockroach-seed.sh
+++ b/antithesis/cockroach-seed.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# TODO-RAINCLAUDE: populates a fresh single-node CockroachDB store with schema/crdb/dbinit.sql, then stops the node cleanly so the image ships a consistent store.
+
+set -euo pipefail
+
+store_dir="${1:?usage: cockroach-seed.sh STORE_DIR}"
+listen_addr="127.0.0.1:26257"
+http_addr="127.0.0.1:8080"
+pid_file="/tmp/cockroach-seed.pid"
+
+cockroach start-single-node \
+    --insecure \
+    --store="path=${store_dir},ballast-size=0" \
+    --listen-addr="${listen_addr}" \
+    --http-addr="${http_addr}" \
+    --pid-file="${pid_file}" \
+    --background
+
+cockroach sql \
+    --insecure \
+    --host="${listen_addr}" \
+    --file=/opt/oxide/schema/crdb/dbinit.sql
+
+cockroach sql \
+    --insecure \
+    --host="${listen_addr}" \
+    --file=/opt/oxide/schema/cockroach-seed-antithesis.sql
+
+version="$(cockroach sql --insecure --host="${listen_addr}" --format=csv \
+    --execute='SELECT version FROM omicron.public.db_metadata' | tail -n 1)"
+echo "seeded omicron database at schema version ${version}"
+
+cockroach node drain --insecure --host="${listen_addr}" --self
+kill -TERM "$(cat "${pid_file}")"
+while kill -0 "$(cat "${pid_file}")" 2>/dev/null; do
+    sleep 1
+done
+rm -f "${pid_file}"

--- a/antithesis/config/dns-server.toml
+++ b/antithesis/config/dns-server.toml
@@ -1,0 +1,10 @@
+[dropshot]
+default_request_body_max_bytes = 104857600
+
+[log]
+level = "info"
+mode = "stderr-terminal"
+
+[storage]
+storage_path = "/var/oxide/dns-storage"
+keep_old_generations = 3

--- a/antithesis/config/docker-compose.yaml
+++ b/antithesis/config/docker-compose.yaml
@@ -1,0 +1,150 @@
+# TODO-RAINCLAUDE: Antithesis deployment of the simulated control plane; addresses here must match antithesis/config/nexus.toml and the sled-agent-sim arguments.
+name: omicron
+
+networks:
+  underlay:
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: fd00:1122:3344:101::/64
+
+services:
+  cockroach:
+    container_name: cockroach
+    hostname: cockroach
+    platform: linux/amd64
+    init: true
+    build:
+      context: ../..
+      dockerfile: antithesis/Dockerfile
+      target: omicron-antithesis-cockroach
+    image: omicron-antithesis-cockroach:latest
+    environment:
+      NO_COLOR: "1"
+    # TODO-RAINCLAUDE: same flags as test-utils/src/dev/db.rs apart from the fixed addresses.
+    command:
+      - cockroach
+      - start-single-node
+      - --insecure
+      - --store=path=/data,ballast-size=0
+      - --listen-addr=[::]:32221
+      - --http-addr=[::]:8080
+      - --max-sql-memory=256MiB
+    healthcheck:
+      test: ["CMD", "/opt/oxide/bin/cockroach-healthcheck.sh"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+    networks:
+      underlay:
+        ipv6_address: fd00:1122:3344:101::4
+
+  # TODO-RAINCLAUDE: only the nexus service carries the build: for omicron-antithesis; podman's compose path builds once per service that declares build:, so the other users of the image reference it by name.
+  internal-dns:
+    container_name: internal-dns
+    hostname: internal-dns
+    platform: linux/amd64
+    init: true
+    image: omicron-antithesis:latest
+    environment:
+      NO_COLOR: "1"
+    command:
+      - dns-server
+      - --config-file=/opt/oxide/config/dns-server.toml
+      - --http-address=[fd00:1122:3344:101::3]:5353
+      - --dns-address=[fd00:1122:3344:101::3]:53
+    # TODO-RAINCLAUDE: a plain TCP connect rather than an HTTP request: the dns-server API is versioned and logs an error for every request without an api-version header, and pinning a version here would rot.
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/fd00:1122:3344:101::3/5353"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+    networks:
+      underlay:
+        ipv6_address: fd00:1122:3344:101::3
+
+  nexus:
+    container_name: nexus
+    hostname: nexus
+    platform: linux/amd64
+    init: true
+    build:
+      context: ../..
+      dockerfile: antithesis/Dockerfile
+      target: omicron-antithesis
+    image: omicron-antithesis:latest
+    environment:
+      NO_COLOR: "1"
+    command:
+      - nexus
+      - /opt/oxide/config/nexus.toml
+    depends_on:
+      cockroach:
+        condition: service_healthy
+      internal-dns:
+        condition: service_healthy
+    # TODO-RAINCLAUDE: healthy means the internal API accepts TCP connections; the external API only appears after the sled-agent-sim handoff, so checking it here would deadlock, and an HTTP request without an api-version header is logged as an error on every probe.
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/fd00:1122:3344:101::5/12221"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+    networks:
+      underlay:
+        ipv6_address: fd00:1122:3344:101::5
+
+  sled-agent-sim:
+    container_name: sled-agent-sim
+    hostname: sled-agent-sim
+    platform: linux/amd64
+    init: true
+    image: omicron-antithesis:latest
+    environment:
+      NO_COLOR: "1"
+    command:
+      - sled-agent-sim
+      - b6d65341-167c-41df-9b5c-41cded99c229
+      - "[fd00:1122:3344:101::6]:12345"
+      - "[fd00:1122:3344:101::5]:12221"
+      - "12232"
+      - --rss-nexus-external-addr=[fd00:1122:3344:101::5]:12220
+      # TODO-RAINCLAUDE: deployment.id in nexus.toml. The recovery silo and user are left at sled-agent-sim's defaults (demo-silo, demo-privileged, password oxide), which the workload also defaults to.
+      - --rss-nexus-id=e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c
+      - --rss-internal-dns-dns-addr=[fd00:1122:3344:101::3]:53
+      - --rss-internal-dns-http-addr=[fd00:1122:3344:101::3]:5353
+      - --cockroach-addr=[fd00:1122:3344:101::4]:32221
+      - --rack-subnet=fd00:1122:3344::/56
+    depends_on:
+      nexus:
+        condition: service_healthy
+      internal-dns:
+        condition: service_healthy
+    networks:
+      underlay:
+        ipv6_address: fd00:1122:3344:101::6
+
+  workload:
+    container_name: workload
+    hostname: workload
+    platform: linux/amd64
+    init: true
+    build:
+      context: ../..
+      dockerfile: antithesis/Dockerfile
+      target: omicron-antithesis-workload
+    image: omicron-antithesis-workload:latest
+    environment:
+      NO_COLOR: "1"
+    # TODO-RAINCLAUDE: wait-ready emits setup_complete; the container then stays up so Antithesis can exec the test commands baked into /opt/antithesis/test/v1.
+    command:
+      - /bin/sh
+      - -c
+      - omicron-antithesis-workload wait-ready && exec sleep infinity
+    depends_on:
+      nexus:
+        condition: service_healthy
+      sled-agent-sim:
+        condition: service_started
+    networks:
+      underlay:
+        ipv6_address: fd00:1122:3344:101::7

--- a/antithesis/config/nexus.toml
+++ b/antithesis/config/nexus.toml
@@ -1,0 +1,124 @@
+# TODO-RAINCLAUDE: Nexus configuration for the Antithesis deployment; derived from nexus/examples/config.toml with addresses matching antithesis/config/docker-compose.yaml.
+
+[console]
+static_dir = "/opt/oxide/console-assets"
+session_idle_timeout_minutes = 480
+session_absolute_timeout_minutes = 1440
+
+[authn]
+schemes_external = ["session_cookie", "access_token", "scim_token"]
+
+[log]
+level = "info"
+mode = "stderr-terminal"
+
+# TODO-RAINCLAUDE: no ClickHouse in phase 1; leaving the address unset keeps Nexus bootable without it.
+[timeseries_db]
+
+[deployment]
+id = "e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"
+rack_id = "c19a698f-c6f9-4a17-ae30-20d711b8f7dc"
+# TODO-RAINCLAUDE: Nexus refuses to start with no upstream resolvers (nexus/src/app/mod.rs), and the Antithesis environment has no internet, so point it at the internal DNS server: lookups of external names fail fast with NXDOMAIN instead of timing out against an unreachable public resolver.
+external_dns_servers = ["fd00:1122:3344:101::3"]
+
+[deployment.dropshot_external]
+bind_address = "[fd00:1122:3344:101::5]:12220"
+default_request_body_max_bytes = 1048576
+compression = "gzip"
+
+[deployment.dropshot_internal]
+bind_address = "[fd00:1122:3344:101::5]:12221"
+default_request_body_max_bytes = 1048576
+
+[deployment.dropshot_lockstep]
+bind_address = "[fd00:1122:3344:101::5]:12232"
+default_request_body_max_bytes = 1048576
+
+[deployment.internal_dns]
+type = "from_address"
+address = "[fd00:1122:3344:101::3]:53"
+
+[deployment.database]
+type = "from_url"
+url = "postgresql://root@[fd00:1122:3344:101::4]:32221/omicron?sslmode=disable"
+
+[tunables]
+max_vpc_ipv4_subnet_prefix = 26
+
+[background_tasks]
+dns_internal.period_secs_config = 60
+dns_internal.period_secs_servers = 60
+dns_internal.period_secs_propagation = 60
+dns_internal.max_concurrent_server_updates = 5
+dns_external.period_secs_config = 60
+dns_external.period_secs_servers = 60
+dns_external.period_secs_propagation = 60
+dns_external.max_concurrent_server_updates = 5
+metrics_producer_gc.period_secs = 60
+external_endpoints.period_secs = 60
+nat_cleanup.period_secs = 30
+inventory.period_secs_load = 15
+inventory.period_secs_collect = 600
+inventory.nkeep = 5
+inventory.disable_collect = false
+phantom_disks.period_secs = 30
+physical_disk_adoption.period_secs = 30
+support_bundle_collector.period_secs = 30
+decommissioned_disk_cleaner.period_secs = 60
+blueprints.period_secs_load = 10
+blueprints.period_secs_plan = 60
+blueprints.period_secs_execute = 60
+blueprints.period_secs_rendezvous = 300
+blueprints.period_secs_collect_crdb_node_ids = 180
+blueprints.period_secs_load_reconfigurator_config = 5
+switch_port_settings_manager.period_secs = 30
+region_replacement.period_secs = 30
+region_replacement_driver.period_secs = 30
+instance_watcher.period_secs = 30
+instance_updater.period_secs = 30
+instance_reincarnation.period_secs = 60
+service_firewall_propagation.period_secs = 300
+v2p_mapping_propagation.period_secs = 30
+abandoned_vmm_reaper.period_secs = 60
+saga_recovery.period_secs = 600
+lookup_region_port.period_secs = 60
+region_snapshot_replacement_start.period_secs = 30
+region_snapshot_replacement_garbage_collection.period_secs = 30
+region_snapshot_replacement_step.period_secs = 30
+region_snapshot_replacement_finish.period_secs = 30
+tuf_artifact_replication.period_secs = 300
+tuf_artifact_replication.min_sled_replication = 1
+tuf_repo_pruner.period_secs = 300
+tuf_repo_pruner.nkeep_extra_target_releases = 1
+tuf_repo_pruner.nkeep_extra_newly_uploaded = 1
+alert_dispatcher.period_secs = 60
+webhook_deliverator.period_secs = 60
+read_only_region_replacement_start.period_secs = 30
+sp_ereport_ingester.period_secs = 30
+fm.sitrep_load_period_secs = 15
+fm.config_load_period_secs = 15
+fm.analysis_period_secs = 120
+fm.sitrep_gc_period_secs = 600
+fm.sitrep_history_prune_period_secs = 600
+fm.rendezvous_period_secs = 300
+probe_distributor.period_secs = 60
+multicast_reconciler.period_secs = 60
+trust_quorum.period_secs = 60
+attached_subnet_manager.period_secs = 60
+session_cleanup.period_secs = 300
+session_cleanup.max_delete_per_activation = 10000
+audit_log_timeout_incomplete.period_secs = 600
+audit_log_timeout_incomplete.timeout_secs = 14400
+audit_log_timeout_incomplete.max_timed_out_per_activation = 1000
+audit_log_cleanup.period_secs = 600
+audit_log_cleanup.retention_days = 90
+audit_log_cleanup.max_deleted_per_activation = 10000
+populate_switch_ports.period_secs = 30
+
+# TODO-RAINCLAUDE: a fixed seed keeps region allocation ordering deterministic so Antithesis controls the only randomness.
+[default_region_allocation_strategy]
+type = "random"
+seed = 0
+
+[omdb]
+bin_path = "/opt/oxide/bin/omdb"

--- a/antithesis/scratchbook/plan.md
+++ b/antithesis/scratchbook/plan.md
@@ -1,0 +1,189 @@
+# Antithesis for Nexus and CockroachDB: plan
+
+Date: 2026-08-27. Repo state: omicron `main` at `[9/n gen] [nexus] add typed InstanceStateGeneration (#11175)`.
+
+## Summary
+
+The goal is to run Nexus against CockroachDB inside Antithesis so that its fault injector (network partitions, congestion, node hangs, CPU throttling, clock jitter, thread pauses, and, once enabled, process kills) exercises the Nexus↔CRDB path and Nexus's own state machines: sagas, background tasks, and the instance and disk lifecycles. Properties are checked with the Antithesis Rust SDK from a workload container and from a few feature-gated hooks inside Nexus.
+
+Recommendation:
+
+1. Add an `antithesis/` harness directory to omicron laid out the way the `antithesis-skills` expect (`config/`, `scratchbook/`, `test/`, one Dockerfile), so the Antithesis skills and `snouty` work unmodified.
+2. Build one multi-stage Dockerfile that produces an instrumented `omicron-antithesis` image (nexus, sled-agent-sim, dns-server, and a new workload binary, all built in a single `cargo build` with the sancov rustflags) and an `omicron-antithesis-cockroach` image from the pinned Oxide CockroachDB fork with a pre-seeded `omicron` database.
+3. Phase 1 topology is five containers on an IPv6 network: `cockroach`, `internal-dns`, `nexus`, `sled-agent-sim`, `workload`. Grow to a three-node CockroachDB cluster with DNS-based discovery (phase 3), then multiple Nexus instances (phase 4).
+4. Make a small set of changes to omicron proper: fix and generalize standalone `sled-agent-sim` (it is documented broken and hard-codes `::1`), add an `antithesis` cargo feature to `omicron-nexus` that turns on the SDK and instrumentation, and add three or four assertions in guaranteed code paths.
+5. Write the workload in Rust as a workspace crate that reuses `oxide-client` and `nexus-lockstep-client`, exposed through thin `/opt/antithesis/test/v1/nexus/*` wrappers.
+
+The biggest unknowns, all resolvable in a one-week derisking phase: whether Antithesis's compose networking supports IPv6 (omicron's internal DNS is IPv6-only), whether `-Cpasses=sancov-module` works with the pinned rustc 1.97.1, and how long an instrumented release build of Nexus takes.
+
+## What Antithesis requires, and where it bites omicron
+
+Sources: [setup overview](https://antithesis.com/docs/setup/overview/), [docker compose setup](https://antithesis.com/docs/setup/docker_compose/), [test command reference](https://antithesis.com/docs/product/writing_tests/test_templates/test_composer_reference/), [Rust instrumentation](https://antithesis.com/docs/reference/sdk/rust/instrumentation/), and the [antithesis-skills](https://github.com/antithesishq/antithesis-skills) reference files.
+
+| Requirement | Consequence for omicron |
+|---|---|
+| Linux x86-64 container images, hermetic (no internet at runtime). All downloads happen in `RUN` steps. | Nexus already builds and passes its full test suite on Linux (`build-and-test (ubuntu-22.04)` job). CockroachDB, ClickHouse, dpd stub, mgd, and ddmd all have Linux artifacts via `cargo xtask download`. Nothing needed at runtime is illumos-only. |
+| `docker-compose.yaml` in `antithesis/config/`; every service has `container_name` == `hostname` (no underscores), `platform: linux/amd64`, `init: true`, `image:` plus `build:`; `depends_on` with `condition: service_healthy`; no `logging:` override, no `internal: true` networks, no `pull_policy`. | Straightforward. The container names below follow this. |
+| Services reach each other by hostname; Antithesis generates DNS from service names. | Omicron does not use Docker DNS. Nexus and `sled-agent-sim` need literal addresses, and internal DNS records are IPv6 (`DnsConfigBuilder::host_zone(_, Ipv6Addr)`). The compose network must be IPv6 with static `ipv6_address` per service. **Confirm IPv6 support with Antithesis in phase 0.** |
+| A `setup_complete` JSON line written to `$ANTITHESIS_OUTPUT_DIR/sdk.jsonl` by any process; the first one starts testing. | Emitted by the workload container once Nexus's external API answers, login works, and the simulated sled is registered (which proves the RSS handoff completed). |
+| Test commands are executables in `/opt/antithesis/test/v1/<template>/` with prefixes `first_`, `parallel_driver_`, `serial_driver_`, `singleton_driver_`, `anytime_`, `eventually_`, `finally_`. Faults pause during `first_`, `eventually_`, `finally_`. | Wrappers in `antithesis/test/v1/nexus/` exec the workload binary. Invariant checks that need a quiescent system go in `eventually_`. |
+| Rust: `antithesis_sdk = "0.2"` (no-op with `default-features = false`), `antithesis-instrumentation = "0.1"` plus rustflags `-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id`; DWARF symbols in `/symbols`. | Flags go in a separate `antithesis/cargo-config.toml` passed with `--config`, **not** in `.cargo/config.toml`. Because `target.<triple>.rustflags` replaces `build.rustflags`, the file must also carry `--cfg tokio_unstable`. |
+| Assertion names must be inline string literals (static cataloging). `NO_COLOR=1` everywhere. | Nexus logs bunyan JSON via slog; use `mode = "stderr-terminal"`, `level = "info"`. |
+| Node termination faults are off by default. | Ask Antithesis to enable them for `nexus` once saga recovery properties exist (phase 2). |
+| `snouty` CLI: `snouty validate antithesis/config` checks the harness reaches `setup_complete` locally; `snouty launch` pushes images and starts a run. Supports GitHub Actions OIDC. | Needs a tenant, registry (`us-central1-docker.pkg.dev/molten-verve-216720/<tenant>-repository`), and credentials. Request these from Antithesis now; they gate phase 1. |
+
+## Current state of omicron (what we build on)
+
+- **CockroachDB** is an Oxide fork pinned at `v22.1.22-64-g86fdbfca06` (`tools/cockroachdb_version`, `tools/cockroachdb_checksums`), downloaded from buildomat by `cargo xtask download cockroach` (`dev-tools/downloader/src/lib.rs:676`) with a Linux checksum. Test startup flags live in `test-utils/src/dev/db.rs`: `start-single-node --insecure --http-addr=:0 --store=path=<dir>,ballast-size=0 --listen-addr [::1]:<port> --max-sql-memory 256MiB`. Schema comes from `schema/crdb/dbinit.sql` (version 296.0.0); `cargo xtask db-dev -- run|populate|wipe` wraps this. The test suite pre-seeds a store tarball (`test-utils/src/dev/seed.rs`), which is the pattern to copy for the container image.
+- **Nexus** boots with a config file (`nexus/examples/config.toml`). Hard requirements at boot: CockroachDB (the pool is created in `ApiContext::for_internal`), an internal DNS address (`from_address` or `from_subnet`), and a debug dropbox directory. The **external API only comes up after the RSS handoff** (`nexus/src/lib.rs`, `Server::start`), which is a `rack_initialization_complete` call on the lockstep API carrying an initial blueprint, recovery silo, DNS config, and disks/zpools/datasets. ClickHouse is optional (`timeseries_db.address` is `Option`). Dendrite, mgd, MGS, oximeter, and crucible pantry are looked up via internal DNS by background tasks, which log warnings and retry when absent. `nexus/` has essentially no `cfg(target_os)` gating (five lines in `db-queries/src/db/pool.rs`).
+- **`sled-agent-sim`** (`sled-agent/src/bin/sled-agent-sim.rs`, `sled-agent/src/sim/server.rs::run_standalone_server`) is the only standalone thing that performs the handoff: it registers a simulated Gimlet (10 × 1 TiB U.2, 32 threads, 64 GiB), runs an in-process internal DNS server and crucible pantry, builds the `RackInitializationRequest`, and calls `handoff_to_nexus`. It takes `SocketAddrV6` for its own and the DNS addresses and hard-codes `Ipv6Addr::LOCALHOST` for `gz_address` and `rack_subnet` (`server.rs:467,724`). It is documented as broken (`docs/how-to-run-simulated.adoc` CAUTION, [omicron#4421](https://github.com/oxidecomputer/omicron/issues/4421): the sled agent fails to bind because the repo depot server already took the same address). `omicron-dev run-all` works but is the integration-test harness running everything in one process, which gives Antithesis nothing to partition.
+- **No OCI packaging exists.** `package-manifest.toml` emits illumos zones only. There is no Dockerfile anywhere in the repo.
+- **No fault-injection framework exists.** `RetargetableTcpProxy` (`test-utils/src/dev/tcp_proxy.rs`) with `ProxyTarget::Refuse` and dendrite stop/restart are the only primitives. Determinism tooling (`typed-rng`, `nexus-reconfigurator-simulation`) covers the planner, not the live control plane. Antithesis supplies the missing piece from outside the process.
+- **Existing test surface to mine for properties:** 489 `#[nexus_test]` integration tests (all run on Linux), saga unwind tests (`nexus/src/app/sagas/test_helpers.rs`), `nexus/tests/integration_tests/{quiesce,schema,cockroach,crucible_replacements,instances,disks}.rs`, and the `live-tests` for Nexus add/remove and handoff.
+- **Build config:** `.cargo/config.toml` sets `build.rustflags = "--cfg tokio_unstable"`; `[profile.release]` has `panic = "abort"` (good: a panic becomes a process crash Antithesis notices) and `[profile.dev]` uses `debug = "line-tables-only"`. Nexus links libpq dynamically (`pq-sys`; the zone ships `/opt/ooce/pgsql-18/lib/amd64`), so the runtime image needs `libpq5`.
+
+## Target topology
+
+### Phase 1 (minimal, five containers)
+
+Network `underlay`: `enable_ipv6: true`, subnet `fd00:1122:3344:101::/64` (omicron's conventional rack prefix, one sled subnet). Every service gets a static `ipv6_address`.
+
+| Container | Image | Role | Process | Talks to |
+|---|---|---|---|---|
+| `cockroach` | `omicron-antithesis-cockroach` | dependency | `cockroach start-single-node --insecure --store=path=/data,ballast-size=0 --listen-addr=[::]:32221 --http-addr=[::]:8080 --max-sql-memory=256MiB` on a store pre-seeded with `dbinit.sql` at image build | (none) |
+| `internal-dns` | `omicron-antithesis` | dependency | `dns-server --config-file /opt/oxide/config/dns-server.toml --http-address [addr]:5353 --dns-address [addr]:53` | (none) |
+| `nexus` | `omicron-antithesis` | service (instrumented) | `nexus /opt/oxide/config/nexus.toml` | `cockroach:32221`, `internal-dns:53`, `sled-agent-sim`, `internal-dns:5353` (DNS propagation) |
+| `sled-agent-sim` | `omicron-antithesis` | service | `sled-agent-sim <uuid> [addr]:12345 [nexus]:12221 12232 --rss-... --rack-subnet ...` (after phase 0 changes) | `nexus:12221`, `nexus:12232` (handoff), `internal-dns:5353` |
+| `workload` | `omicron-antithesis` | client | `omicron-antithesis-workload wait-ready && sleep infinity`; mounts `antithesis/test` at `/opt/antithesis/test/v1` | `nexus:12220` (external), `nexus:12232` (lockstep, for saga list), `cockroach:32221` (read-only invariant queries) |
+
+Nexus and the handoff point at the separate `internal-dns` container rather than the DNS server `sled-agent-sim` runs in-process today, so DNS propagation crosses a container boundary and can be faulted. Phase 0 makes the in-process server optional (`--rss-internal-dns-http-addr` pointing at an external server).
+
+Nexus config: start from `nexus/examples/config.toml` and change only the `[deployment]` block (external `[::]:12220`, internal and lockstep on the container's static address, `internal_dns.type = "from_address"`, `database.type = "from_url"` pointing at `cockroach`), drop `[deployment.dropshot_external.tls]`, `[dendrite]`, `[mgd]`, and `[pkg.timeseries_db].address`, set `[log] level = "info"`, and keep `[default_region_allocation_strategy] seed = 0`.
+
+### Phase 3 (realism)
+
+- `cockroach-1..3` running `cockroach start --join=...`, `cockroach init` and `dbinit.sql` applied by a `first_` step or by the workload's readiness loop. Nexus switches to `database.type = "from_dns"` and discovers nodes via SRV records that the handoff's `internal_dns_zone_config` must include (add `host_zone_with_one_backend` records for the three cockroach zones in the generalized `sled-agent-sim`).
+- `sp-sim` + `mgs` so inventory collection, the blueprint planner, and executor run. Both are pure Rust and portable.
+- `clickhouse` + `oximeter` only if metrics properties are wanted; otherwise leave out (every extra container expands the state space).
+
+### Phase 4
+
+Two or three `nexus` containers, with the extra ones registered in the initial blueprint. This unlocks saga ownership, blueprint execution leadership, DNS generation races, and the quiesce/handoff flow tested today only by `live-tests`.
+
+## Work plan
+
+### Phase 0: derisk (about one week)
+
+Exit criteria: every unknown below has an answer written into `antithesis/scratchbook/`.
+
+1. **Instrumented build.** Add `[profile.antithesis]` (`inherits = "release"`, `debug = "line-tables-only"`, `strip = "none"`) and `antithesis/cargo-config.toml`:
+   ```toml
+   [target.x86_64-unknown-linux-gnu]
+   rustflags = [
+       "--cfg", "tokio_unstable",
+       "-Ccodegen-units=1",
+       "-Cpasses=sancov-module",
+       "-Cllvm-args=-sanitizer-coverage-level=3",
+       "-Cllvm-args=-sanitizer-coverage-trace-pc-guard",
+       "-Clink-args=-Wl,--build-id",
+   ]
+   ```
+   Run `cargo build --profile antithesis --config antithesis/cargo-config.toml --features omicron-nexus/antithesis --bin nexus` on an x86-64 Linux box. Verify with `nm target/x86_64-unknown-linux-gnu/antithesis/nexus | grep antithesis_load_libvoidstar` and `readelf -S ... | grep sancov`. Record wall-clock time and binary size (this decides whether CI builds nightly or weekly).
+2. **Standalone `sled-agent-sim`.** Fix omicron#4421 (repo depot and sled agent binding the same address) and add arguments for the rack subnet, the sled's underlay address, an external internal-DNS HTTP address, and the recovery silo. Prove `dns-server`, `cockroach`, `nexus`, `sled-agent-sim` run by hand on non-loopback IPv6 addresses on a Linux host and the external API comes up. This also un-breaks `docs/how-to-run-simulated.adoc`.
+3. **IPv6 in Antithesis.** Ask Antithesis whether compose networks with `enable_ipv6` and static `ipv6_address` are supported. Fallback if not: run `nexus`, `internal-dns`, and `sled-agent-sim` in one container on `::1` and keep `cockroach` and `workload` separate over IPv4 (`from_url` accepts an IPv4 URL). That preserves the Nexus↔CRDB fault surface, which is the primary target.
+4. **Credentials and tooling.** Obtain tenant, registry, and API key; install `snouty`; run `snouty doctor`. Install the `antithesis-skills` plugin for Claude Code.
+5. **CockroachDB image.** Build `debian:stable-slim` + the buildomat tarball (use `cargo xtask download cockroach` in the builder stage so the pin and checksum stay single-sourced), confirm the binary runs on Debian's glibc, and seed `/data` with `dbinit.sql` at build time.
+
+### Phase 1: harness (one to two weeks)
+
+Exit criteria: `snouty validate antithesis/config` reaches `setup_complete` with no internet; a 30-minute setup-mode run shows "Software was instrumented" and the bootstrap property.
+
+1. Run the `antithesis-research` skill with this document as the external reference; it produces `antithesis/scratchbook/{sut-analysis,property-catalog,deployment-topology}.md`. Edit the topology to match the table above.
+2. `antithesis/Dockerfile` (multi-stage):
+   - `builder`: `rust:1.97.1-bookworm` (or `debian:stable-slim` + rustup pinned by `rust-toolchain.toml`), `apt-get install libpq-dev pkg-config clang`, `cargo xtask download cockroach`, then the instrumented `cargo build` of `nexus`, `sled-agent-sim`, `dns-server`, `schema-updater`, `omdb`, `omicron-antithesis-workload`.
+   - `omicron-antithesis`: `debian:stable-slim` + `libpq5 ca-certificates`, binaries in `/opt/oxide/bin`, unstripped binaries symlinked into `/symbols`, `schema/crdb` in `/opt/oxide/schema`, `ENV NO_COLOR=1`.
+   - `omicron-antithesis-cockroach`: as in phase 0, with a `/opt/oxide/bin/healthcheck.sh` hitting `http://localhost:8080/health?ready=1`.
+   - `omicron-antithesis-config`: `FROM scratch`, `COPY config/ /`.
+3. `antithesis/config/docker-compose.yaml` with the five services, healthchecks (`cockroach` HTTP health, `internal-dns` HTTP `GET /config`, `nexus` `GET /v1/ping` on the external port), `depends_on ... service_healthy`, the IPv6 network, and `volumes: - ../test:/opt/antithesis/test/v1` on `workload`.
+4. `antithesis/config/nexus.toml`, `antithesis/config/dns-server.toml`, plus a `README.adoc` in `antithesis/` describing how to build and run locally (`docker compose -f antithesis/config/docker-compose.yaml up`, and `unshare -n` to prove hermeticity).
+5. Workload crate `antithesis/workload` (`omicron-antithesis-workload`, in the workspace) with a `wait-ready` subcommand: poll `GET /v1/ping`, log in as `test-privileged`/`oxide` in `test-suite-silo`, wait for `GET /v1/system/hardware/sleds` to list the simulated sled, then `antithesis_sdk::lifecycle::setup_complete`.
+6. Bootstrap assertion in Nexus: `antithesis_sdk::antithesis_init()` and `use antithesis_instrumentation as _;` in `nexus/src/bin/nexus.rs` behind `#[cfg(feature = "antithesis")]`, and `assert_reachable!("nexus: external API started")` after `Server::start` brings up the external server.
+7. `.snouty.toml` at the repo root (tenant and repository; credentials via environment only).
+
+### Phase 2: first workload (one to two weeks)
+
+Exit criteria: a 2-hour run with at least three "sometimes" properties reached and no vacuous "always" properties; node termination enabled for `nexus`.
+
+Test template `antithesis/test/v1/nexus/`, each a two-line shell wrapper around the workload binary:
+
+- `first_seed.sh`: create project `antithesis`, an IP pool with a range, and link it to the silo (the harness equivalent is `create_default_ip_pool`).
+- `parallel_driver_instances.sh`: loop choosing with `antithesis_sdk::random::random_choice` among create / start / stop / reboot / delete instance, attach / detach disk, attach / detach external IP. Treat 503, timeouts, and conflicts as expected; `assert_always!(status != 500, "external API never returns 500")`; `assert_sometimes!` per operation succeeding.
+- `parallel_driver_disks.sh` and `parallel_driver_snapshots.sh`: disk create / delete / snapshot / delete; the `volume_delete` and `region_snapshot_replacement_*` sagas are historically fragile.
+- `anytime_read.sh`: list endpoints across projects, instances, disks, sleds, blueprints; reads never 500.
+- `eventually_sagas_settle.sh`: poll `saga_list` on the lockstep API until every saga is done or unwound; `assert_always!` no saga remains running after a bounded wait.
+- `eventually_invariants.sh`: after sagas settle, check virtual provisioning accounting against the instance list, disk attachment exclusivity, external IP uniqueness, and VMM reservations on the sled versus its capacity (raw SQL via `tokio-postgres`, with `omdb db` as the interactive counterpart).
+
+In-Nexus assertions (no-ops unless `antithesis_sdk/full` is on): `assert_sometimes!("CRDB transaction retried")` in `nexus/db-queries/src/transaction_retry.rs::retry_callback`, `assert_sometimes!("saga unwound")` and `assert_sometimes!("saga completed")` where saga completion is recorded, and `assert_always_or_unreachable!` that saga recovery on startup finds only sagas owned by this Nexus.
+
+### Phase 3: realism (two weeks)
+
+Three-node CockroachDB with `from_dns` discovery, `sp-sim` + `mgs`, node termination on `cockroach-*`. New properties: the external API recovers within N seconds of a single CRDB node partition; `crdb_node_id_collector` and the blueprint planner make progress; inventory collections eventually complete; blueprint target generation is monotonic with exactly one target.
+
+### Phase 4: multi-Nexus and upgrades
+
+Two or three Nexus containers; properties around saga ownership, one executor per blueprint, DNS generation monotonicity, and quiesce/handoff (`nexus/tests/integration_tests/quiesce.rs`, `live-tests/tests/test_nexus_handoff.rs` are the specifications). Schema upgrade under faults: start from an image seeded at an older `dbinit` (`cargo xtask schema generate-base`), then run `schema-updater` as a `singleton_driver_` while faults are active, asserting the `db_metadata` version ends at `SCHEMA_VERSION` and every `upNN.sql` is idempotent on retry.
+
+### Phase 5: CI
+
+A GitHub Actions workflow (`workflow_dispatch` plus a weekly cron) on a large x86-64 runner: build the images, `snouty validate`, then `snouty launch --duration 120` with OIDC credentials, posting the triage report link. Buildomat can build the images too, but `snouty` has native GitHub OIDC support and Docker is already present on GitHub runners. Also add a fast Linux CI check that the `antithesis` feature builds without the sancov flags (so `check-features` and hakari stay green).
+
+## Changes to omicron proper
+
+| Area | Change | Why |
+|---|---|---|
+| `sled-agent/src/bin/sled-agent-sim.rs`, `sled-agent/src/sim/server.rs` | Fix the double bind (omicron#4421). Add `--rack-subnet`, `--sled-underlay-ip`, `--rss-internal-dns-http-addr` (use an external DNS server instead of the in-process one), `--rss-external-dns-*` already exists, and options for the recovery silo. Emit cockroach zone records into `internal_dns_zone_config` when given `--cockroach-addr` (repeatable). | Standalone handoff on real container addresses; also fixes the "run the pieces by hand" docs. |
+| `Cargo.toml` | `[profile.antithesis]`; workspace deps `antithesis_sdk = { version = "0.2", default-features = false }` and `antithesis-instrumentation = "0.1"`; new workspace member `antithesis/workload`. | One instrumented profile; no-op SDK everywhere else. |
+| `nexus/Cargo.toml`, `nexus/src/bin/nexus.rs` | Feature `antithesis = ["antithesis_sdk/full", "dep:antithesis-instrumentation"]`; `antithesis_init()` and the `use antithesis_instrumentation as _;` behind it. | Nothing changes for normal builds or the zone. |
+| `nexus/src/lib.rs`, `nexus/db-queries/src/transaction_retry.rs`, `nexus/src/app/saga.rs` | Three or four `assert_*` calls with literal names. | Bootstrap property and proof that faults reach the DB and saga paths. |
+| `workspace-hack`, `dev-tools/xtask` | Run `cargo hakari generate`; `check-workspace-deps` allowances if needed; `check-features` includes the new feature. | Keep the workspace lints green. |
+| `docs/how-to-run-simulated.adoc` | Replace the CAUTION with the working standalone procedure; link `antithesis/README.adoc`. | The fix is a side effect of phase 0. |
+
+Everything else (Dockerfile, compose, configs, wrappers, scratchbook) lives under `antithesis/` and is inert for the rest of the repo.
+
+## Seed property catalog
+
+These seed `antithesis/scratchbook/property-catalog.md`; the research skill will expand and re-rank them. Type key: S = safety (`assert_always!`), L = liveness (`assert_sometimes!` or `eventually_` checker), R = reachability.
+
+| Slug | Type | Property | Where checked | Phase |
+|---|---|---|---|---|
+| `nexus-started` | R | Nexus brings up the external API. | in Nexus | 1 |
+| `no-internal-server-errors` | S | External and lockstep APIs never return 500 for well-formed requests; CRDB unavailability surfaces as 503. | workload | 2 |
+| `nexus-never-crashes` | S | `panic = "abort"` means any panic is a crash Antithesis records natively. | platform | 1 |
+| `sagas-settle` | L | Every saga reaches done or unwound within a bounded time after faults stop. | `eventually_` | 2 |
+| `saga-recovery-after-restart` | S+L | After a Nexus kill, `saga_recovery` resumes or unwinds every in-flight saga and resources end consistent. Needs node termination. | `eventually_` + in Nexus | 2 |
+| `crdb-transaction-retries-exercised` | L | The `RetryHelper` retry path runs at least once (proves faults reach the DB layer). | in Nexus | 2 |
+| `virtual-provisioning-accounting` | S | Silo and project `virtual_provisioning_collection` equals the sum over live instances and disks. Historically bug-prone. | `eventually_` | 2 |
+| `disk-attach-exclusive` | S | A disk is attached to at most one instance. | `eventually_` | 2 |
+| `external-ip-unique-and-in-pool` | S | No two instances share an external IP; every allocated IP is inside a linked pool range. | `eventually_` | 2 |
+| `sled-vmm-reservations-bounded` | S | Sum of VMM reservations on a sled never exceeds its advertised threads and memory. | `eventually_` | 2 |
+| `instance-lifecycle-converges` | L | Start reaches Running, stop reaches Stopped, delete removes the record. | workload | 2 |
+| `db-schema-version-stable` | S | `db_metadata.version` equals `SCHEMA_VERSION` for the whole run (phase 4 relaxes this during upgrade). | `anytime_` | 2 |
+| `internal-dns-converges` | L | Each DNS server's generation eventually equals Nexus's latest generation. | `eventually_` | 2 |
+| `api-recovers-from-crdb-node-loss` | L | With one of three CRDB nodes partitioned, the external API answers within N seconds. | workload | 3 |
+| `blueprint-target-monotonic` | S | Target blueprint generation never decreases; exactly one target exists. | `anytime_` | 3 |
+| `inventory-collections-complete` | L | Inventory collection succeeds at least once under faults. | in Nexus | 3 |
+| `single-blueprint-executor` | S | Two Nexus instances never both execute the same blueprint generation. | in Nexus | 4 |
+| `schema-upgrade-resumable` | S | `schema-updater` interrupted mid-migration completes on retry and lands at `SCHEMA_VERSION`. | `singleton_driver_` | 4 |
+
+## Risks and open questions
+
+- **IPv6 in Antithesis compose networks.** Unverified in their docs. Fallback described in phase 0.
+- **`sancov-module` on rustc 1.97.1.** Antithesis documents stable rustc, but the LLVM pass name and `-Cllvm-args` acceptance can drift across LLVM majors. Verify first.
+- **Build time and image size.** `codegen-units=1` plus a release build of the whole workspace on one target is slow (expect well over an hour on a laptop) and the unstripped binaries are large. Mitigation: build only the four binaries, cache the builder stage in CI, and accept weekly cadence if needed.
+- **Log volume.** Nexus's 51 background tasks retry failed DNS lookups for services that are not deployed (dpd, mgd, MGS, oximeter, pantry). Antithesis ingests every log line. Mitigation: `level = "info"`, lengthen `period_secs` for tasks whose services are absent in phase 1, and add the missing services in phase 3 rather than silencing tasks.
+- **Snapshot-vs-live invariants.** Accounting checks are only meaningful on a quiescent system, which is why they run in `eventually_`. `anytime_` checks stay restricted to invariants that hold at every instant.
+- **Time-dependent behaviour.** Clock jitter affects session expiry, `audit_log_timeout_incomplete`, and `time_deleted` ordering. Nothing blocks on it; expect surprises here.
+- **Feature unification and hakari.** `antithesis_sdk` with `default-features = false` will appear in `workspace-hack`; enabling `full` only through `--features omicron-nexus/antithesis` in the Docker build keeps normal builds no-op. Confirm `cargo xtask check-features` and `check-workspace-deps` pass.
+- **CockroachDB is uninstrumented.** It is a Go binary from the fork; Antithesis still injects faults against it but gets no coverage guidance inside it. Acceptable for now; instrumenting the fork with Antithesis's Go instrumentor is a later option if CRDB-internal bugs become the target.
+- **Hermeticity of Nexus startup.** Nexus fetches nothing at runtime, but confirm with `unshare -n docker compose up` in phase 1; `external_dns_servers` must be non-empty (Nexus refuses to start otherwise), so it points at the internal DNS container, which answers NXDOMAIN for external names.
+- **Ownership.** Phases 0 and 1 are one engineer for two to three weeks; phase 2 onward benefits from whoever owns sagas and the DB layer reviewing the property catalog.

--- a/antithesis/test/v1/nexus/eventually_sagas_settle.sh
+++ b/antithesis/test/v1/nexus/eventually_sagas_settle.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# TODO-RAINCLAUDE: runs after faults stop; asserts every saga reaches a terminal state.
+set -euo pipefail
+exec /opt/oxide/bin/omicron-antithesis-workload sagas-settle

--- a/antithesis/test/v1/nexus/first_seed.sh
+++ b/antithesis/test/v1/nexus/first_seed.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# TODO-RAINCLAUDE: runs once per timeline before any driver; creates the project and IP pool the drivers use.
+set -euo pipefail
+exec /opt/oxide/bin/omicron-antithesis-workload seed

--- a/antithesis/workload/Cargo.toml
+++ b/antithesis/workload/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "omicron-antithesis-workload"
+version = "0.1.0"
+edition.workspace = true
+license = "MPL-2.0"
+
+[lints]
+workspace = true
+
+[features]
+# TODO-RAINCLAUDE: only antithesis/Dockerfile enables this; without it the SDK calls compile to no-ops.
+antithesis = ["antithesis_sdk/full", "dep:antithesis-instrumentation"]
+
+[dependencies]
+anyhow.workspace = true
+antithesis-instrumentation = { workspace = true, optional = true }
+antithesis_sdk.workspace = true
+clap.workspace = true
+dropshot.workspace = true
+futures.workspace = true
+http.workspace = true
+nexus-lockstep-client.workspace = true
+omicron-workspace-hack.workspace = true
+oxide-client.workspace = true
+oxide-tokio-rt.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+slog.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+nexus-config.workspace = true

--- a/antithesis/workload/src/main.rs
+++ b/antithesis/workload/src/main.rs
@@ -1,0 +1,396 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// TODO-RAINCLAUDE: Antithesis workload for the simulated Omicron control plane; see antithesis/README.adoc.
+
+use anyhow::Context;
+use anyhow::anyhow;
+use anyhow::bail;
+// TODO-RAINCLAUDE: linking the instrumentation crate is what lets an Antithesis build load libvoidstar for coverage.
+#[cfg(feature = "antithesis")]
+use antithesis_instrumentation as _;
+use clap::Parser;
+use clap::Subcommand;
+use dropshot::ConfigLogging;
+use dropshot::ConfigLoggingLevel;
+use futures::TryStreamExt;
+use http::HeaderMap;
+use http::HeaderValue;
+use http::StatusCode;
+use nexus_lockstep_client::types::SagaState;
+use oxide_client::ClientProjectsExt;
+use oxide_client::ClientSystemHardwareExt;
+use oxide_client::ClientSystemIpPoolsExt;
+use oxide_client::ClientSystemStatusExt;
+use serde_json::json;
+use slog::Logger;
+use slog::info;
+use slog::warn;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+use std::time::Instant;
+
+const DEFAULT_NEXUS_EXTERNAL_URL: &str = "http://[fd00:1122:3344:101::5]:12220";
+const DEFAULT_NEXUS_LOCKSTEP_URL: &str = "http://[fd00:1122:3344:101::5]:12232";
+const DEFAULT_SILO: &str = "demo-silo";
+const DEFAULT_USERNAME: &str = "demo-privileged";
+const DEFAULT_PASSWORD: &str = "oxide";
+const SEED_PROJECT_NAME: &str = "antithesis";
+const SEED_IP_POOL_NAME: &str = "antithesis";
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Parser)]
+#[clap(name = "omicron-antithesis-workload")]
+struct Args {
+    #[clap(long, default_value = DEFAULT_NEXUS_EXTERNAL_URL)]
+    nexus_external_url: String,
+
+    #[clap(long, default_value = DEFAULT_NEXUS_LOCKSTEP_URL)]
+    nexus_lockstep_url: String,
+
+    #[clap(long, default_value = DEFAULT_SILO)]
+    silo: String,
+
+    #[clap(long, default_value = DEFAULT_USERNAME)]
+    username: String,
+
+    #[clap(long, default_value = DEFAULT_PASSWORD)]
+    password: String,
+
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    // TODO-RAINCLAUDE: waits for Nexus's external API, a working login, and a registered sled, then emits the Antithesis setup_complete signal.
+    WaitReady {
+        #[clap(long, default_value = "600")]
+        timeout_secs: u64,
+    },
+    // TODO-RAINCLAUDE: creates the project and IP pool the drivers use; safe to run repeatedly.
+    Seed,
+    // TODO-RAINCLAUDE: waits until no saga is running and asserts that it happened within the timeout.
+    SagasSettle {
+        #[clap(long, default_value = "300")]
+        timeout_secs: u64,
+    },
+}
+
+fn main() {
+    antithesis_sdk::antithesis_init();
+    if let Err(error) = oxide_tokio_rt::run(do_run()) {
+        eprintln!("omicron-antithesis-workload: {error:#}");
+        std::process::exit(1);
+    }
+}
+
+async fn do_run() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let log = ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info }
+        .to_logger("omicron-antithesis-workload")
+        .context("initializing logger")?;
+
+    match args.command {
+        Command::WaitReady { timeout_secs } => {
+            wait_ready(&log, &args, Duration::from_secs(timeout_secs)).await
+        }
+        Command::Seed => seed(&log, &args).await,
+        Command::SagasSettle { timeout_secs } => {
+            sagas_settle(&log, &args, Duration::from_secs(timeout_secs)).await
+        }
+    }
+}
+
+fn reqwest_builder() -> reqwest::ClientBuilder {
+    reqwest::ClientBuilder::new()
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(60))
+}
+
+async fn login(
+    log: &Logger,
+    args: &Args,
+) -> anyhow::Result<oxide_client::Client> {
+    let login_url =
+        format!("{}/v1/login/{}/local", args.nexus_external_url, args.silo);
+    let username: oxide_client::types::UserId =
+        args.username.parse().map_err(|error| {
+            anyhow!(
+                "username {:?} is not a valid user id: {error}",
+                args.username
+            )
+        })?;
+    let password: oxide_client::types::Password =
+        args.password.parse().map_err(|error| {
+            anyhow!("password is not a valid password: {error}")
+        })?;
+
+    let session_token = oxide_client::login(
+        reqwest_builder(),
+        &login_url,
+        username,
+        password,
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "logging into silo {:?} at {login_url} as {:?}; check that the \
+             recovery silo and user passed to sled-agent-sim match",
+            args.silo, args.username
+        )
+    })?;
+    info!(log, "logged in"; "silo" => &args.silo, "user" => &args.username);
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        http::header::COOKIE,
+        HeaderValue::from_str(&format!("session={session_token}"))
+            .context("session token is not a valid header value")?,
+    );
+    let client = reqwest_builder()
+        .default_headers(headers)
+        .build()
+        .context("building HTTP client")?;
+    Ok(oxide_client::Client::new_with_client(&args.nexus_external_url, client))
+}
+
+async fn wait_ready(
+    log: &Logger,
+    args: &Args,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let unauthenticated = oxide_client::Client::new(&args.nexus_external_url);
+
+    loop {
+        match unauthenticated.ping().send().await {
+            Ok(_) => break,
+            Err(error) => {
+                warn!(log, "Nexus external API not ready"; "error" => %error);
+            }
+        }
+        wait_or_timeout(deadline, "Nexus external API to answer /v1/ping")
+            .await?;
+    }
+    info!(log, "Nexus external API is up");
+
+    let client = loop {
+        match login(log, args).await {
+            Ok(client) => break client,
+            Err(error) => {
+                warn!(log, "login not ready"; "error" => format!("{error:#}"));
+            }
+        }
+        wait_or_timeout(deadline, "login to succeed").await?;
+    };
+
+    let sleds = loop {
+        match client.sled_list().limit(1).send().await {
+            Ok(page) if !page.items.is_empty() => break page.items.len(),
+            Ok(_) => {
+                warn!(log, "no sleds registered yet");
+            }
+            Err(error) => {
+                warn!(log, "listing sleds failed"; "error" => %error);
+            }
+        }
+        wait_or_timeout(deadline, "a sled to be registered").await?;
+    };
+    info!(log, "sled registered; system is ready");
+
+    let details = json!({
+        "nexus_external_url": args.nexus_external_url,
+        "silo": args.silo,
+        "sleds": sleds,
+    });
+    antithesis_sdk::lifecycle::setup_complete(&details);
+    info!(log, "sent setup_complete");
+    Ok(())
+}
+
+async fn wait_or_timeout(deadline: Instant, what: &str) -> anyhow::Result<()> {
+    if Instant::now() >= deadline {
+        bail!(
+            "timed out waiting for {what}; Nexus or sled-agent-sim did not \
+             come up (check their logs and the addresses in \
+             antithesis/config/docker-compose.yaml)"
+        );
+    }
+    tokio::time::sleep(POLL_INTERVAL).await;
+    Ok(())
+}
+
+fn is_conflict<E: std::fmt::Debug>(error: &oxide_client::Error<E>) -> bool {
+    match error {
+        oxide_client::Error::ErrorResponse(response) => {
+            response.status() == StatusCode::CONFLICT
+        }
+        _ => false,
+    }
+}
+
+async fn seed(log: &Logger, args: &Args) -> anyhow::Result<()> {
+    let client = login(log, args).await?;
+
+    match client
+        .project_create()
+        .body(oxide_client::types::ProjectCreate {
+            name: SEED_PROJECT_NAME.parse().unwrap(),
+            description: String::from("Antithesis workload project"),
+        })
+        .send()
+        .await
+    {
+        Ok(_) => info!(log, "created project"; "name" => SEED_PROJECT_NAME),
+        Err(error) if is_conflict(&error) => {
+            info!(log, "project already exists"; "name" => SEED_PROJECT_NAME)
+        }
+        Err(error) => {
+            return Err(anyhow!(error)).context("creating project");
+        }
+    }
+
+    match client
+        .system_ip_pool_create()
+        .body(oxide_client::types::IpPoolCreate {
+            name: SEED_IP_POOL_NAME.parse().unwrap(),
+            description: String::from("Antithesis workload IP pool"),
+            ip_version: oxide_client::types::IpVersion::V4,
+            pool_type: oxide_client::types::IpPoolType::Unicast,
+            assignment: oxide_client::types::IpPoolAssignment::Silos,
+        })
+        .send()
+        .await
+    {
+        Ok(_) => info!(log, "created IP pool"; "name" => SEED_IP_POOL_NAME),
+        Err(error) if is_conflict(&error) => {
+            info!(log, "IP pool already exists"; "name" => SEED_IP_POOL_NAME)
+        }
+        Err(error) => {
+            return Err(anyhow!(error)).context("creating IP pool");
+        }
+    }
+
+    // TODO-RAINCLAUDE: TEST-NET-2 (RFC 5737) so the range can never collide with anything real.
+    let range =
+        oxide_client::types::IpRange::V4(oxide_client::types::Ipv4Range {
+            first: Ipv4Addr::new(198, 51, 100, 1),
+            last: Ipv4Addr::new(198, 51, 100, 254),
+        });
+    match client
+        .system_ip_pool_range_add()
+        .pool(SEED_IP_POOL_NAME)
+        .body(range)
+        .send()
+        .await
+    {
+        Ok(_) => info!(log, "added IP pool range"),
+        Err(error) if is_conflict(&error) => {
+            info!(log, "IP pool range already present")
+        }
+        Err(error) => {
+            return Err(anyhow!(error)).context("adding IP pool range");
+        }
+    }
+
+    match client
+        .system_ip_pool_silo_link()
+        .pool(SEED_IP_POOL_NAME)
+        .body(oxide_client::types::IpPoolLinkSilo {
+            silo: oxide_client::types::NameOrId::Name(
+                args.silo.parse().map_err(|error| {
+                    anyhow!("silo {:?} is not a valid name: {error}", args.silo)
+                })?,
+            ),
+            is_default: true,
+        })
+        .send()
+        .await
+    {
+        Ok(_) => info!(log, "linked IP pool to silo"; "silo" => &args.silo),
+        Err(error) if is_conflict(&error) => {
+            info!(log, "IP pool already linked to silo"; "silo" => &args.silo)
+        }
+        Err(error) => {
+            return Err(anyhow!(error)).context("linking IP pool to silo");
+        }
+    }
+
+    Ok(())
+}
+
+async fn sagas_settle(
+    log: &Logger,
+    args: &Args,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let client = nexus_lockstep_client::Client::new(
+        &args.nexus_lockstep_url,
+        log.new(slog::o!("component" => "NexusLockstepClient")),
+    );
+    let deadline = Instant::now() + timeout;
+
+    let running = loop {
+        let sagas: Vec<_> = client
+            .saga_list_stream(None, None)
+            .try_collect()
+            .await
+            .with_context(|| {
+                format!("listing sagas at {}", args.nexus_lockstep_url)
+            })?;
+        let running: Vec<_> = sagas
+            .iter()
+            .filter(|saga| match saga.state {
+                SagaState::Running => true,
+                SagaState::Succeeded
+                | SagaState::Failed { .. }
+                | SagaState::Stuck { .. } => false,
+            })
+            .map(|saga| saga.id)
+            .collect();
+        if running.is_empty() {
+            info!(log, "all sagas settled"; "total" => sagas.len());
+            break running;
+        }
+        if Instant::now() >= deadline {
+            warn!(
+                log,
+                "sagas still running after timeout";
+                "running" => ?running,
+            );
+            break running;
+        }
+        info!(log, "waiting for sagas to settle"; "running" => running.len());
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    let details =
+        json!({ "running": running, "timeout_secs": timeout.as_secs() });
+    antithesis_sdk::assert_always!(
+        running.is_empty(),
+        "workload: all sagas settle after faults stop",
+        &details
+    );
+    if running.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "{} saga(s) still running after {}s: {running:?}",
+            running.len(),
+            timeout.as_secs()
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    // TODO-RAINCLAUDE: guards the config shipped in the Antithesis image the same way nexus-config guards nexus/examples/config.toml.
+    #[test]
+    fn antithesis_nexus_config_is_valid() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../config/nexus.toml");
+        nexus_config::NexusConfig::from_file(path)
+            .expect("antithesis/config/nexus.toml parsed");
+    }
+}

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -10,7 +10,12 @@ workspace = true
 [build-dependencies]
 omicron-rpaths.workspace = true
 
+[features]
+# TODO-RAINCLAUDE: only antithesis/Dockerfile enables this; the sancov rustflags it uses need every binary to link the instrumentation crate.
+antithesis = ["dep:antithesis-instrumentation"]
+
 [dependencies]
+antithesis-instrumentation = { workspace = true, optional = true }
 anyhow.workspace = true
 async-bb8-diesel.workspace = true
 async-trait.workspace = true

--- a/dev-tools/omdb/src/bin/omdb/main.rs
+++ b/dev-tools/omdb/src/bin/omdb/main.rs
@@ -36,6 +36,9 @@
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::ensure;
+// TODO-RAINCLAUDE: linking the instrumentation crate is what lets an Antithesis build load libvoidstar for coverage.
+#[cfg(feature = "antithesis")]
+use antithesis_instrumentation as _;
 use clap::Args;
 use clap::ColorChoice;
 use clap::Parser;

--- a/dns-server/Cargo.toml
+++ b/dns-server/Cargo.toml
@@ -7,7 +7,12 @@ license = "MPL-2.0"
 [lints]
 workspace = true
 
+[features]
+# TODO-RAINCLAUDE: only antithesis/Dockerfile enables this; the sancov rustflags it uses need every binary to link the instrumentation crate.
+antithesis = ["dep:antithesis-instrumentation"]
+
 [dependencies]
+antithesis-instrumentation = { workspace = true, optional = true }
 anyhow.workspace = true
 camino.workspace = true
 chrono.workspace = true

--- a/dns-server/src/bin/dns-server.rs
+++ b/dns-server/src/bin/dns-server.rs
@@ -7,6 +7,9 @@
 
 use anyhow::Context;
 use anyhow::anyhow;
+// TODO-RAINCLAUDE: linking the instrumentation crate is what lets an Antithesis build load libvoidstar for coverage.
+#[cfg(feature = "antithesis")]
+use antithesis_instrumentation as _;
 use clap::Parser;
 use serde::Deserialize;
 use slog::info;

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -9,12 +9,16 @@ workspace = true
 
 [features]
 multicast = []
+# TODO-RAINCLAUDE: only antithesis/Dockerfile enables this; without it the SDK calls compile to no-ops.
+antithesis =["antithesis_sdk/full", "dep:antithesis-instrumentation"]
 
 [build-dependencies]
 omicron-rpaths.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+antithesis-instrumentation = { workspace = true, optional = true }
+antithesis_sdk.workspace = true
 async-bb8-diesel.workspace = true
 assert_matches.workspace = true
 async-trait.workspace = true

--- a/nexus/db-queries/Cargo.toml
+++ b/nexus/db-queries/Cargo.toml
@@ -12,6 +12,7 @@ omicron-rpaths.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+antithesis_sdk.workspace = true
 async-bb8-diesel.workspace = true
 async-trait.workspace = true
 camino.workspace = true

--- a/nexus/db-queries/src/transaction_retry.rs
+++ b/nexus/db-queries/src/transaction_retry.rs
@@ -167,6 +167,11 @@ impl RetryHelper {
             "Retryable transaction failure";
             "retry_after (ms)" => duration.as_millis(),
         );
+        // TODO-RAINCLAUDE: Antithesis liveness hook showing that injected faults reach the CockroachDB retry path.
+        antithesis_sdk::assert_sometimes!(
+            true,
+            "nexus: CockroachDB transaction retried"
+        );
         tokio::time::sleep(duration).await;
 
         // Now that we've finished sleeping, reset the timer and bump the number

--- a/nexus/src/app/saga.rs
+++ b/nexus/src/app/saga.rs
@@ -431,6 +431,22 @@ impl RunningSaga {
     pub(crate) async fn wait_until_stopped(self) -> StoppedSaga {
         let result = self.saga_completion_future.await;
         info!(self.log, "saga finished"; "saga_result" => ?result);
+        // TODO-RAINCLAUDE: Antithesis hooks; a stuck saga (failed undo) is always a bug worth surfacing.
+        match &result.kind {
+            Ok(_) => {
+                antithesis_sdk::assert_sometimes!(
+                    true,
+                    "nexus: saga completed"
+                );
+            }
+            Err(saga_error) => {
+                antithesis_sdk::assert_sometimes!(true, "nexus: saga unwound");
+                antithesis_sdk::assert_always!(
+                    saga_error.undo_failure.is_none(),
+                    "nexus: saga unwinding never fails"
+                );
+            }
+        }
         StoppedSaga { id: self.id, result, log: self.log }
     }
 }

--- a/nexus/src/bin/nexus.rs
+++ b/nexus/src/bin/nexus.rs
@@ -12,6 +12,9 @@
 
 use anyhow::Context;
 use anyhow::anyhow;
+// TODO-RAINCLAUDE: linking the instrumentation crate is what lets an Antithesis build load libvoidstar for coverage.
+#[cfg(feature = "antithesis")]
+use antithesis_instrumentation as _;
 use camino::Utf8PathBuf;
 use clap::Parser;
 use nexus_config::NexusConfig;
@@ -31,6 +34,8 @@ struct Args {
 }
 
 fn main() {
+    // TODO-RAINCLAUDE: registers the Antithesis assertion catalog; a no-op unless the `antithesis` feature is on.
+    antithesis_sdk::antithesis_init();
     if let Err(cmd_error) = oxide_tokio_rt::run(do_run()) {
         fatal(cmd_error);
     }

--- a/nexus/src/bin/schema-updater.rs
+++ b/nexus/src/bin/schema-updater.rs
@@ -5,6 +5,9 @@
 //! Upgrades CRDB schema
 
 use anyhow::anyhow;
+// TODO-RAINCLAUDE: linking the instrumentation crate is what lets an Antithesis build load libvoidstar for coverage.
+#[cfg(feature = "antithesis")]
+use antithesis_instrumentation as _;
 use camino::Utf8PathBuf;
 use clap::Parser;
 use clap::Subcommand;

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -304,6 +304,8 @@ impl Server {
                 producer_server,
             )
             .await;
+        // TODO-RAINCLAUDE: bootstrap Antithesis property proving the SDK and instrumentation are wired up.
+        antithesis_sdk::assert_reachable!("nexus: external API started");
         let server = Server { apictx: apictx.clone() };
         Ok(server)
     }

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 omicron-rpaths.workspace = true
 
 [dependencies]
+antithesis-instrumentation = { workspace = true, optional = true }
 anyhow.workspace = true
 async-trait.workspace = true
 atomicwrites.workspace = true
@@ -31,6 +32,7 @@ clickhouse-admin-types.workspace = true
 derive_more.workspace = true
 dice-verifier = { workspace = true, features = ["ipcc", "mock"] }
 display-error-chain.workspace = true
+dns-service-client.workspace = true
 # XXX NOTE this is due to https://github.com/oxidecomputer/omicron/issues/9704
 # This is the R20 dpd client
 # dpd-client.workspace = true
@@ -181,6 +183,8 @@ name = "sled-agent"
 doc = false
 
 [features]
+# TODO-RAINCLAUDE: only antithesis/Dockerfile enables this; the sancov rustflags it uses need every binary to link the instrumentation crate.
+antithesis = ["dep:antithesis-instrumentation"]
 image-trampoline = []
 switch-asic = []
 switch-stub = []

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -10,15 +10,23 @@ use clap::Parser;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
+use omicron_common::api::external::Name;
+use omicron_common::api::external::UserId;
 use omicron_common::api::internal::nexus::Certificate;
 use omicron_common::cmd::CmdError;
 use omicron_common::cmd::fatal;
+// TODO-RAINCLAUDE: linking the instrumentation crate is what lets an Antithesis build load libvoidstar for coverage.
+#[cfg(feature = "antithesis")]
+use antithesis_instrumentation as _;
+use omicron_sled_agent::sim::InternalDnsConfig;
 use omicron_sled_agent::sim::RssArgs;
 use omicron_sled_agent::sim::{
     Config, ConfigHardware, ConfigStorage, ConfigZpool, SimMode, ZpoolConfig,
     run_standalone_server,
 };
+use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledUuid;
+use oxnet::Ipv6Net;
 use sled_agent_types::inventory::ZpoolHealth;
 use sled_hardware_types::{Baseboard, SledCpuFamily};
 use std::net::SocketAddr;
@@ -62,6 +70,10 @@ struct Args {
     /// cause Nexus to publish DNS names to external DNS.
     rss_nexus_external_addr: Option<SocketAddr>,
 
+    // TODO-RAINCLAUDE: must equal `deployment.id` in the Nexus config, or Nexus never finds itself in the initial blueprint and never opens its external API.
+    #[clap(long, name = "NEXUS_ZONE_ID", action)]
+    rss_nexus_id: Option<OmicronZoneUuid>,
+
     #[clap(long, name = "EXTERNAL_DNS_INTERNAL_IP:PORT", action)]
     /// If specified, when the simulated sled agent initializes the rack, it
     /// will record the external DNS service running with the specified internal
@@ -73,6 +85,30 @@ struct Args {
     /// If specified, the sled agent will create a DNS server exposing the
     /// following socket address for the DNS interface.
     rss_internal_dns_dns_addr: Option<SocketAddrV6>,
+
+    // TODO-RAINCLAUDE: with this set, no DNS server is started; the one at this HTTP address is populated instead, and INTERNAL_DNS_INTERNAL_IP:PORT names where it serves DNS.
+    #[clap(
+        long,
+        name = "INTERNAL_DNS_HTTP_IP:PORT",
+        requires = "INTERNAL_DNS_INTERNAL_IP:PORT",
+        action
+    )]
+    rss_internal_dns_http_addr: Option<SocketAddrV6>,
+
+    // TODO-RAINCLAUDE: repeatable; each CockroachDB node is recorded in internal DNS and the initial blueprint.
+    #[clap(long = "cockroach-addr", name = "COCKROACH_IP:PORT", action = clap::ArgAction::Append)]
+    cockroach_addrs: Vec<SocketAddrV6>,
+
+    // TODO-RAINCLAUDE: defaults to the /56 containing SA_IP.
+    #[clap(long, name = "RACK_SUBNET", action)]
+    rack_subnet: Option<Ipv6Net>,
+
+    #[clap(long, name = "RECOVERY_SILO_NAME", action)]
+    rss_recovery_silo_name: Option<Name>,
+
+    // TODO-RAINCLAUDE: the recovery user's password is always "oxide".
+    #[clap(long, name = "RECOVERY_USER_NAME", action)]
+    rss_recovery_user_name: Option<UserId>,
 
     #[clap(long, name = "TLS_CERT_PEM_FILE", action)]
     /// If this flag and TLS_KEY_PEM_FILE are specified, when the simulated sled
@@ -99,6 +135,8 @@ async fn do_run() -> Result<(), CmdError> {
     let config = Config {
         dropshot: ConfigDropshot {
             bind_address: args.sled_agent_addr.into(),
+            // TODO-RAINCLAUDE: dropshot's default of 1 KiB rejects every sled config and firewall rule push from Nexus; this matches `Config::for_testing`.
+            default_request_body_max_bytes: 1024 * 1024,
             ..Default::default()
         },
         storage: ConfigStorage {
@@ -150,10 +188,32 @@ async fn do_run() -> Result<(), CmdError> {
         }
     };
 
+    // TODO-RAINCLAUDE: clap's `requires` already rejects an HTTP address without a DNS address, but that is not visible to the type system, so the usage error is spelled out here as well.
+    let internal_dns =
+        match (args.rss_internal_dns_http_addr, args.rss_internal_dns_dns_addr)
+        {
+            (Some(http_addr), Some(dns_addr)) => {
+                InternalDnsConfig::External { http_addr, dns_addr }
+            }
+            (None, dns_addr) => InternalDnsConfig::InProcess { dns_addr },
+            (Some(_), None) => {
+                return Err(CmdError::Usage(String::from(
+                    "--rss-internal-dns-http-addr requires \
+                     --rss-internal-dns-dns-addr (Nexus must be told where \
+                     the external DNS server serves DNS)",
+                )));
+            }
+        };
+
     let rss_args = RssArgs {
         nexus_external_addr: args.rss_nexus_external_addr,
+        nexus_id: args.rss_nexus_id,
         external_dns_internal_addr: args.rss_external_dns_internal_addr,
-        internal_dns_dns_addr: args.rss_internal_dns_dns_addr,
+        internal_dns,
+        cockroach_addrs: args.cockroach_addrs,
+        rack_subnet: args.rack_subnet,
+        recovery_silo_name: args.rss_recovery_silo_name,
+        recovery_user_name: args.rss_recovery_user_name,
         tls_certificate,
     };
 

--- a/sled-agent/src/sim/mod.rs
+++ b/sled-agent/src/sim/mod.rs
@@ -21,7 +21,10 @@ pub use config::{
     Baseboard, Config, ConfigHardware, ConfigStorage, ConfigZpool, SimMode,
     TEST_HARDWARE_THREADS, TEST_RESERVOIR_RAM, ZpoolConfig,
 };
-pub use server::{NexusRegistration, RssArgs, Server, run_standalone_server};
+pub use server::{
+    InternalDnsConfig, NexusRegistration, RssArgs, Server,
+    run_standalone_server,
+};
 pub use sled_agent::SledAgent;
 pub use storage::PantryServer;
 pub(crate) use storage::Storage;

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -17,6 +17,7 @@ use crucible_agent_client::types::State as RegionState;
 use iddqd::IdOrdMap;
 use illumos_utils::zpool::ZpoolName;
 use internal_dns_types::config::DnsConfigBuilder;
+use internal_dns_types::config::DnsConfigParams;
 use internal_dns_types::names::DNS_ZONE_EXTERNAL_TESTING;
 use internal_dns_types::names::ServiceName;
 use nexus_client::types as NexusTypes;
@@ -37,15 +38,22 @@ use omicron_common::address::IpRange;
 use omicron_common::address::Ipv4Range;
 use omicron_common::address::Ipv6Range;
 use omicron_common::address::NEXUS_OPTE_IPV4_SUBNET;
+use omicron_common::address::RACK_PREFIX_LENGTH;
 use omicron_common::address::{DNS_OPTE_IPV4_SUBNET, Ipv6Subnet};
 use omicron_common::api::external::MacAddr;
+use omicron_common::api::external::Name;
+use omicron_common::api::external::UserId;
 use omicron_common::api::external::Vni;
 use omicron_common::api::internal::nexus::Certificate;
 use omicron_common::api::internal::shared::PrivateIpConfig;
 use omicron_common::backoff::{
     BackoffError, retry_notify, retry_policy_internal_service_aggressive,
 };
-use omicron_generation_kinds::{Generation, NexusGeneration};
+use omicron_common::disk::DatasetKind;
+use omicron_common::disk::DatasetName;
+use omicron_generation_kinds::{
+    Generation, NexusGeneration, SledConfigGeneration,
+};
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -58,16 +66,24 @@ use sled_agent_rack_setup::{
     from_ipaddr_to_external_floating_ip,
     from_sockaddr_to_external_floating_addr,
 };
+use sled_agent_types::disk::CompressionAlgorithm;
+use sled_agent_types::disk::DatasetConfig;
 use sled_agent_types::disk::DiskIdentity;
+use sled_agent_types::disk::OmicronPhysicalDiskConfig;
+use sled_agent_types::disk::SharedDatasetConfig;
 use sled_agent_types::early_networking::PortConfig;
 use sled_agent_types::early_networking::UplinkPorts;
+use sled_agent_types::inventory::HostPhase2DesiredSlots;
 use sled_agent_types::inventory::NetworkInterface;
 use sled_agent_types::inventory::NetworkInterfaceKind;
+use sled_agent_types::inventory::OmicronSledConfig;
+use sled_agent_types::inventory::OmicronSledUpdateDisposition;
+use sled_agent_types::inventory::OmicronZoneConfig;
 use sled_agent_types::inventory::OmicronZoneDataset;
-use slog::{Drain, Logger, info};
+use slog::{Drain, Logger, info, warn};
+use std::collections::BTreeSet;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
-use std::net::Ipv6Addr;
 use std::net::SocketAddr;
 use std::net::SocketAddrV6;
 use std::sync::Arc;
@@ -349,14 +365,145 @@ pub struct RssArgs {
     /// Specify the external address of Nexus so that we can include it in
     /// external DNS
     pub nexus_external_addr: Option<SocketAddr>,
+    // TODO-RAINCLAUDE: the zone id recorded for Nexus in the initial blueprint; Nexus only opens its external API once it finds its own `deployment.id` in the target blueprint, so this must match that config value.
+    pub nexus_id: Option<OmicronZoneUuid>,
     /// Specify the (internal) address of an external DNS server so that Nexus
     /// will know about it and keep it up to date
     pub external_dns_internal_addr: Option<SocketAddrV6>,
-    /// Specify the (dns) address of an internal DNS server
-    pub internal_dns_dns_addr: Option<SocketAddrV6>,
+    // TODO-RAINCLAUDE: which internal DNS server to populate during rack initialization.
+    pub internal_dns: InternalDnsConfig,
+    // TODO-RAINCLAUDE: CockroachDB nodes to record in internal DNS and the initial blueprint so Nexus can use `database.type = "from_dns"`.
+    pub cockroach_addrs: Vec<SocketAddrV6>,
+    // TODO-RAINCLAUDE: rack subnet reported to Nexus; defaults to the /56 containing the sled agent's address.
+    pub rack_subnet: Option<Ipv6Net>,
+    // TODO-RAINCLAUDE: recovery silo and user names; the password is always "oxide" (see the hash below).
+    pub recovery_silo_name: Option<Name>,
+    pub recovery_user_name: Option<UserId>,
     /// Specify a certificate and associated private key for the initial Silo's
     /// initial TLS certificates
     pub tls_certificate: Option<Certificate>,
+}
+
+// TODO-RAINCLAUDE: how the standalone simulated sled agent obtains the internal DNS server it populates during rack initialization; an external server needs both addresses (Nexus is told the DNS address, the sled agent talks to the HTTP address), so the pair is one variant rather than two independent options.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InternalDnsConfig {
+    // TODO-RAINCLAUDE: start a DNS server in this process, optionally at a fixed DNS address.
+    InProcess { dns_addr: Option<SocketAddrV6> },
+    // TODO-RAINCLAUDE: populate an already-running DNS server via its HTTP API.
+    External { http_addr: SocketAddrV6, dns_addr: SocketAddrV6 },
+}
+
+impl Default for InternalDnsConfig {
+    fn default() -> Self {
+        InternalDnsConfig::InProcess { dns_addr: None }
+    }
+}
+
+// TODO-RAINCLAUDE: the standalone server either owns an in-process DNS server or points at an external one whose addresses are only known from the arguments.
+enum InternalDns {
+    InProcess(TransientDnsServer),
+    External { http_addr: SocketAddrV6, dns_addr: SocketAddrV6 },
+}
+
+impl InternalDns {
+    async fn new(
+        log: &Logger,
+        config: &InternalDnsConfig,
+    ) -> Result<InternalDns, anyhow::Error> {
+        match config {
+            InternalDnsConfig::External { http_addr, dns_addr } => {
+                Ok(InternalDns::External {
+                    http_addr: *http_addr,
+                    dns_addr: *dns_addr,
+                })
+            }
+            InternalDnsConfig::InProcess { dns_addr: Some(dns_addr) } => {
+                Ok(InternalDns::InProcess(
+                    TransientDnsServer::new_with_address(
+                        log,
+                        (*dns_addr).into(),
+                    )
+                    .await?,
+                ))
+            }
+            InternalDnsConfig::InProcess { dns_addr: None } => {
+                Ok(InternalDns::InProcess(TransientDnsServer::new(log).await?))
+            }
+        }
+    }
+
+    fn http_addr(&self) -> Result<SocketAddrV6, anyhow::Error> {
+        match self {
+            InternalDns::InProcess(dns) => {
+                match dns.dropshot_server.local_addr() {
+                    SocketAddr::V4(addr) => bail!(
+                        "internal DNS HTTP server bound an IPv4 address \
+                         ({addr}); internal DNS zones require IPv6"
+                    ),
+                    SocketAddr::V6(addr) => Ok(addr),
+                }
+            }
+            InternalDns::External { http_addr, .. } => Ok(*http_addr),
+        }
+    }
+
+    fn dns_addr(&self) -> Result<SocketAddrV6, anyhow::Error> {
+        match self {
+            InternalDns::InProcess(dns) => {
+                match dns.dns_server.local_address() {
+                    SocketAddr::V4(addr) => bail!(
+                        "internal DNS server bound an IPv4 address ({addr}); \
+                         internal DNS zones require IPv6"
+                    ),
+                    SocketAddr::V6(addr) => Ok(addr),
+                }
+            }
+            InternalDns::External { dns_addr, .. } => Ok(*dns_addr),
+        }
+    }
+
+    async fn initialize_with_config(
+        &self,
+        log: &Logger,
+        dns_config: &DnsConfigParams,
+    ) -> Result<(), anyhow::Error> {
+        match self {
+            InternalDns::InProcess(dns) => {
+                dns.initialize_with_config(log, dns_config).await
+            }
+            InternalDns::External { http_addr, .. } => {
+                let client = dns_service_client::Client::new(
+                    &format!("http://{http_addr}"),
+                    log.new(o!("component" => "DnsServiceClient")),
+                );
+                // TODO-RAINCLAUDE: the external DNS server may still be starting, so retry the way the Nexus handoff does.
+                let put_config = || async {
+                    client
+                        .dns_config_put(dns_config)
+                        .await
+                        .map_err(BackoffError::transient)
+                };
+                let log_failure = |err, delay| {
+                    warn!(
+                        log,
+                        "failed to initialize internal DNS at {http_addr}, \
+                         will retry in {delay:?}";
+                        "error" => ?err,
+                    );
+                };
+                retry_notify(
+                    retry_policy_internal_service_aggressive(),
+                    put_config,
+                    log_failure,
+                )
+                .await
+                .with_context(|| {
+                    format!("initializing internal DNS at {http_addr}")
+                })?;
+                Ok(())
+            }
+        }
+    }
 }
 
 /// Run an instance of the `Server` which is able to handoff to Nexus.
@@ -399,12 +546,16 @@ pub async fn run_standalone_server(
     .await?;
     info!(log, "sled agent started successfully");
 
-    // Start the Internal DNS server
-    let dns = if let Some(addr) = rss_args.internal_dns_dns_addr {
-        TransientDnsServer::new_with_address(&log, addr.into()).await?
-    } else {
-        TransientDnsServer::new(&log).await?
+    let underlay_address = match server.http_server.local_addr() {
+        SocketAddr::V4(addr) => {
+            bail!("sled agent bound an IPv4 address ({addr}); it must be IPv6")
+        }
+        SocketAddr::V6(addr) => addr,
     };
+    let sled_ip = *underlay_address.ip();
+
+    // Start the Internal DNS server
+    let dns = InternalDns::new(&log, &rss_args.internal_dns).await?;
     let mut dns_config_builder = DnsConfigBuilder::new();
 
     // Start the Crucible Pantry
@@ -429,6 +580,48 @@ pub async fn run_standalone_server(
         )
         .expect("failed to set up DNS");
 
+    // TODO-RAINCLAUDE: CockroachDB zones go into DNS now and into the blueprint below; the blueprint executor rewrites DNS from the blueprint, so both must agree.
+    let cockroach_zones: Vec<(OmicronZoneUuid, SocketAddrV6)> = rss_args
+        .cockroach_addrs
+        .iter()
+        .map(|addr| (OmicronZoneUuid::new_v4(), *addr))
+        .collect();
+    for (zone_id, addr) in &cockroach_zones {
+        dns_config_builder
+            .host_zone_with_one_backend(*zone_id, ServiceName::Cockroach, *addr)
+            .with_context(|| {
+                format!("adding CockroachDB node {addr} to internal DNS")
+            })?;
+    }
+
+    // TODO-RAINCLAUDE: Nexus discovers DNS servers through `_nameservice._tcp` and its peers through `_nexus._tcp`, and the blueprint executor cannot publish those records until it can find a DNS server, so the initial config must carry them; the zone ids are reused in the blueprint below so the executor's rewrite agrees with them.
+    let internal_dns_zone_id = OmicronZoneUuid::new_v4();
+    dns_config_builder
+        .host_zone_internal_dns(
+            internal_dns_zone_id,
+            ServiceName::InternalDns,
+            dns.http_addr()?,
+            dns.dns_addr()?,
+        )
+        .context("adding the internal DNS server to internal DNS")?;
+    let nexus_internal_addr = match config.nexus_address {
+        SocketAddr::V4(addr) => {
+            bail!("Nexus internal address {addr} must be IPv6")
+        }
+        SocketAddr::V6(addr) => addr,
+    };
+    let nexus_zone_id =
+        rss_args.nexus_id.unwrap_or_else(OmicronZoneUuid::new_v4);
+    if rss_args.nexus_external_addr.is_some() {
+        dns_config_builder
+            .host_zone_nexus(
+                nexus_zone_id,
+                nexus_internal_addr,
+                nexus_lockstep_port,
+            )
+            .context("adding Nexus to internal DNS")?;
+    }
+
     // Initialize the internal DNS entries
     let dns_config =
         dns_config_builder.build_full_config_for_initial_generation();
@@ -444,27 +637,20 @@ pub async fn run_standalone_server(
 
     // Record the internal DNS server as though RSS had provisioned it so
     // that Nexus knows about it.
-    let http_bound = match dns.dropshot_server.local_addr() {
-        SocketAddr::V4(_) => panic!("did not expect v4 address"),
-        SocketAddr::V6(a) => a,
-    };
-    let pool_name = ZpoolName::new_external(ZpoolUuid::new_v4());
+    // TODO-RAINCLAUDE: every zone's filesystem pool must be one of the simulated sled's real zpools, because the sled config ledgered below lists exactly those disks and Nexus cross-checks zone pools against them.
+    let pool_name = get_random_zpool();
     let mut zones = IdOrdMap::new();
     zones
         .insert_unique(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
-            id: OmicronZoneUuid::new_v4(),
+            id: internal_dns_zone_id,
             zone_type: BlueprintZoneType::InternalDns(
                 blueprint_zone_type::InternalDns {
                     dataset: OmicronZoneDataset { pool_name },
-                    http_address: http_bound,
-                    dns_address: match dns.dns_server.local_address() {
-                        SocketAddr::V4(_) => {
-                            panic!("did not expect v4 address")
-                        }
-                        SocketAddr::V6(a) => a,
-                    },
-                    gz_address: Ipv6Addr::LOCALHOST,
+                    http_address: dns.http_addr()?,
+                    dns_address: dns.dns_addr()?,
+                    // TODO-RAINCLAUDE: nothing in the simulation routes through the global zone, so the sled's own address stands in for it.
+                    gz_address: sled_ip,
                     gz_address_index: 0,
                 },
             ),
@@ -474,12 +660,30 @@ pub async fn run_standalone_server(
         })
         .expect("freshly generated zone IDs are unique");
 
+    for (zone_id, address) in cockroach_zones {
+        let pool_name = get_random_zpool();
+        zones
+            .insert_unique(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id: zone_id,
+                zone_type: BlueprintZoneType::CockroachDb(
+                    blueprint_zone_type::CockroachDb {
+                        address,
+                        dataset: OmicronZoneDataset { pool_name },
+                    },
+                ),
+                filesystem_pool: pool_name,
+                image_source: BlueprintZoneImageSource::InstallDataset,
+            })
+            .expect("freshly generated zone IDs are unique");
+    }
+
     let mut internal_services_ipv4_ranges = vec![];
     let mut internal_services_ipv6_ranges = vec![];
     let mut macs = MacAddr::iter_system();
     if let Some(nexus_external_addr) = rss_args.nexus_external_addr {
         let external_ip = nexus_external_addr.ip();
-        let id = OmicronZoneUuid::new_v4();
+        let id = nexus_zone_id;
         let private_ip = NEXUS_OPTE_IPV4_SUBNET
             .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES + 1)
             .unwrap();
@@ -493,12 +697,7 @@ pub async fn run_standalone_server(
                 id,
                 zone_type: BlueprintZoneType::Nexus(
                     blueprint_zone_type::Nexus {
-                        internal_address: match config.nexus_address {
-                            SocketAddr::V4(_) => {
-                                panic!("did not expect v4 address")
-                            }
-                            SocketAddr::V6(a) => a,
-                        },
+                        internal_address: nexus_internal_addr,
                         lockstep_port: nexus_lockstep_port,
                         external_ip: from_ipaddr_to_external_floating_ip(
                             external_ip,
@@ -548,7 +747,7 @@ pub async fn run_standalone_server(
         let ip_config =
             PrivateIpConfig::new_ipv4(private_ip, *DNS_OPTE_IPV4_SUBNET)
                 .context("creating private IP configuration")?;
-        let pool_name = ZpoolName::new_external(ZpoolUuid::new_v4());
+        let pool_name = get_random_zpool();
         zones
             .insert_unique(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
@@ -585,8 +784,14 @@ pub async fn run_standalone_server(
     }
 
     let recovery_silo = RecoverySiloConfig {
-        silo_name: "demo-silo".parse().unwrap(),
-        user_name: "demo-privileged".parse().unwrap(),
+        silo_name: rss_args
+            .recovery_silo_name
+            .clone()
+            .unwrap_or_else(|| "demo-silo".parse().unwrap()),
+        user_name: rss_args
+            .recovery_user_name
+            .clone()
+            .unwrap_or_else(|| "demo-privileged".parse().unwrap()),
         // The following is a hash for the password "oxide".  This is
         // (obviously) only intended for transient deployments in
         // development with no sensitive data or resources.  You can change
@@ -626,17 +831,76 @@ pub async fn run_standalone_server(
         None => vec![],
     };
 
+    // TODO-RAINCLAUDE: RSS ledgers a sled config on every sled before handing off to Nexus, and the blueprint below is derived from what the sled reports as ledgered (see `inventory.ledgered_sled_config`), so the standalone path has to do the same or the handoff cannot be built. Mirrors nexus-test-utils `configure_sled_agents`: one disk per zpool, one transient-zone dataset per zone, generation 2.
+    let sled_config_generation = SledConfigGeneration::from_u32(2);
+    let mut disk_configs = IdOrdMap::new();
+    for zpool in &zpools {
+        let disk = physical_disks
+            .iter()
+            .find(|disk| disk.id == zpool.physical_disk_id)
+            .with_context(|| {
+                format!(
+                    "zpool {} refers to unknown physical disk {}",
+                    zpool.id, zpool.physical_disk_id
+                )
+            })?;
+        disk_configs
+            .insert_unique(OmicronPhysicalDiskConfig {
+                identity: DiskIdentity {
+                    vendor: disk.vendor.clone(),
+                    model: disk.model.clone(),
+                    serial: disk.serial.clone(),
+                },
+                id: disk.id,
+                pool_id: ZpoolUuid::from_untyped_uuid(zpool.id),
+            })
+            .map_err(|_| {
+                anyhow!("physical disk {} backs more than one zpool", disk.id)
+            })?;
+    }
+    let mut dataset_configs = IdOrdMap::new();
+    for zone in &zones {
+        dataset_configs
+            .insert_unique(DatasetConfig {
+                id: DatasetUuid::new_v4(),
+                name: DatasetName::new(
+                    zone.filesystem_pool,
+                    DatasetKind::TransientZone {
+                        name: illumos_utils::zone::zone_name(
+                            zone.zone_type.kind().zone_prefix(),
+                            Some(zone.id),
+                        ),
+                    },
+                ),
+                inner: SharedDatasetConfig {
+                    compression: CompressionAlgorithm::Off,
+                    quota: None,
+                    reservation: None,
+                },
+            })
+            .expect("freshly generated dataset IDs are unique");
+    }
+    server
+        .sled_agent
+        .set_omicron_config(OmicronSledConfig {
+            generation: sled_config_generation,
+            disks: disk_configs,
+            datasets: dataset_configs,
+            zones: zones.iter().cloned().map(OmicronZoneConfig::from).collect(),
+            remove_mupdate_override: None,
+            host_phase_2: HostPhase2DesiredSlots::current_contents(),
+            measurements: BTreeSet::new(),
+            update_disposition: OmicronSledUpdateDisposition::Available,
+        })
+        .map_err(|error| {
+            anyhow!("ledgering the simulated sled config: {error}")
+        })?;
+
     let blueprint = {
         let sled_config =
             server.sled_agent.omicron_sled_config().unwrap_or_default();
-        let underlay_address = match server.http_server.local_addr() {
-            SocketAddr::V4(_) => {
-                bail!("sled_agent_ip must be v6")
-            }
-            SocketAddr::V6(addr) => addr,
-        };
 
-        let subnet = Ipv6Subnet::new(*underlay_address.ip());
+        let subnet = Ipv6Subnet::new(sled_ip);
         let last_allocated_ip_subnet_offset = LastAllocatedSubnetIpOffset::new(
             zones
                 .iter()
@@ -721,7 +985,10 @@ pub async fn run_standalone_server(
         external_dns_zone_name: DNS_ZONE_EXTERNAL_TESTING.to_owned(),
         recovery_silo,
         rack_network_config: RackNetworkConfig {
-            rack_subnet: Ipv6Net::host_net(Ipv6Addr::LOCALHOST),
+            // TODO-RAINCLAUDE: default to the /56 around the sled so that non-loopback deployments (containers) get a subnet that contains their zones.
+            rack_subnet: rss_args.rack_subnet.unwrap_or_else(|| {
+                Ipv6Subnet::<RACK_PREFIX_LENGTH>::new(sled_ip).net()
+            }),
             infra_ip_first: IpAddr::V4(Ipv4Addr::LOCALHOST),
             infra_ip_last: IpAddr::V4(Ipv4Addr::LOCALHOST),
             // `UplinkPorts` must be non-empty; the simulated rack doesn't

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -168,10 +168,15 @@ impl SledAgent {
 
         simulated_upstairs.register_storage(id, &storage);
 
+        // TODO-RAINCLAUDE: the repo depot must not reuse the sled agent's own port (omicron#4421); port 0 is fine because Nexus learns the port from sled_agent_put.
+        let repo_depot_dropshot = dropshot::ConfigDropshot {
+            bind_address: SocketAddr::new(config.dropshot.bind_address.ip(), 0),
+            ..config.dropshot.clone()
+        };
         let repo_depot =
             ArtifactStore::new(&log, SimArtifactStorage::new(), None)
                 .await
-                .start(&log, &config.dropshot);
+                .start(&log, &repo_depot_dropshot);
 
         let health_monitor = HealthMonitorHandle::stub();
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -111,10 +111,8 @@ ppv-lite86 = { version = "0.2.21", default-features = false, features = ["simd",
 predicates = { version = "3.1.4" }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.45" }
-rand-274715c4dabd11b0 = { package = "rand", version = "0.9.2" }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.6" }
-rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9.0", default-features = false, features = ["std"] }
-rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3.1", default-features = false, features = ["std"] }
+rand = { version = "0.9.2" }
+rand_chacha = { version = "0.9.0", default-features = false, features = ["std"] }
 regex = { version = "1.12.3" }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }
@@ -266,10 +264,8 @@ ppv-lite86 = { version = "0.2.21", default-features = false, features = ["simd",
 predicates = { version = "3.1.4" }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.45" }
-rand-274715c4dabd11b0 = { package = "rand", version = "0.9.2" }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.6" }
-rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9.0", default-features = false, features = ["std"] }
-rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3.1", default-features = false, features = ["std"] }
+rand = { version = "0.9.2" }
+rand_chacha = { version = "0.9.0", default-features = false, features = ["std"] }
 regex = { version = "1.12.3" }
 regex-automata = { version = "0.4.14", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
 regex-syntax = { version = "0.8.10" }


### PR DESCRIPTION
<details>

<summary>From Claude</summary>

Adds an antithesis/ directory (Dockerfile, compose topology, configs, workload crate, test commands, scratchbook) so the simulated control plane can run under Antithesis, plus the omicron changes that requires:

- an `antithesis` cargo profile and per-binary `antithesis` features that link the Antithesis SDK and instrumentation; the SDK compiles to no-ops otherwise, and hakari excludes both crates so that stays true.
- a few SDK assertions in Nexus (external API started, CRDB transaction retried, saga completed/unwound, saga unwinding never fails).
- standalone sled-agent-sim fixes so it can perform the RSS handoff on real (non-loopback) addresses: repo depot no longer binds the sled agent's port (omicron#4421), the rack subnet and gz address derive from the sled IP, the sled config is ledgered before the handoff as RSS does, the initial DNS config carries the internal DNS and Nexus zones, the Nexus zone id is configurable so Nexus can find itself in the blueprint, an external internal-DNS server can be populated instead of the in-process one, CockroachDB nodes can be recorded for from_dns discovery, and the request body limit matches the test harness.

Locally the five-container stack reaches setup_complete, `snouty validate` passes (exactly one copy of each test command, in the workload image), and the seed and sagas-settle test commands pass.

</details>

TODO:

- [ ] break up/deslop