### PR TITLE
Rename `alert` field on `Alert` response to `payload`

### DIFF
--- a/nexus/db-model/src/alert.rs
+++ b/nexus/db-model/src/alert.rs
@@ -135,7 +135,7 @@ impl From<Alert> for external_api::alert::Alert {
             identity: _, // we already converted this above
             class,
             version,
-            payload: alert,
+            payload,
             // internal dispatch data is not included in the API model
             num_dispatched: _,
             time_dispatched: _,
@@ -146,7 +146,7 @@ impl From<Alert> for external_api::alert::Alert {
             identity,
             class: class.to_string(),
             version: version.into(),
-            alert,
+            payload,
         }
     }
 }

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -38,6 +38,7 @@ use nexus_types_versions::v2026_02_13_01;
 use nexus_types_versions::v2026_04_16_00;
 use nexus_types_versions::v2026_05_07_00;
 use nexus_types_versions::v2026_06_05_00;
+use nexus_types_versions::v2026_08_14_00;
 use omicron_common::address::IpRange;
 use omicron_common::api::external::{
     http_pagination::{
@@ -87,6 +88,7 @@ api_versions!([
     // |  date-based version should be at the top of the list.
     // v
     // (next_yyyy_mm_dd_nn, IDENT),
+    (2026_09_11_00, ALERT_PAYLOAD),
     (2026_09_08_00, PROJECT_AND_VPC_CREATE_DEFAULTS),
     (2026_08_28_00, SILO_USER_DOCS),
     (2026_08_19_01, BGP_PEER_SRC_ADDR),
@@ -9375,24 +9377,69 @@ pub trait NexusExternalApi {
         method = GET,
         path = "/v1/alerts",
         tags = ["system/alerts"],
-        versions = VERSION_ALERT_LIST..
+        versions = VERSION_ALERT_PAYLOAD..
     }]
     async fn alert_list(
         rqctx: RequestContext<Self::Context>,
         pagination: Query<PaginatedByTimeAndId<latest::alert::AlertListParams>>,
     ) -> Result<HttpResponseOk<ResultsPage<latest::alert::Alert>>, HttpError>;
 
+    /// List alerts
+    ///
+    /// Alerts may be filtered by alert class or alert class glob and by an
+    /// inclusive creation time range.
+    #[endpoint {
+        operation_id = "alert_list",
+        method = GET,
+        path = "/v1/alerts",
+        tags = ["system/alerts"],
+        versions = VERSION_ALERT_LIST..VERSION_ALERT_PAYLOAD
+    }]
+    async fn alert_list_v2026_08_14_00(
+        rqctx: RequestContext<Self::Context>,
+        pagination: Query<
+            PaginatedByTimeAndId<v2026_08_14_00::alert::AlertListParams>,
+        >,
+    ) -> Result<
+        HttpResponseOk<ResultsPage<v2026_08_14_00::alert::Alert>>,
+        HttpError,
+    > {
+        Self::alert_list(rqctx, pagination).await.map(|HttpResponseOk(page)| {
+            HttpResponseOk(ResultsPage {
+                items: page.items.into_iter().map(Into::into).collect(),
+                next_page: page.next_page,
+            })
+        })
+    }
+
     /// Fetch alert
     #[endpoint {
         method = GET,
         path = "/v1/alerts/{alert_id}",
         tags = ["system/alerts"],
-        versions = VERSION_ALERT_LIST..
+        versions = VERSION_ALERT_PAYLOAD..
     }]
     async fn alert_view(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<latest::alert::AlertSelector>,
     ) -> Result<HttpResponseOk<latest::alert::Alert>, HttpError>;
+
+    /// Fetch alert
+    #[endpoint {
+        operation_id = "alert_view",
+        method = GET,
+        path = "/v1/alerts/{alert_id}",
+        tags = ["system/alerts"],
+        versions = VERSION_ALERT_LIST..VERSION_ALERT_PAYLOAD
+    }]
+    async fn alert_view_v2026_08_14_00(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<v2025_11_20_00::alert::AlertSelector>,
+    ) -> Result<HttpResponseOk<v2026_08_14_00::alert::Alert>, HttpError> {
+        Self::alert_view(rqctx, path_params)
+            .await
+            .map(|HttpResponseOk(alert)| HttpResponseOk(alert.into()))
+    }
 
     /// List alert classes
     #[endpoint {

--- a/nexus/tests/integration_tests/alerts.rs
+++ b/nexus/tests/integration_tests/alerts.rs
@@ -229,7 +229,7 @@ async fn test_alert_list_and_view(ctx: &ControlPlaneTestContext) {
     assert_eq!(view.identity.id, foo_bar_id.into_untyped_uuid());
     assert_eq!(view.class, "test.foo.bar");
     assert_eq!(view.version, 0);
-    assert_eq!(view.alert, serde_json::json!({ "sequence": 2 }));
+    assert_eq!(view.payload, serde_json::json!({ "sequence": 2 }));
 
     alert_list_expect_error(
         client,

--- a/nexus/types/versions/src/alert_payload/alert.rs
+++ b/nexus/types/versions/src/alert_payload/alert.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::v2025_11_20_00::asset::AssetIdentityMetadata;
+use crate::v2026_08_14_00;
+
+/// An alert.
+///
+/// Alerts provide notifications about events that occurred in the system at a
+/// point in time. See the guide-level documentation on alerts for details.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Alert {
+    #[serde(flatten)]
+    pub identity: AssetIdentityMetadata,
+    /// The alert's class.
+    ///
+    /// See the guide-level documentation on alerts for details on alert
+    /// classes.
+    pub class: String,
+    /// The schema version of this alert's data payload.
+    ///
+    /// Alert schemas are versioned on a per-alert-class basis. The schema
+    /// version for a particular alert class does not correspond to an Oxide API
+    /// version. Clients should expect to encounter earlier schema versions when
+    /// retrieving alerts recorded by an earlier version of the system software.
+    ///
+    /// See the guide-level documentation on alerts for details.
+    pub version: u32,
+    /// The alert's data payload.
+    ///
+    /// The schema for this object depends on the alert class and version.
+    pub payload: serde_json::Value,
+}
+
+impl From<Alert> for v2026_08_14_00::alert::Alert {
+    fn from(new: Alert) -> Self {
+        Self {
+            identity: new.identity,
+            class: new.class,
+            version: new.version,
+            alert: new.payload,
+        }
+    }
+}

--- a/nexus/types/versions/src/alert_payload/mod.rs
+++ b/nexus/types/versions/src/alert_payload/mod.rs
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Version `ALERT_PAYLOAD` of the Nexus external API.
+//!
+//! Renames the `alert` field on the `Alert` response type to `payload`.
+
+pub mod alert;

--- a/nexus/types/versions/src/latest.rs
+++ b/nexus/types/versions/src/latest.rs
@@ -57,8 +57,9 @@ pub mod alert {
     pub use crate::v2025_11_20_00::alert::WebhookSecretSelector;
     pub use crate::v2025_11_20_00::alert::WebhookSecrets;
 
-    pub use crate::v2026_08_14_00::alert::Alert;
     pub use crate::v2026_08_14_00::alert::AlertListParams;
+
+    pub use crate::v2026_09_11_00::alert::Alert;
 }
 
 pub mod audit {

--- a/nexus/types/versions/src/lib.rs
+++ b/nexus/types/versions/src/lib.rs
@@ -105,3 +105,5 @@ pub mod v2026_08_14_00;
 pub mod v2026_08_14_01;
 #[path = "project_and_vpc_create_defaults/mod.rs"]
 pub mod v2026_09_08_00;
+#[path = "alert_payload/mod.rs"]
+pub mod v2026_09_11_00;

--- a/openapi/nexus/nexus-2026090800.0.0-1dca5e.json.gitstub
+++ b/openapi/nexus/nexus-2026090800.0.0-1dca5e.json.gitstub
@@ -1,0 +1,1 @@
+7ff4a2103d771b3f9c66a3778def67c61d17f780:openapi/nexus/nexus-2026090800.0.0-1dca5e.json

--- a/openapi/nexus/nexus-2026091100.0.0-017ed2.json
+++ b/openapi/nexus/nexus-2026091100.0.0-017ed2.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "2026090800.0.0"
+    "version": "2026091100.0.0"
   },
   "paths": {
     "/device/auth": {
@@ -16243,9 +16243,6 @@
         "description": "An alert.\n\nAlerts provide notifications about events that occurred in the system at a point in time. See the guide-level documentation on alerts for details.",
         "type": "object",
         "properties": {
-          "alert": {
-            "description": "The alert's data payload.\n\nThe schema for this object depends on the alert class and version."
-          },
           "class": {
             "description": "The alert's class.\n\nSee the guide-level documentation on alerts for details on alert classes.",
             "type": "string"
@@ -16254,6 +16251,9 @@
             "description": "Unique, immutable, system-controlled identifier for each resource",
             "type": "string",
             "format": "uuid"
+          },
+          "payload": {
+            "description": "The alert's data payload.\n\nThe schema for this object depends on the alert class and version."
           },
           "time_created": {
             "description": "Timestamp when this resource was created",
@@ -16273,9 +16273,9 @@
           }
         },
         "required": [
-          "alert",
           "class",
           "id",
+          "payload",
           "time_created",
           "time_modified",
           "version"

--- a/openapi/nexus/nexus-latest.json
+++ b/openapi/nexus/nexus-latest.json
@@ -1,1 +1,1 @@
-nexus-2026090800.0.0-1dca5e.json
+nexus-2026091100.0.0-017ed2.json


### PR DESCRIPTION
While working on https://github.com/oxidecomputer/console/pull/3320, we found the `alert` field on the `Alert` response a little awkward to talk about, a sign about naming that we try to take seriously when it's not too costly. Fortunately the alert list endpoint added in #11072 has not been in a release yet, so it's really no big deal to change it. Here we rename it to `payload`. @hawkw, @fakemonster, and I considered alternatives like `data` and `details`, but we're landing on `payload`.

`data` was a strong candidate because in the actual body we send to the webhook receiver, we call the whole thing the payload and we call the alert contents `data` there (see below). Still, I like that `payload` indicates it's the thing that is sent on somewhere. Somehow the metonymy there is much more tolerable than `alert` and `Alert` — maybe just because it's across two different objects rather than within the same one.

https://github.com/oxidecomputer/omicron/blob/9d95e0cf4542d2bc776c40b69f97ba6e05cff199/nexus/src/app/webhook.rs#L497-L504
