### PR TITLE
Poison ClickHouse connections when they could be desynchronized

### DIFF
--- a/oximeter/db/src/native/connection.rs
+++ b/oximeter/db/src/native/connection.rs
@@ -20,6 +20,7 @@ use super::packets::server::Hello as ServerHello;
 use super::packets::server::Packet as ServerPacket;
 use super::packets::server::Progress;
 use super::packets::server::REVISION;
+use crate::native::packets::client::Settings;
 use crate::native::probes;
 use futures::SinkExt as _;
 use futures::StreamExt as _;
@@ -61,6 +62,9 @@ impl backend::Connector for Connector {
         &self,
         conn: &mut Self::Connection,
     ) -> Result<(), QorbError> {
+        if conn.is_poisoned {
+            return Err(QorbError::from(Error::Poisoned));
+        }
         conn.ping().await.map_err(QorbError::from)
     }
 
@@ -68,17 +72,30 @@ impl backend::Connector for Connector {
         &self,
         conn: &mut Self::Connection,
     ) -> Result<(), QorbError> {
+        if conn.is_poisoned {
+            return Err(QorbError::from(Error::Poisoned));
+        }
         // We try to cancel an outstanding query. But if there is _no_
         // outstanding query, we sill want to run the validation check of
         // pinging the server. That notifies `qorb` if the server is alive in
         // the case that there was no query to cancel
-        if conn.cancel().await.map_err(QorbError::from)? {
-            Ok(())
-        } else {
-            // No query, so let's run the validation check.
-            self.is_valid(conn).await
+        match conn.cancel().await.map_err(QorbError::from)? {
+            CancelResult::Cancelled => Ok(()),
+            CancelResult::NoOutstandingQuery => {
+                // No query, so let's run the validation check.
+                self.is_valid(conn).await
+            }
         }
     }
+}
+
+/// The result of attempting to cancel a query.
+#[derive(Clone, Copy, Debug)]
+pub enum CancelResult {
+    /// The query was cancelled successfully.
+    Cancelled,
+    /// There was no outstanding query to cancel.
+    NoOutstandingQuery,
 }
 
 /// A connection to a ClickHouse server.
@@ -96,7 +113,24 @@ pub struct Connection {
     /// A writer for encoding packets to the server.
     writer: FramedWrite<OwnedWriteHalf, Encoder>,
     /// True if we are currently executing a query.
-    outstanding_query: bool,
+    has_outstanding_query: bool,
+    /// True if the connection should be torn down when returned to the pool.
+    ///
+    /// The ClickHouse native protocol doesn't include things like message
+    /// lengths in its headers. That means we can only know how much data to
+    /// read if we can fully, successfully decode the packet. If that fails, or
+    /// we have an unknown packet, we don't know how much to read to get to the
+    /// start of the next message frame.
+    ///
+    /// This being true means we hit such an error, and we will signal to the
+    /// connection pool that the connection should be reset and replaced
+    /// entirely, rather than lent back out to another claimant.
+    ///
+    /// This is pretty conservative today, and is set any time we hit an
+    /// unexpected error. That includes things like unexpected packets, short
+    /// reads, or unsupported protocol features -- basically any error except an
+    /// explicit `Server::Exception` packet, which we do know how to decode.
+    is_poisoned: bool,
 }
 
 #[allow(dead_code)]
@@ -119,7 +153,8 @@ impl Connection {
             server_info,
             reader,
             writer,
-            outstanding_query: false,
+            has_outstanding_query: false,
+            is_poisoned: false,
         })
     }
 
@@ -167,55 +202,112 @@ impl Connection {
         Ok(hello)
     }
 
+    /// Poison the connection, run an exchange with the server, and then clear
+    /// the poison flag if the exchange completes. Note that "completes" does
+    /// not mean there is no error, only that we can positively say that we've
+    /// read to the end of a framed exchange.
+    ///
+    /// See `Self.is_poisoned` for details.
+    async fn poison_and_clear_on_completion<T, F>(
+        &mut self,
+        exchange: F,
+    ) -> Result<T, Error>
+    where
+        F: AsyncFnOnce(&mut Self) -> Result<T, Error>,
+    {
+        self.is_poisoned = true;
+        let result = exchange(self).await;
+        if matches!(&result, Ok(_) | Err(Error::Exception { .. })) {
+            self.is_poisoned = false;
+        }
+        result
+    }
+
+    /// Handle an unexpected packet from the server.
+    fn on_unexpected_packet(&self, kind: &'static str) -> Error {
+        probes::unexpected__server__packet!(|| (
+            self.address.ip().to_string(),
+            kind,
+        ));
+        Error::UnexpectedPacket(kind)
+    }
+
+    /// Handle a generic error decoding a packet from the server.
+    fn on_decode_error(&self, err: Error) -> Error {
+        probes::decode__failed!(|| {
+            (self.address.ip().to_string(), err.to_string())
+        });
+        err
+    }
+
+    /// Handle being disconnected from the server.
+    fn on_disconnected(&self) -> Error {
+        probes::disconnected!(|| self.address.ip().to_string());
+        Error::Disconnected
+    }
+
+    /// Handle a protocol error.
+    fn on_protocol_error(&self, err: Error) -> Error {
+        probes::protocol__error!(|| {
+            (self.address.ip().to_string(), err.to_string())
+        });
+        err
+    }
+
     /// Send a ping message to the server to check the connection's health.
     ///
     /// This is a cheap way to check that the server is alive and the connection
     /// is still valid. It will await the pong response from the server.
     pub async fn ping(&mut self) -> Result<(), Error> {
+        if self.is_poisoned {
+            return Err(Error::Poisoned);
+        }
+        self.poison_and_clear_on_completion(Self::ping_impl).await
+    }
+
+    async fn ping_impl(&mut self) -> Result<(), Error> {
         self.writer.send(ClientPacket::Ping).await?;
         match self.reader.next().await {
             Some(Ok(ServerPacket::Pong)) => Ok(()),
-            Some(Ok(packet)) => {
-                probes::unexpected__server__packet!(|| (
-                    self.address.ip().to_string(),
-                    packet.kind()
-                ));
-                Err(Error::UnexpectedPacket(packet.kind()))
-            }
-            Some(Err(e)) => Err(e),
-            None => {
-                probes::disconnected!(|| self.address.ip().to_string());
-                Err(Error::Disconnected)
-            }
+            Some(Ok(packet)) => Err(self.on_unexpected_packet(packet.kind())),
+            Some(Err(e)) => Err(self.on_decode_error(e)),
+            None => Err(self.on_disconnected()),
         }
     }
 
     // Cancel a running query, if one exists.
     //
     // This returns an error if there is a query and we could not cancel it for
-    // some reason. It returns `Ok(true)` if we successfully canceled the query,
-    // or `Ok(false)` if there was no query to cancel at all.
-    async fn cancel(&mut self) -> Result<bool, Error> {
-        if self.outstanding_query {
-            self.writer.send(ClientPacket::Cancel).await?;
-            // Await EOS, throwing everything else away except errors.
-            let res = loop {
-                match self.reader.next().await {
-                    Some(Ok(ServerPacket::EndOfStream)) => break Ok(true),
-                    Some(Ok(other_packet)) => {
-                        probes::unexpected__server__packet!(|| (
-                            self.address.ip().to_string(),
-                            other_packet.kind()
-                        ));
-                    }
-                    Some(Err(e)) => break Err(e),
-                    None => break Err(Error::Disconnected),
-                };
-            };
-            self.outstanding_query = false;
-            return res;
+    // some reason.
+    async fn cancel(&mut self) -> Result<CancelResult, Error> {
+        if !self.has_outstanding_query {
+            return Ok(CancelResult::NoOutstandingQuery);
         }
-        Ok(false)
+        self.poison_and_clear_on_completion(Self::cancel_impl).await
+    }
+
+    async fn cancel_impl(&mut self) -> Result<CancelResult, Error> {
+        self.writer.send(ClientPacket::Cancel).await?;
+        // Await EOS, throwing everything else away except errors.
+        let res = loop {
+            match self.reader.next().await {
+                Some(Ok(ServerPacket::EndOfStream)) => {
+                    break Ok(CancelResult::Cancelled);
+                }
+                Some(Ok(other_packet)) => {
+                    // Do _not_ break here, so we can drain the entire stream if
+                    // possible.
+                    probes::unexpected__server__packet!(|| (
+                        self.address.ip().to_string(),
+                        other_packet.kind(),
+                    ));
+                }
+                Some(Err(e)) => break Err(self.on_decode_error(e)),
+                None => break Err(self.on_disconnected()),
+            };
+        };
+        self.has_outstanding_query = false;
+        res
     }
 
     /// Send a SQL query that inserts data.
@@ -225,7 +317,7 @@ impl Connection {
         query: &str,
         block: Block,
     ) -> Result<QueryResult, Error> {
-        self.query_inner(query_id, query, Some(block)).await
+        self.query_inner(query_id, query, Some(block), Settings::new()).await
     }
 
     /// Send a SQL query, without any data.
@@ -234,7 +326,46 @@ impl Connection {
         query_id: Uuid,
         query: &str,
     ) -> Result<QueryResult, Error> {
-        self.query_inner(query_id, query, None).await
+        self.query_inner(query_id, query, None, Settings::new()).await
+    }
+
+    /// Check that the block to insert matches the expected structure, then
+    /// insert it.
+    ///
+    /// When inserting data, we first send the query itself. The server then
+    /// responds with an empty data block that describes the columns of the
+    /// table we're inserting into. We're checking that the block we're trying
+    /// to insert actually matches, and then inserting it.
+    async fn check_block_structure_and_insert(
+        &mut self,
+        block_to_insert: Block,
+        received_block: Block,
+    ) -> Result<(), Error> {
+        // Server's data block isn't actually empty.
+        if received_block.n_rows() != 0 {
+            return Err(self.on_protocol_error(Error::ExpectedEmptyDataBlock));
+        }
+
+        // Don't concatenate the block, but check that its
+        // structure matches what we're about to insert.
+        if !block_to_insert.matches_structure(&received_block) {
+            return Err(self.on_protocol_error(Error::MismatchedBlockStructure));
+        }
+
+        // Finally, send the actual data block and an empty
+        // block to tell the server we're finished.
+        self.writer.send(ClientPacket::Data(block_to_insert)).await?;
+        self.writer.send(ClientPacket::Data(Block::empty())).await
+    }
+
+    #[cfg(test)]
+    async fn query_with_settings(
+        &mut self,
+        query_id: Uuid,
+        query: &str,
+        settings: Settings,
+    ) -> Result<QueryResult, Error> {
+        self.query_inner(query_id, query, None, settings).await
     }
 
     // Send a SQL query, possibly with data.
@@ -251,6 +382,23 @@ impl Connection {
         query_id: Uuid,
         query: &str,
         maybe_data: Option<Block>,
+        settings: Settings,
+    ) -> Result<QueryResult, Error> {
+        if self.is_poisoned {
+            return Err(Error::Poisoned);
+        }
+        self.poison_and_clear_on_completion(async |conn| {
+            conn.query_inner_impl(query_id, query, maybe_data, settings).await
+        })
+        .await
+    }
+
+    async fn query_inner_impl(
+        &mut self,
+        query_id: Uuid,
+        query: &str,
+        maybe_data: Option<Block>,
+        settings: Settings,
     ) -> Result<QueryResult, Error> {
         let mut query_result = QueryResult {
             id: query_id,
@@ -260,9 +408,14 @@ impl Connection {
             profile_info: None,
             profile_events: None,
         };
-        let query = Query::new(query_result.id, self.address, query);
+        let query = Query::new_with_settings(
+            query_result.id,
+            self.address,
+            query,
+            settings,
+        );
         self.writer.send(ClientPacket::Query(Box::new(query))).await?;
-        self.outstanding_query = true;
+        self.has_outstanding_query = true;
 
         // If we have data to send, wait for the server to send an empty block
         // that describes its structure.
@@ -276,38 +429,10 @@ impl Connection {
                             // inserted our data.
                             | ServerPacket::EndOfStream =>
                         {
-                            let kind = packet.kind();
-                            probes::unexpected__server__packet!(|| (self.address.ip().to_string(), kind));
-                            break Err(Error::UnexpectedPacket(kind));
+                            break Err(self.on_unexpected_packet(packet.kind()));
                         }
                         ServerPacket::Data(block) => {
-                            // Similar to when selecting data, the server sends
-                            // a block with zero rows that describes the table
-                            // structure, so any block with a non-zero number of
-                            // rows is an error here.
-                            if block.n_rows() != 0 {
-                                break Err(Error::ExpectedEmptyDataBlock);
-                            }
-
-                            // Don't concatenate the block, but check that its
-                            // structure matches what we're about to insert.
-                            if !block_to_insert.matches_structure(&block) {
-                                break Err(Error::MismatchedBlockStructure);
-                            }
-
-                            // Finally, send the actual data block and an empty
-                            // block to tell the server we're finished.
-                            if let Err(e) = self
-                                .writer
-                                .send(ClientPacket::Data(block_to_insert))
-                                .await
-                            {
-                                break Err(e);
-                            }
-                            break self
-                                .writer
-                                .send(ClientPacket::Data(Block::empty()))
-                                .await;
+                            break self.check_block_structure_and_insert(block_to_insert, block).await;
                         }
                         ServerPacket::Exception(exceptions) => {
                             break Err(Error::Exception { exceptions })
@@ -322,19 +447,19 @@ impl Connection {
                             if !block_to_insert
                                 .insertable_into(&columns)
                             {
-                                break Err(Error::MismatchedBlockStructure);
+                                break Err(self.on_protocol_error(Error::MismatchedBlockStructure));
                             }
                         }
                         ServerPacket::ProfileEvents(block) => {
                             let _ = query_result.profile_events.replace(block);
                         }
                     },
-                    Some(Err(e)) => break Err(e),
-                    None => break Err(Error::Disconnected),
+                    Some(Err(e)) => break Err(self.on_decode_error(e)),
+                    None => break Err(self.on_disconnected()),
                 }
             };
             if let Err(e) = res {
-                self.outstanding_query = false;
+                self.has_outstanding_query = false;
                 return Err(e);
             }
         }
@@ -346,12 +471,7 @@ impl Connection {
                     ServerPacket::Hello(_)
                     | ServerPacket::Pong
                     | ServerPacket::TableColumns(_) => {
-                        let kind = packet.kind();
-                        probes::unexpected__server__packet!(|| (
-                            self.address.ip().to_string(),
-                            kind
-                        ));
-                        break Err(Error::UnexpectedPacket(kind));
+                        break Err(self.on_unexpected_packet(packet.kind()));
                     }
                     ServerPacket::Data(block) => {
                         // Empty blocks are sent twice: the beginning of the
@@ -380,25 +500,29 @@ impl Connection {
                         let _ = query_result.profile_events.replace(block);
                     }
                 },
-                Some(Err(e)) => break Err(e),
-                None => break Err(Error::Disconnected),
+                Some(Err(e)) => break Err(self.on_decode_error(e)),
+                None => break Err(self.on_disconnected()),
             }
         };
-        self.outstanding_query = false;
+        self.has_outstanding_query = false;
         res
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::Connector;
     use crate::native::block::Block;
     use crate::native::block::Column;
     use crate::native::block::DataType;
     use crate::native::block::ValueArray;
     use crate::native::connection::Connection;
+    use crate::native::packets::client::Setting;
+    use crate::native::packets::client::Settings;
     use indexmap::IndexMap;
     use omicron_test_utils::dev::clickhouse::ClickHouseDeployment;
     use omicron_test_utils::dev::test_setup_log;
+    use qorb::backend::Connector as _;
     use std::sync::Arc;
     use tokio::sync::Mutex;
     use tokio::sync::oneshot;
@@ -616,17 +740,17 @@ mod tests {
         let task = tokio::spawn(async move {
             let mut conn = conn_.lock().await;
             const QUERY: &str = "select count(*) from system.numbers";
-            println!("query task: unning query: '{QUERY}'");
+            println!("query task: running query: '{QUERY}'");
             let res = conn.query(Uuid::new_v4(), QUERY);
             tokio::select! {
                 query_result = res => {
-                    println!("query task: uery future awaited");
+                    println!("query task: query future awaited");
                     Some(query_result)
                 }
                 _ = cancel_rx => {
-                    println!("query task: ancel rx awaited, cancelling the query");
+                    println!("query task: cancel rx awaited, cancelling the query");
                     conn.cancel().await.unwrap();
-                    println!("query task: uery cancelled");
+                    println!("query task: query cancelled");
                     None
                 }
             }
@@ -758,6 +882,106 @@ mod tests {
         };
         let id: uuid::Uuid = ids[0].parse().unwrap();
         assert_eq!(id, ID, "UUID stored incorrectly in ClickHouse");
+        db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn ensure_desynced_connections_are_poisoned() {
+        let logctx = test_setup_log("ensure_desynced_connections_are_poisoned");
+        let mut db = ClickHouseDeployment::new_single_node(&logctx)
+            .await
+            .expect("Failed to start ClickHouse");
+        let mut conn =
+            Connection::new(db.native_address().into()).await.unwrap();
+        assert!(!conn.is_poisoned, "new connection should not be poisoned");
+
+        // Run a query that gives us an unsupported data type. We only learn
+        // this partway through the query, at which point we abort processing
+        // the rest of the stream. That should leave some junk in the buffers,
+        // and we definitely want to mark the connection as poisoned.
+        let res = conn.query(Uuid::new_v4(), "SELECT map('a', 1) AS m").await;
+        assert!(
+            res.is_err(),
+            "expected decoding error with unsupported map data type"
+        );
+        assert!(
+            conn.is_poisoned,
+            "connection should be poisoned after a failure mid-stream"
+        );
+
+        // Sanity check, but make sure we report to qorb that the connections
+        // are unhealthy.
+        let connector = Connector;
+        assert!(connector.is_valid(&mut conn).await.is_err());
+        assert!(connector.on_recycle(&mut conn).await.is_err());
+
+        db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn ensure_dropped_query_future_poisons_connection() {
+        let logctx =
+            test_setup_log("ensure_dropped_query_future_poisons_connection");
+        let mut db = ClickHouseDeployment::new_single_node(&logctx)
+            .await
+            .expect("Failed to start ClickHouse");
+        let mut conn =
+            Connection::new(db.native_address().into()).await.unwrap();
+        assert!(!conn.is_poisoned, "new connection should not be poisoned");
+
+        // Run an infinite query and drop it right away. We should poison the
+        // connection because it's not been fully completed.
+        let res = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            conn.query(Uuid::new_v4(), "SELECT COUNT(*) FROM system.numbers"),
+        )
+        .await;
+        assert!(res.is_err(), "should have timed out");
+        assert!(
+            conn.is_poisoned,
+            "dropping a query future should leave a connection poisoned"
+        );
+
+        db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn ensure_settings_correctly_encoded() {
+        let logctx = test_setup_log("ensure_settings_correctly_encoded");
+        let mut db = ClickHouseDeployment::new_single_node(&logctx)
+            .await
+            .expect("Failed to start ClickHouse");
+        let mut conn =
+            Connection::new(db.native_address().into()).await.unwrap();
+
+        // Simple query with some non-empty settings.
+        let mut settings = Settings::new();
+        settings.insert(
+            "max_threads".into(),
+            Setting { value: "1".into(), important: false },
+        );
+        let query_result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            conn.query_with_settings(
+                Uuid::new_v4(),
+                "SELECT toString(getSetting('max_threads')) AS x",
+                settings,
+            ),
+        )
+        .await
+        .expect("query with custom settings should not have timed out")
+        .expect("query with custom settings should have succeeded");
+        let block = query_result.data.expect("query should have data");
+        let ValueArray::String(values) = block.column_values("x").unwrap()
+        else {
+            panic!("expected a String result");
+        };
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0], "1", "server failed to apply settings");
+
         db.cleanup().await.unwrap();
         logctx.cleanup_successful();
     }

--- a/oximeter/db/src/native/io/packet/client.rs
+++ b/oximeter/db/src/native/io/packet/client.rs
@@ -126,8 +126,8 @@ impl Encoder {
     fn encode_settings(&self, settings: Settings, mut dst: &mut BytesMut) {
         for (name, setting) in settings.iter() {
             io::string::encode(name, &mut dst);
-            io::string::encode(&setting.value, &mut dst);
             dst.put_u8(u8::from(setting.important));
+            io::string::encode(&setting.value, &mut dst);
         }
 
         // There is no prefix for the length of the settings map. It's NULL
@@ -159,7 +159,14 @@ impl tokio_util::codec::Encoder<Packet> for Encoder {
         match item {
             Packet::Hello(hello) => self.encode_hello(&hello, dst),
             Packet::Query(query) => self.encode_query(query, dst),
-            Packet::Data(block) => self.encode_block(block, dst)?,
+            Packet::Data(block) => {
+                if let Err(e) = self.encode_block(block, dst) {
+                    probes::packet__send__failed!(|| {
+                        (self.addr.to_string(), kind, e.to_string())
+                    });
+                    return Err(e);
+                }
+            }
             Packet::Cancel => dst.put_u8(Packet::CANCEL),
             Packet::Ping => dst.put_u8(Packet::PING),
         };

--- a/oximeter/db/src/native/io/packet/server.rs
+++ b/oximeter/db/src/native/io/packet/server.rs
@@ -128,17 +128,15 @@ impl tokio_util::codec::Decoder for Decoder {
                     Err(e) => {
                         // We failed to correctly decode the packet.
                         //
-                        // We may need to do something else in the future, but
-                        // for now, just throw away the buffer. We have no idea
-                        // how much data we need to lop off. We should
-                        // realistically RST the whole TCP connection, most
-                        // likely.
+                        // There's not much we can do here, since we don't have
+                        // a length to move to the end of this packet. Instead,
+                        // we'll just return the error, and the connection will
+                        // stay poisoned.
                         probes::invalid__packet!(|| (
                             self.addr.to_string(),
                             "Hello",
                             src.len()
                         ));
-                        src.clear();
                         return Err(e);
                     }
                 }
@@ -152,7 +150,6 @@ impl tokio_util::codec::Decoder for Decoder {
                         "Data",
                         src.len()
                     ));
-                    src.clear();
                     return Err(e);
                 }
             },
@@ -165,7 +162,6 @@ impl tokio_util::codec::Decoder for Decoder {
                         "Exception",
                         src.len()
                     ));
-                    src.clear();
                     return Err(e);
                 }
             },
@@ -193,7 +189,6 @@ impl tokio_util::codec::Decoder for Decoder {
                             "TableColumns",
                             src.len()
                         ));
-                        src.clear();
                         return Err(e);
                     }
                 }
@@ -208,22 +203,21 @@ impl tokio_util::codec::Decoder for Decoder {
                         "ProfileEvents",
                         src.len()
                     ));
-                    src.clear();
                     return Err(e);
                 }
             },
             _ => {
                 // We don't know anything about the packet, drop it.
                 //
-                // Again, we probably need to handle this more gracefully, but
-                // it's not clear how in the absence of a header with the packet
-                // size.
+                // Similar to a decoding error, we can't move beyond this
+                // unknown packet without a length in the header. There's
+                // nothing to do but return the error and consider the
+                // connection poisoned.
                 probes::unrecognized__server__packet!(|| (
                     self.addr.to_string(),
                     u64::from(kind),
                     src.len()
                 ));
-                src.clear();
                 return Err(Error::UnrecognizedServerPacket(kind));
             }
         };
@@ -337,10 +331,15 @@ mod tests {
         );
         assert_eq!(prefix.len(), 10);
 
+        let n_bytes = suffix.len();
         decoder.decode(&mut suffix).expect_err(
             "Should return an error when decoding from the middle of a frame",
         );
-        assert!(suffix.is_empty(), "Should truncate the input buffer on error");
+        assert_eq!(
+            suffix.len(),
+            n_bytes,
+            "Should leave the input buffer untouched on error"
+        );
     }
 
     #[test]

--- a/oximeter/db/src/native/mod.rs
+++ b/oximeter/db/src/native/mod.rs
@@ -143,6 +143,9 @@ mod probes {
     ) {
     }
 
+    /// Fires just after failing to send a packet.
+    fn packet__send__failed(addr: &str, kind: &str, message: &str) {}
+
     /// Fires just after we finish sending a packet.
     fn packet__send__done(addr: &str) {}
 
@@ -158,7 +161,7 @@ mod probes {
     fn disconnected(addr: &str) {}
 
     /// Emitted when we receive an unrecognized packet, with the kind and the
-    /// length of the discarded buffer.
+    /// length of the unprocessed buffer.
     fn unrecognized__server__packet(addr: &str, kind: u64, len: usize) {}
 
     /// Emitted when we receive an unexpected packet, based on the messages we've
@@ -166,8 +169,14 @@ mod probes {
     fn unexpected__server__packet(addr: &str, kind: &str) {}
 
     /// Emitted when we receive an invalid packet, with the kind we think it is
-    /// supposed to be and the length of the discarded buffer.
+    /// supposed to be and the length of the unprocessed buffer.
     fn invalid__packet(addr: &str, kind: &str, len: usize) {}
+
+    /// Emitted when we fail to decode a message frame from the server.
+    fn decode__failed(addr: &str, message: &str) {}
+
+    /// Emitted when there is a generic protocol error.
+    fn protocol__error(addr: &str, message: &str) {}
 }
 
 /// An error interacting ClickHouse over the native protocol.
@@ -250,6 +259,9 @@ pub enum Error {
         "A query unexpectedly resulted in an empty data block; query: {query}"
     )]
     UnexpectedEmptyBlock { query: String },
+
+    #[error("TCP connection to the ClickHouse server is poisoned")]
+    Poisoned,
 }
 
 impl Error {

--- a/oximeter/db/src/native/packets/client.rs
+++ b/oximeter/db/src/native/packets/client.rs
@@ -113,10 +113,19 @@ pub struct Query {
 
 impl Query {
     pub fn new(id: Uuid, address: SocketAddr, query: &str) -> Self {
+        Self::new_with_settings(id, address, query, Settings::new())
+    }
+
+    pub fn new_with_settings(
+        id: Uuid,
+        address: SocketAddr,
+        query: &str,
+        settings: Settings,
+    ) -> Self {
         Self {
             id: id.to_string().into(),
             client_info: ClientInfo::new(id.to_string(), address),
-            settings: Settings::new(),
+            settings,
             secret: "".into(),
             stage: Stage::Complete,
             compression: 0,

--- a/oximeter/db/src/native/packets/server.rs
+++ b/oximeter/db/src/native/packets/server.rs
@@ -214,7 +214,7 @@ impl core::ops::Add for Progress {
                 .saturating_add(rhs.total_rows_to_read),
             total_bytes_to_read: self
                 .total_bytes_to_read
-                .saturating_add(rhs.total_rows_to_read),
+                .saturating_add(rhs.total_bytes_to_read),
             rows_written: self.rows_written.saturating_add(rhs.rows_written),
             bytes_written: self.bytes_written.saturating_add(rhs.bytes_written),
             query_time: self.query_time.saturating_add(rhs.query_time),
@@ -232,7 +232,7 @@ impl core::ops::AddAssign for Progress {
                 .saturating_add(rhs.total_rows_to_read),
             total_bytes_to_read: self
                 .total_bytes_to_read
-                .saturating_add(rhs.total_rows_to_read),
+                .saturating_add(rhs.total_bytes_to_read),
             rows_written: self.rows_written.saturating_add(rhs.rows_written),
             bytes_written: self.bytes_written.saturating_add(rhs.bytes_written),
             query_time: self.query_time.saturating_add(rhs.query_time),


### PR DESCRIPTION
- Add an `is_poisoned` flag to the ClickHouse native connection type, which is used to detect when the connection is no longer usable. This is set whenever we get an unexpected packet, unsupported protocol feature, or otherwise fail to decode a full message from the TCP buffers. Since the protocol doesn't include frame lengths, we have no way of correctly skipping to the start of the next frame, and we fail any other attempt to use the stream.
- Use the `is_poisoned` bit to report the connection as unhealthy to `qorb` on recycling. `qorb` uses that to destroy the connection and add another one to the pool.
- Cleans up the client-side protocol state machine code, and also adds a wrapper to assist poisoning. This always sets the poison flag right away, runs some provided exchange function, and then only clears the flag if that exchange succeeds. This also makes it easy to cover _dropping_ the exchange future and still cleaning up the connection when returning to a pool.
- Fixes #11255 and adds regression tests
- Also fixes a bug encoding settings from the client, and adds a regression test for that.
- Also fixes a tiny copy-paste bug in accumulating progress reports