### PR TITLE
Replace switch backend variables with tagged deployment enum

### DIFF
--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -873,7 +873,8 @@ output.type = "zone"
 # $ cargo run --release --bin omicron-package -- package
 # $ pfexec ./target/release/omicron-package install
 #
-# The sled-agent config must also set switch_backend = "tofino_stub".
+# The sled-agent config must set
+# deployment = { kind = "custom", sled_mode = "scrimlet", switch = "tofino_stub" }.
 [package.switch-stub]
 service_name = "switch"
 only_for_targets.switch = "stub"
@@ -903,8 +904,8 @@ output.type = "zone"
 # $ pfexec ./target/release/omicron-package install
 #
 # The sled-agent config selects between a SoftNPU zone on this host
-# (switch_backend = "soft_npu_zone") and a propolis SoftNPU device, which is
-# detected at startup.
+# (deployment kind "standalone") and a propolis SoftNPU device, which is
+# detected at startup (deployment kind "virtual").
 [package.switch-softnpu]
 service_name = "switch"
 only_for_targets.switch = "softnpu"

--- a/sled-agent/src/bootstrap/pre_server.rs
+++ b/sled-agent/src/bootstrap/pre_server.rs
@@ -14,9 +14,8 @@ use super::maghemite;
 use super::pumpkind;
 use super::server::StartError;
 use crate::config::Config;
-use crate::config::SidecarRevision;
+use crate::config::Deployment;
 use crate::config::SledMode as SledModeConfig;
-use crate::config::SwitchBackend;
 use crate::ddm_reconciler::DdmReconciler;
 use crate::long_running_tasks::{
     LongRunningTaskHandles, LongRunningTaskResult, spawn_all_longrunning_tasks,
@@ -40,8 +39,7 @@ use omicron_common::address::Ipv6Subnet;
 use sled_agent_config_reconciler::ConfigReconcilerSpawnToken;
 use sled_hardware::DendriteAsic;
 use sled_hardware::SledMode;
-use sled_hardware::SwitchDetectError;
-use sled_hardware::SwitchHardware;
+use sled_hardware::SoftNpuDetectError;
 use sled_hardware::underlay;
 use sled_hardware::underlay::BootstrapInterface;
 use slog::Drain;
@@ -145,7 +143,7 @@ impl BootstrapAgentStartup {
             ddm_reconciler,
             startup_networking,
             sled_mode,
-            config.sidecar_revision.clone(),
+            config.deployment.sidecar_revision(),
             config.switch_zone_maghemite_links.clone(),
             long_running_task_handles.zone_image_resolver.clone(),
         );
@@ -294,132 +292,91 @@ async fn ensure_zfs_ramdisk_dataset() -> Result<(), StartError> {
     .map_err(StartError::EnsureZfsRamdiskDataset)
 }
 
-// Combine the `sled_mode` and `switch_backend` config with switch hardware to
-// determine the actual sled mode.
+// Resolve the deployment to a sled mode.
 async fn sled_mode_from_config(
     config: &Config,
     log: &Logger,
 ) -> Result<SledMode, StartError> {
-    let sled_mode = config.sled_mode.clone();
-    let switch_backend = config.switch_backend.clone();
-    let sidecar_revision = config.sidecar_revision.clone();
+    let deployment = config.deployment.clone();
     let log = log.clone();
-    // Because detection touches devinfo and device nodes, it
-    // may block, so spawn it on the blocking runtime.
+    // The probe touches devinfo and device nodes, so it may block.
     tokio::task::spawn_blocking(move || {
-        resolve_sled_mode(
-            &sled_mode,
-            &switch_backend,
-            &sidecar_revision,
-            || sled_hardware::detect_switch_hardware(&log),
-        )
+        resolve_sled_mode(&deployment, || {
+            sled_hardware::find_softnpu_device(&log)
+        })
     })
     .await
     .expect("sled mode resolution panicked")
 }
 
-// Detected hardware wins in the priority order of `SwitchHardware`. With none
-// detected, `auto` leaves Tofino detection to the hardware monitor and
-// `scrimlet` assumes a Tofino ASIC when a physical sidecar is configured.
-// `detect` runs only when the config leaves the backend to detection; it is
-// a parameter so the decision can be tested without hardware.
+// Resolve the deployment to a sled mode. `probe` reports whether the propolis
+// SoftNPU device is attached.
 fn resolve_sled_mode(
-    sled_mode: &SledModeConfig,
-    switch_backend: &SwitchBackend,
-    sidecar_revision: &SidecarRevision,
-    detect: impl FnOnce() -> Result<Option<SwitchHardware>, SwitchDetectError>,
+    deployment: &Deployment,
+    probe: impl FnOnce() -> Result<bool, SoftNpuDetectError>,
 ) -> Result<SledMode, StartError> {
-    let forced_scrimlet = match sled_mode {
-        SledModeConfig::Sled => return Ok(SledMode::Sled),
-        SledModeConfig::Auto => false,
-        SledModeConfig::Scrimlet => true,
-    };
-
-    let asic = match switch_backend {
-        SwitchBackend::TofinoStub | SwitchBackend::SoftNpuZone
-            if !forced_scrimlet =>
-        {
-            return Err(StartError::SledModeConfig(
-                "switch_backend override requires sled_mode = \"scrimlet\"",
-            ));
-        }
-        SwitchBackend::TofinoStub => DendriteAsic::TofinoStub,
-        SwitchBackend::SoftNpuZone => {
-            if !matches!(sidecar_revision, SidecarRevision::SoftZone(_)) {
+    let asic = deployment.switch();
+    let sled_mode = match (deployment.sled_mode(), asic) {
+        (SledModeConfig::Sled, _) => SledMode::Sled,
+        // The hardware monitor detects the Tofino ASIC after startup.
+        (SledModeConfig::Auto, DendriteAsic::TofinoAsic) => SledMode::Auto,
+        // The propolis SoftNPU device is the only backend probed here.
+        (mode, DendriteAsic::SoftNpuPropolisDevice) => {
+            if probe().map_err(StartError::DetectSwitch)? {
+                SledMode::Scrimlet { asic }
+            } else if mode == SledModeConfig::Auto {
+                SledMode::Sled
+            } else {
                 return Err(StartError::SledModeConfig(
-                    "switch_backend soft_npu_zone requires \
-                     sidecar_revision.soft_zone",
+                    "sled_mode is scrimlet but no SoftNPU device is present",
                 ));
             }
-            DendriteAsic::SoftNpuZone
         }
-        SwitchBackend::Detect => {
-            match detect().map_err(StartError::DetectSwitch)? {
-                Some(SwitchHardware::Tofino) => DendriteAsic::TofinoAsic,
-                Some(SwitchHardware::SoftNpuPropolis { .. }) => {
-                    if !matches!(
-                        sidecar_revision,
-                        SidecarRevision::SoftPropolis(_)
-                    ) {
-                        return Err(StartError::SledModeConfig(
-                            "SoftNPU device present but sidecar_revision is \
-                             not soft_propolis",
-                        ));
-                    }
-                    DendriteAsic::SoftNpuPropolisDevice
-                }
-                None if !forced_scrimlet => return Ok(SledMode::Auto),
-                None if sidecar_revision.is_physical() => {
-                    DendriteAsic::TofinoAsic
-                }
-                None => {
-                    return Err(StartError::SledModeConfig(
-                        "sled_mode is scrimlet but no switch hardware was \
-                         detected and sidecar_revision is not physical",
-                    ));
-                }
-            }
+        // The stub and zone backends have nothing to detect.
+        (SledModeConfig::Auto, _) => {
+            return Err(StartError::SledModeConfig(
+                "switch backend has no hardware to detect",
+            ));
         }
+        (SledModeConfig::Scrimlet, asic) => SledMode::Scrimlet { asic },
     };
-    Ok(SledMode::Scrimlet { asic })
+    Ok(sled_mode)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::SoftPortConfig;
+    use crate::config::Switch;
 
     const AUTO: SledModeConfig = SledModeConfig::Auto;
     const SLED: SledModeConfig = SledModeConfig::Sled;
     const SCRIMLET: SledModeConfig = SledModeConfig::Scrimlet;
-    const DETECT: SwitchBackend = SwitchBackend::Detect;
-    const STUB: SwitchBackend = SwitchBackend::TofinoStub;
-    const ZONE: SwitchBackend = SwitchBackend::SoftNpuZone;
 
-    fn ports() -> SoftPortConfig {
-        SoftPortConfig { front_port_count: 2, rear_port_count: 4 }
+    fn production() -> Deployment {
+        Deployment::Production { sidecar_revision: "b".to_string() }
     }
 
-    fn physical() -> SidecarRevision {
-        SidecarRevision::Physical("b".to_string())
+    fn virtual_lab() -> Deployment {
+        Deployment::Virtual { front_port_count: 2, rear_port_count: 4 }
     }
 
-    fn soft_propolis() -> SidecarRevision {
-        SidecarRevision::SoftPropolis(ports())
+    fn standalone() -> Deployment {
+        Deployment::Standalone { front_port_count: 1, rear_port_count: 1 }
     }
 
-    fn soft_zone() -> SidecarRevision {
-        SidecarRevision::SoftZone(ports())
-    }
-
-    fn tofino() -> Option<SwitchHardware> {
-        Some(SwitchHardware::Tofino)
-    }
-
-    fn softnpu() -> Option<SwitchHardware> {
-        Some(SwitchHardware::SoftNpuPropolis {
-            path: "/devices/pci@0,0/pci1af4,9@6:9p".to_string(),
-        })
+    fn custom(sled_mode: SledModeConfig, asic: DendriteAsic) -> Deployment {
+        let switch = match asic {
+            TofinoAsic => Switch::TofinoAsic { sidecar_revision: "b".into() },
+            TofinoStub => Switch::TofinoStub { sidecar_revision: "b".into() },
+            SoftNpuPropolisDevice => Switch::SoftNpuPropolisDevice {
+                front_port_count: 1,
+                rear_port_count: 1,
+            },
+            SoftNpuZone => {
+                Switch::SoftNpuZone { front_port_count: 1, rear_port_count: 1 }
+            }
+        };
+        Deployment::Custom { sled_mode, switch }
     }
 
     #[derive(Debug, PartialEq)]
@@ -435,65 +392,50 @@ mod tests {
         Mode(SledMode::Scrimlet { asic })
     }
 
+    // `device` is the probe result, or None when the probe must not run.
     #[test]
     fn resolve_sled_mode_table() {
         let cases = [
-            // Production gimlet config: auto with a physical sidecar. Nothing
-            // detected leaves Tofino detection to the hardware monitor.
-            (AUTO, DETECT, physical(), None, Mode(SledMode::Auto)),
-            (AUTO, DETECT, physical(), tofino(), scrimlet(TofinoAsic)),
-            // gimlet-standalone: scrimlet with a physical sidecar, including
-            // a Tofino whose driver has not attached yet.
-            (SCRIMLET, DETECT, physical(), tofino(), scrimlet(TofinoAsic)),
-            (SCRIMLET, DETECT, physical(), None, scrimlet(TofinoAsic)),
-            // Tofino wins under any sidecar config.
-            (AUTO, DETECT, soft_propolis(), tofino(), scrimlet(TofinoAsic)),
-            (AUTO, DETECT, soft_zone(), tofino(), scrimlet(TofinoAsic)),
-            // A sled ignores attached hardware.
-            (SLED, DETECT, physical(), tofino(), Mode(SledMode::Sled)),
-            (SLED, DETECT, soft_propolis(), softnpu(), Mode(SledMode::Sled)),
-            (SLED, STUB, physical(), None, Mode(SledMode::Sled)),
-            // Voxel: scrimlets carry a SoftNPU device; auto works the same
-            // way with the device deciding.
+            // Production leaves Tofino detection to the hardware monitor.
+            (production(), None, Mode(SledMode::Auto)),
+            // Virtual labs decide by the SoftNPU device alone.
+            (virtual_lab(), Some(true), scrimlet(SoftNpuPropolisDevice)),
+            (virtual_lab(), Some(false), Mode(SledMode::Sled)),
+            // Standalone is always a scrimlet with nothing to detect.
+            (standalone(), None, scrimlet(SoftNpuZone)),
+            // Custom: a sled never probes and never runs a switch zone.
+            (custom(SLED, TofinoAsic), None, Mode(SledMode::Sled)),
+            (custom(SLED, SoftNpuPropolisDevice), None, Mode(SledMode::Sled)),
+            // Custom scrimlet: the tofino backends wait on the monitor, the
+            // zone and stub run as configured, propolis must be present.
+            (custom(SCRIMLET, TofinoAsic), None, scrimlet(TofinoAsic)),
+            (custom(SCRIMLET, TofinoStub), None, scrimlet(TofinoStub)),
+            (custom(SCRIMLET, SoftNpuZone), None, scrimlet(SoftNpuZone)),
             (
-                SCRIMLET,
-                DETECT,
-                soft_propolis(),
-                softnpu(),
+                custom(SCRIMLET, SoftNpuPropolisDevice),
+                Some(true),
+                scrimlet(SoftNpuPropolisDevice),
+            ),
+            (custom(SCRIMLET, SoftNpuPropolisDevice), Some(false), ConfigError),
+            // Custom auto matches production and virtual.
+            (custom(AUTO, TofinoAsic), None, Mode(SledMode::Auto)),
+            (
+                custom(AUTO, SoftNpuPropolisDevice),
+                Some(true),
                 scrimlet(SoftNpuPropolisDevice),
             ),
             (
-                AUTO,
-                DETECT,
-                soft_propolis(),
-                softnpu(),
-                scrimlet(SoftNpuPropolisDevice),
+                custom(AUTO, SoftNpuPropolisDevice),
+                Some(false),
+                Mode(SledMode::Sled),
             ),
-            (AUTO, DETECT, soft_propolis(), None, Mode(SledMode::Auto)),
-            // Scrimlet with nothing detected needs a physical sidecar.
-            (SCRIMLET, DETECT, soft_propolis(), None, ConfigError),
-            (SCRIMLET, DETECT, soft_zone(), None, ConfigError),
-            // SoftNPU needs a soft_propolis sidecar.
-            (SCRIMLET, DETECT, physical(), softnpu(), ConfigError),
-            (AUTO, DETECT, soft_zone(), softnpu(), ConfigError),
-            // Overrides: dev SoftNPU zone and stub Dendrite, scrimlet only,
-            // and the zone needs a soft_zone sidecar.
-            (SCRIMLET, ZONE, soft_zone(), None, scrimlet(SoftNpuZone)),
-            (SCRIMLET, ZONE, soft_propolis(), None, ConfigError),
-            (SCRIMLET, STUB, physical(), None, scrimlet(TofinoStub)),
-            (AUTO, STUB, physical(), None, ConfigError),
-            (AUTO, ZONE, soft_zone(), None, ConfigError),
         ];
 
-        for (i, (mode, backend, sidecar, found, expected)) in
-            cases.into_iter().enumerate()
+        for (i, (deployment, device, expected)) in cases.into_iter().enumerate()
         {
-            let actual = match resolve_sled_mode(
-                &mode,
-                &backend,
-                &sidecar,
-                || Ok(found),
-            ) {
+            let probe =
+                || Ok(device.unwrap_or_else(|| panic!("case {i}: probe ran")));
+            let actual = match resolve_sled_mode(&deployment, probe) {
                 Ok(mode) => Mode(mode),
                 Err(StartError::SledModeConfig(_)) => ConfigError,
                 Err(e) => panic!("case {i}: unexpected error {e:?}"),
@@ -502,20 +444,12 @@ mod tests {
         }
     }
 
-    // Hardware is only probed when the backend is left to detection.
     #[test]
-    fn no_probe_without_detect() {
-        let cases = [
-            (SLED, DETECT, physical()),
-            (SCRIMLET, STUB, physical()),
-            (SCRIMLET, ZONE, soft_zone()),
-        ];
-        for (mode, backend, sidecar) in cases {
-            resolve_sled_mode(&mode, &backend, &sidecar, || {
-                panic!("probe ran")
-            })
-            .unwrap();
-        }
+    fn custom_deployment_validation() {
+        assert!(custom(AUTO, TofinoStub).validate().is_err());
+        assert!(custom(AUTO, SoftNpuZone).validate().is_err());
+        assert!(custom(SCRIMLET, TofinoStub).validate().is_ok());
+        assert!(custom(AUTO, TofinoAsic).validate().is_ok());
     }
 }
 

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -135,7 +135,7 @@ pub enum StartError {
     SledModeConfig(&'static str),
 
     #[error("Failed to detect switch hardware")]
-    DetectSwitch(#[source] sled_hardware::SwitchDetectError),
+    DetectSwitch(#[source] sled_hardware::SoftNpuDetectError),
 
     #[error("Failed to start HardwareManager: {0}")]
     StartHardwareManager(String),

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -14,10 +14,11 @@ use illumos_utils::dladm::PhysicalLink;
 use omicron_common::vlan::VlanID;
 use serde::Deserialize;
 use sled_hardware::DataLinks;
+use sled_hardware::DendriteAsic;
 use sled_hardware::ExternalDisks;
 use sprockets_tls::keys::SprocketsConfig;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum SledMode {
     Auto,
@@ -26,20 +27,154 @@ pub enum SledMode {
     Scrimlet,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum SwitchBackend {
-    /// Probe for switch hardware: the Tofino ASIC first, then a SoftNPU 9p device
-    #[default]
-    Detect,
-    /// Run the stub Dendrite; no switch hardware
-    TofinoStub,
-    /// Run Dendrite against a SoftNPU zone on this host
-    SoftNpuZone,
+/// Switch backend of a `custom` deployment, with the parameters it needs.
+/// Flattened into the deployment table: `switch` names the backend and its
+/// parameters sit beside it.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "switch")]
+pub enum Switch {
+    TofinoAsic {
+        #[serde(default = "default_sidecar_revision")]
+        sidecar_revision: String,
+    },
+    TofinoStub {
+        #[serde(default = "default_sidecar_revision")]
+        sidecar_revision: String,
+    },
+    SoftNpuPropolisDevice {
+        front_port_count: u8,
+        rear_port_count: u8,
+    },
+    SoftNpuZone {
+        front_port_count: u8,
+        rear_port_count: u8,
+    },
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "snake_case")]
+impl Switch {
+    pub fn asic(&self) -> DendriteAsic {
+        match self {
+            Switch::TofinoAsic { .. } => DendriteAsic::TofinoAsic,
+            Switch::TofinoStub { .. } => DendriteAsic::TofinoStub,
+            Switch::SoftNpuPropolisDevice { .. } => {
+                DendriteAsic::SoftNpuPropolisDevice
+            }
+            Switch::SoftNpuZone { .. } => DendriteAsic::SoftNpuZone,
+        }
+    }
+
+    fn sidecar_revision(&self) -> SidecarRevision {
+        match self {
+            Switch::TofinoAsic { sidecar_revision }
+            | Switch::TofinoStub { sidecar_revision } => {
+                SidecarRevision::Physical(sidecar_revision.clone())
+            }
+            Switch::SoftNpuPropolisDevice {
+                front_port_count,
+                rear_port_count,
+            } => SidecarRevision::SoftPropolis(SoftPortConfig {
+                front_port_count: *front_port_count,
+                rear_port_count: *rear_port_count,
+            }),
+            Switch::SoftNpuZone { front_port_count, rear_port_count } => {
+                SidecarRevision::SoftZone(SoftPortConfig {
+                    front_port_count: *front_port_count,
+                    rear_port_count: *rear_port_count,
+                })
+            }
+        }
+    }
+}
+
+/// How this sled is deployed. Selects the switch backend and whether the
+/// sled is a scrimlet, which is detected where the backend allows it.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum Deployment {
+    /// Oxide rack. The hardware monitor detects the Tofino ASIC.
+    Production {
+        /// Sidecar board revision
+        #[serde(default = "default_sidecar_revision")]
+        sidecar_revision: String,
+    },
+    /// Propolis-hosted lab. A SoftNPU device makes the sled a scrimlet.
+    Virtual { front_port_count: u8, rear_port_count: u8 },
+    /// One host running a SoftNPU zone. Always a scrimlet.
+    Standalone { front_port_count: u8, rear_port_count: u8 },
+    /// Explicit sled mode and switch backend.
+    Custom {
+        sled_mode: SledMode,
+        #[serde(flatten)]
+        switch: Switch,
+    },
+}
+
+fn default_sidecar_revision() -> String {
+    "b".to_string()
+}
+
+impl Deployment {
+    /// Reject custom combinations that cannot be resolved at startup.
+    pub fn validate(&self) -> Result<(), String> {
+        match self {
+            Deployment::Custom {
+                sled_mode: SledMode::Auto,
+                switch:
+                    switch
+                    @ (Switch::TofinoStub { .. } | Switch::SoftNpuZone { .. }),
+            } => Err(format!(
+                "switch {:?} has no hardware to detect; sled_mode must be \
+                 \"sled\" or \"scrimlet\"",
+                switch.asic()
+            )),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn sled_mode(&self) -> SledMode {
+        match self {
+            Deployment::Production { .. } | Deployment::Virtual { .. } => {
+                SledMode::Auto
+            }
+            Deployment::Standalone { .. } => SledMode::Scrimlet,
+            Deployment::Custom { sled_mode, .. } => *sled_mode,
+        }
+    }
+
+    pub fn switch(&self) -> DendriteAsic {
+        match self {
+            Deployment::Production { .. } => DendriteAsic::TofinoAsic,
+            Deployment::Virtual { .. } => DendriteAsic::SoftNpuPropolisDevice,
+            Deployment::Standalone { .. } => DendriteAsic::SoftNpuZone,
+            Deployment::Custom { switch, .. } => switch.asic(),
+        }
+    }
+
+    /// Sidecar parameters for the switch zone services.
+    pub fn sidecar_revision(&self) -> SidecarRevision {
+        match self {
+            Deployment::Production { sidecar_revision } => {
+                SidecarRevision::Physical(sidecar_revision.clone())
+            }
+            Deployment::Virtual { front_port_count, rear_port_count } => {
+                SidecarRevision::SoftPropolis(SoftPortConfig {
+                    front_port_count: *front_port_count,
+                    rear_port_count: *rear_port_count,
+                })
+            }
+            Deployment::Standalone { front_port_count, rear_port_count } => {
+                SidecarRevision::SoftZone(SoftPortConfig {
+                    front_port_count: *front_port_count,
+                    rear_port_count: *rear_port_count,
+                })
+            }
+            Deployment::Custom { switch, .. } => switch.sidecar_revision(),
+        }
+    }
+}
+
+/// Sidecar parameters derived from the deployment.
+#[derive(Debug, Clone)]
 pub enum SidecarRevision {
     Physical(String),
     SoftZone(SoftPortConfig),
@@ -55,7 +190,7 @@ impl SidecarRevision {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct SoftPortConfig {
     /// Number of front ports
     pub front_port_count: u8,
@@ -74,18 +209,8 @@ pub struct Config {
     pub dropshot: ConfigDropshot,
     /// Configuration for the sled agent debug log
     pub log: ConfigLogging,
-    /// The sled's mode of operation (auto detect or force gimlet/scrimlet).
-    pub sled_mode: SledMode,
-    // TODO: Remove once this can be auto-detected.
-    pub sidecar_revision: SidecarRevision,
-    /// Which switch backend to run when acting as a scrimlet.
-    ///
-    /// If this is not provided, it defaults to [`SwitchBackend::Detect`],
-    /// which will probe for switch hardware at runtime. The Tofino stub
-    /// and SoftNPU zone modes must be explicitly requested, and require
-    /// `sled_mode = "scrimlet"`.
-    #[serde(default)]
-    pub switch_backend: SwitchBackend,
+    /// How this sled is deployed, which selects the switch backend.
+    pub deployment: Deployment,
     /// Optional percentage of otherwise-unbudgeted DRAM to reserve for guest
     /// memory, after accounting for expected host OS memory consumption and, if
     /// set, `vmm_reservoir_size_mb`.
@@ -156,6 +281,8 @@ pub enum ConfigError {
         #[source]
         err: anyhow::Error,
     },
+    #[error("Invalid deployment in {path}: {reason}")]
+    InvalidDeployment { path: Utf8PathBuf, reason: String },
     #[error("Loading certificate")]
     Certificate(#[source] anyhow::Error),
     #[error("Could not determine if host is an Oxide sled")]
@@ -169,8 +296,11 @@ impl Config {
         let path = path.as_ref();
         let contents = std::fs::read_to_string(&path)
             .map_err(|err| ConfigError::Io { path: path.into(), err })?;
-        let config = toml::from_str(&contents).map_err(|err| {
+        let config: Self = toml::from_str(&contents).map_err(|err| {
             ConfigError::Parse { path: path.into(), err: err.into() }
+        })?;
+        config.deployment.validate().map_err(|reason| {
+            ConfigError::InvalidDeployment { path: path.into(), reason }
         })?;
         Ok(config)
     }

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -714,8 +714,10 @@ impl SledAgent {
             config_reconciler_spawn_token.subscribe_update_disposition(),
         )?;
 
-        let svc_config =
-            services::Config::new(identifiers, config.sidecar_revision.clone());
+        let svc_config = services::Config::new(
+            identifiers,
+            config.deployment.sidecar_revision(),
+        );
 
         // Get our system network config from the bootstore; we cannot proceed
         // until we have this, as we need to set up uplinks inside the switch

--- a/sled-hardware/src/illumos/mod.rs
+++ b/sled-hardware/src/illumos/mod.rs
@@ -7,9 +7,7 @@ use crate::ExternalDisks;
 use crate::HardwareView;
 use crate::TofinoSnapshot;
 use crate::TofinoView;
-use crate::{
-    DendriteAsic, SledMode, SwitchDetectError, SwitchHardware, UnparsedDisk,
-};
+use crate::{DendriteAsic, SledMode, UnparsedDisk};
 use camino::Utf8PathBuf;
 use gethostname::gethostname;
 use illumos_devinfo::{DevInfo, DevLinkType, DevLinks, Node, Property};
@@ -33,24 +31,9 @@ mod softnpu;
 mod sysconf;
 
 pub use partitions::{NvmeFormattingError, ensure_partition_layout};
+pub use softnpu::find_softnpu_device;
 
 const TOFINO_MONITOR: &'static str = "/opt/oxide/sled-agent/tofino-monitor";
-
-/// Detect attached switch hardware, checking each backend in the priority
-/// order of [`SwitchHardware`]. Tofino presence uses the same snapshot the
-/// hardware monitor polls, so startup detection and `is_scrimlet` agree.
-pub fn detect_switch_hardware(
-    log: &Logger,
-) -> Result<Option<SwitchHardware>, SwitchDetectError> {
-    let mut devinfo =
-        DevInfo::new_force_load().map_err(SwitchDetectError::DevInfo)?;
-    if get_tofino_snapshot(log, &mut devinfo).exists {
-        info!(log, "found tofino asic");
-        return Ok(Some(SwitchHardware::Tofino));
-    }
-    Ok(softnpu::find_softnpu_device(log, &mut devinfo)?
-        .map(|path| SwitchHardware::SoftNpuPropolis { path }))
-}
 
 #[derive(thiserror::Error, Debug)]
 enum Error {

--- a/sled-hardware/src/illumos/softnpu.rs
+++ b/sled-hardware/src/illumos/softnpu.rs
@@ -4,7 +4,7 @@
 
 //! Detection of the propolis SoftNPU 9p device.
 
-use crate::SwitchDetectError;
+use crate::SoftNpuDetectError;
 use crate::softnpu::{SOFTNPU_9P_VERSION, decode_rversion, encode_tversion};
 use illumos_devinfo::{DevInfo, Node};
 use slog::{Logger, debug, info, warn};
@@ -27,33 +27,32 @@ enum Probe {
     Busy,
 }
 
-/// Returns the devfs path of the SoftNPU 9p device when one is attached.
+/// Returns whether the propolis SoftNPU 9p device is attached.
 ///
 /// Every virtio 9p node with an attached driver is opened exclusively and
 /// asked for its 9P version. Only the propolis SoftNPU handler answers with
 /// `9P2000.P4`. A device that stays busy across retries, fails to open, or
 /// answers with anything other than an Rversion is logged and skipped. Only
 /// device tree failures are fatal.
-pub(super) fn find_softnpu_device(
-    log: &Logger,
-    devinfo: &mut DevInfo,
-) -> Result<Option<String>, SwitchDetectError> {
+pub fn find_softnpu_device(log: &Logger) -> Result<bool, SoftNpuDetectError> {
+    let mut devinfo =
+        DevInfo::new_force_load().map_err(SoftNpuDetectError::DevInfo)?;
     for node in devinfo.walk_node() {
-        let node = node.map_err(SwitchDetectError::DevInfo)?;
-        if let Some(path) = probe_node(log, &node)? {
-            return Ok(Some(path));
+        let node = node.map_err(SoftNpuDetectError::DevInfo)?;
+        if probe_node(log, &node)? {
+            return Ok(true);
         }
     }
-    Ok(None)
+    Ok(false)
 }
 
-/// Returns the devfs path when `node` is the SoftNPU 9p device.
+/// Returns whether `node` is the SoftNPU 9p device.
 fn probe_node(
     log: &Logger,
     node: &Node<'_>,
-) -> Result<Option<String>, SwitchDetectError> {
+) -> Result<bool, SoftNpuDetectError> {
     if !is_virtio_9p(node)? {
-        return Ok(None);
+        return Ok(false);
     }
     let Some(path) = ninep_minor_path(node)? else {
         debug!(
@@ -61,12 +60,12 @@ fn probe_node(
             "virtio 9p node has no {NINEP_MINOR} minor";
             "node" => node.node_name(),
         );
-        return Ok(None);
+        return Ok(false);
     };
     match probe_version(&path) {
         Ok(Probe::Version(version)) if version == SOFTNPU_9P_VERSION => {
-            info!(log, "found SoftNPU 9p device"; "path" => &path);
-            Ok(Some(path))
+            info!(log, "found SoftNPU 9p device"; "path" => path);
+            Ok(true)
         }
         Ok(Probe::Version(version)) => {
             debug!(
@@ -75,32 +74,32 @@ fn probe_node(
                 "path" => path,
                 "version" => version,
             );
-            Ok(None)
+            Ok(false)
         }
         Ok(Probe::Busy) => {
             warn!(log, "virtio 9p device busy; skipping"; "path" => path);
-            Ok(None)
+            Ok(false)
         }
         Err(
-            e @ (SwitchDetectError::Io { .. }
-            | SwitchDetectError::Protocol { .. }),
+            e @ (SoftNpuDetectError::Io { .. }
+            | SoftNpuDetectError::Protocol { .. }),
         ) => {
             warn!(
                 log,
                 "virtio 9p device probe failed; skipping";
                 "error" => InlineErrorChain::new(&e),
             );
-            Ok(None)
+            Ok(false)
         }
         Err(e) => Err(e),
     }
 }
 
-fn is_virtio_9p(node: &Node<'_>) -> Result<bool, SwitchDetectError> {
+fn is_virtio_9p(node: &Node<'_>) -> Result<bool, SoftNpuDetectError> {
     let mut vendor = None;
     let mut device = None;
     for prop in node.props() {
-        let prop = prop.map_err(SwitchDetectError::DevInfo)?;
+        let prop = prop.map_err(SoftNpuDetectError::DevInfo)?;
         match prop.name().as_str() {
             "vendor-id" => vendor = prop.as_i32(),
             "device-id" => device = prop.as_i32(),
@@ -113,12 +112,12 @@ fn is_virtio_9p(node: &Node<'_>) -> Result<bool, SwitchDetectError> {
 
 fn ninep_minor_path(
     node: &Node<'_>,
-) -> Result<Option<String>, SwitchDetectError> {
+) -> Result<Option<String>, SoftNpuDetectError> {
     for minor in node.minors() {
-        let minor = minor.map_err(SwitchDetectError::DevInfo)?;
+        let minor = minor.map_err(SoftNpuDetectError::DevInfo)?;
         if minor.name() == NINEP_MINOR {
             let path =
-                minor.devfs_path().map_err(SwitchDetectError::DevInfo)?;
+                minor.devfs_path().map_err(SoftNpuDetectError::DevInfo)?;
             return Ok(Some(format!("/devices{path}")));
         }
     }
@@ -129,7 +128,7 @@ fn ninep_minor_path(
 ///
 /// The driver permits a single exclusive open, so EBUSY means another
 /// consumer such as scadm or a 9p mount currently holds the device.
-fn probe_version(path: &str) -> Result<Probe, SwitchDetectError> {
+fn probe_version(path: &str) -> Result<Probe, SoftNpuDetectError> {
     for attempt in 1..=OPEN_ATTEMPTS {
         let mut file = match OpenOptions::new()
             .read(true)
@@ -145,24 +144,22 @@ fn probe_version(path: &str) -> Result<Probe, SwitchDetectError> {
                 continue;
             }
             Err(err) => {
-                return Err(SwitchDetectError::Io {
+                return Err(SoftNpuDetectError::Io {
                     path: path.to_string(),
                     err,
                 });
             }
         };
-        let io_err =
-            |err| SwitchDetectError::Io { path: path.to_string(), err };
-        file.write_all(&encode_tversion(SOFTNPU_9P_VERSION)).map_err(io_err)?;
+        let io = |err| SoftNpuDetectError::Io { path: path.to_string(), err };
+        file.write_all(&encode_tversion(SOFTNPU_9P_VERSION)).map_err(io)?;
         let mut buf = vec![0u8; REPLY_BUF_LEN];
-        let n = file.read(&mut buf).map_err(io_err)?;
+        let n = file.read(&mut buf).map_err(io)?;
         return decode_rversion(&buf[..n]).map(Probe::Version).map_err(
-            |reason| SwitchDetectError::Protocol {
+            |reason| SoftNpuDetectError::Protocol {
                 path: path.to_string(),
                 reason,
             },
         );
     }
-
     Ok(Probe::Busy)
 }

--- a/sled-hardware/src/lib.rs
+++ b/sled-hardware/src/lib.rs
@@ -26,17 +26,9 @@ pub use disk::*;
 pub mod softnpu;
 pub mod underlay;
 
-/// Switch hardware attached to a sled, in detection priority order.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SwitchHardware {
-    /// Tofino ASIC node in the device tree
-    Tofino,
-    /// Propolis SoftNPU virtio 9p device at this devfs path
-    SoftNpuPropolis { path: String },
-}
-
+/// Failure while probing for the propolis SoftNPU device.
 #[derive(Debug, thiserror::Error)]
-pub enum SwitchDetectError {
+pub enum SoftNpuDetectError {
     #[error("failed to walk device tree: {0}")]
     DevInfo(anyhow::Error),
 

--- a/sled-hardware/src/non_illumos/mod.rs
+++ b/sled-hardware/src/non_illumos/mod.rs
@@ -87,9 +87,9 @@ pub fn is_oxide_sled() -> anyhow::Result<bool> {
     Ok(false)
 }
 
-/// Detect attached switch hardware.
-pub fn detect_switch_hardware(
+/// Returns whether the propolis SoftNPU 9p device is attached.
+pub fn find_softnpu_device(
     _log: &Logger,
-) -> Result<Option<crate::SwitchHardware>, crate::SwitchDetectError> {
-    Ok(None)
+) -> Result<bool, crate::SoftNpuDetectError> {
+    Ok(false)
 }

--- a/smf/sled-agent/gimlet-standalone/config.toml
+++ b/smf/sled-agent/gimlet-standalone/config.toml
@@ -1,18 +1,7 @@
 # Sled Agent Configuration
 
-# Identifies whether sled agent treats itself as a scrimlet or a gimlet.
-#
-# If this is set to "scrimlet", the sled agent treats itself as a scrimlet.
-# If this is set to "gimlet", the sled agent treats itself as a gimlet.
-# If this is set to "auto":
-# - On illumos, the sled automatically detects whether or not it is a scrimlet.
-# - On all other platforms, the sled assumes it is a gimlet.
-sled_mode = "scrimlet"
-
-# Identifies the revision of the sidecar that is attached, if one is attached.
-# TODO: This field should be removed once Gimlets have the ability to auto-detect
-# this information.
-sidecar_revision.physical = "b"
+# A single gimlet with a sidecar, forced to run as a scrimlet.
+deployment = { kind = "custom", sled_mode = "scrimlet", switch = "tofino_asic" }
 
 # Setting this to true causes sled-agent to always report that its time is
 # in-sync, rather than querying its NTP zone.

--- a/smf/sled-agent/gimlet/config.toml
+++ b/smf/sled-agent/gimlet/config.toml
@@ -1,18 +1,9 @@
 # Sled Agent Configuration
 
-# Identifies whether sled agent treats itself as a scrimlet or a gimlet.
-#
-# If this is set to "scrimlet", the sled agent treats itself as a scrimlet.
-# If this is set to "gimlet", the sled agent treats itself as a gimlet.
-# If this is set to "auto":
-# - On illumos, the sled automatically detects whether or not it is a scrimlet.
-# - On all other platforms, the sled assumes it is a gimlet.
-sled_mode = "auto"
-
-# Identifies the revision of the sidecar that is attached, if one is attached.
-# TODO: This field should be removed once Gimlets have the ability to auto-detect
-# this information.
-sidecar_revision.physical = "b"
+# Oxide rack. The hardware monitor detects the Tofino ASIC and the sled runs
+# as a scrimlet when one is present. The sidecar board revision defaults to
+# "b".
+deployment = { kind = "production" }
 
 # An optional data link from which we extract a MAC address.
 # This is used as a unique identifier for the bootstrap address.

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -1,24 +1,11 @@
 # Sled Agent Configuration
 
-# Identifies whether sled agent treats itself as a scrimlet or a gimlet.
-#
-# If this is set to "scrimlet", the sled agent treats itself as a scrimlet.
-# If this is set to "gimlet", the sled agent treats itself as a gimlet.
-# If this is set to "auto":
-# - On illumos, the sled automatically detects whether or not it is a scrimlet.
-# - On all other platforms, the sled assumes it is a gimlet.
-sled_mode = "scrimlet"
-
-# Identifies the revision of the sidecar that is attached, if one is attached.
-# TODO: This field should be removed once Gimlets have the ability to auto-detect
-# this information.
-sidecar_revision.soft_zone = { front_port_count = 1, rear_port_count = 1 }
-
-# Selects the switch backend for a scrimlet. "detect" (the default) probes for
-# a SoftNPU 9p device and otherwise expects a Tofino ASIC. "soft_npu_zone" runs
-# Dendrite against a SoftNPU zone on this host and "tofino_stub" runs the stub
-# Dendrite. Both overrides require sled_mode = "scrimlet".
-switch_backend = "soft_npu_zone"
+# One host running a SoftNPU zone; always a scrimlet. Other kinds:
+# "production" (Tofino, detected), "virtual" (propolis SoftNPU device,
+# detected, with port counts), and "custom" with an explicit sled_mode and
+# switch: "tofino_asic" or "tofino_stub" (optional sidecar_revision), or
+# "soft_npu_propolis_device" or "soft_npu_zone" (with port counts).
+deployment = { kind = "standalone", front_port_count = 1, rear_port_count = 1 }
 
 # Setting this to true causes sled-agent to always report that its time is
 # in-sync, rather than querying its NTP zone.


### PR DESCRIPTION
Changes based on feedback in oxidecomputer/omicron#11237. This method drastically simplifies the tracking of switch backend by sled-agent and improves downstream understanding by naming the types of configs. It also means no startup probe is run when `production` option (tofino) is chosen which is more in line with the current method. Current checked in configs are `production`, `virtual`, `standalone`, and `custom`.