### PR TITLE
[wip] [gateway]  add component VPD to hardware-component metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9123,6 +9123,7 @@ dependencies = [
  "oximeter",
  "oximeter-instruments",
  "oximeter-producer",
+ "pretty_assertions",
  "schemars 0.8.22",
  "serde",
  "serde_json",

--- a/gateway-test-utils/configs/sp_sim_config.test.toml
+++ b/gateway-test-utils/configs/sp_sim_config.test.toml
@@ -48,6 +48,21 @@ sensors = [
     { name = "South", kind = "Temperature", last_error.value = "DeviceError", last_error.timestamp = 1234 },
 ]
 
+[[simulated_sps.sidecar.components]]
+id = "ibc"
+device = "bmr491"
+description = "FAKE intermediate bus converter"
+capabilities = 0x20
+presence = "Present"
+
+[simulated_sps.sidecar.components.vpd.pmbus]
+mfr_id = "Flex"
+mfr_model = "BMR4913203851"
+mfr_revision = "R1C A"
+mfr_location = "CB6"
+mfr_date = "2023-02-25"
+mfr_serial = "FP1C481050"
+
 [simulated_sps.sidecar.ereport_config]
 restart_id = "0d3e464a-666e-4687-976f-90e31238be8b"
 
@@ -79,6 +94,21 @@ bind_addr = "[::1]:0"
 [[simulated_sps.sidecar.ereport_network_config]]
 [simulated_sps.sidecar.ereport_network_config.simulated]
 bind_addr = "[::1]:0"
+
+[[simulated_sps.sidecar.components]]
+id = "ibc"
+device = "bmr491"
+description = "FAKE intermediate bus converter"
+capabilities = 0x20
+presence = "Present"
+
+[simulated_sps.sidecar.components.vpd.pmbus]
+mfr_id = "Flex"
+mfr_model = "BMR4913203851"
+mfr_revision = "R1C A"
+mfr_location = "CB6"
+mfr_date = "2023-02-26"
+mfr_serial = "FP1C481051"
 
 [[simulated_sps.gimlet]]
 serial_number = "SimGimlet00"
@@ -124,6 +154,7 @@ device = "tmp117"
 description = "FAKE temperature sensor"
 capabilities = 0x2
 presence = "Present"
+vpd = { tmp11x = { id = 0x0117, eeprom1 = 0x0101, eeprom2 = 0x0102, eeprom3 = 0x0103 } }
 sensors = [
     { name = "South", kind = "Temperature", last_data.value = 42.5625, last_data.timestamp = 1234 },
 ]
@@ -134,6 +165,7 @@ device = "tmp117"
 description = "FAKE Southeast temperature sensor"
 capabilities = 0x2
 presence = "Present"
+vpd = { tmp11x = { id = 0x0117, eeprom1 = 0x0201, eeprom2 = 0x0202, eeprom3 = 0x0203 } }
 sensors = [
     { name = "Southeast", kind = "Temperature", last_data.value = 41.570313, last_data.timestamp = 1234 },
 ]
@@ -144,6 +176,7 @@ device = "at24csw080"
 description = "FAKE U.2 Sharkfin A VPD"
 capabilities = 0x0
 presence = "Present"
+vpd = { barcode = "0XV2:913-0000028:001:2SHRKFN1" }
 
 [[simulated_sps.gimlet.components]]
 id = "dev-7"
@@ -201,6 +234,37 @@ sensors = [
     { name = "Southwest", kind = "Speed", last_data.value = 2649.0, last_data.timestamp = 1234 },
     { name = "Northwest", kind = "Speed", last_data.value = 2275.0, last_data.timestamp = 1234 },
 ]
+
+[[simulated_sps.gimlet.components]]
+id = "fan-tray-vpd"
+device = "at24csw080"
+description = "FAKE Fan tray VPD"
+capabilities = 0x0
+presence = "Present"
+
+[simulated_sps.gimlet.components.vpd.sled_fan_tray]
+identity = "0XV2:991-0000151:001:TST01234567"
+vpd_board_identity = "0XV2:913-0000027:001:TST01234568"
+fans = [
+    "MPN1:SYD:9CRA0848P8G012:C:WWYY1SSS",
+    "0XV1:1250000456:002:FAN01234569",
+    "MPN1:ABC:ASDF-1000:032:123456789",
+]
+
+[[simulated_sps.gimlet.components]]
+id = "ibc"
+device = "bmr491"
+description = "FAKE intermediate bus converter"
+capabilities = 0x20
+presence = "Present"
+
+[simulated_sps.gimlet.components.vpd.pmbus]
+mfr_id = "Flex"
+mfr_model = "BMR4913203851"
+mfr_revision = "R1C A"
+mfr_location = "CB6"
+mfr_date = "2023-02-27"
+mfr_serial = "FP1C481052"
 
 [simulated_sps.gimlet.ereport_config]
 restart_id = "af1ebf85-36ba-4c31-bbec-b9825d6d9d8b"
@@ -279,6 +343,7 @@ device = "tmp117"
 description = "FAKE temperature sensor"
 capabilities = 0x2
 presence = "Present"
+vpd = { tmp11x = { id = 0x0117, eeprom1 = 0x1001, eeprom2 = 0x1002, eeprom3 = 0x1003 } }
 sensors = [
     { name = "Southwest", kind = "Temperature", last_data.value = 41.3629, last_data.timestamp = 1234 },
 ]
@@ -288,6 +353,7 @@ device = "tmp117"
 description = "FAKE temperature sensor"
 capabilities = 0x2
 presence = "Present"
+vpd = { tmp11x = { id = 0x0117, eeprom1 = 0x1101, eeprom2 = 0x1102, eeprom3 = 0x1103 } }
 sensors = [
     { name = "South", kind = "Temperature", last_data.value = 42.5625, last_data.timestamp = 1234 },
 ]
@@ -298,6 +364,7 @@ device = "tmp117"
 description = "FAKE Southeast temperature sensor"
 capabilities = 0x2
 presence = "Present"
+vpd = { tmp11x = { id = 0x0117, eeprom1 = 0x1201, eeprom2 = 0x1202, eeprom3 = 0x1203 } }
 sensors = [
     { name = "Southeast", kind = "Temperature", last_data.value = 41.570313, last_data.timestamp = 1234 },
 ]
@@ -308,6 +375,7 @@ device = "at24csw080"
 description = "FAKE U.2 Sharkfin A VPD"
 capabilities = 0x0
 presence = "Present"
+vpd = { barcode = "0XV2:913-0000028:001:2SHRKFN2" }
 
 [[simulated_sps.gimlet.components]]
 id = "dev-7"
@@ -365,6 +433,21 @@ sensors = [
     { name = "Southwest", kind = "Speed", last_data.value = 2680.0, last_data.timestamp = 1234 },
     { name = "Northwest", kind = "Speed", last_data.value = 2212.0, last_data.timestamp = 1234 },
 ]
+
+[[simulated_sps.gimlet.components]]
+id = "ibc"
+device = "bmr491"
+description = "FAKE intermediate bus converter"
+capabilities = 0x20
+presence = "Present"
+
+[simulated_sps.gimlet.components.vpd.pmbus]
+mfr_id = "Flex"
+mfr_model = "BMR4913203851"
+mfr_revision = "R1C A"
+mfr_location = "CB6"
+mfr_date = "2023-02-28"
+mfr_serial = "FP1C481053"
 
 [simulated_sps.gimlet.ereport_config]
 restart_id = "55e30cc7-a109-492f-aca9-735ed725df3c"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -59,6 +59,7 @@ omicron-test-utils.workspace = true
 serde_json.workspace = true
 sp-sim.workspace = true
 subprocess.workspace = true
+pretty_assertions.workspace = true
 
 [[bin]]
 name = "mgs"

--- a/gateway/tests/integration_tests/component_list.rs
+++ b/gateway/tests/integration_tests/component_list.rs
@@ -9,6 +9,7 @@ use gateway_messages::SpPort;
 use gateway_test_utils::current_simulator_state;
 use gateway_test_utils::setup;
 use gateway_types::component::SpType;
+use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn component_list() {

--- a/gateway/tests/integration_tests/component_list.rs
+++ b/gateway/tests/integration_tests/component_list.rs
@@ -41,7 +41,7 @@ async fn component_list() {
                 device: SpComponent::SP3_HOST_CPU.const_as_str().to_string(),
                 serial_number: None,
                 description: "FAKE host cpu".to_string(),
-                capabilities: 0,
+                capabilities: 4,
                 presence: SpComponentPresence::Present,
             },
             SpComponentInfo {
@@ -58,7 +58,8 @@ async fn component_list() {
                 device: "tmp117".to_string(),
                 serial_number: None,
                 description: "FAKE temperature sensor".to_string(),
-                capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                capabilities: (DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    | DeviceCapabilities::HAS_VPD)
                     .bits(),
                 presence: SpComponentPresence::Present,
             },
@@ -67,7 +68,8 @@ async fn component_list() {
                 device: "tmp117".to_string(),
                 serial_number: None,
                 description: "FAKE Southeast temperature sensor".to_string(),
-                capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                capabilities: (DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    | DeviceCapabilities::HAS_VPD)
                     .bits(),
                 presence: SpComponentPresence::Present,
             },
@@ -76,7 +78,7 @@ async fn component_list() {
                 device: "at24csw080".to_string(),
                 serial_number: None,
                 description: "FAKE U.2 Sharkfin A VPD".to_string(),
-                capabilities: 0,
+                capabilities: DeviceCapabilities::HAS_VPD.bits(),
                 presence: SpComponentPresence::Present,
             },
             SpComponentInfo {
@@ -123,6 +125,24 @@ async fn component_list() {
                 serial_number: None,
                 description: "FAKE Fan controller".to_string(),
                 capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    .bits(),
+                presence: SpComponentPresence::Present,
+            },
+            SpComponentInfo {
+                component: "fan-tray-vpd".to_string(),
+                device: "at24csw080".to_string(),
+                serial_number: None,
+                description: "FAKE Fan tray VPD".to_string(),
+                capabilities: DeviceCapabilities::HAS_VPD.bits(),
+                presence: SpComponentPresence::Present,
+            },
+            SpComponentInfo {
+                component: "ibc".to_string(),
+                device: "bmr491".to_string(),
+                serial_number: None,
+                description: "FAKE intermediate bus converter".to_string(),
+                capabilities: (DeviceCapabilities::IS_PMBUS
+                    | DeviceCapabilities::HAS_VPD)
                     .bits(),
                 presence: SpComponentPresence::Present,
             },
@@ -141,7 +161,7 @@ async fn component_list() {
                 device: SpComponent::SP3_HOST_CPU.const_as_str().to_string(),
                 serial_number: None,
                 description: "FAKE host cpu".to_string(),
-                capabilities: 0,
+                capabilities: 4,
                 presence: SpComponentPresence::Present,
             },
             SpComponentInfo {
@@ -149,7 +169,8 @@ async fn component_list() {
                 device: "tmp117".to_string(),
                 serial_number: None,
                 description: "FAKE temperature sensor".to_string(),
-                capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                capabilities: (DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    | DeviceCapabilities::HAS_VPD)
                     .bits(),
                 presence: SpComponentPresence::Present,
             },
@@ -158,7 +179,8 @@ async fn component_list() {
                 device: "tmp117".to_string(),
                 serial_number: None,
                 description: "FAKE temperature sensor".to_string(),
-                capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                capabilities: (DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    | DeviceCapabilities::HAS_VPD)
                     .bits(),
                 presence: SpComponentPresence::Present,
             },
@@ -167,7 +189,8 @@ async fn component_list() {
                 device: "tmp117".to_string(),
                 serial_number: None,
                 description: "FAKE Southeast temperature sensor".to_string(),
-                capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                capabilities: (DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    | DeviceCapabilities::HAS_VPD)
                     .bits(),
                 presence: SpComponentPresence::Present,
             },
@@ -176,7 +199,7 @@ async fn component_list() {
                 device: "at24csw080".to_string(),
                 serial_number: None,
                 description: "FAKE U.2 Sharkfin A VPD".to_string(),
-                capabilities: 0,
+                capabilities: DeviceCapabilities::HAS_VPD.bits(),
                 presence: SpComponentPresence::Present,
             },
             SpComponentInfo {
@@ -223,6 +246,16 @@ async fn component_list() {
                 serial_number: None,
                 description: "FAKE Fan controller".to_string(),
                 capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    .bits(),
+                presence: SpComponentPresence::Present,
+            },
+            SpComponentInfo {
+                component: "ibc".to_string(),
+                device: "bmr491".to_string(),
+                serial_number: None,
+                description: "FAKE intermediate bus converter".to_string(),
+                capabilities: (DeviceCapabilities::IS_PMBUS
+                    | DeviceCapabilities::HAS_VPD)
                     .bits(),
                 presence: SpComponentPresence::Present,
             },
@@ -256,6 +289,16 @@ async fn component_list() {
                 capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
                     .bits(),
                 presence: SpComponentPresence::Failed,
+            },
+            SpComponentInfo {
+                component: "ibc".to_string(),
+                device: "bmr491".to_string(),
+                serial_number: None,
+                description: "FAKE intermediate bus converter".to_string(),
+                capabilities: (DeviceCapabilities::IS_PMBUS
+                    | DeviceCapabilities::HAS_VPD)
+                    .bits(),
+                presence: SpComponentPresence::Present,
             },
         ]
     );

--- a/gateway/tests/integration_tests/component_vpd.rs
+++ b/gateway/tests/integration_tests/component_vpd.rs
@@ -9,6 +9,7 @@ use gateway_types::component_vpd::{
     Barcode, ComponentVpd, Mpn1Barcode, OxideBarcode, PmbusDevice, SledFanTray,
     Tmp11x,
 };
+use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn pmbus_vpd() {

--- a/gateway/tests/integration_tests/component_vpd.rs
+++ b/gateway/tests/integration_tests/component_vpd.rs
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use gateway_messages::SpPort;
+use gateway_test_utils::setup;
+use gateway_types::component::SpType;
+use gateway_types::component_vpd::{
+    Barcode, ComponentVpd, Mpn1Barcode, OxideBarcode, PmbusDevice, SledFanTray,
+    Tmp11x,
+};
+
+#[tokio::test]
+async fn pmbus_vpd() {
+    fn mk_ibc(date: &str, serial_number: &str) -> ComponentVpd {
+        ComponentVpd::Pmbus(PmbusDevice {
+            mfr_id: Some(b"Flex".to_vec()),
+            mfr_model: Some(b"BMR4913203851".to_vec()),
+            mfr_revision: Some(b"R1C A".to_vec()),
+            mfr_location: Some(b"CB6".to_vec()),
+            mfr_date: Some(date.as_bytes().to_vec()),
+            mfr_serial: Some(serial_number.as_bytes().to_vec()),
+            ic_device_id: None,
+            ic_device_rev: None,
+        })
+    }
+
+    let testctx = setup::test_setup("pmbus_vpd", SpPort::One).await;
+    let client = &testctx.client;
+
+    for (sp_type, slot, date, serial_number) in [
+        (SpType::Switch, 0, "2023-02-25", "FP1C481050"),
+        (SpType::Switch, 1, "2023-02-26", "FP1C481051"),
+        (SpType::Sled, 0, "2023-02-27", "FP1C481052"),
+        (SpType::Sled, 1, "2023-02-28", "FP1C481053"),
+    ] {
+        let vpd = client
+            .sp_component_vpd_get(&sp_type, slot, "ibc")
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            vpd,
+            mk_ibc(date, serial_number),
+            "IBC PMBus VPD for {sp_type} {slot}"
+        );
+    }
+
+    testctx.teardown().await;
+}
+
+#[tokio::test]
+async fn tmp11x_vpd() {
+    let testctx = setup::test_setup("tmp11x_vpd", SpPort::One).await;
+    let client = &testctx.client;
+    for (slot, component, eeprom1, eeprom2, eeprom3) in [
+        (0, "dev-1", 0x0101, 0x0102, 0x0103),
+        (0, "dev-2", 0x0201, 0x0202, 0x0203),
+        (1, "dev-0", 0x1001, 0x1002, 0x1003),
+        (1, "dev-1", 0x1101, 0x1102, 0x1103),
+        (1, "dev-2", 0x1201, 0x1202, 0x1203),
+    ] {
+        let vpd = client
+            .sp_component_vpd_get(&SpType::Sled, slot, component)
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            vpd,
+            ComponentVpd::Tmp11x(Tmp11x {
+                device_id: 0x0117,
+                eeprom1,
+                eeprom2,
+                eeprom3,
+            }),
+            "TMP117 VPD for sled {slot} {component}"
+        );
+    }
+
+    testctx.teardown().await;
+}
+
+#[tokio::test]
+async fn single_barcode_vpd() {
+    let testctx = setup::test_setup("single_barcode_vpd", SpPort::One).await;
+    let client = &testctx.client;
+    for (slot, serial_number) in [(0, "2SHRKFN1"), (1, "2SHRKFN2")] {
+        let vpd = client
+            .sp_component_vpd_get(&SpType::Sled, slot, "dev-6")
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            vpd,
+            ComponentVpd::OxideBarcode(OxideBarcode {
+                part_number: "913-0000028".to_owned(),
+                revision: 1,
+                serial_number: serial_number.to_owned(),
+            }),
+            "Sharkfin barcode for sled {slot}"
+        );
+    }
+
+    testctx.teardown().await;
+}
+
+#[tokio::test]
+async fn fan_tray_barcode_vpd() {
+    let testctx = setup::test_setup("fan_tray_barcode_vpd", SpPort::One).await;
+    let client = &testctx.client;
+    let vpd = client
+        .sp_component_vpd_get(&SpType::Sled, 0, "fan-tray-vpd")
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        vpd,
+        ComponentVpd::SledFanTray(SledFanTray {
+            identity: OxideBarcode {
+                part_number: "991-0000151".to_owned(),
+                revision: 1,
+                serial_number: "TST01234567".to_owned(),
+            },
+            vpd_board_identity: OxideBarcode {
+                part_number: "913-0000027".to_owned(),
+                revision: 1,
+                serial_number: "TST01234568".to_owned(),
+            },
+            fan0: Barcode::Mpn1(Mpn1Barcode {
+                manufacturer: "SYD".to_owned(),
+                part_number: "9CRA0848P8G012".to_owned(),
+                revision: "C".to_owned(),
+                serial_number: "WWYY1SSS".to_owned(),
+            }),
+            fan1: Barcode::Oxide(OxideBarcode {
+                part_number: "125-0000456".to_owned(),
+                revision: 2,
+                serial_number: "FAN01234569".to_owned(),
+            }),
+            fan2: Barcode::Mpn1(Mpn1Barcode {
+                manufacturer: "ABC".to_owned(),
+                part_number: "ASDF-1000".to_owned(),
+                revision: "032".to_owned(),
+                serial_number: "123456789".to_owned(),
+            }),
+        }),
+        "fan tray for sled 0"
+    );
+
+    testctx.teardown().await;
+}

--- a/gateway/tests/integration_tests/mod.rs
+++ b/gateway/tests/integration_tests/mod.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod component_list;
+mod component_vpd;
 mod config;
 mod ereports;
 mod location_discovery;

--- a/oximeter/oximeter/schema/hardware-component.toml
+++ b/oximeter/oximeter/schema/hardware-component.toml
@@ -17,6 +17,23 @@ versions = [
         "component_kind",
         "component_id",
         "description",
+    ]},
+    { version = 2,  fields = [
+        "rack_id",
+        "slot",
+        "chassis_kind",
+        "chassis_serial",
+        "chassis_model",
+        "chassis_revision",
+        "hubris_archive_id",
+        "gateway_id",
+        "component_kind",
+        "component_id",
+        "description",
+        "component_manufacturer",
+        "component_model",
+        "component_revision",
+        "component_serial",
     ]}
 ]
 
@@ -96,6 +113,52 @@ This will be one of 'temperature', 'current', 'power', 'voltage', \
 'input_power', 'output_energy', or 'input_energy' (the same \
 names as the metrics emitted by these sensors when they are read \
 successfully)."""
+
+[fields.component_manufacturer]
+type = "string"
+description = """
+A string identifying the manufacturer of this hardware component, if this is \
+necessary to interpret the component's  identity.
+
+This field is included if and only if the manufacturer identity is necessary \
+in order to interpret the component's `component_model`, `component_revision`, \
+and `component_serial` fields. If the component does not have those fields, or \
+if the component's serial number is assigned by Oxide, this field will be the \
+empty string."""
+
+[fields.component_model]
+type = "string"
+description = """
+A string representation of a model number or similar identifier for this \
+hardware component, if it has one.
+
+If this field is present and the `component_manufacturer` field is the empty \
+string, this field contains the Oxide part number (CPN) for this component. \
+Otherwise, if  `component_manufacturer` is present, this is a \
+manufacturer-provided part or model number (MPN) for this hardware component."""
+
+[fields.component_revision]
+type = "string"
+description = """
+A string representation of a revision number or string for this hardware \
+component, if it is known.
+
+If this field is present and the `component_manufacturer` field is the empty \
+string, this field contains the Oxide revision number for this component, \
+which is a non-negative integer.  Otherwise, if `component_manufacturer` is \
+non-empty, this is a revision identifier assigned by the component's \
+manufacturer, and may be any string."""
+
+[fields.component_serial]
+type = "string"
+description = """
+A string representation of this hardware component's serial number, if it is \
+known.
+
+If this field is present and the `component_manufacturer` field is the empty \
+string, this field contains the Oxide serial number for this component. \
+Otherwise, if `component_manufacturer` is non-empty, this is a serial number \
+assigned by the component's manufacturer."""
 
 [[metrics]]
 name = "temperature"

--- a/oximeter/oximeter/schema/hardware-component.toml
+++ b/oximeter/oximeter/schema/hardware-component.toml
@@ -17,25 +17,11 @@ versions = [
         "component_kind",
         "component_id",
         "description",
-    ]},
-    { version = 2,  fields = [
-        "rack_id",
-        "slot",
-        "chassis_kind",
-        "chassis_serial",
-        "chassis_model",
-        "chassis_revision",
-        "hubris_archive_id",
-        "gateway_id",
-        "component_kind",
-        "component_id",
-        "description",
         "component_manufacturer",
         "component_model",
         "component_revision",
         "component_serial",
     ]}
-]
 
 [fields.rack_id]
 type = "uuid"

--- a/sp-sim/examples/config.toml
+++ b/sp-sim/examples/config.toml
@@ -23,6 +23,21 @@ bind_addr = "[::1]:44400"
 [simulated_sps.sidecar.ereport_network_config.simulated]
 bind_addr = "[::1]:44401"
 
+[[simulated_sps.sidecar.components]]
+id = "ibc"
+device = "bmr491"
+description = "FAKE intermediate bus converter"
+capabilities = 0x20
+presence = "Present"
+
+[simulated_sps.sidecar.components.vpd.pmbus]
+mfr_id = "Flex"
+mfr_model = "BMR4913203851"
+mfr_revision = "R1C A"
+mfr_location = "CB6"
+mfr_date = "2023-02-25"
+mfr_serial = "FP1C481050"
+
 [[simulated_sps.gimlet]]
 serial_number = "SimGimlet0"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
@@ -58,6 +73,7 @@ device = "tmp117"
 description = "FAKE Southwest temperature sensor"
 capabilities = 2
 presence = "Present"
+vpd = { tmp11x = { id = 0x0117, eeprom1 = 0x1111, eeprom2 = 0x2222, eeprom3 = 0x3333 } }
 sensors = [
     { name = "Southwest", kind = "Temperature", last_data.value = 41.7890625, last_data.timestamp = 1234 },
 ]
@@ -70,6 +86,45 @@ capabilities = 2
 presence = "Present"
 sensors = [
     { name = "CPU", kind = "Temperature", last_data.value = 64.5, last_data.timestamp = 1234 },
+]
+
+[[simulated_sps.gimlet.components]]
+id = "sharkfin-vpd"
+device = "at24csw080"
+description = "FAKE U.2 Sharkfin A VPD"
+capabilities = 0
+presence = "Present"
+vpd = { barcode = "0XV2:913-0000028:001:2SHRKFN" }
+
+[[simulated_sps.gimlet.components]]
+id = "ibc"
+device = "bmr491"
+description = "FAKE intermediate bus converter"
+capabilities = 0x20
+presence = "Present"
+
+[simulated_sps.gimlet.components.vpd.pmbus]
+mfr_id = "FlexAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+mfr_model = "BMR4913203851"
+mfr_revision = "R1C A"
+mfr_location = "CB6"
+mfr_date = "2023-02-27"
+mfr_serial = "FP1C481052"
+
+[[simulated_sps.gimlet.components]]
+id = "fan-tray-vpd"
+device = "at24csw080"
+description = "FAKE Fan tray VPD"
+capabilities = 0
+presence = "Present"
+
+[simulated_sps.gimlet.components.vpd.sled_fan_tray]
+identity = "0XV2:123-0000456:023:TST01234567"
+vpd_board_identity = "0XV1:1240000456:001:TST01234568"
+fans = [
+    "MPN1:SYD:9CRA0848P8G012:C:WWYY1SSS",
+    "0XV2:125-0000456:002:TST01234569",
+    "MPN1:ABC:ASDF-1000:032:123456789",
 ]
 
 [simulated_sps.gimlet.ereport_config]
@@ -148,6 +203,7 @@ device = "tmp117"
 description = "FAKE Southwest temperature sensor"
 capabilities = 2
 presence = "Present"
+vpd = { tmp11x = { id = 0x0117, eeprom1 = 0x1001, eeprom2 = 0x1002, eeprom3 = 0x1003 } }
 sensors = [
     { name = "Southwest", kind = "Temperature", last_data.value = 41.7890625, last_data.timestamp = 1234 },
 ]
@@ -162,6 +218,20 @@ sensors = [
     { name = "CPU", kind = "Temperature", last_data.value = 63.1, last_data.timestamp = 1234 },
 ]
 
+[[simulated_sps.gimlet.components]]
+id = "ibc"
+device = "bmr491"
+description = "FAKE intermediate bus converter"
+capabilities = 0x20
+presence = "Present"
+
+[simulated_sps.gimlet.components.vpd.pmbus]
+mfr_id = "Flex"
+mfr_model = "BMR4913203851"
+mfr_revision = "R1C A"
+mfr_location = "CB6"
+mfr_date = "2023-02-28"
+mfr_serial = "FP1C481053"
 
 [simulated_sps.gimlet.ereport_config]
 restart_id = "55e30cc7-a109-492f-aca9-735ed725df3c"

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -10,6 +10,7 @@ use crate::sensors;
 use dropshot::ConfigLogging;
 use gateway_messages::DeviceCapabilities;
 use gateway_messages::DevicePresence;
+use gateway_messages::vpd as gw_vpd;
 use nexus_types::inventory::Caboose;
 use serde::Deserialize;
 use serde::Serialize;
@@ -142,8 +143,102 @@ pub struct SpComponentConfig {
     /// Only supported for components inside a [`GimletConfig`].
     pub serial_console: Option<SocketAddrV6>,
 
+    /// Simulated vital product data returned for this component.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub vpd: Option<ComponentVpdConfig>,
+
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub sensors: Vec<SensorConfig>,
+}
+
+impl SpComponentConfig {
+    /// Determine the capabilities to advertise for this component based on the
+    /// config.
+    ///
+    /// This combines the capabilities bits specified directly in the config
+    /// file with additional capabilities that are implied by behaviors this
+    /// component is configured to simulate. For example, if the component is
+    /// configured to simulate sensors, we add `HAS_MEASUREMENT_CHANNELS`.
+    pub(crate) fn configured_capabilities(&self) -> DeviceCapabilities {
+        let mut capabilities = self.capabilities;
+
+        // If this component is configured to report VPD, add the capability.
+        if let Some(ref vpd) = self.vpd {
+            capabilities |= DeviceCapabilities::HAS_VPD;
+
+            if let ComponentVpdConfig::Pmbus(_) = vpd {
+                capabilities |= DeviceCapabilities::IS_PMBUS;
+            }
+        }
+
+        // If this component has sensors, add the corresponding capability.
+        if !self.sensors.is_empty() {
+            capabilities |= DeviceCapabilities::HAS_MEASUREMENT_CHANNELS;
+        }
+
+        // If this component has a simulated serial console, well, you know the
+        // drill.
+        if self.serial_console.is_some() {
+            capabilities |= DeviceCapabilities::HAS_SERIAL_CONSOLE;
+        }
+
+        // TODO(eliza): when we add support for configuring simulated PMBus
+        // status responses, add the IS_PMBUS bit here too.
+
+        capabilities
+    }
+}
+
+/// Vital product data returned for a simulated component.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentVpdConfig {
+    Pmbus(Box<PmbusVpdConfig>),
+    Barcode(gw_vpd::Barcode),
+    SledFanTray(Box<gw_vpd::SledFanTrayVpd>),
+    Tmp11x(gw_vpd::Tmp11xVpd),
+}
+
+/// One PMBus block-read response for a simulated PMBus device's VPD.
+///
+/// This can be configured either as a  string or a byte array, to make it
+/// easier to configure simulated VPD for devices which are expected to respond
+/// to VPD commands with strings.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum PmbusBlockConfig {
+    String(String),
+    Bytes(Vec<u8>),
+}
+
+impl PmbusBlockConfig {
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::String(value) => value.as_bytes(),
+            Self::Bytes(value) => value,
+        }
+    }
+}
+
+/// PMBus vital product data returned for a simulated component.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct PmbusVpdConfig {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mfr_id: Option<PmbusBlockConfig>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mfr_model: Option<PmbusBlockConfig>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mfr_revision: Option<PmbusBlockConfig>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mfr_location: Option<PmbusBlockConfig>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mfr_date: Option<PmbusBlockConfig>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mfr_serial: Option<PmbusBlockConfig>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub ic_device_id: Option<PmbusBlockConfig>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub ic_device_rev: Option<PmbusBlockConfig>,
 }
 
 /// Configuration of a simulated sidecar SP

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -17,6 +17,7 @@ use crate::server::SimSpHandler;
 use crate::server::UdpServer;
 use crate::update::BaseboardKind;
 use crate::update::SimSpUpdate;
+use crate::vpd::ComponentVpds;
 use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
 use futures::Future;
@@ -836,6 +837,7 @@ struct Handler {
     update_state: SimSpUpdate,
     reset_pending: Option<SpComponent>,
     sensors: Sensors,
+    component_vpds: ComponentVpds,
 
     last_request_handled: Option<SimSpHandledRequest>,
 
@@ -873,6 +875,8 @@ impl Handler {
         }
 
         let sensors = Sensors::from_component_configs(&components);
+        let component_vpds = ComponentVpds::from_component_configs(&components)
+            .expect("component VPD configuration should be valid");
 
         let sp_dumps = HashMap::new();
 
@@ -880,6 +884,7 @@ impl Handler {
             log,
             common,
             sensors,
+            component_vpds,
             leaked_component_device_strings,
             leaked_component_description_strings,
             attached_mgs,
@@ -1398,7 +1403,7 @@ impl SpHandler for Handler {
             component: SpComponent::try_from(c.id.as_str()).unwrap(),
             device: self.leaked_component_device_strings[index],
             description: self.leaked_component_description_strings[index],
-            capabilities: c.capabilities,
+            capabilities: c.configured_capabilities(),
             presence: c.presence,
         }
     }
@@ -1574,17 +1579,9 @@ impl SpHandler for Handler {
     fn component_get_vpd(
         &mut self,
         component: SpComponent,
-        _buf: &mut [u8],
+        buf: &mut [u8],
     ) -> Result<usize, SpError> {
-        // TODO(eliza): we should allow configuring a VPD response in the sim
-        // config file...
-        warn!(
-            &self.log,
-            "asked to read VPD for component, which the simulator doesn't
-             implement yet";
-            "component" => ?component,
-        );
-        Err(SpError::RequestUnsupportedForComponent)
+        self.component_vpds.component_get_vpd(&component, buf)
     }
 
     fn read_sensor(

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -10,6 +10,7 @@ mod sensors;
 mod server;
 mod sidecar;
 mod update;
+mod vpd;
 
 pub use anyhow::Result;
 use async_trait::async_trait;

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -19,6 +19,7 @@ use crate::server::SimSpHandler;
 use crate::server::UdpServer;
 use crate::update::BaseboardKind;
 use crate::update::SimSpUpdate;
+use crate::vpd::ComponentVpds;
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::Future;
@@ -502,6 +503,7 @@ struct Handler {
     leaked_component_device_strings: Vec<&'static str>,
     leaked_component_description_strings: Vec<&'static str>,
     sensors: Sensors,
+    component_vpds: ComponentVpds,
 
     serial_number: String,
     ignition: FakeIgnition,
@@ -544,6 +546,8 @@ impl Handler {
         }
 
         let sensors = Sensors::from_component_configs(&components);
+        let component_vpds = ComponentVpds::from_component_configs(&components)
+            .expect("component VPD configuration should be valid");
 
         let sp_dumps = HashMap::new();
 
@@ -551,6 +555,7 @@ impl Handler {
             log,
             components,
             sensors,
+            component_vpds,
             leaked_component_device_strings,
             leaked_component_description_strings,
             serial_number,
@@ -1002,7 +1007,7 @@ impl SpHandler for Handler {
             component: SpComponent::try_from(c.id.as_str()).unwrap(),
             device: self.leaked_component_device_strings[index],
             description: self.leaked_component_description_strings[index],
-            capabilities: c.capabilities,
+            capabilities: c.configured_capabilities(),
             presence: c.presence,
         }
     }
@@ -1176,17 +1181,9 @@ impl SpHandler for Handler {
     fn component_get_vpd(
         &mut self,
         component: SpComponent,
-        _buf: &mut [u8],
+        buf: &mut [u8],
     ) -> Result<usize, SpError> {
-        // TODO(eliza): we should allow configuring a VPD response in the sim
-        // config file...
-        warn!(
-            &self.log,
-            "asked to read VPD for component, which the simulator doesn't
-             implement yet";
-            "component" => ?component,
-        );
-        Err(SpError::RequestUnsupportedForComponent)
+        self.component_vpds.component_get_vpd(&component, buf)
     }
 
     fn read_sensor(

--- a/sp-sim/src/vpd.rs
+++ b/sp-sim/src/vpd.rs
@@ -1,0 +1,136 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Runtime component VPD responses constructed from simulator configuration.
+
+use crate::config::ComponentVpdConfig;
+use crate::config::PmbusBlockConfig;
+use crate::config::SpComponentConfig;
+
+use gateway_messages::SpComponent;
+use gateway_messages::SpError;
+use gateway_messages::vpd as gw;
+
+use anyhow::Context;
+use anyhow::anyhow;
+use anyhow::bail;
+use std::collections::HashMap;
+
+pub(crate) struct ComponentVpds {
+    by_component: HashMap<SpComponent, ComponentVpd>,
+}
+
+#[derive(Debug)]
+struct ComponentVpd {
+    vpd: gw::Vpd,
+}
+
+impl ComponentVpds {
+    pub(crate) fn from_component_configs<'a>(
+        configs: impl IntoIterator<Item = &'a SpComponentConfig>,
+    ) -> anyhow::Result<Self> {
+        let mut by_component = HashMap::new();
+        for config in configs {
+            let Some(vpd_config) = &config.vpd else {
+                continue;
+            };
+            let component = SpComponent::try_from(config.id.as_str())
+                .map_err(|_| anyhow!("invalid component ID {:?}", config.id))?;
+            let vpd =
+                ComponentVpd::from_config(vpd_config).with_context(|| {
+                    format!("invalid VPD config for component {component}")
+                })?;
+            if by_component.insert(component, vpd).is_some() {
+                bail!(
+                    "invalid config file: duplicate VPD configs for component
+                     ID {component}"
+                );
+            }
+        }
+        Ok(Self { by_component })
+    }
+
+    pub(crate) fn component_get_vpd(
+        &self,
+        component: &SpComponent,
+        buf: &mut [u8],
+    ) -> Result<usize, SpError> {
+        let vpd = self
+            .by_component
+            .get(component)
+            .ok_or(SpError::RequestUnsupportedForComponent)?;
+        // TODO(eliza): allow simulating errors as well here?
+        match gateway_messages::serialize(buf, &vpd.vpd) {
+            Ok(len) => Ok(len),
+            Err(e) => {
+                panic!(
+                    "failed to serialize component_get_vpd response for \
+                     {component}: {e}"
+                )
+            }
+        }
+    }
+}
+
+impl ComponentVpd {
+    fn from_config(config: &ComponentVpdConfig) -> anyhow::Result<Self> {
+        let vpd = match config {
+            ComponentVpdConfig::Pmbus(config) => {
+                let vpd = gw::PmbusVpd {
+                    mfr_id: pmbus_block(config.mfr_id.as_ref())
+                        .context("invalid PMBus mfr_id")?,
+                    mfr_model: pmbus_block(config.mfr_model.as_ref())
+                        .context("invalid PMBus mfr_model")?,
+                    mfr_revision: pmbus_block(config.mfr_revision.as_ref())
+                        .context("invalid PMBus mfr_revision")?,
+                    mfr_location: pmbus_block(config.mfr_location.as_ref())
+                        .context("invalid PMBus mfr_location")?,
+                    mfr_date: pmbus_block(config.mfr_date.as_ref())
+                        .context("invalid PMBus mfr_date")?,
+                    mfr_serial: pmbus_block(config.mfr_serial.as_ref())
+                        .context("invalid PMBus mfr_serial")?,
+                    ic_device_id: pmbus_block(config.ic_device_id.as_ref())
+                        .context("invalid PMBus ic_device_id")?,
+                    ic_device_rev: pmbus_block(config.ic_device_rev.as_ref())
+                        .context("invalid PMBus ic_device_rev")?,
+                };
+                gw::Vpd::Pmbus(vpd)
+            }
+            ComponentVpdConfig::Barcode(vpd) => gw::Vpd::Barcode(*vpd),
+            ComponentVpdConfig::SledFanTray(vpd) => {
+                gw::Vpd::SledFanTray((**vpd).clone())
+            }
+            ComponentVpdConfig::Tmp11x(vpd) => gw::Vpd::Tmp11x(vpd.clone()),
+        };
+        Ok(Self { vpd })
+    }
+}
+
+fn pmbus_block(
+    value: Option<&PmbusBlockConfig>,
+) -> anyhow::Result<gw::SmbusBlock> {
+    let mut block = gw::SmbusBlock::UNSUPPORTED;
+    let Some(value) = value else {
+        return Ok(block);
+    };
+    let value = value.as_bytes();
+    if value.len() > gw::SmbusBlock::MAX_LEN {
+        bail!(
+            "the simulated response value for this PMBus VPD command is {}B, \
+             which exceeds the SP's maximum supported length of {}B",
+            value.len(),
+            gw::SmbusBlock::MAX_LEN,
+        );
+    }
+    block
+        .read_into(|buf| {
+            buf[..value.len()].copy_from_slice(value);
+            Ok::<_, std::convert::Infallible>(Some(value.len()))
+        })
+        .expect(
+            "we just checked that the configured response is within the \
+            max length",
+        );
+    Ok(block)
+}


### PR DESCRIPTION
Depends on #11287.

This branch implements #9000 by adding new fields to the `hardware_component` metrics to represent the vital product data of the individual hardware components that produced a metric.