### PR TITLE
Add regression test for #11251

### DIFF
--- a/nexus/src/app/metrics.rs
+++ b/nexus/src/app/metrics.rs
@@ -113,15 +113,7 @@ impl super::Nexus {
         self.timeseries_client
             .timeseries_schema_list(&pagination.page, limit)
             .await
-            .map_err(|e| match e {
-                oximeter_db::Error::DatabaseUnavailable(_)
-                | oximeter_db::Error::Connection(_) => {
-                    Error::ServiceUnavailable {
-                        internal_message: e.to_string(),
-                    }
-                }
-                _ => Error::InternalError { internal_message: e.to_string() },
-            })
+            .map_err(super::oximeter::map_oximeter_err)
     }
 
     /// Run an OxQL query against the timeseries database.
@@ -139,7 +131,7 @@ impl super::Nexus {
         self.timeseries_client
             .oxql_query(query, QueryAuthzScope::Fleet)
             .await
-            .map_err(map_timeseries_err)
+            .map_err(super::oximeter::map_oximeter_err)
     }
 
     /// Run an OxQL query against the timeseries database, scoped to a specific project.
@@ -161,18 +153,6 @@ impl super::Nexus {
                 },
             )
             .await
-            .map_err(map_timeseries_err)
-    }
-}
-
-fn map_timeseries_err(e: oximeter_db::Error) -> Error {
-    match e {
-        oximeter_db::Error::DatabaseUnavailable(_)
-        | oximeter_db::Error::Connection(_) => Error::unavail(&e.to_string()),
-        oximeter_db::Error::Oxql(_)
-        | oximeter_db::Error::TimeseriesNotFound(_) => {
-            Error::invalid_request(e.to_string())
-        }
-        _ => Error::internal_error(&e.to_string()),
+            .map_err(super::oximeter::map_oximeter_err)
     }
 }

--- a/nexus/src/app/oximeter.rs
+++ b/nexus/src/app/oximeter.rs
@@ -15,6 +15,7 @@ use omicron_common::api::internal::nexus::{self, ProducerEndpoint};
 use oximeter_client::Client as OximeterClient;
 use oximeter_db::Measurement;
 use oximeter_db::query::Timestamp;
+use slog_error_chain::InlineErrorChain;
 use std::net::SocketAddr;
 use std::num::NonZeroU32;
 use std::time::Duration;
@@ -254,13 +255,16 @@ pub(crate) async fn unassign_producer(
     }
 }
 
-fn map_oximeter_err(error: oximeter_db::Error) -> Error {
-    match error {
+pub(crate) fn map_oximeter_err(e: oximeter_db::Error) -> Error {
+    let as_str = InlineErrorChain::new(&e).to_string();
+    match e {
         oximeter_db::Error::DatabaseUnavailable(_)
-        | oximeter_db::Error::Connection(_) => {
-            Error::ServiceUnavailable { internal_message: error.to_string() }
+        | oximeter_db::Error::Connection(_) => Error::unavail(&as_str),
+        oximeter_db::Error::Oxql(_)
+        | oximeter_db::Error::TimeseriesNotFound(_) => {
+            Error::invalid_request(as_str)
         }
-        _ => Error::InternalError { internal_message: error.to_string() },
+        _ => Error::internal_error(as_str),
     }
 }
 

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -252,16 +252,11 @@ impl Client {
         }
 
         let query = query_builder.build();
-        let mut handle = self.claim_connection().await?;
         let info = match query.field_query() {
             Some(field_query) => {
-                self.select_matching_timeseries_info(
-                    &mut handle,
-                    &field_query,
-                    &schema,
-                )
-                .await?
-                .1
+                self.select_matching_timeseries_info(&field_query, &schema)
+                    .await?
+                    .1
             }
             None => BTreeMap::new(),
         };
@@ -277,13 +272,7 @@ impl Client {
             // a way that is arbitrary with respect to the query.
             Err(Error::InvalidLimitQuery)
         } else {
-            self.select_timeseries_with_keys(
-                &mut handle,
-                &query,
-                &info,
-                &schema,
-            )
-            .await
+            self.select_timeseries_with_keys(&query, &info, &schema).await
         }
     }
 
@@ -318,29 +307,18 @@ impl Client {
         }
 
         let query = query_builder.build();
-        let mut handle = self.claim_connection().await?;
         let info = match query.field_query() {
             Some(field_query) => {
-                self.select_matching_timeseries_info(
-                    &mut handle,
-                    &field_query,
-                    &schema,
-                )
-                .await?
-                .1
+                self.select_matching_timeseries_info(&field_query, &schema)
+                    .await?
+                    .1
             }
             None => BTreeMap::new(),
         };
         let results = if info.is_empty() {
             vec![]
         } else {
-            self.select_timeseries_with_keys(
-                &mut handle,
-                &query,
-                &info,
-                &schema,
-            )
-            .await?
+            self.select_timeseries_with_keys(&query, &info, &schema).await?
         };
         Ok(ResultsPage::new(results, &params, |_, _| {
             NonZeroU32::try_from(limit.get() + offset).unwrap()
@@ -1263,14 +1241,18 @@ impl Client {
     // query.
     async fn select_matching_timeseries_info(
         &self,
-        handle: &mut Handle,
         field_query: &str,
         schema: &TimeseriesSchema,
     ) -> Result<
         (oxql_types::QuerySummary, BTreeMap<TimeseriesKey, (Target, Metric)>),
         Error,
     > {
-        let result = self.execute_with_block(handle, field_query).await?;
+        let result = self
+            .execute_with_block(
+                &mut self.claim_connection().await?,
+                field_query,
+            )
+            .await?;
         let summary = result.query_summary();
         let Some(block) = &result.data else {
             error!(
@@ -1296,7 +1278,6 @@ impl Client {
     // measurements from timeseries with those keys.
     async fn select_timeseries_with_keys(
         &self,
-        handle: &mut Handle,
         query: &query::SelectQuery,
         info: &BTreeMap<TimeseriesKey, (Target, Metric)>,
         schema: &TimeseriesSchema,
@@ -1304,8 +1285,13 @@ impl Client {
         let mut timeseries_by_key = BTreeMap::new();
         let keys = info.keys().copied().collect::<Vec<_>>();
         let measurement_query = query.measurement_query(&keys);
-        let Some(block) =
-            self.execute_with_block(handle, &measurement_query).await?.data
+        let Some(block) = self
+            .execute_with_block(
+                &mut self.claim_connection().await?,
+                &measurement_query,
+            )
+            .await?
+            .data
         else {
             error!(
                 self.log,

--- a/oximeter/db/src/client/oxql.rs
+++ b/oximeter/db/src/client/oxql.rs
@@ -4,7 +4,6 @@
 
 //! Client methods for running OxQL queries against the timeseries database.
 
-use super::Handle;
 use crate::Error;
 use crate::Metric;
 use crate::Target;
@@ -177,7 +176,6 @@ impl Client {
         let result = self
             .run_oxql_query(
                 &query_log,
-                &mut self.claim_connection().await?,
                 query_id,
                 filtered_query,
                 &mut total_rows_fetched,
@@ -330,11 +328,9 @@ impl Client {
     // concatenate the results; and then apply all the remaining
     // transformations.
     #[async_recursion::async_recursion]
-    #[allow(clippy::too_many_arguments)]
     async fn run_oxql_query(
         &self,
         query_log: &Logger,
-        handle: &mut Handle,
         query_id: Uuid,
         query: oxql::Query,
         total_rows_fetched: &mut u64,
@@ -365,7 +361,6 @@ impl Client {
                 let res = self
                     .run_oxql_query(
                         query_log,
-                        handle,
                         query_id,
                         subq,
                         total_rows_fetched,
@@ -403,6 +398,18 @@ impl Client {
 
         // This is a flat query, let's just run it directly. First step is
         // getting the schema itself.
+        //
+        // TODO-robustness: This seems fragile when running against a replicated
+        // ClickHouse cluster. In that case, each of these different query
+        // components could execute against a different replica, which might
+        // have different sets of data from one another depending on the
+        // replication status. In that case, we could run into weird races or
+        // inconsistencies. Holding a database claim across the entire OxQL
+        // query is slightly better (though terrible for other reasons), but
+        // still not perfect: ClickHouse's weak gaurantees around consistency
+        // and the fact that we're inserting into multiple tables today make it
+        // possible that querying even a single replica could cause consistency
+        // problems.
         let query_start = Instant::now();
         let oxql::ast::SplitQuery::Flat(query) = split else {
             unreachable!();
@@ -503,11 +510,7 @@ impl Client {
             let all_fields_query =
                 self.all_fields_query(&schema, predicates.as_ref())?;
             let (summary, consistent_keys) = self
-                .select_matching_timeseries_info(
-                    handle,
-                    &all_fields_query,
-                    &schema,
-                )
+                .select_matching_timeseries_info(&all_fields_query, &schema)
                 .await?;
             debug!(
                 query_log,
@@ -551,7 +554,6 @@ impl Client {
         let (summaries, timeseries_by_key) = self
             .select_matching_samples(
                 query_log,
-                handle,
                 &schema,
                 &consistent_key_groups,
                 limit,
@@ -607,7 +609,6 @@ impl Client {
     async fn select_matching_samples(
         &self,
         query_log: &Logger,
-        handle: &mut Handle,
         schema: &TimeseriesSchema,
         consistent_key_groups: &[ConsistentKeyGroup],
         limit: Option<Limit>,
@@ -641,8 +642,12 @@ impl Client {
                 limit,
                 total_rows_fetched,
             )?;
-            let result =
-                self.execute_with_block(handle, &measurements_query).await?;
+            let result = self
+                .execute_with_block(
+                    &mut self.claim_connection().await?,
+                    &measurements_query,
+                )
+                .await?;
             let summary = result.query_summary();
             summaries.push(summary);
             let Some(block) = result.data.as_ref() else {

--- a/oximeter/db/src/client/oxql.rs
+++ b/oximeter/db/src/client/oxql.rs
@@ -1199,6 +1199,8 @@ mod tests {
     };
     use oximeter::{FieldValue, TimeseriesName, types::Cumulative};
     use oxql_types::{Table, Timeseries, point::Points};
+    use qorb::policy::{Policy, SetConfig};
+    use qorb::resolvers::fixed::FixedResolver;
     use std::collections::{BTreeMap, BTreeSet};
     use std::time::Duration;
 
@@ -1903,5 +1905,45 @@ mod tests {
             )
         );
         logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn oxql_query_uses_at_most_one_concurrent_claim() {
+        let ctx =
+            setup_oxql_test("oxql_query_uses_at_most_one_concurrent_claim")
+                .await;
+
+        // Construct a pool with exactly one claim. This ensures that we never
+        // try to acquire a claim while already holding one.
+        let policy = Policy {
+            max_slots: 1,
+            claim_timeout: Duration::from_secs(5),
+            set_config: SetConfig { max_count: 1, ..Default::default() },
+            ..Default::default()
+        };
+        let client = Client::new_with_pool_policy(
+            Box::new(FixedResolver::new([ctx
+                .clickhouse
+                .native_address()
+                .into()])),
+            "single-slot-test",
+            policy,
+            &ctx.logctx.log,
+        );
+
+        // Run a stupid-simple query under a timeout to avoid stalling the test
+        // itself.
+        let result = tokio::time::timeout(
+            Duration::from_secs(30),
+            client.oxql_query(
+                "get some_target:some_metric | last 1",
+                QueryAuthzScope::Fleet,
+            ),
+        )
+        .await
+        .expect("oxql query should not time out")
+        .expect("oxql query should succeed with a single-slot pool");
+        assert!(!result.tables.is_empty(), "Should have some result tables");
+        ctx.cleanup_successful().await;
     }
 }


### PR DESCRIPTION
This adds a regression test that proves OxQL queries hold connections for too long, and specifically that the client attempts to checkout a claim when already has one. The test creates a `qorb` pool of size exactly one, and shows that the test times out attempting to get the second claim.