### PR TITLE
live-tests: allow overriding the rack subnet via LIVE_TESTS_RACK_SUBNET

### DIFF
--- a/live-tests/tests/common/mod.rs
+++ b/live-tests/tests/common/mod.rs
@@ -104,7 +104,32 @@ fn create_resolver(log: &slog::Logger) -> Result<Resolver, anyhow::Error> {
     // deployments today.  That's because while the base subnet is in principle
     // configurable in config-rss.toml, it's very uncommon to change it from the
     // default value used here.
-    let subnet = Ipv6Subnet::new("fd00:1122:3344:0100::".parse().unwrap());
+    //
+    // For deployments that _do_ use a non-default base subnet (e.g. racks whose
+    // ULA prefix was randomized at RSS time), the subnet can be overridden by
+    // setting LIVE_TESTS_RACK_SUBNET to any IPv6 address within the AZ subnet
+    // (for example, an internal DNS server address).
+    const RACK_SUBNET_ENV: &str = "LIVE_TESTS_RACK_SUBNET";
+    let subnet = match std::env::var(RACK_SUBNET_ENV) {
+        Ok(value) => {
+            let addr =
+                value.parse::<std::net::Ipv6Addr>().with_context(|| {
+                    format!(
+                        "parsing {} value {:?} as an IPv6 address",
+                        RACK_SUBNET_ENV, value
+                    )
+                })?;
+            Ipv6Subnet::new(addr)
+        }
+        Err(std::env::VarError::NotPresent) => {
+            Ipv6Subnet::new("fd00:1122:3344:0100::".parse().unwrap())
+        }
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!("reading environment variable {}", RACK_SUBNET_ENV)
+            });
+        }
+    };
     eprintln!("note: using DNS server for subnet {}", subnet.net());
     internal_dns_resolver::Resolver::new_from_subnet(log.clone(), subnet)
         .with_context(|| {


### PR DESCRIPTION
The create_resolver() function hardcoded fd00:1122:3344:0100:: , which makes current live-test executions fail. 
This change is to make the selection dynamic, so that an available address get picked by LIVE_TESTS_RACK_SUBNET.