### PR TITLE
`ReconfiguratorConfig`: move `disruption_policy` into `PlannerConfig`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus/reconfigurator_config.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus/reconfigurator_config.rs
@@ -73,14 +73,15 @@ impl ReconfiguratorConfigOpts {
             planner_enabled: self
                 .planner_enabled
                 .unwrap_or(current.planner_enabled),
-            planner_config: PlannerConfig::default(),
+            planner_config: PlannerConfig {
+                disruption_policy: self
+                    .disruption_policy
+                    .map(|p| p.into())
+                    .unwrap_or(current.planner_config.disruption_policy),
+            },
             tuf_repo_pruner_enabled: self
                 .tuf_repo_pruner_enabled
                 .unwrap_or(current.tuf_repo_pruner_enabled),
-            disruption_policy: self
-                .disruption_policy
-                .map(|p| p.into())
-                .unwrap_or(current.disruption_policy),
             blueprint_pruner_enabled: self
                 .blueprint_pruner_enabled
                 .unwrap_or(current.blueprint_pruner_enabled),

--- a/dev-tools/omdb/src/bin/omdb/reconfigurator.rs
+++ b/dev-tools/omdb/src/bin/omdb/reconfigurator.rs
@@ -435,9 +435,8 @@ async fn cmd_reconfigurator_config_history(
                 config:
                     ReconfiguratorConfig {
                         planner_enabled,
-                        planner_config: PlannerConfig {},
+                        planner_config: PlannerConfig { disruption_policy },
                         tuf_repo_pruner_enabled,
-                        disruption_policy,
                         blueprint_pruner_enabled,
                         blueprint_pruner_nkeep,
                     },

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -2245,10 +2245,12 @@ Reconfigurator config:
     version: 1
     modified time: <REDACTED_TIMESTAMP>
     tuf repo pruner enabled: true
-    disruption policy: terminate
-    planner enabled: false
     blueprint pruner enabled: true
     blueprint pruner nkeep: 1000
+    planner enabled: false
+    planner config:
+        disruption policy: terminate
+
 ---------------------------------------------
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
@@ -2357,10 +2359,12 @@ Reconfigurator config:
     version: 3
     modified time: <REDACTED_TIMESTAMP>
     tuf repo pruner enabled: true
-    disruption policy: live-migrate or terminate
-    planner enabled: true
     blueprint pruner enabled: true
     blueprint pruner nkeep: 1000
+    planner enabled: true
+    planner config:
+        disruption policy: live-migrate or terminate
+
 ---------------------------------------------
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
@@ -25,7 +25,7 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-load-pick-collection-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-load-pick-collection-stdout
@@ -103,6 +103,6 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
@@ -22,7 +22,7 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-stdout
@@ -22,7 +22,7 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 
 > sled-list

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
@@ -22,7 +22,7 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 
 
@@ -83,7 +83,7 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 
 
@@ -1195,7 +1195,7 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 
 
@@ -1222,7 +1222,7 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 
 > load saved.out --collection-id 61f451b3-2121-4ed6-91c7-a550054f6c21
@@ -1286,7 +1286,7 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
@@ -63,7 +63,7 @@ cockroachdb settings:
     version::::::::::::   (none)
     preserve downgrade:   (not set)
 planner config:
-    (no current planner configs)
+    disruption policy: terminate
 
 
 

--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -1174,7 +1174,6 @@ mod test {
     use super::*;
 
     use nexus_types::deployment::PlannerConfig;
-    use nexus_types::deployment::ReconfiguratorDisruptionPolicy;
     use omicron_common::address::{
         CLICKHOUSE_TCP_PORT, Ipv6Subnet, RACK_PREFIX_LENGTH,
     };
@@ -1498,7 +1497,6 @@ mod test {
                         planner_enabled: true,
                         planner_config: PlannerConfig::default(),
                         tuf_repo_pruner_enabled: false,
-                        disruption_policy: ReconfiguratorDisruptionPolicy::Terminate,
                         blueprint_pruner_enabled: false,
                         blueprint_pruner_nkeep: 137,
                     }),

--- a/nexus/db-model/src/reconfigurator_config.rs
+++ b/nexus/db-model/src/reconfigurator_config.rs
@@ -28,7 +28,11 @@ impl From<deployment::ReconfiguratorConfigView> for ReconfiguratorConfig {
             planner_enabled: value.config.planner_enabled,
             time_modified: value.time_modified,
             tuf_repo_pruner_enabled: value.config.tuf_repo_pruner_enabled,
-            disruption_policy: value.config.disruption_policy.into(),
+            disruption_policy: value
+                .config
+                .planner_config
+                .disruption_policy
+                .into(),
             blueprint_pruner_enabled: value.config.blueprint_pruner_enabled,
             blueprint_pruner_nkeep: value.config.blueprint_pruner_nkeep.into(),
         }
@@ -41,9 +45,10 @@ impl From<ReconfiguratorConfig> for deployment::ReconfiguratorConfigView {
             version: value.version.into(),
             config: deployment::ReconfiguratorConfig {
                 planner_enabled: value.planner_enabled,
-                planner_config: deployment::PlannerConfig::default(),
+                planner_config: deployment::PlannerConfig {
+                    disruption_policy: value.disruption_policy.into(),
+                },
                 tuf_repo_pruner_enabled: value.tuf_repo_pruner_enabled,
-                disruption_policy: value.disruption_policy.into(),
                 blueprint_pruner_enabled: value.blueprint_pruner_enabled,
                 blueprint_pruner_nkeep: value.blueprint_pruner_nkeep.into(),
             },

--- a/nexus/db-queries/src/db/datastore/reconfigurator_config.rs
+++ b/nexus/db-queries/src/db/datastore/reconfigurator_config.rs
@@ -156,9 +156,8 @@ impl DataStore {
             config:
                 ReconfiguratorConfig {
                     planner_enabled,
-                    planner_config: PlannerConfig {},
+                    planner_config: PlannerConfig { disruption_policy },
                     tuf_repo_pruner_enabled,
-                    disruption_policy,
                     blueprint_pruner_enabled,
                     blueprint_pruner_nkeep,
                 },
@@ -196,7 +195,6 @@ mod tests {
     use crate::db::pub_test_utils::TestDatabase;
     use nexus_types::deployment::{
         DEFAULT_BLUEPRINT_PRUNER_NKEEP, PlannerConfig, ReconfiguratorConfig,
-        ReconfiguratorDisruptionPolicy,
     };
     use omicron_test_utils::dev;
 
@@ -223,7 +221,6 @@ mod tests {
                 planner_enabled: false,
                 planner_config: PlannerConfig::default(),
                 tuf_repo_pruner_enabled: true,
-                disruption_policy: ReconfiguratorDisruptionPolicy::default(),
                 blueprint_pruner_enabled: true,
                 blueprint_pruner_nkeep: DEFAULT_BLUEPRINT_PRUNER_NKEEP,
             },

--- a/nexus/src/app/background/tasks/reconfigurator_config.rs
+++ b/nexus/src/app/background/tasks/reconfigurator_config.rs
@@ -91,7 +91,7 @@ mod test {
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::deployment::{
         DEFAULT_BLUEPRINT_PRUNER_NKEEP, PlannerConfig, ReconfiguratorConfig,
-        ReconfiguratorConfigParam, ReconfiguratorDisruptionPolicy,
+        ReconfiguratorConfigParam,
     };
     use nexus_types::internal_api::background::BlueprintPlannerStatus;
     use nexus_types::internal_api::background::BlueprintPrunerStatus;
@@ -153,7 +153,6 @@ mod test {
             planner_enabled: !default_switches.config.planner_enabled,
             planner_config: PlannerConfig::default(),
             tuf_repo_pruner_enabled: true,
-            disruption_policy: ReconfiguratorDisruptionPolicy::default(),
             blueprint_pruner_enabled: true,
             blueprint_pruner_nkeep: DEFAULT_BLUEPRINT_PRUNER_NKEEP,
         };
@@ -187,7 +186,6 @@ mod test {
             planner_enabled: !expected_switches.planner_enabled,
             planner_config: PlannerConfig::default(),
             tuf_repo_pruner_enabled: true,
-            disruption_policy: ReconfiguratorDisruptionPolicy::default(),
             blueprint_pruner_enabled: true,
             blueprint_pruner_nkeep: DEFAULT_BLUEPRINT_PRUNER_NKEEP,
         };
@@ -246,7 +244,6 @@ mod test {
             planner_enabled: false,
             planner_config: PlannerConfig::default(),
             tuf_repo_pruner_enabled: false,
-            disruption_policy: ReconfiguratorDisruptionPolicy::default(),
             blueprint_pruner_enabled: false,
             blueprint_pruner_nkeep: DEFAULT_BLUEPRINT_PRUNER_NKEEP,
         };
@@ -291,7 +288,6 @@ mod test {
             planner_enabled: true,
             planner_config: PlannerConfig::default(),
             tuf_repo_pruner_enabled: true,
-            disruption_policy: ReconfiguratorDisruptionPolicy::default(),
             blueprint_pruner_enabled: true,
             blueprint_pruner_nkeep: DEFAULT_BLUEPRINT_PRUNER_NKEEP,
         };

--- a/nexus/test-utils/src/starter.rs
+++ b/nexus/test-utils/src/starter.rs
@@ -59,7 +59,6 @@ use nexus_types::deployment::OximeterReadMode;
 use nexus_types::deployment::PendingMgsUpdates;
 use nexus_types::deployment::PlannerConfig;
 use nexus_types::deployment::ReconfiguratorConfig;
-use nexus_types::deployment::ReconfiguratorDisruptionPolicy;
 use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::external_api::sled::SledState;
 use nexus_types::internal_api::params::DnsConfigParams;
@@ -591,7 +590,6 @@ impl<'a, N: NexusServer> ControlPlaneStarter<'a, N> {
                 planner_enabled: false,
                 planner_config: PlannerConfig::default(),
                 tuf_repo_pruner_enabled: true,
-                disruption_policy: ReconfiguratorDisruptionPolicy::default(),
                 blueprint_pruner_enabled: true,
                 blueprint_pruner_nkeep: DEFAULT_BLUEPRINT_PRUNER_NKEEP,
             });

--- a/nexus/types/src/deployment/reconfigurator_config.rs
+++ b/nexus/types/src/deployment/reconfigurator_config.rs
@@ -162,6 +162,7 @@ impl Default for ReconfiguratorConfig {
     strum::VariantArray,
 )]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub enum ReconfiguratorDisruptionPolicy {
     /// Terminate instances during updates -- do not attempt to migrate
     /// instances. This is currently the default.

--- a/nexus/types/src/deployment/reconfigurator_config.rs
+++ b/nexus/types/src/deployment/reconfigurator_config.rs
@@ -118,7 +118,6 @@ pub struct ReconfiguratorConfig {
     #[serde(default)]
     pub planner_config: PlannerConfig,
     pub tuf_repo_pruner_enabled: bool,
-    pub disruption_policy: ReconfiguratorDisruptionPolicy,
     pub blueprint_pruner_enabled: bool,
     pub blueprint_pruner_nkeep: u32,
 }
@@ -142,7 +141,6 @@ impl Default for ReconfiguratorConfig {
             planner_enabled: true,
             planner_config: PlannerConfig::default(),
             tuf_repo_pruner_enabled: true,
-            disruption_policy: ReconfiguratorDisruptionPolicy::default(),
             blueprint_pruner_enabled: true,
             blueprint_pruner_nkeep: DEFAULT_BLUEPRINT_PRUNER_NKEEP,
         }
@@ -212,18 +210,17 @@ impl fmt::Display for ReconfiguratorConfigDisplay<'_> {
             config:
                 ReconfiguratorConfig {
                     planner_enabled,
-                    planner_config: _,
+                    planner_config,
                     tuf_repo_pruner_enabled,
-                    disruption_policy,
                     blueprint_pruner_enabled,
                     blueprint_pruner_nkeep,
                 },
         } = self;
         writeln!(f, "tuf repo pruner enabled: {}", tuf_repo_pruner_enabled)?;
-        writeln!(f, "disruption policy: {}", disruption_policy)?;
-        writeln!(f, "planner enabled: {}", planner_enabled)?;
         writeln!(f, "blueprint pruner enabled: {}", blueprint_pruner_enabled)?;
         writeln!(f, "blueprint pruner nkeep: {}", blueprint_pruner_nkeep)?;
+        writeln!(f, "planner enabled: {}", planner_enabled)?;
+        writeln!(f, "planner config:\n{}", planner_config.display())?;
 
         Ok(())
     }
@@ -243,9 +240,8 @@ impl fmt::Display for ReconfiguratorConfigDiffDisplay<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let ReconfiguratorConfigDiff {
             planner_enabled,
-            planner_config: _,
+            planner_config: PlannerConfigDiff { disruption_policy },
             tuf_repo_pruner_enabled,
-            disruption_policy,
             blueprint_pruner_enabled,
             blueprint_pruner_nkeep,
         } = self.diff;
@@ -262,9 +258,6 @@ impl fmt::Display for ReconfiguratorConfigDiffDisplay<'_, '_> {
         );
         // No need for writeln! here because KvList adds its own newlines.
         write!(f, "{list}")?;
-
-        // When there are fields in `PlannerConfigDiff`, this is where their
-        // display would go.
 
         Ok(())
     }
@@ -284,7 +277,9 @@ impl fmt::Display for ReconfiguratorConfigDiffDisplay<'_, '_> {
     JsonSchema,
 )]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
-pub struct PlannerConfig {}
+pub struct PlannerConfig {
+    pub disruption_policy: ReconfiguratorDisruptionPolicy,
+}
 
 impl PlannerConfig {
     pub fn display(&self) -> PlannerConfigDisplay<'_> {
@@ -297,7 +292,7 @@ impl PlannerConfig {
 #[expect(clippy::derivable_impls)]
 impl Default for PlannerConfig {
     fn default() -> Self {
-        Self {}
+        Self { disruption_policy: ReconfiguratorDisruptionPolicy::default() }
     }
 }
 
@@ -307,10 +302,7 @@ pub struct PlannerConfigDisplay<'a> {
 
 impl<'a> fmt::Display for PlannerConfigDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { config: PlannerConfig {} } = self;
-        // `PlannerConfig` currently has no fields; once it gains some, we'll
-        // render them here as a `KvList`. The 4-space indent matches where
-        // those rows would appear.
-        writeln!(f, "    (no current planner configs)")
+        let Self { config: PlannerConfig { disruption_policy } } = self;
+        writeln!(f, "    disruption policy: {}", disruption_policy)
     }
 }


### PR DESCRIPTION
This is a little prep work to make the upcoming "planner manages sled evacuation" change smaller. (There will probably be a handful of these.)

I think the planner is the only consumer of `disruption_policy` (other than omdb / diffing / etc debugging things), because it's the one that has to set it when deciding to evacuate a sled. So I think moving it into `PlannerConfig` is reasonable? But would appreciate a gut check. (If we _don't_ do this, we'll need to pass it down into the planning input some other way.)